### PR TITLE
added feature to compute flux of far fields in dft_near2far

### DIFF
--- a/libctl/meep-ctl-swig.hpp
+++ b/libctl/meep-ctl-swig.hpp
@@ -30,6 +30,9 @@ ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt,
                                 double rel_amp_thresh, double amp_thresh);
 
 ctlio::number_list dft_flux_flux(meep::dft_flux *f);
+ctlio::number_list dft_energy_electric(meep::dft_energy *f);
+ctlio::number_list dft_energy_magnetic(meep::dft_energy *f);
+ctlio::number_list dft_energy_total(meep::dft_energy *f);
 ctlio::number_list dft_force_force(meep::dft_force *f);
 ctlio::number_list dft_ldos_ldos(meep::dft_ldos *f);
 ctlio::cnumber_list dft_ldos_F(meep::dft_ldos *f);

--- a/libctl/meep.cpp
+++ b/libctl/meep.cpp
@@ -91,6 +91,30 @@ ctlio::number_list dft_flux_flux(dft_flux *f)
   return res;
 }
 
+ctlio::number_list dft_energy_electric(dft_energy *f)
+{
+  ctlio::number_list res;
+  res.num_items = f->Nfreq;
+  res.items = f->electric();
+  return res;
+}
+
+ctlio::number_list dft_energy_magnetic(dft_energy *f)
+{
+  ctlio::number_list res;
+  res.num_items = f->Nfreq;
+  res.items = f->magnetic();
+  return res;
+}
+
+ctlio::number_list dft_energy_total(dft_energy *f)
+{
+  ctlio::number_list res;
+  res.num_items = f->Nfreq;
+  res.items = f->total();
+  return res;
+}
+
 ctlio::number_list dft_force_force(dft_force *f)
 {
   ctlio::number_list res;

--- a/libctl/meep.scm.in
+++ b/libctl/meep.scm.in
@@ -578,6 +578,74 @@
   (meep-dft-flux-scale-dfts flux -1.0))
 
 ; ****************************************************************
+; Energy spectra
+
+(define-class energy-region no-parent
+  (define-property center no-default 'vector3)
+  (define-property size (vector3 0 0 0) 'vector3)
+  (define-property direction 0 'integer)
+  (define-property weight 1.0 'cnumber))
+
+(define (fields-add-energy fields fcen df nfreq . energys)
+  (fields-add-fluxish-stuff meep-fields-add-dft-energy 
+			    fields fcen df nfreq energys))
+
+(define (add-energy fcen df nfreq . energys)
+  (if (null? fields) (init-fields))
+  (apply fields-add-energy (append (list fields fcen df nfreq) energys)))
+
+(define (scale-energy-fields s f)
+  (meep-dft-energy-scale-dfts f s))
+
+(define (get-energy-freqs f)
+  (arith-sequence
+   (meep-dft-energy-freq-min-get f)
+   (meep-dft-energy-dfreq-get f)
+   (meep-dft-energy-Nfreq-get f)))
+
+(define (get-electric f)
+  (dft-energy-electric f))
+
+(define (get-magnetic f)
+  (dft-energy-magnetic f))
+
+(define (get-total f)
+  (dft-energy-total f))
+
+(define (display-electric-energy . energys)
+  (if (not (null? energys))
+      (apply display-csv
+	     (append (list "electric-energy"
+			   (get-energy-freqs (car energys)))
+		     (map get-electric energys)))))
+
+(define (display-magnetic-energy . energys)
+  (if (not (null? energys))
+      (apply display-csv
+	     (append (list "magnetic-energy"
+			   (get-energy-freqs (car energys)))
+		     (map get-magnetic energys)))))
+
+(define (display-total-energy . energys)
+  (if (not (null? energys))
+      (apply display-csv
+	     (append (list "total-energy"
+			   (get-energy-freqs (car energys)))
+		     (map get-total energys)))))
+
+(define (load-energy fname energy)
+  (if (null? fields) (init-fields))
+  (meep-dft-energy-load-hdf5 energy fields fname "" (get-filename-prefix)))
+
+(define (save-energy fname energy)
+  (if (null? fields) (init-fields))
+  (meep-dft-energy-save-hdf5 energy fields fname "" (get-filename-prefix)))
+
+(define (load-minus-energy fname energy)
+  (load-energy fname energy)
+  (meep-dft-energy-scale-dfts energy -1.0))
+
+; ****************************************************************
 ; Force spectra (from stress tensor) - very similar interface to flux spectra
 
 (define-class force-region no-parent

--- a/libctl/meep.scm.in
+++ b/libctl/meep.scm.in
@@ -658,6 +658,9 @@
   (meep-dft-near2far-save-farfields near2far fname (get-filename-prefix)
                                     where resolution))
 
+(define (output-farflux near2far df where resolution)
+  (meep-dft-near2far-flux near2far df where resolution))
+
 (define (load-near2far fname near2far)
   (if (null? fields) (init-fields))
   (meep-dft-near2far-load-hdf5 near2far fields fname "" (get-filename-prefix)))

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -492,10 +492,8 @@ double *dft_energy::total() {
   double *Fm = magnetic();
   double *F = new double[Nfreq];
   for (int i = 0; i < Nfreq; ++i) F[i] = Fe[i]+Fm[i];
-  double *Fsum = new double[Nfreq];
-  sum_to_all(F, Fsum, Nfreq);
-  delete[] F;
-  return Fsum;
+  delete[] Fe, Fm;
+  return F;
 }
 
 dft_energy fields::add_dft_energy(const volume_list *where_,

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -441,6 +441,151 @@ dft_flux fields::add_dft_flux(const volume_list *where_,
   return dft_flux(cE[0], cH[0], E, H, freq_min, freq_max, Nfreq);
 }
 
+dft_energy::dft_energy(dft_chunk *E_, dft_chunk *H_, 
+		       dft_chunk *D_, dft_chunk *B_, 
+		       double fmin, double fmax, int Nf)
+{
+  if (Nf <= 1) fmin = fmax = (fmin + fmax) * 0.5;
+  freq_min = fmin;
+  Nfreq = Nf;
+  dfreq = Nf <= 1 ? 0.0 : (fmax - fmin) / (Nf - 1);
+  E = E_; H = H_; D = D_; B = B_;
+}
+
+dft_energy::dft_energy(const dft_energy &f) {
+  freq_min = f.freq_min; Nfreq = f.Nfreq; dfreq = f.dfreq;
+  E = f.E; H = f.H; D = f.D; B = f.B;
+}
+
+double *dft_energy::electric() {
+  double *F = new double[Nfreq];
+  for (int i = 0; i < Nfreq; ++i) F[i] = 0;
+  for (dft_chunk *curE = E, *curD = D; curE && curD;
+       curE = curE->next_in_dft, curD = curD->next_in_dft)
+    for (int k = 0; k < curE->N; ++k)
+      for (int i = 0; i < Nfreq; ++i)
+	F[i] += 0.5*real(conj(curE->dft[k*Nfreq + i])
+			 * curD->dft[k*Nfreq + i]);
+  double *Fsum = new double[Nfreq];
+  sum_to_all(F, Fsum, Nfreq);
+  delete[] F;
+  return Fsum;
+}
+
+double *dft_energy::magnetic() {
+  double *F = new double[Nfreq];
+  for (int i = 0; i < Nfreq; ++i) F[i] = 0;
+  for (dft_chunk *curH = H, *curB = B; curH && curB;
+       curH = curH->next_in_dft, curB = curB->next_in_dft)
+    for (int k = 0; k < curH->N; ++k)
+      for (int i = 0; i < Nfreq; ++i)
+	F[i] += 0.5*real(conj(curH->dft[k*Nfreq + i])
+			 * curB->dft[k*Nfreq + i]);
+  double *Fsum = new double[Nfreq];
+  sum_to_all(F, Fsum, Nfreq);
+  delete[] F;
+  return Fsum;
+}
+
+double *dft_energy::total() {
+  double *Fe = electric();
+  double *Fm = magnetic();
+  double *F = new double[Nfreq];
+  for (int i = 0; i < Nfreq; ++i) F[i] = Fe[i]+Fm[i];
+  double *Fsum = new double[Nfreq];
+  sum_to_all(F, Fsum, Nfreq);
+  delete[] F;
+  return Fsum;
+}
+
+dft_energy fields::add_dft_energy(const volume_list *where_,
+			      double freq_min, double freq_max, int Nfreq) {
+  dft_chunk *E = 0, *D = 0, *H = 0, *B = 0;
+  volume_list *where = S.reduce(where_);
+  volume_list *where_save = where;
+  while (where) {
+    LOOP_OVER_FIELD_DIRECTIONS(gv.dim, d) {
+      E = add_dft(direction_component(Ex, d), where->v, freq_min, freq_max, Nfreq,
+		  true, 1.0, E);      
+      D = add_dft(direction_component(Dx, d), where->v, freq_min, freq_max, Nfreq,
+		  true, 1.0, D);      
+      H = add_dft(direction_component(Hx, d), where->v, freq_min, freq_max, Nfreq,
+		  true, 1.0, H);      
+      B = add_dft(direction_component(Bx, d), where->v, freq_min, freq_max, Nfreq,
+		  true, 1.0, B);
+    }
+    where = where->next;
+  }
+  delete where_save;
+
+  return dft_energy(E, H, D, B, freq_min, freq_max, Nfreq);
+}
+
+void dft_energy::save_hdf5(h5file *file, const char *dprefix) {
+  save_dft_hdf5(E, "E", file, dprefix);
+  file->prevent_deadlock(); // hackery
+  save_dft_hdf5(D, "D", file, dprefix);
+  file->prevent_deadlock(); // hackery
+  save_dft_hdf5(H, "H", file, dprefix);
+  file->prevent_deadlock(); // hackery
+  save_dft_hdf5(B, "B", file, dprefix);
+}
+
+void dft_energy::load_hdf5(h5file *file, const char *dprefix) {
+  load_dft_hdf5(E, "E", file, dprefix);
+  file->prevent_deadlock(); // hackery
+  load_dft_hdf5(D, "D", file, dprefix);
+  file->prevent_deadlock(); // hackery
+  load_dft_hdf5(H, "H", file, dprefix);
+  file->prevent_deadlock(); // hackery
+  load_dft_hdf5(B, "B", file, dprefix);
+}
+
+void dft_energy::save_hdf5(fields &f, const char *fname, const char *dprefix,
+			 const char *prefix) {
+  h5file *ff = f.open_h5file(fname, h5file::WRITE, prefix);
+  save_hdf5(ff, dprefix);
+  delete ff;
+}
+
+void dft_energy::load_hdf5(fields &f, const char *fname, const char *dprefix,
+			 const char *prefix) {
+  h5file *ff = f.open_h5file(fname, h5file::READONLY, prefix);
+  load_hdf5(ff, dprefix);
+  delete ff;
+}
+
+void dft_energy::scale_dfts(complex<double> scale) {
+  if (E) E->scale_dft(scale);
+  if (D) D->scale_dft(scale);
+  if (H) H->scale_dft(scale);
+  if (B) B->scale_dft(scale);
+}
+
+void dft_energy::remove()
+{
+  while (E) {
+    dft_chunk *nxt = E->next_in_dft;
+    delete E;
+    E = nxt;
+  }
+  while (D) {
+    dft_chunk *nxt = D->next_in_dft;
+    delete D;
+    D = nxt;
+  }
+  while (H) {
+    dft_chunk *nxt = H->next_in_dft;
+    delete H;
+    H = nxt;
+  }
+  while (B) {
+    dft_chunk *nxt = B->next_in_dft;
+    delete B;
+    B = nxt;
+  }
+}
+
 direction fields::normal_direction(const volume &where) const {
   direction d = where.normal_direction();
   if (d == NO_DIRECTION) {

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -915,6 +915,37 @@ public:
   component cE, cH;
 };
 
+// dft.cpp (normally created with fields::add_dft_energy)
+class dft_energy {
+public:
+  dft_energy(dft_chunk *E_, dft_chunk *H_, dft_chunk *D_, dft_chunk *B_,
+	     double fmin, double fmax, int Nf);
+  dft_energy(const dft_energy &f);
+
+  double *electric();
+  double *magnetic();
+  double *total();
+
+  void save_hdf5(h5file *file, const char *dprefix = 0);
+  void load_hdf5(h5file *file, const char *dprefix = 0);
+
+  void operator-=(const dft_energy &fl) { if (E && fl.E) *E -= *fl.E; if (H && fl.H) *H -= *fl.H; 
+                                          if (D && fl.D) *D -= *fl.D; if (B && fl.B) *B -= *fl.B; }
+
+  void save_hdf5(fields &f, const char *fname, const char *dprefix = 0,
+		 const char *prefix = 0);
+  void load_hdf5(fields &f, const char *fname, const char *dprefix = 0,
+		 const char *prefix = 0);
+
+  void scale_dfts(std::complex<double> scale);
+
+  void remove();
+
+  double freq_min, dfreq;
+  int Nfreq;
+  dft_chunk *E, *H, *D, *B;
+};
+
 // stress.cpp (normally created with fields::add_dft_force)
 class dft_force {
 public:
@@ -1412,6 +1443,9 @@ class fields {
 			      double freq_min, double freq_max, int Nfreq);
   dft_flux add_dft_flux(const volume_list *where,
 			double freq_min, double freq_max, int Nfreq);
+
+  dft_energy add_dft_energy(const volume_list *where,
+			  double freq_min, double freq_max, int Nfreq);
 
   // stress.cpp
   dft_force add_dft_force(const volume_list *where,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -965,6 +965,9 @@ public:
   void save_farfields(const char *fname, const char *prefix,
                       const volume &where, double resolution);
 
+  /* output Poynting vector of far fields */
+  double *flux(direction df, const volume &where, double resolution);
+
   void save_hdf5(h5file *file, const char *dprefix = 0);
   void load_hdf5(h5file *file, const char *dprefix = 0);
 

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -62,13 +62,16 @@ bool broadcast(int from, bool);
 double max_to_master(double); // Only returns the correct value to proc 0.
 double max_to_all(double);
 int max_to_all(int);
+float sum_to_master(float); // Only returns the correct value to proc 0.
 double sum_to_master(double); // Only returns the correct value to proc 0.
 double sum_to_all(double);
 void sum_to_all(const double *in, double *out, int size);
+void sum_to_master(const float *in, float *out, int size);
 void sum_to_master(const double *in, double *out, int size);
 void sum_to_all(const float *in, double *out, int size);
 void sum_to_all(const std::complex<float> *in, std::complex<double> *out, int size);
 void sum_to_all(const std::complex<double> *in, std::complex<double> *out, int size);
+void sum_to_master(const std::complex<float> *in, std::complex<float> *out, int size);
 void sum_to_master(const std::complex<double> *in, std::complex<double> *out, int size);
 long double sum_to_all(long double);
 std::complex<double> sum_to_all(std::complex<double> in);

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -269,6 +269,14 @@ ivec max_to_all(const ivec &pt) {
   return ptout;
 }
 
+float sum_to_master(float in) {
+  float out = in;
+#ifdef HAVE_MPI
+  MPI_Reduce(&in,&out,1,MPI_FLOAT,MPI_SUM,0,mycomm);
+#endif
+  return out;
+}
+
 double sum_to_master(double in) {
   double out = in;
 #ifdef HAVE_MPI
@@ -293,6 +301,14 @@ void sum_to_all(const double *in, double *out, int size) {
 #endif
 }
 
+void sum_to_master(const float *in, float *out, int size) {
+#ifdef HAVE_MPI
+  MPI_Reduce((void*) in, out, size, MPI_FLOAT,MPI_SUM,0,mycomm);
+#else
+  memcpy(out, in, sizeof(float) * size);
+#endif
+}
+
 void sum_to_master(const double *in, double *out, int size) {
 #ifdef HAVE_MPI
   MPI_Reduce((void*) in, out, size, MPI_DOUBLE,MPI_SUM,0,mycomm);
@@ -300,6 +316,7 @@ void sum_to_master(const double *in, double *out, int size) {
   memcpy(out, in, sizeof(double) * size);
 #endif
 }
+
 
 void sum_to_all(const float *in, double *out, int size) {
   double *in2 = new double[size];
@@ -314,6 +331,10 @@ void sum_to_all(const complex<double> *in, complex<double> *out, int size) {
 
 void sum_to_all(const complex<float> *in, complex<double> *out, int size) {
   sum_to_all((const float*) in, (double*) out, 2*size);
+}
+
+void sum_to_master(const complex<float> *in, complex<float> *out, int size) {
+  sum_to_master((const float*) in, (float*) out, 2*size);
 }
 
 void sum_to_master(const complex<double> *in, complex<double> *out, int size) {

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -416,7 +416,6 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
       abort("cannot get flux for near2far: co-ordinate mismatch");
 
     double *F = new double[Nfreq];
-    double *F_ = new double[Nfreq]; // temp array for sum to master
     std::complex<double> *ff_EH[6];
     std::complex<double> *cE[2], *cH[2];
     for (int i = 0; i < Nfreq; ++i) {
@@ -428,17 +427,16 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
       case Z: cE[0] = ff_EH[0], cE[1] = ff_EH[1], cH[0] = ff_EH[4], cH[1] = ff_EH[3]; break;
       case NO_DIRECTION: abort("cannot get flux in NO_DIRECTION");
       }
-      F_[i] = 0;
+      F[i] = 0;
       for (int j = 0; j < 2; ++j) {
         double flux_sum = 0;
 	for (int p = 0; p < N; ++p)
 	  flux_sum += real(cE[j][p]*conj(cH[j][p]));
-	F_[i] += flux_sum * (1 - 2*j);
+	F[i] += flux_sum * (1 - 2*j);
       }
-      master_printf("near2far-flux:, %0.2g, %0.5g\n",freq_min+i*dfreq,F_[i]);
+      master_printf("near2far-flux:, %0.2g, %0.5g\n",freq_min+i*dfreq,F[i]);
     }
-    sum_to_all(F_, F, Nfreq);
-    delete[] F_;
+    delete[] EH;
     return F;
 }
 

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -23,6 +23,7 @@
 #include <meep.hpp>
 #include <assert.h>
 #include "config.h"
+#include <math.h>
 
 using namespace std;
 
@@ -361,6 +362,84 @@ void dft_near2far::save_farfields(const char *fname, const char *prefix,
     }
 
     delete[] EH;
+}
+
+double *dft_near2far::flux(direction df, const volume &where, double resolution) {
+
+    /* compute output grid size etc. */
+    int dims[4] = {1,1,1,1};
+    double dx[3] = {0,0,0};
+    direction dirs[3] = {X,Y,Z};
+    int rank = 0, N = 1;
+    LOOP_OVER_DIRECTIONS(where.dim, d) {
+      dims[rank] = int(floor(where.in_direction(d) * resolution));
+      if (dims[rank] <= 1) {
+	dims[rank] = 1;
+	dx[rank] = 0;
+      }
+      else
+	dx[rank] = where.in_direction(d) / (dims[rank] - 1);
+      N *= dims[rank];
+      dirs[rank++] = d;
+    }
+
+    /* 6 x N x Nfreq array of fields in row-major order */
+    std::complex<double> *EH = new std::complex<double>[6*N*Nfreq];
+    std::complex<double> *EH_ = new std::complex<double>[6*N*Nfreq]; // temp array for sum_to_master
+ 
+    /* fields for farfield_lowlevel for a single output point x */
+    std::complex<double> *EH1 = new std::complex<double>[6*Nfreq];
+
+    vec x(where.dim);
+    for (int i0 = 0; i0 < dims[0]; ++i0) {
+      x.set_direction(dirs[0], where.in_direction_min(dirs[0]) + i0*dx[0]);
+      for (int i1 = 0; i1 < dims[1]; ++i1) {
+	x.set_direction(dirs[1],
+			where.in_direction_min(dirs[1]) + i1*dx[1]);
+	for (int i2 = 0; i2 < dims[2]; ++i2) {
+	  x.set_direction(dirs[2],
+			  where.in_direction_min(dirs[2]) + i2*dx[2]);
+	  farfield_lowlevel(EH1, x);
+	  int idx = (i0 * dims[1] + i1) * dims[2] + i2;
+	  for (int i = 0; i < Nfreq; ++i)
+	    for (int k = 0; k < 6; ++k)
+	      EH_[(k * N + idx) + (6 * N * i)] = EH1[i * 6 + k];
+	}
+      }
+    }
+
+    delete[] EH1;
+    sum_to_master(EH_, EH, 6*N*Nfreq);
+    delete[] EH_;
+
+    if (coordinate_mismatch(where.dim, df) || where.dim == Dcyl)
+      abort("cannot get flux for near2far: co-ordinate mismatch");
+
+    double *F = new double[Nfreq];
+    double *F_ = new double[Nfreq]; // temp array for sum to master
+    std::complex<double> *ff_EH[6];
+    std::complex<double> *cE[2], *cH[2];
+    for (int i = 0; i < Nfreq; ++i) {
+      for (int k = 0; k < 6; ++k)
+	ff_EH[k] = EH + (k * N) + (6 * N * i);
+      switch (df) {
+      case X: cE[0] = ff_EH[1], cE[1] = ff_EH[2], cH[0] = ff_EH[5], cH[1] = ff_EH[4]; break;
+      case Y: cE[0] = ff_EH[2], cE[1] = ff_EH[0], cH[0] = ff_EH[3], cH[1] = ff_EH[5]; break;
+      case Z: cE[0] = ff_EH[0], cE[1] = ff_EH[1], cH[0] = ff_EH[4], cH[1] = ff_EH[3]; break;
+      case NO_DIRECTION: abort("cannot get flux in NO_DIRECTION");
+      }
+      F_[i] = 0;
+      for (int j = 0; j < 2; ++j) {
+        double flux_sum = 0;
+	for (int p = 0; p < N; ++p)
+	  flux_sum += real(cE[j][p]*conj(cH[j][p]));
+	F_[i] += flux_sum * (1 - 2*j);
+      }
+      master_printf("near2far-flux:, %0.2g, %0.5g\n",freq_min+i*dfreq,F_[i]);
+    }
+    sum_to_all(F_, F, Nfreq);
+    delete[] F_;
+    return F;
 }
 
 static double approxeq(double a, double b) { return fabs(a - b) < 0.5e-11 * (fabs(a) + fabs(b)); }


### PR DESCRIPTION
A new function in dft_near2far class is created to compute the flux (or Poynting vector) of the far fields. The function first computes the far fields and then the flux at each of Nfreq frequencies. The results are displayed in standard output as a comma-delimited array. This function duplicates the far-field generation code from dft_near2far::save_farfields which is slow and not parallelized. In the case where the user wants to both save the far fields and compute its flux, the far-field calculation happens twice and is therefore inefficient. A proper implementation would be to compute and store the far fields once and then to use these stored fields in the two separate functions. This function has been validated by comparing its results to that obtained using post-processing of the far fields.
