### PR TITLE
Material function working with polygons

### DIFF
--- a/src/anisotropic_averaging.cpp
+++ b/src/anisotropic_averaging.cpp
@@ -260,6 +260,1314 @@ void structure_chunk::set_chi1inv(component c,
   medium.unset_volume();
 }
 
+
+////////////////////////////////////////////////////////////
+//--- Begin: defs for polygon-based material functions ---//
+////////////////////////////////////////////////////////////
+
+// polygon defined by a numpy array with dimensions N*2 (containing the points) and defining an area with a certain epsilon
+simple_polygon::simple_polygon(double* matrix, int dimX, int dimY) {
+    if (dimY != 2) {
+        abort("Array with polygon points should have a shape X,2. The second dimension is not 2.");
+    }
+
+    //make sure last point equals first point. If not, append copy of first point to end:
+    if (dimX > 0 && (matrix[0] != matrix[dimY * (dimX - 1)] || matrix[1] != matrix[dimY * dimX - 1]))
+        this->_number_of_points = dimX + 1;
+    else
+        this->_number_of_points = dimX;
+
+    // copy matrix:
+    _polygon_points = new double*[_number_of_points];
+    for (int i = 0; i < dimX; i++) {
+        _polygon_points[i] = new double[2];
+        _polygon_points[i][0] = matrix[dimY * i];
+        _polygon_points[i][1] = matrix[dimY * i + 1];
+    }
+
+    //if last point does not equal first point -> append copy of first point to end:
+    if (this->_number_of_points == dimX + 1) {
+        _polygon_points[dimX] = new double[2];
+        _polygon_points[dimX][0] = matrix[0];
+        _polygon_points[dimX][1] = matrix[1];
+    }
+};
+
+simple_polygon::simple_polygon(double** matrix, int dimX) {
+    // if this constructor is used, care must be taken that matrix is not deleted
+    // externally. The memory pointed to by matrix will be deleted with ~polygon()
+    // First point of polygon must equal last point.
+
+    //make sure last point equals first point:
+    if (dimX > 0 && (matrix[0][0] != matrix[dimX - 1][0] || matrix[0][1] != matrix[dimX - 1][1]))
+        abort("Error creating polygon: First point should equal last point.");
+
+    this->_number_of_points = dimX;
+    _polygon_points = matrix;
+    //the caller should set matrix = 0;
+}
+
+simple_polygon::~simple_polygon() {
+    for (int i = 0; i < _number_of_points; i++) {
+        delete [] _polygon_points[i];
+    }
+    delete [] _polygon_points;
+};
+
+double simple_polygon::get_area() {
+    //Returns the absolute area of polygon.
+    //For self-intersecting polygons, this will return the difference between clockwise
+    //parts and anti-clockwise parts, not the real area.
+    int n = _number_of_points;
+    if (n < 3)
+        return 0;
+    //2A = \sum_{i=0}^{n-1}( (x_{i-1} - x_{i+1}) * y_i ) # Gauss's area formula (aka shoelace algorithm)
+    double sum = (_polygon_points[n - 1][0] - _polygon_points[1][0]) * _polygon_points[0][1]; // (i = 0)
+    for (int i = 1; i < n - 1; ++i)
+        sum += (_polygon_points[i - 1][0] - _polygon_points[i + 1][0]) * _polygon_points[i][1];
+    sum += (_polygon_points[n - 2][0] - _polygon_points[0][0]) * _polygon_points[n - 1][1]; // (i = n-1)
+    return fabs(0.5 * sum);
+}
+
+polygon::~polygon() {
+    for(vector<simple_polygon*>::iterator p = _inner_polygons.begin(); p != _inner_polygons.end(); ++p) {
+        delete (*p);
+    }
+};
+
+void polygon::add_inner_polygon(double* matrix, int dimX, int dimY) {
+    // TODO? check if inner polygon is real inner polygon of parent:
+    // first point is inside parent polygon AND inner polygon's edges does not cross parent polygon's edges
+    _inner_polygons.push_back(new simple_polygon(matrix, dimX, dimY));
+}
+
+double polygon::get_area() {
+    double parea = simple_polygon::get_area();
+    for(vector<simple_polygon*>::iterator inner_p = _inner_polygons.begin(); inner_p != _inner_polygons.end(); ++inner_p) {
+        parea -= (*inner_p)->get_area(); //all inner polygons must be real inner polygons (i.e. completely inside parent polygon)
+    }
+    return parea;
+}
+
+material_stack::material_stack(const double* material_heights,
+                               const double* epsilon_values, const int number_of_layers)
+{
+    init_material_stack(material_heights, epsilon_values, number_of_layers);
+};
+
+material_stack::material_stack(const double* material_heights, const int mh_dim,
+                               const double* epsilon_values, const int ev_dim)
+{
+    if (mh_dim != ev_dim)
+        abort("material_heights and epsilon_values must have same length, \
+        i. e. the number of layers in the material stack.");
+    init_material_stack(material_heights, epsilon_values, mh_dim);
+}
+
+void material_stack::init_material_stack(const double* material_heights,
+                                         const double* epsilon_values, const int number_of_layers)
+{
+    if (number_of_layers == 0)
+        abort("Please specify at least one layer in material stack.");
+
+    // make copy of arrays:
+    // It is really important that the user supplies the right length of the two
+    // arrays with number_of_layers, else some undefined memory outside of the
+    // arrays could be accessed. Unfortunately, this can't be checked here.
+    this->_material_heights = new double[number_of_layers];
+    this->_epsilon_values = new double[number_of_layers];
+    for (int i = 0; i < number_of_layers; ++i) {
+        this->_material_heights[i] = material_heights[i];
+        this->_epsilon_values[i] = epsilon_values[i];
+    }
+    _number_of_layers = number_of_layers;
+}
+
+material_stack::~material_stack(){
+    delete[] _material_heights;
+    delete[] _epsilon_values;
+};
+
+bool material_stack::interface_inside_block(
+    double center_z, double half_block_size,
+    double &lower_layer_eps, double &upper_layer_eps,
+    double &percentage_upper_layer) const
+    {
+        if (_number_of_layers == 1) {
+            // no interface
+            lower_layer_eps = _epsilon_values[0];
+            upper_layer_eps = 0.0;
+            percentage_upper_layer = 0.0;
+            return false;
+        }
+
+        double lower = center_z - half_block_size;
+        double higher = center_z + half_block_size;
+        double height;
+        double z = 0.0;
+        for (int i = 0; i < _number_of_layers - 1; i++)
+        {
+            z += _material_heights[i];
+            if (lower < z) {
+                lower_layer_eps = _epsilon_values[i];
+                if (higher <= z) {
+                    // no interface
+                    upper_layer_eps = 0.0;
+                    percentage_upper_layer = 0.0;
+                    return false;
+                }
+                else {
+                    height = higher - z;
+                    if (i < _number_of_layers - 2 && // upmost layer may be thinner than resolution
+                        height > _material_heights[i + 1])
+                        abort("Layer specified in material_stack too thin or resolution too poor.");
+                    upper_layer_eps = _epsilon_values[i + 1];
+                    percentage_upper_layer = height / half_block_size / 2.0;
+                    return true;
+                }
+            }
+        }
+        // lower > z, i.e. block is in highest layer or above:
+        lower_layer_eps = _epsilon_values[_number_of_layers - 1];
+        upper_layer_eps = 0.0;
+        percentage_upper_layer = 0.0;
+        return false;
+    }
+
+    polygons_for_single_material::polygons_for_single_material(
+        material_stack * mat_stack, double block_size, int nx, int ny, int nz)
+    {
+        init_pfsm(mat_stack, 0, block_size, nx, ny, nz);
+    }
+
+    polygons_for_single_material::polygons_for_single_material(
+        double epsilon, double block_size, int nx, int ny)
+    {
+        init_pfsm(0, epsilon, block_size, nx, ny, 0);
+    }
+
+    void polygons_for_single_material::init_pfsm(material_stack * mat_stack,
+                                                    double epsilon, double block_size, int nx, int ny, int nz)
+    {
+        _material_stack = mat_stack;
+        _epsilon = epsilon;
+        _block_size = block_size;
+        _nx = nx;
+        _ny = ny;
+        _nz = nz;
+        splitting_done = false;
+        _areas = new double*[nx];
+        for (int i = 0; i < nx; ++i){
+            _areas[i] = new double[ny];
+            for (int j = 0; j < ny; ++j) {
+                _areas[i][j] = 0;
+            }
+        }
+    };
+
+    polygons_for_single_material::~polygons_for_single_material() {
+        //delete polygons list:
+        while (!_polygons.empty()){
+            delete _polygons.front(); //delete polygon object
+            _polygons.pop(); //delete pointer to polygon object
+        }
+
+        delete _material_stack;
+
+        // delete _areas:
+        for (int i = 0; i < _nx; ++i)
+            delete[] _areas[i];
+        delete[] _areas;
+    };
+
+    polygon* polygons_for_single_material::add_polygon(polygon* pol) {
+        if (splitting_done)
+            abort("Cannot add polygons after splitting has been done.");
+        _polygons.push(pol);
+        return pol;
+    };
+
+    bool polygons_for_single_material::is_trivial(const ivec &small_ivec, const ivec &big_ivec)
+    {
+        if (!splitting_done)
+            update_splitting();
+        int i2, j2;
+        for (int i = small_ivec.x(); i < big_ivec.x(); ++i)
+        {
+            // If pixel is at outer edge, overlapping the undefined area outside
+            // the grid volume, wrap the structure to the opposite side. If a PML
+            // boundary is used, there shouldn't be a structure close to the
+            // boundary anyways, and if periodic boundary conditions are used, we
+            // would want to wrap the structure:
+            i2 = i;
+            if (i2 < 0)
+                i2 += _nx;
+            else if (i2 >= _nx)
+                i2 -= _nx;
+            for (int j = small_ivec.y(); j < big_ivec.y(); ++j)
+            {
+                j2 = j;
+                if (j2 < 0)
+                    j2 += _ny;
+                else if (j2 >= _ny)
+                    j2 -= _ny;
+                if (_areas[i2][j2] != 0 && _areas[i2][j2] != 1)
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    vec polygons_for_single_material::normal_vector(const ivec &center)
+    {
+        if (!splitting_done)
+            update_splitting();
+        // Initialize the 4x4 blocks (=2x2 pixels) that will be used as parameter in
+        // calc_gradient_4x4:
+        double** area_cols = new double*[4];
+        bool created_area_cols = false;
+        int xi, yi;
+        vec result;
+        if (center.y() < 2 || center.y() + 1 >= _ny) {
+            // If pixel is at outer edge, overlapping the undefined area outside
+            // the grid volume, wrap the structure to the opposite side. If a PML
+            // boundary is used, there shouldn't be a structure close to the
+            // boundary anyways, and if periodic boundary conditions are used, we
+            // would want to wrap the structure.
+            for (int i = 0; i < 4; ++i)
+            {
+                xi = center.x() - 2 + i;
+                if (xi < 0)
+                    xi += _nx;
+                else if (xi >= _nx)
+                    xi -= _nx;
+                area_cols[i] = new double[4];
+                created_area_cols = true;
+                for (int j = 0; j < 4; ++j)
+                {
+                    yi = center.y() - 2 + j;
+                    if (yi < 0)
+                        yi += _ny;
+                    else if (yi >= _ny)
+                        yi -= _ny;
+                    area_cols[i][j] = _areas[xi][yi];
+                }
+            }
+
+
+            result = calc_gradient_4x4(area_cols);
+            if (center == ivec(216, 0, 0)) {
+                master_printf("singmat normvec: %f, %f, %f; area cols, wrapping: \n", result.x(), result.y(), result.z() );
+                for(int i = 0; i < 4; ++i)
+                    master_printf("%f, %f, %f, %f\n", area_cols[i][0], area_cols[i][1], area_cols[i][2], area_cols[i][3]);
+            }
+        }
+        else
+        {
+            for (int i = 0; i < 4; ++i) {
+                xi = center.x() - 2 + i;
+                if (xi < 0)
+                    xi += _nx;
+                else if (xi >= _nx)
+                    xi -= _nx;
+                area_cols[i] = &_areas[xi][center.y() - 2];
+            }
+            result = calc_gradient_4x4(area_cols);
+        }
+        if (is_3D()){
+            double lower_layer_eps;
+            double upper_layer_eps;
+            double percentage_upper_layer;
+            double z;
+            if (_material_stack->interface_inside_block(
+                center.z() * _block_size, _block_size,
+                                                        lower_layer_eps, upper_layer_eps,
+                                                        percentage_upper_layer))
+            {
+                z = upper_layer_eps < lower_layer_eps ? 1.0     : -1.0;
+                if (abs(result) < 1e-8)
+                    // interface only in z direction
+                    return vec(0.0, 0.0, z);
+                else
+                {
+                    // Interface in z and transversal direction;
+                    // Need to return approximate vector for corner.
+                    // This is the only time the sign of the normal vector is
+                    // important, because the transversal vector (from polygons)
+                    // and the z vector (from material stack) must be combined,
+                    // and the resulting vector will point in a different direction
+                    // if transversal and z vector have opposite sign than when
+                    // both have same sign.
+                    // This is difficult, because a neigboring polygon (on same
+                    // block) with different material function (= different
+                    // polygons_for_single_material) could have same epsilon on
+                    // different height, e.g. going lower and higher up than the
+                    // currently regarded point, which would mean the transversal
+                    // part of this polygon is actually pointing inward.
+                    // The only possible way to solve this is on a higher level,
+                    // so this problem is moved to
+                    // material_function_for_polygons::normal_vector().
+                    // For now, just return the combined vector ignoring possible
+                    // neighbors, with vector pointing from high to low eps:
+
+
+                    // height of material with higher eps:
+                    double h = upper_layer_eps < lower_layer_eps ?
+                    1 - percentage_upper_layer :
+                    percentage_upper_layer;
+                    // square for better comparability with area:
+                    h *= h;
+                    // area of current 2x2 block (= 1 pixel):
+                    double area = area_cols[1][1] + area_cols[1][2] +
+                    area_cols[2][1] + area_cols[2][2];
+                    // scale transversal vector:
+                    result = result * (h * (1.0 - area));
+                    // add scaled z component:
+                    result.set_direction(Z, area * (1.0 - h) * z);
+                    // normalize:
+                    if (abs(result) != 0.0)
+                        result = result / abs(result);
+                }
+            }
+        }
+        // delete area_cols[] if arrays have been created earlier:
+        if (created_area_cols)
+            for (int i = 0; i < 4; ++i)
+                delete[] area_cols[i];
+            delete[] area_cols;
+        return result;
+    }
+
+    double polygons_for_single_material::get_area(int i, int j) {
+        if (!splitting_done)
+            update_splitting();
+        while (i < 0)
+            i += _nx;
+        while (i >= _nx)
+            i -= _nx;
+        while (j < 0)
+            j += _ny;
+        while (j >= _ny)
+            j -= _ny;
+        return _areas[i][j];
+    }
+
+    void polygons_for_single_material::message_truncate(double* pt) {
+        if (pt[0] < 0 || pt[0] - 1e-8 > _nx * _block_size || //TODO hardcoded epsilon: yuck!
+            pt[1] < 0 || pt[1] - 1e-8 > _ny * _block_size)
+            // if point is exactly on upper border, this will also be called,
+            // but point will not really be truncated, so check bounds again.
+            master_printf(//"~");
+        "point (%f, %f) outside computational grid (%f, %f) - polygon will be truncated.\n",
+                            pt[0], pt[1], _nx * _block_size, _ny * _block_size);
+    }
+
+    void polygons_for_single_material::split_in_one_dimension(queue<double*>* arr, int arr_size, queue<double*>* qpol, int axis){
+        if (qpol->empty())
+            return;
+        double *f = qpol->front();
+        double *b = qpol->back();
+        // check if last point equals first point
+        if (f[0] != b[0] || f[1] != b[1]){
+            // add copy of first point to end:
+            b = new double[2];
+            b[0] = f[0];
+            b[1] = f[1];
+            qpol->push(b);
+        }
+        std::size_t pol_size = qpol->size();
+        double** matrix = new double*[pol_size];
+        for (std::size_t i = 0; i < pol_size; ++i) {
+            matrix[i] = qpol->front();
+            qpol->pop();
+        }
+        simple_polygon* pol = new simple_polygon(matrix, pol_size);
+        matrix = 0; //the memory pointed to by matrix is now owned by pol;
+        split_in_one_dimension(arr, arr_size, pol, axis);
+        delete pol;
+    }
+
+    void polygons_for_single_material::split_in_one_dimension(queue<double*>* arr, int arr_size, simple_polygon* pol, int axis){
+        // The split polygons will be added to arr:
+        // (arr item = polygon = queue of points)
+        // arr_size is the length of arr (the number of cols/rows to split the polygon into).
+        // pol will only be split along axis (0 or 1).
+        // The array arr must be initialized before call, but the items (the queues)
+        // must be empty.
+
+        double *pt, *pt2, *ept, *ept2;
+        int col, col2;
+        double u;
+        int other_axis = axis == 0 ? 1 : 0;
+
+        /* Go through all points. Check inside which column
+            *                                                e ach point is, and add the point to the polygon o*f
+            *                                                this column in arr. If column changes from one
+            *                                                point to next, calculate edge point (= intersection of line
+            *                                                connecting the two points and border between columns) and add
+            *                                                this point to polygons in both columns in arr:
+            *                                                arr[n]: (other points, previous point, edge point);
+            *                                                arr[n+1]: (other points, edge point, current point)
+            *                                                Algorithm only works if polygon's first point equals last point,
+            *                                                but this is always true for simple_polygon class.*/
+
+        pt = pol->get_polygon_point(0); //get first point
+        // note: There can't be any empty polygons (with zero points)
+        // at this point, since they have been sorted out in
+        // add_polygon already.
+        col = static_cast<int>(floor(pt[axis] / _block_size)); //TODO: special handling if point is exactly on border:
+        // such a point belongs to current col
+        // compare to col = ceil(pt) - 1
+        // don't add point to neighbouring column - it will happen automatically
+        // if next point is inside neighbouring column.
+        //calculate inside which column pt is
+        if (col >= 0 && col < arr_size) {
+            //add point to last polygon in column:
+            arr[col].push(pt);
+            // steal point (=double* with length 2) from pol,
+            // so it will not be deleted together with pol:
+            pol->take_ownership_of_point(0);
+        }
+        else
+            message_truncate(pt);
+
+        //go through remaining points:
+        for (int i = 1; i < pol->get_number_of_points(); ++i){
+            pt2 = pol->get_polygon_point(i); //get next point
+            //calculate inside which column pt2 is:
+            col2 = static_cast<int>(floor(pt2[axis] / _block_size));//TODO: special handling if point is exactly on border:
+            // such a point belongs to current col
+            // compare to col = ceil(pt) - 1
+            // don't add point to neighbouring column - it will happen automatically
+            // if next point is inside neighbouring column.
+            if (col == col2){
+                // pt2 is in same column than previous point;
+                // add point to last polygon in column :
+                if (col2 >= 0 && col2 < arr_size) {
+                    arr[col2].push(pt2);
+                    // steal point (=double* with length 2) from pol,
+                    // so it will not be deleted together with pol:
+                    pol->take_ownership_of_point(i);
+                }
+                else
+                    message_truncate(pt2);
+                pt = pt2;
+            }
+            else {
+                // pt2 is in different column than previous point ->
+                // add edge point to last polygon in both columns
+                // (and to additional columns in between, if neccessary);
+
+                // calculate slope of line:
+                u = (pt2[other_axis] - pt[other_axis]) / (pt2[axis] - pt[axis]);
+
+                if (col2 > col){ // line is going from left to right
+                    for (int c = col; c < col2; ++c){
+                        // calculate edge point:
+                        ept = new double[2];
+                        ept[axis] = _block_size * (c + 1); //right border
+                        ept[other_axis] = pt[other_axis] + (ept[axis] - pt[axis]) * u;
+                        if (c >= 0 && c < arr_size) {
+                            // add edge_point to right side of current c:
+                            arr[c].push(ept); // TODO: only add if ept differs from previous point
+                            // if previous point was exactly on border, it will not differ
+                            if (c + 1 != arr_size) {
+                                // add copy of edge_point to left side of next c:
+                                ept2 = new double[2];
+                                ept2[0] = ept[0];
+                                ept2[1] = ept[1];
+                                arr[c + 1].push(ept2);
+                            }
+                        }
+                        else if (c == -1)
+                            // add edge_point to left side of leftmost c:
+                            arr[c + 1].push(ept);
+                        else
+                            // both this and next column are outside computational volume
+                            delete[] ept;
+                    }
+                }
+                else { // line is going from right to left
+                    for (int c = col; c > col2; --c){
+                        // calculate edge point:
+                        ept = new double[2];
+                        ept[axis] = _block_size * c; //left border
+                        ept[other_axis] = pt[other_axis] + (ept[axis] - pt[axis]) * u;
+                        if (c >= 0 && c < arr_size) {
+                            // add edge_point to left side of current c:
+                            arr[c].push(ept);  // TODO: only add if ept differs from previous point
+                            // if previous point was exactly on border, it will not differ
+                            if (c != 0) {
+                                // add copy of edge_point to right side of next c:
+                                ept2 = new double[2];
+                                ept2[0] = ept[0];
+                                ept2[1] = ept[1];
+                                arr[c - 1].push(ept2);
+                            }
+                        }
+                        else if (c == arr_size)
+                            // add edge_point to right side of rightmost c:
+                            arr[c - 1].push(ept);
+                        else
+                            // both this and next column are outside computational volume
+                            delete[] ept;
+                    }
+                }
+                //add point2 after last edge point:
+                if (col2 >= 0 && col2 < arr_size) {
+                    arr[col2].push(pt2);
+                    // steal point (=double* with length 2) from pol,
+                    // so it will not be deleted together with pol:
+                    pol->take_ownership_of_point(i);
+                }
+                else
+                    message_truncate(pt2);
+                pt = pt2; // update current point
+                col = col2; // update current column
+            }
+        }
+        // TODO?: remove ghost lines & points: if polpoints enter and leave column again on the same side, start new polygon in that column.
+        // at end, go through first added point, if in same column than last added point - polygons should be merged.
+    }
+
+    double polygons_for_single_material::split_polygon(simple_polygon* pol,
+                                                        bool inner_polygon, queue<double*>* col_arr, queue<double*>* row_arr)
+    {
+        std::size_t pol_size;
+        double** matrix;
+        simple_polygon *spol;
+        double pol_area = 0;
+        double split_area = 0;
+
+        // split polygon into columns and save in col_arr:
+        split_in_one_dimension(col_arr, _nx, pol, 0);
+        // now, go through columns (col_arr) separately and split each
+        // polygon into rows:
+        for (int c = 0; c < _nx; ++c) {
+            if (!col_arr[c].empty()){
+                // split col_arr[c] in rows and save in row_arr:
+                split_in_one_dimension(row_arr, _ny, &col_arr[c], 1);
+                // after the call to split_in_one_dimension, all polygons in
+                // col_arr[c] are empty.
+
+                // go through row_arr, make polygons,
+                // get and save areas, delete polygons again:
+                for (int j = 0; j < _ny; ++j){
+                    pol_size = row_arr[j].size();
+                    if (pol_size > 0) { //don't add empty polygons
+                        double *f = row_arr[j].front();
+                        double *b = row_arr[j].back();
+                        // check if last point equals first point
+                        if (f[0] != b[0] || f[1] != b[1]){
+                            // add copy of first point to end:
+                            b = new double[2];
+                            b[0] = f[0];
+                            b[1] = f[1];
+                            pol_size ++;
+                        }
+                        else
+                            b = 0;
+                        matrix = new double*[pol_size];
+                        for (std::size_t k = 0; k < pol_size - int(b!=0); ++k){
+                            //get first point in queue (double[2] point):
+                            matrix[k] = row_arr[j].front();
+                            //pop this point:
+                            row_arr[j].pop();
+                        }
+                        if (b)
+                            matrix[pol_size - 1] = b;
+
+                        // now, row_arr should be empty
+                        spol = new simple_polygon(matrix, pol_size);
+                        //the memory pointed to by matrix is now owned by spol:
+                        matrix = 0;
+                        pol_area = spol->get_area();
+                        if (inner_polygon)
+                            _areas[c][j] -= pol_area;
+                        else
+                            _areas[c][j] += pol_area;
+                        split_area += pol_area;
+                        delete spol;
+                    }
+                }
+            }
+        }
+        return split_area;
+    }
+
+    void polygons_for_single_material::update_splitting() {
+        /*Splits all _polygons in blocks with size _blocksize x _blocksize.
+         * 
+         *  This is a quick and efficient algorithm, which can be us*ed for both simple
+         *  and for selfintersecting polygons, both convex and concave.
+         *
+         *  It might produce ghost lines in the case of concave polygons (i.e. concave
+         *  polygons will never be split in more than two polygons by one splitting border,
+         *  with ghost lines connecting otherwise seperate polygons). The additional area
+         *  created by these ghost lines is zero, so this will not be an issue for most
+         *  applications.*/
+
+
+        // first, split polygons into columns, then afterwards split these columns also in the rows.
+        // If it is not done in this way, blocks completely enclosed by a single polygon will be left out.
+
+        // the column-wise split polygons will be temporary saved in col_arr,
+        // the row-wise split col_arr elements will be temporary saved in split_arr:
+        // (column item = polygon = queue of points)
+        queue<double*>* col_arr = new queue<double*>[_nx];
+        queue<double*>* row_arr = new queue<double*>[_ny];
+
+        polygon* pol;
+        simple_polygon* spol;
+        double area = 0; // area calculated directly from given polygons
+        double area2 = 0; // area calculated from split polygons, for comparison
+        // go through each polygon separately:
+        while (!_polygons.empty()){
+            pol = _polygons.front();
+            area += pol->get_area();
+            // split polygon into blocks, save area sizes in _areas:
+            area2 += split_polygon(pol, false, col_arr, row_arr);
+            //col_arr and row_arr are empty after split_polygon()
+            // repeat for inner polygons:
+            for (int i = 0; i < pol->get_number_inner_polygons(); ++i){
+                spol = pol->get_inner_polygon(i);
+                // split polygon into blocks, save area sizes in _areas:
+                area2 -= split_polygon(spol, true, col_arr, row_arr);
+                //col_arr and row_arr are empty after split_polygon()
+            }
+            delete pol;
+            _polygons.pop();
+        }
+
+        delete[] col_arr; //delete array, free memory
+        delete[] row_arr; //delete array, free memory
+
+        if (fabs(area - area2) > 1e-6) { //TODO: hardcoded epsilon: yuck!
+            master_printf("input polygons area: %f\n", area);
+            master_printf("area after splitting: %f\n", area2);
+            master_printf("WARNING, total polygon area differs after splitting, which could lead to errors in defined structure.\n");
+            master_printf("Please provide only simple, non self-intersecting polygons\n");
+        }
+
+        bool overlap_message_printed = false;
+        // areas must be relative area occupied per block, so normalize with
+        // block area:
+        double block_area = _block_size * _block_size;
+        for (int i = 0; i < _nx; ++i){
+            for (int j = 0; j < _ny; ++j) {
+                _areas[i][j] /= block_area;
+                // try to round to trivial cases:
+                if (fabs(_areas[i][j]) < 1E-12)
+                    _areas[i][j] = 0.0;
+                else if (fabs(1.0 - _areas[i][j]) < 1E-12)
+                    _areas[i][j] = 1.0;
+                // Catch overlapping polygons. This will not catch all overlapping polygons, but at least the user gets a message:
+                if ((_areas[i][j] < 0) || (_areas[i][j] > 1)) {
+                    if (!overlap_message_printed) {
+                        // print the message only once (per material)
+                        master_printf("WARNING: There are overlapping polygons. Structure will be inexact.\n");
+                        overlap_message_printed = true;
+                    }
+                    if (_areas[i][j] < 0)
+                        _areas[i][j] = 0.0;
+                    else
+                        _areas[i][j] = 1.0;
+                }
+            }
+        }
+        splitting_done = true;
+    };
+
+    vec polygons_for_single_material::rightanglerotate_2Dvec(
+        vec v, int num, bool mirror_x_before, bool mirror_y_before) const
+    {
+        while (num < 0) // modulo works strange for negative numbers
+            num += 4;
+        num %= 4;
+        double x = v.x() * (mirror_x_before ? -1 : 1);
+        double y = v.y() * (mirror_y_before ? -1 : 1);
+        switch (num)
+        {
+            case 0 : v.set_direction(X, x); v.set_direction(Y, y); break;
+            case 1 : v.set_direction(X, -y); v.set_direction(Y, x); break;
+            case 2 : v.set_direction(X, -x); v.set_direction(Y, -y); break;
+            case 3 : v.set_direction(X, y); v.set_direction(Y, -x); break;
+            default : abort("strange error in rightanglerotate_2Dvec");
+        }
+        return v;
+    };
+
+    vec polygons_for_single_material::calc_grad_case1(const double A1, const double A2) const
+    {
+        double x1 = 2.0 * (sqrt(A1 * (A1 + A2)) - A1);
+        double x2 = 2.0 * A2 - x1;
+        double dy = x2 - x1;
+        double a = sqrt(1.0 + dy * dy);
+        return is_3D() ? vec(1.0 / a, dy / a, 0.0) : vec(1.0 / a, dy / a);
+    };
+
+    vec polygons_for_single_material::calc_grad_case2(const double A1, const double A2) const
+    {
+        double y1, y2, dx, a;
+        if (A1 == 0.0) {
+            y1 = 0.0;
+            y2 = 2.0 * (1.0 - A2);
+        }
+        else {
+            y1 = 2.0 * (A1 + sqrt(A1 * (1.0 - A2)));
+            y2 = y1 * (0.5 * y1 / A1 - 1.0);
+        }
+        dx = y1 + y2;
+        a = sqrt(1.0 + dx * dx);
+        return is_3D() ? vec(dx / a, 1.0 / a, 0.0) : vec(dx / a, 1.0 / a);
+    };
+
+    vec polygons_for_single_material::calc_grad_case3(const double A1, const double A2) const
+    {
+        double dy = A2 - A1;
+        double a = sqrt(1.0 + dy * dy);
+        return is_3D() ? vec(1.0 / a, dy / a, 0.0) : vec(1.0 / a, dy / a);
+    };
+
+    vec polygons_for_single_material::calc_gradient_4x4(double** areas) const
+    {
+        double A11, A12, A21, A22, above_left, below_left, left_bottom;
+        double above_right, below_right, right_top;
+        // First, find out which rough position the interface has relative to the
+        // squares, then we know which of the three cases to calculate and which two
+        // squares to use for the calculation.
+        // Since there are many possibilities, first check all possible positions
+        // that are unique for one orientation. If the rough position could not be
+        // found, rotate the whole problem by 90 degrees and try again, rotate the
+        // resulting vector back 90 degrees accordingly if it could be calculated,
+        // otherwise rotate more, and so forth:
+        for (int rotate = 0; rotate < 4; rotate++)
+        {
+            switch (rotate)
+            {
+                case 0:
+                    A11 = areas[1][1];
+                    A12 = areas[1][2];
+                    A21 = areas[2][1];
+                    A22 = areas[2][2];
+                    above_left = areas[1][3];
+                    below_left = areas[1][0];
+                    left_bottom = areas[0][1];
+                    above_right = areas[2][3];
+                    below_right = areas[2][0];
+                    right_top = areas[3][2];
+                    break;
+                case 1: // rotate blocks in anticlockwise-direction:
+                    A11 = areas[2][1];
+                    A12 = areas[1][1];
+                    A21 = areas[2][2];
+                    A22 = areas[1][2];
+                    above_left = areas[0][1];
+                    below_left = areas[3][1];
+                    left_bottom = areas[2][0];
+                    above_right = areas[0][2];
+                    below_right = areas[3][2];
+                    right_top = areas[1][3];
+                    break;
+                case 2: // rotate blocks in anticlockwise-direction:
+                    A11 = areas[2][2];
+                    A12 = areas[2][1];
+                    A21 = areas[1][2];
+                    A22 = areas[1][1];
+                    above_left = areas[2][0];
+                    below_left = areas[2][3];
+                    left_bottom = areas[3][2];
+                    above_right = areas[1][0];
+                    below_right = areas[1][3];
+                    right_top = areas[0][1];
+                    break;
+                default: // rotate == 3: // rotate blocks in anticlockwise-direction:
+                    A11 = areas[1][2];
+                    A12 = areas[2][2];
+                    A21 = areas[1][1];
+                    A22 = areas[2][1];
+                    above_left = areas[3][2];
+                    below_left = areas[0][2];
+                    left_bottom = areas[1][3];
+                    above_right = areas[3][1];
+                    below_right = areas[0][1];
+                    right_top = areas[2][0];
+                    break;
+            }
+            // check case:
+            if ((A11 == 0 && A12 == 0 && A21 == 0 && A22 == 0) ||
+                (A11 == 1 && A12 == 1 && A21 == 1 && A22 == 1))
+                // no border in center block
+                return vec(D2 + int(is_3D()), 0.0);
+            if ((A11 == 0 && A22 == 0 && A12 != 0 && A21 != 0) ||
+                (A12 == 0 && A21 == 0 && A11 != 0 && A22 != 0))
+                // two separate polygons inside block;
+                // the resolution should be increased
+                return vec(D2 + int(is_3D()), 0.0);
+            if (A12 == 0 && A21 == 0 && A22 == 0) // A11 != 0
+            {
+                if (left_bottom < below_left)
+                    return rightanglerotate_2Dvec(
+                        calc_grad_case2(A11, below_left),
+                                                rotate);
+                    else
+                        return rightanglerotate_2Dvec(
+                            calc_grad_case2(A11, left_bottom),
+                                                    rotate - 1, true, false);
+            }
+            if (A11 != 0 && A12 != 0)
+            {
+                if (A21 == 0 && A22 == 0)
+                {
+                    if ((above_left != 0 && below_left != 0) ||
+                        (above_left == 0 && below_left == 0))
+                        // last one means there is a corner somewhere;
+                        // then calculate approx. easy solution
+                        return rightanglerotate_2Dvec(
+                            calc_grad_case3(A12, A11), rotate);
+                        else if (above_left == 0) // below_left != 0
+                            return rightanglerotate_2Dvec(calc_grad_case1(A12, A11),
+                                                        rotate);
+                            else // above_left != 0; below_left == 0
+                                return rightanglerotate_2Dvec(calc_grad_case1(A11, A12),
+                                                            rotate, false, true);
+                }
+                else if (A21 != 0 && A22 == 0)
+                {
+                    if (A12 < A21)
+                        return rightanglerotate_2Dvec(
+                            calc_grad_case2(A12, A11),
+                                                    rotate);
+                        else
+                            return rightanglerotate_2Dvec(
+                                calc_grad_case2(A21, A11),
+                                                        rotate - 1, true, false);
+                }
+                else if (A21 != 0 && A22 != 0) // all != 0
+                {
+                    if (A11 == 1 && A12 != 1 && A21 != 1 && A22 != 1)
+                    {
+                        if (A12 < A21)
+                            return rightanglerotate_2Dvec(
+                                calc_grad_case2(A22, A21),
+                                                        rotate);
+                            else
+                                return rightanglerotate_2Dvec(
+                                    calc_grad_case2(A22, A12),
+                                                            rotate - 1, true, false);
+                    }
+                    else if (A11 == 1 && A12 == 1 && A21 != 1 && A22 != 1)
+                    {
+                        if ((above_right != 1 && below_right != 1) ||
+                            (above_right == 1 && below_right == 1))
+                            // last one means there is a corner somewhere;
+                            // then calculate approx. easy solution
+                            return rightanglerotate_2Dvec(
+                                calc_grad_case3(A22, A21), rotate);
+                            else if (above_right != 1) // below_right == 1
+                                return rightanglerotate_2Dvec(
+                                    calc_grad_case1(1.0 - A21, 1.0 - A22),
+                                                            rotate);
+                                else // above_right == 1; below_right != 1
+                                    return rightanglerotate_2Dvec(
+                                        calc_grad_case1(1.0 - A22, 1.0 - A21),
+                                                                rotate, false, true);
+                    }
+                    else if (A11 == 1 && A12 == 1 && A21 == 1 && A22 != 1)
+                    {
+                        if (above_right < right_top)
+                            return rightanglerotate_2Dvec(
+                                calc_grad_case2(above_right, A22),
+                                                        rotate);
+                            else
+                                return rightanglerotate_2Dvec(
+                                    calc_grad_case2(right_top, A22),
+                                                            rotate - 1, true, false);
+                    }
+                }
+            }
+        }
+        // if this is reached, it can only mean there is a corner somewhere or even
+        // multiple polygons in one block. To fix this, the resolution must be
+        // increased. For now, an approximate solution based on the Sobel operator
+        // (expanded for 4x4 pixel, to be symmetric around the interesting center
+        // point of v) for edge detection is calculated:
+
+
+        // Define the two kernels of the 'expanded' Sobel operator:
+        int G_avg_weights[4] = {1, 2, 2, 1};
+        int G_diff[4] = {+1, 0, 0, -1};
+        double Gx = 0;
+        double Gy = 0;
+        for (int i = 0; i < 4; ++i)
+            for (int j = 0; j < 4; ++j){
+                Gx += G_avg_weights[j] * G_diff[i] * areas[i][j];
+                Gy += G_avg_weights[i] * G_diff[j] * areas[i][j];
+            }
+            double a = sqrt(Gx * Gx + Gy * Gy);
+        if (a == 0.0)
+            return is_3D() ? vec(0.0, 0.0, 0.0) : vec(0.0, 0.0);
+        else
+            return is_3D() ? vec(Gx / a, Gy / a, 0.0) : vec(Gx / a, Gy / a);
+    };
+
+    bool polygons_for_single_material::index_in_bounds(int x, int y){
+        return (x >= 0 && x < _nx && y >= 0 && y < _ny);
+    }
+
+    material_function_for_polygons::material_function_for_polygons(
+        const grid_volume &thegv)
+    {
+        if ((thegv.dim != D2) && (thegv.dim != D3))
+            abort("material_function_for_polygons only available for 2D and 3D.\n");
+        nx = thegv.nx() * 2;
+        ny = thegv.ny() * 2; // Number of blocks to split polygons into. One block should have halve the size of one pixel
+        // to allow calculating averaged eps for different components (half pixel apart due to yee lattice).
+        // The smooting diameter should stay 1 pixel (Meep default) or be an integer multiple thereof,
+        // in which case material_function_for_polygons::eff_chi1inv_row() must be changed.
+        nz = thegv.nz() * 2;
+
+        block_size = thegv.inva * 0.5;
+    };
+
+    material_function_for_polygons::~material_function_for_polygons() {
+        for (vector<polygons_for_single_material*>::const_iterator it = _polygons.begin();
+            it != _polygons.end();
+        ++it)
+            {
+                delete (*it); //delete polygons_for_single_material object
+            }
+            _polygons.clear(); //delete all pointers
+    }
+
+    //Adds a material stack to the material function, for use in 3D case. Returns mat_ID, which must
+    //be used for add_polygon(polygon, mat_ID)
+    unsigned int material_function_for_polygons::add_material_stack(
+        double* material_heights, int mh_dim, double* epsilon_values, int ev_dim)
+    {
+        if (!is_3D()) {
+            abort("Specifying material stack is only available in 3D.\n%s",
+                "For 2D, please specify epsilon in add_polygon().\n");
+        }
+        material_stack * mat_stack = new material_stack(material_heights, mh_dim,
+                                                        epsilon_values, ev_dim);
+        _polygons.push_back(new polygons_for_single_material(mat_stack, block_size,
+                                                            nx, ny, nz));
+        //_material_stacks.push_back(new material_stack(material_heights,
+        //              refractive_indices, number_of_layers));
+        //_polygons.push_back(new queue<polygon*>());
+        return _polygons.size() - 1;
+    };
+
+    // Adds a polygon with predefined stack (->mat_ID) to the simulation.
+    // Care must be taken that none of the polygons overlap. Only for 3D simulation.
+    polygon& material_function_for_polygons::add_polygon(polygon* pol, unsigned int mat_ID){
+        // TODO? check if polygon overlaps other already added polygon:
+        // first point is outside other polygon AND polygon's edges does not cross other polygon's edges
+        if (!is_3D()) {
+            abort("Specifying material stack is only available in 3D.\n%s",
+                "For 2D, please specify epsilon in add_polygon().\n");
+        }
+        if (mat_ID >= _polygons.size())
+            abort("Wrong mat_ID specified in add_polygon. Please add material stacks before adding polygons.");
+        polygon* result = 0;
+        if (pol->get_area() > 0){
+            result = _polygons[mat_ID]->add_polygon(pol);
+        }
+        else {
+            master_printf("polygon with zero area not added.\n");
+        }
+        return *result;
+    };
+
+    // Adds a polygon with predefined stack (->mat_ID) to the simulation.
+    // Care must be taken that none of the polygons overlap. Only for 3D simulation.
+    polygon& material_function_for_polygons::add_polygon(double* matrix, int dimX, int dimY, unsigned int mat_ID) {
+        if (!is_3D()) {
+            abort("Specifying material stack is only available in 3D.\n%s",
+                "For 2D, please specify epsilon in add_polygon().\n");
+        }
+        return add_polygon(new polygon(matrix, dimX, dimY), mat_ID);
+    };
+
+    // Adds a polygon with epsilon value eps to the simulation.
+    // Care must be taken that none of the polygons overlap.
+    polygon& material_function_for_polygons::add_polygon(polygon* pol, double eps){
+        // TODO? check if polygon overlaps other already added polygon:
+        // first point is outside other polygon AND polygon's edges does not cross other polygon's edges
+        if (is_3D()) {
+            abort("Specifying polygon with epsilon value is only available in 2D.\n%s",
+                "For 3D, please specify material_stack ID instead.\n");
+        }
+        polygon* result = 0;
+        if (pol->get_area() > 0){
+            // only adds eps if neccessary, else use id
+            // of previously added eps:
+            int id = add_epsilon(eps);
+            result = _polygons[id]->add_polygon(pol);
+        }
+        else {
+            master_printf("polygon with zero area not added.\n");
+        }
+        return *result;
+    };
+
+    // Adds a polygon with epsilon value eps to the simulation.
+    // Care must be taken that none of the polygons overlap.
+    polygon& material_function_for_polygons::add_polygon(double* matrix, int dimX, int dimY, double eps) {
+        if (is_3D()) {
+            abort("Specifying polygon with epsilon value is only available in 2D.\n%s",
+                "For 3D, please specify material_stack ID instead.\n");
+        }
+        return add_polygon(new polygon(matrix, dimX, dimY), eps);
+    };
+
+    vec material_function_for_polygons::normal_vector(const ivec &center)
+    {
+        int debugn = 216; //108;
+        for (vector<polygons_for_single_material*>::const_iterator it = _polygons.begin();
+            it != _polygons.end();
+        ++it)
+            {
+                if ((*it)->is_trivial(center - one_ivec(center.dim),
+                    center + one_ivec(center.dim)))
+                {
+                    if (center == ivec(debugn, 0, 0))
+                        master_printf("pol for single mat is trivial\n");
+                    continue;
+                }
+                else {
+                    if (center == ivec(debugn, 0, 0))
+                        master_printf("pol for single mat is not trivial\n");
+                    // Return normal vector of first material that's non-trivial in v.
+                    // If a second material is non-trivial, it's (absolute) normal
+                    // vector should be the same. If that's not the case, the polygons
+                    // have been defined badly by the user, or the user should increase
+                    // the resolution.
+                    // TODO: This changes slightly in 3D: The sign of the normal vector's
+                    // xy components could change for example in following situation:
+                    // An interface dividing the pixel into two halves left and right,
+                    // both sides with different material-stacks. The left side has
+                    // an interface in z direction (high-eps below, 1 above), the right
+                    // side has no interface, just the whole pixel height with high-eps.
+                    // The resulting surface vector should point to high z and to the
+                    // left, but when only the left side is regarded, it will point to
+                    // high z and to the right. If only the right side is regarded, it
+                    // will only point to the left.
+                    // Possible solution: calculate normal_vector for all non-trivial
+                    // polygons, then logically combine the results.
+                    // Since it is not exactly clear how to handle corners and edges
+                    // (also not in original MEEP-1.2.1), I will postpone the
+                    // implementation until later.
+                    return (*it)->normal_vector(center);
+                }
+            }
+            if (!is_3D())
+                // no interface of polygon in volume
+                return vec(D2, 0.0);
+            else
+                // return vector pointing in z direction if on interface of material
+                // stack whose polygon area is one (i.e. not zero):
+                for (vector<polygons_for_single_material*>::const_iterator it = _polygons.begin();
+                    it != _polygons.end();
+                ++it)
+                    {
+                        // polygons must all be trivial (see above), so just check at one
+                        // point whether area == 1:
+                        if ((*it)->get_area(center) == 1) {
+                            if (center == ivec(debugn, 0, 0))
+                                master_printf("found area = 1\n");
+                            double lower_layer_eps;
+                            double upper_layer_eps;
+                            double percentage_upper_layer;
+                            if ((*it)->get_material_stack()->interface_inside_block(
+                                center.z() * block_size, block_size,
+                                                                                    lower_layer_eps, upper_layer_eps,
+                                                                                    percentage_upper_layer))
+                            {
+                                if (center == ivec(debugn, 0, 0))
+                                    master_printf("interface in z\n");
+                                // interface in z only; return vector pointing to lower eps:
+                                return vec(0.0, 0.0,
+                                            upper_layer_eps < lower_layer_eps ? 1.0 : -1.0);
+                            }
+                            else {
+                                if (center == ivec(debugn, 0, 0))
+                                    master_printf("no interface in z\n");
+                                // no interface, also not in z
+                                return vec(D3, 0.0);
+                            }
+                        }
+                    }
+                    // no interface in block (all areas are trivial and no areas are one):
+                    if (center == ivec(debugn, 0, 0))
+                        master_printf("all blocks zero, i.e no interface\n");
+                    return vec(D3, 0.0);
+    }
+
+    double material_function_for_polygons::mean_eps(const ivec &center){
+        // start with complete area/volume, multiplied by 1 (air):
+        double result = is_3D() ? 8.0 : 4.0;
+        for (vector<polygons_for_single_material*>::const_iterator it = _polygons.begin();
+            it != _polygons.end();
+        ++it)
+            {
+                if (center == ivec(216, 0, 0)) {
+                    master_printf("meaneps areas: \n" );
+                    for (int i = center.x() - 1; i <  center.x() + 1; ++i)
+                        master_printf("%f, %f\n", (*it)->get_area(i, center.y() - 1), (*it)->get_area(i, center.y()));
+                }
+                // add up all 4 areas (in xy):
+                for (int i = center.x() - 1; i <  center.x() + 1; ++i)
+                    for (int j = center.y() - 1; j < center.y() + 1; ++j)
+                        if (!is_3D()) {
+                            // add epsilon, weighted by area,
+                            // minus 1 (=air - already added in beginning)
+                            result += (*it)->get_area(i, j) * ((*it)->get_material_epsilon() - 1.0);
+                        }
+                        else // 3D
+                            for (int k = center.z() - 1; k < center.z() + 1; ++k){
+                                double lower_layer_eps;
+                                double upper_layer_eps;
+                                double percentage_upper_layer;
+                                if ((*it)->get_material_stack()->interface_inside_block(
+                                    k * block_size, block_size / 2.0,
+                                    lower_layer_eps, upper_layer_eps,
+                                    percentage_upper_layer))
+                                {
+                                    // add epsilon, weighted by volume,
+                                    // minus 1 (=air - already added in beginning)
+                                    result += (*it)->get_area(i, j) *
+                                    ((1.0 - percentage_upper_layer) * (lower_layer_eps - 1.0)
+                                    + percentage_upper_layer * (upper_layer_eps - 1.0));
+                                }
+                                else {
+                                    result += (*it)->get_area(i, j) * (lower_layer_eps - 1.0);
+                                    if (center == ivec(216, 0, 0))
+                                        master_printf("meps result so far: %f (area %i, %i: %f; eps: %f)\n", result, i, j, (*it)->get_area(i, j), lower_layer_eps);
+                                }
+                            }
+            }
+            return (is_3D() ? result / 8.0 : result / 4.0);
+        }
+
+        double material_function_for_polygons::mean_inveps(const ivec &center){
+            // start with complete area/volume, multiplied by 1 (air):
+            double result = is_3D() ? 8.0 : 4.0;
+            for (vector<polygons_for_single_material*>::const_iterator it = _polygons.begin();
+                it != _polygons.end();
+            ++it)
+                {
+                    // add up all 4 areas (in xy):
+                    for (int i = center.x() - 1; i <  center.x() + 1; ++i)
+                        for (int j = center.y() - 1; j < center.y() + 1; ++j)
+                            if (!is_3D())
+                                // add 1/epsilon, weighted by area,
+                                // minus 1 (=air - already added in beginning)
+                                result += (*it)->get_area(i, j) * (1.0 / (*it)->get_material_epsilon() - 1.0);
+                            else // 3D
+                                for (int k = center.z() - 1; k < center.z() + 1; ++k){
+                                    double lower_layer_eps;
+                                    double upper_layer_eps;
+                                    double percentage_upper_layer;
+                                    if ((*it)->get_material_stack()->interface_inside_block(
+                                        k * block_size, block_size / 2.0,
+                                        lower_layer_eps, upper_layer_eps,
+                                        percentage_upper_layer))
+                                    {
+                                        // add 1/epsilon, weighted by volume,
+                                        // minus 1 (=air - already added in beginning)
+                                        result += (*it)->get_area(i, j) *
+                                        ((1.0 - percentage_upper_layer) * (1.0 / lower_layer_eps - 1.0)
+                                        + percentage_upper_layer * (1.0 / upper_layer_eps - 1.0));
+                                    }
+                                    else
+                                        result += (*it)->get_area(i, j) * (1.0 / lower_layer_eps - 1.0);
+                                }
+                }
+                return is_3D() ? result / 8.0 : result / 4.0;
+        }
+
+        ivec material_function_for_polygons::round_to_block_edge(const vec &v) {
+            ivec iv(v.dim, 0.0);
+            LOOP_OVER_DIRECTIONS(v.dim, d)
+            {
+                iv.set_direction(d,
+                                my_round(v.in_direction(d) / block_size));
+            }
+            return iv;
+        }
+
+        unsigned int material_function_for_polygons::add_epsilon(double eps) {
+            if (!is_3D()){ //2D
+                for (std::size_t i = 0; i < _polygons.size(); ++i){
+                    if (_polygons[i]->get_material_epsilon() == eps) {
+                        //epsilon value already added before. Just return ID.
+                        return i;
+                    }
+                }
+                // add new polygon_for_single_material with epsilon value and return
+                // new ID:
+                _polygons.push_back(new polygons_for_single_material(eps, block_size,
+                                                                    nx, ny));
+                return _polygons.size() - 1;
+            }
+            else { //3D
+                //TODO to be implemented: create a simple material stack with just one eps an no (inf?) thickness
+                return 0;
+            }
+        };
+
+        #define UNUSED(x) (void) x // silence compiler warnings
+        void material_function_for_polygons::eff_chi1inv_row(component c,
+                                                            double chi1inv_row[3],
+                                                            const volume &v,
+                                                            double tol, int maxeval)
+        {
+            UNUSED(tol);
+            ivec center_ivec(round_to_block_edge(v.center()));
+            if (!maxeval) {
+                trivial:
+                chi1inv_row[0] = chi1inv_row[1] = chi1inv_row[2] = 0.0;
+                chi1inv_row[component_direction(c) % 3] = 1.0 / mean_eps(center_ivec);
+                return;
+            }
+
+            if (v.center() == vec(108.0/20, 0.0, 0.0)) {
+                master_printf("ivec: %i, %i, %i", center_ivec.x(), center_ivec.y(), center_ivec.z());
+                master_printf("normalx: %f\n", normal_vector(center_ivec).x());
+            }
+
+            vec gradient(normal_vector(center_ivec));
+            if (abs(gradient) < 1e-8)
+                goto trivial;
+
+            double meps = mean_eps(center_ivec);
+            double minveps = mean_inveps(center_ivec);
+
+            double n[3] = {0,0,0};
+            //      double nabsinv = 1.0/abs(gradient);
+            LOOP_OVER_DIRECTIONS(gradient.dim, k)
+            n[k%3] = gradient.in_direction(k);// * nabsinv;
+
+            /* get rownum'th row of effective tensor
+            *                                                                                                        P * minveps + (I-P) * 1/meps = P * (minveps-1/mep*s) + I * 1/meps
+            *                                                                                                        where I is the identity and P is the projection matrix
+            *                                                                                                        P_{ij} = n[i] * n[j]. */
+            int rownum = component_direction(c) % 3;
+            for (int i=0; i<3; ++i)
+                chi1inv_row[i] = n[rownum] * n[i] * (minveps - 1/meps);
+            chi1inv_row[rownum] += 1/meps;
+            if (v.center() == vec(108.0/20, 0.0, 0.0)) {
+                master_printf("gradient: %f, %f, %f - ", gradient.x(), gradient.y(), gradient.z());
+                master_printf("meps: %f, minveps: %f, nvec: (%f, %f, %f)\n", meps, minveps, n[0], n[1], n[2]);
+            }
+        }
+
+////////////////////////////////////////////////////////////
+//---- End: defs for polygon-based material functions ----//
+////////////////////////////////////////////////////////////
+
 void structure_chunk::add_susceptibility(material_function &sigma, 
 					 field_type ft,
 					 const susceptibility &sus)

--- a/src/anisotropic_averaging.cpp
+++ b/src/anisotropic_averaging.cpp
@@ -11,6 +11,7 @@ using namespace std;
 
 namespace meep {
 
+
 ////////////////////////////////////////////////////////////////////////////
 
 #include "sphere-quad.h"
@@ -53,7 +54,8 @@ vec material_function::normal_vector(field_type ft, const volume &v)
 {
   vec gradient(zero_vec(v.dim));
   vec p(v.center());
-  double R = v.diameter();  
+  double R = v.diameter();
+
   for (int i = 0; i < num_sphere_quad[number_of_directions(v.dim)-1]; ++i) {
     double weight;
     vec pt = sphere_pt(p, R, i, weight);
@@ -261,1382 +263,2010 @@ void structure_chunk::set_chi1inv(component c,
 }
 
 
+void structure_chunk::add_susceptibility(material_function &sigma,
+                                         field_type ft,
+                                         const susceptibility &sus)
+{
+    if (ft != E_stuff && ft != H_stuff)
+        abort("susceptibilities must be for E or H fields");
+
+    sigma.set_volume(gv.pad().surroundings());
+
+    susceptibility *newsus = sus.clone();
+    newsus->next = NULL;
+    newsus->ntot = gv.ntot();
+    // get rid of previously allocated sigma, normally not the case here:
+    FOR_COMPONENTS(c) FOR_DIRECTIONS(d) if (newsus->sigma[c][d]) {
+        delete[] newsus->sigma[c][d];
+        newsus->sigma[c][d] = NULL;
+        newsus->trivial_sigma[c][d] = true;
+    }
+
+    // if we own this chunk, set up the sigma array(s):
+    if (is_mine()) FOR_FT_COMPONENTS(ft,c) if (gv.has_field(c)) {
+        FOR_FT_COMPONENTS(ft,c2) if (gv.has_field(c2)) {
+            direction d = component_direction(c2);
+            if (!newsus->sigma[c][d]) newsus->sigma[c][d] = new realnum[gv.ntot()];
+            if (!newsus->sigma[c][d]) abort("Memory allocation error.\n");
+        }
+        bool trivial[3] = {true, true, true};
+        direction dc = component_direction(c);
+        direction d0 = X, d1 = Y, d2 = Z;
+        if (gv.dim == Dcyl) { d0 = R; d1 = P; }
+        int idiag = component_index(c);
+        realnum *s0 = newsus->sigma[c][d0];
+        realnum *s1 = newsus->sigma[c][d1];
+        realnum *s2 = newsus->sigma[c][d2];
+        vec shift1(gv[unit_ivec(gv.dim,component_direction(c))
+        * (ft == E_stuff ? 1 : -1)]);
+        LOOP_OVER_VOL(gv, c, i) {
+            double sigrow[3], sigrow_offdiag[3];
+            IVEC_LOOP_LOC(gv, here);
+            sigma.sigma_row(c, sigrow, here);
+            sigma.sigma_row(c, sigrow_offdiag, here - shift1);
+            sigrow[(idiag+1) % 3] = sigrow_offdiag[(idiag+1) % 3];
+            sigrow[(idiag+2) % 3] = sigrow_offdiag[(idiag+2) % 3];
+            if (s0 && (s0[i] = sigrow[0]) != 0.) trivial[0] = false;
+            if (s1 && (s1[i] = sigrow[1]) != 0.) trivial[1] = false;
+            if (s2 && (s2[i] = sigrow[2]) != 0.) trivial[2] = false;
+        }
+
+        direction ds[3]; ds[0] = d0; ds[1] = d1; ds[2] = d2;
+        for (int i = 0; i < 3; ++i) {
+            newsus->trivial_sigma[c][ds[i]] = trivial[i];
+            if (i != idiag && trivial[i]) { // deallocate trivial offdiag
+                delete[] newsus->sigma[c][ds[i]];
+                newsus->sigma[c][ds[i]] = 0;
+            }
+        }
+        // only deallocate trivial diag if entire tensor is trivial
+        if (trivial[0] && trivial[1] && trivial[2]) {
+            delete[] newsus->sigma[c][dc];
+            newsus->sigma[c][dc] = 0;
+        }
+    }
+
+    // finally, add to the beginning of the chiP list:
+    newsus->next = chiP[ft];
+    chiP[ft] = newsus;
+
+    sigma.unset_volume();
+}
+
+
 ////////////////////////////////////////////////////////////
 //--- Begin: defs for polygon-based material functions ---//
 ////////////////////////////////////////////////////////////
 
-// polygon defined by a numpy array with dimensions N*2 (containing the points) and defining an area with a certain epsilon
-simple_polygon::simple_polygon(double* matrix, int dimX, int dimY) {
-    if (dimY != 2) {
-        abort("Array with polygon points should have a shape X,2. The second dimension is not 2.");
+// Returns the absolute area of a polygon.
+// For self-intersecting polygons, this will return the difference between clockwise
+// parts and anti-clockwise parts, not the real area.
+// Last point must equal first point!
+static double get_polygon_area(const double* const* matrix, std::size_t dim1, std::size_t dim2) {
+    if (dim1 < 3)
+        return 0;
+
+    if (dim2 != 2) {
+        abort("get_polygon_area: Array with polygon points should have a shape X,2. The second dimension is not 2.");
     }
 
-    //make sure last point equals first point. If not, append copy of first point to end:
-    if (dimX > 0 && (matrix[0] != matrix[dimY * (dimX - 1)] || matrix[1] != matrix[dimY * dimX - 1]))
-        this->_number_of_points = dimX + 1;
-    else
-        this->_number_of_points = dimX;
+    //2A = \sum_{i=0}^{n-1}( (x_{i-1} - x_{i+1}) * y_i ) # Gauss's area formula (aka shoelace algorithm)
+    double sum = (matrix[dim1 - 1][0] - matrix[1][0]) * matrix[0][1]; // (i = 0)
+    for (std::size_t i = 1; i < dim1 - 1; ++i)
+        sum += (matrix[i - 1][0] - matrix[i + 1][0]) * matrix[i][1];
+    sum += (matrix[dim1 - 2][0] - matrix[0][0]) * matrix[dim1 - 1][1]; // (i = n-1)
+    return fabs(0.5 * sum);
+}
 
-    // copy matrix:
-    _polygon_points = new double*[_number_of_points];
-    for (int i = 0; i < dimX; i++) {
-        _polygon_points[i] = new double[2];
-        _polygon_points[i][0] = matrix[dimY * i];
-        _polygon_points[i][1] = matrix[dimY * i + 1];
+simple_polygon::simple_polygon(const double (* const points)[2], std::size_t num_points) {
+    if (num_points > 0) {
+        //make sure last point equals first point. If not, append copy of first point to end:
+        if (points[0][0] != points[num_points - 1][0] || points[0][1] != points[num_points - 1][1])
+            _number_of_points = num_points + 1;
+        else
+            _number_of_points = num_points;
+
+        // copy matrix:
+        _polygon_points = new double*[_number_of_points];
+        for (std::size_t i = 0; i < num_points; i++) {
+            _polygon_points[i] = new double[2];
+            _polygon_points[i][0] = points[i][0];
+            _polygon_points[i][1] = points[i][1];
+        }
+
+        //if last point does not equal first point -> append copy of first point to end:
+        if (_number_of_points == num_points + 1) {
+            _polygon_points[num_points] = new double[2];
+            _polygon_points[num_points][0] = points[0][0];
+            _polygon_points[num_points][1] = points[0][1];
+        }
+    }
+    else {
+        _number_of_points = 0;
+        _polygon_points = 0;
     }
 
-    //if last point does not equal first point -> append copy of first point to end:
-    if (this->_number_of_points == dimX + 1) {
-        _polygon_points[dimX] = new double[2];
-        _polygon_points[dimX][0] = matrix[0];
-        _polygon_points[dimX][1] = matrix[1];
+}
+
+simple_polygon::simple_polygon(const double* matrix, std::size_t dim1, std::size_t dim2) {
+    if (dim1 > 0) {
+        if (dim2 != 2) {
+            abort("Array with polygon points should have a shape X,2. The second dimension is not 2.");
+        }
+
+        //make sure last point equals first point. If not, append copy of first point to end:
+        if (matrix[0] != matrix[2 * (dim1 - 1)] || matrix[1] != matrix[2 * dim1 - 1])
+            this->_number_of_points = dim1 + 1;
+        else
+            this->_number_of_points = dim1;
+
+        // copy matrix:
+        _polygon_points = new double*[_number_of_points];
+        for (std::size_t i = 0; i < dim1; i++) {
+            _polygon_points[i] = new double[2];
+            _polygon_points[i][0] = matrix[2 * i];
+            _polygon_points[i][1] = matrix[2 * i + 1];
+        }
+
+        //if last point does not equal first point -> append copy of first point to end:
+        if (this->_number_of_points == dim1 + 1) {
+            _polygon_points[dim1] = new double[2];
+            _polygon_points[dim1][0] = matrix[0];
+            _polygon_points[dim1][1] = matrix[1];
+        }
+    }
+    else {
+        _number_of_points = 0;
+        _polygon_points = 0;
     }
 };
 
-simple_polygon::simple_polygon(double** matrix, int dimX) {
-    // if this constructor is used, care must be taken that matrix is not deleted
-    // externally. The memory pointed to by matrix will be deleted with ~polygon()
-    // First point of polygon must equal last point.
+simple_polygon::simple_polygon(const simple_polygon &pol) {
+    this->_number_of_points = pol._number_of_points;
+    // copy matrix:
+    if (_number_of_points > 0) {
+        _polygon_points = new double*[_number_of_points];
+        for (std::size_t i = 0; i < _number_of_points; i++) {
+            _polygon_points[i] = new double[2];
+            _polygon_points[i][0] = pol._polygon_points[i][0];
+            _polygon_points[i][1] = pol._polygon_points[i][1];
+        }
+    }
+    else {
+        _polygon_points = 0;
+    }
+}
 
-    //make sure last point equals first point:
-    if (dimX > 0 && (matrix[0][0] != matrix[dimX - 1][0] || matrix[0][1] != matrix[dimX - 1][1]))
-        abort("Error creating polygon: First point should equal last point.");
+void swap(simple_polygon& first, simple_polygon& second)
+{
+    using std::swap;
+    swap(first._number_of_points, second._number_of_points);
+    swap(first._polygon_points, second._polygon_points);
+}
 
-    this->_number_of_points = dimX;
-    _polygon_points = matrix;
-    //the caller should set matrix = 0;
+simple_polygon& simple_polygon::operator=(simple_polygon other)
+{
+    swap(*this, other);
+    return *this;
 }
 
 simple_polygon::~simple_polygon() {
-    for (int i = 0; i < _number_of_points; i++) {
+    for (std::size_t i = 0; i < _number_of_points; i++) {
         delete [] _polygon_points[i];
     }
     delete [] _polygon_points;
 };
 
+// Clip the polygon by a rectangular boundary:
+void simple_polygon::clip_polygon(
+    double left, double right, double bottom, double top) {
+    // It's easier to do this in two steps: First clip the polygon by left and
+    // right only, then clip the resulting polygon by bottom and top.
+
+    // Note: This whole method was only created so we can compare the area of
+    // the original (apart from this clipping), unsplitted polygons with the
+    // total area of the splitted polygons, which must be equal, in
+    // polygonal_material::update_splitting(). The splitting also
+    // works fine if we don't clip the polygons to the computational cell
+    // before, only it will then output a warning that the areas don't match.
+    // This probably was not worth the effort, but anyway, now the method is
+    // already written and can be used. ;)
+
+    if (_number_of_points == 0)
+        return;
+
+    // Go through points, keep points inside boundaries,
+    // add intersecting points when transitioning from outside->inside or
+    // vice versa.
+
+    // First step, clip by left and right:
+    vector<double*> poly1;
+    double *intp_pt, *pt, *prev_pt = _polygon_points[0];
+    double slope;
+    // -1 for left, 0 for inside, +1 for right of border:
+    int pos, prev_pos = int(prev_pt[0] > right) - int(prev_pt[0] < left);
+    for (std::size_t i = 0; i < _number_of_points; i++) {
+        pt = _polygon_points[i];
+        // -1 for left, 0 for inside, +1 for right of border:
+        pos = int(pt[0] > right) - int(pt[0] < left);
+        if (prev_pos != 0 && prev_pos != pos) {
+            // The polygon entered or crossed the inner area.
+            // Calc intersection point at the entry to inner area:
+            slope = (pt[1] - prev_pt[1]) / (pt[0] - prev_pt[0]);
+            intp_pt = new double[2];
+            intp_pt[0] = prev_pos == -1 ? left : right;
+            intp_pt[1] = prev_pt[1] + (intp_pt[0] - prev_pt[0]) * slope;
+            // add intersection point:
+            poly1.push_back(intp_pt);
+        }
+        if (pos == 0) {
+            // add pt (which is inside):
+            poly1.push_back(pt);
+            // This point is now owned by poly1:
+            _polygon_points[i] = 0;
+        }
+        else if (prev_pos != pos) {
+            // The polygon left or crossed the inner area.
+            // Calc intersection point at the exit from inner area:
+            slope = (pt[1] - prev_pt[1]) / (pt[0] - prev_pt[0]);
+            intp_pt = new double[2];
+            intp_pt[0] = pos == -1 ? left : right;
+            intp_pt[1] = prev_pt[1] + (intp_pt[0] - prev_pt[0]) * slope;
+            // add intersection point:
+            poly1.push_back(intp_pt);
+        }
+        prev_pt = pt;
+        prev_pos = pos;
+    }
+    // End of first step; Add first point if needed:
+    if (poly1.size() > 1 && (
+        poly1.back()[0] != poly1.front()[0] ||
+        poly1.back()[1] != poly1.front()[1]))
+    {
+        pt = new double[2];
+        pt[0] = poly1.front()[0];
+        pt[1] = poly1.front()[1];
+        poly1.push_back(pt);
+    }
+
+    if (poly1.empty()){
+        for (std::size_t i = 0; i < _number_of_points; i++) {
+            delete[] _polygon_points[i];
+        }
+        delete[] _polygon_points;
+        _number_of_points = 0;
+        _polygon_points = 0;
+        return;
+    }
+
+    // Second step, clip by top and bottom:
+    vector<double*> poly2;
+    prev_pt = poly1[0];
+    // -1 for below, 0 for inside, +1 for above border:
+    prev_pos = int(prev_pt[1] > top) - int(prev_pt[1] < bottom);
+    for (std::size_t i = 0; i < poly1.size(); i++) {
+        pt = poly1[i];
+        // -1 for below, 0 for inside, +1 for above border:
+        pos = int(pt[1] > top) - int(pt[1] < bottom);
+        if (prev_pos != 0 && pos != prev_pos) {
+            // The polygon entered or crossed the inner area.
+            // Calc intersection point at the entry to inner area:
+            slope = (pt[0] - prev_pt[0]) / (pt[1] - prev_pt[1]);
+            intp_pt = new double[2];
+            intp_pt[1] = prev_pos == -1 ? bottom : top;
+            intp_pt[0] = prev_pt[0] + (intp_pt[1] - prev_pt[1]) * slope;
+            // add intersection point:
+            poly2.push_back(intp_pt);
+        }
+        if (pos == 0) {
+            // add pt (which is inside):
+            poly2.push_back(pt);
+            // This point is now owned by poly2:
+            poly1[i] = 0;
+        }
+        else if (pos != prev_pos) {
+            // The polygon left or crossed the inner area.
+            // Calc intersection point at the exit from inner area:
+            slope = (pt[0] - prev_pt[0]) / (pt[1] - prev_pt[1]);
+            intp_pt = new double[2];
+            intp_pt[1] = pos == -1 ? bottom : top;
+            intp_pt[0] = prev_pt[0] + (intp_pt[1] - prev_pt[1]) * slope;
+            // add intersection point:
+            poly2.push_back(intp_pt);
+        }
+        prev_pt = pt;
+        prev_pos = pos;
+    }
+
+    // End of second step; Add first point if needed:
+    if (poly2.size() > 1 && (
+        poly2.back()[0] != poly2.front()[0] ||
+        poly2.back()[1] != poly2.front()[1]))
+    {
+        pt = new double[2];
+        pt[0] = poly2.front()[0];
+        pt[1] = poly2.front()[1];
+        poly2.push_back(pt);
+    }
+
+    // finally set the polygon's points to the clipped ones in poly2:
+    for (std::size_t i = 0; i < _number_of_points; i++) {
+        delete[] _polygon_points[i];
+    }
+    delete[] _polygon_points;
+    _number_of_points = poly2.size();
+    if (_number_of_points > 0) {
+        _polygon_points = new double*[_number_of_points];
+        for (std::size_t i = 0; i < _number_of_points; i++) {
+            _polygon_points[i] = poly2[i];
+        }
+    }
+    else
+        _polygon_points = NULL;
+    // Now all points in poly2 belong to _polygons.
+
+    // clean up:
+    for (std::size_t i = 0; i < poly1.size(); i++) {
+        delete[] poly1[i];
+    }
+    poly1.clear();
+    poly2.clear();
+}
+
 double simple_polygon::get_area() {
-    //Returns the absolute area of polygon.
-    //For self-intersecting polygons, this will return the difference between clockwise
-    //parts and anti-clockwise parts, not the real area.
-    int n = _number_of_points;
-    if (n < 3)
-        return 0;
-    //2A = \sum_{i=0}^{n-1}( (x_{i-1} - x_{i+1}) * y_i ) # Gauss's area formula (aka shoelace algorithm)
-    double sum = (_polygon_points[n - 1][0] - _polygon_points[1][0]) * _polygon_points[0][1]; // (i = 0)
-    for (int i = 1; i < n - 1; ++i)
-        sum += (_polygon_points[i - 1][0] - _polygon_points[i + 1][0]) * _polygon_points[i][1];
-    sum += (_polygon_points[n - 2][0] - _polygon_points[0][0]) * _polygon_points[n - 1][1]; // (i = n-1)
-    return fabs(0.5 * sum);
+    return get_polygon_area(_polygon_points, _number_of_points, 2);
+}
+
+polygon::polygon(const polygon &pol) : simple_polygon(pol) {
+    for(vector<simple_polygon*>::const_iterator p = pol._inner_polygons.begin();
+        p != pol._inner_polygons.end(); ++p)
+    {
+        _inner_polygons.push_back(new simple_polygon(**p));
+    }
+}
+
+void swap(polygon& first, polygon& second)
+{
+    using std::swap;
+    swap(static_cast<simple_polygon&>(first), static_cast<simple_polygon&>(second));
+    swap(first._inner_polygons, second._inner_polygons);
+}
+
+polygon& polygon::operator=(polygon other)
+{
+    swap(*this, other);
+    return *this;
 }
 
 polygon::~polygon() {
+    //_polygon_points from parent class are deleted in parent class destructor.
     for(vector<simple_polygon*>::iterator p = _inner_polygons.begin(); p != _inner_polygons.end(); ++p) {
         delete (*p);
     }
 };
 
-void polygon::add_inner_polygon(double* matrix, int dimX, int dimY) {
-    // TODO? check if inner polygon is real inner polygon of parent:
-    // first point is inside parent polygon AND inner polygon's edges does not cross parent polygon's edges
-    _inner_polygons.push_back(new simple_polygon(matrix, dimX, dimY));
+// TODO? all add_inner_polygon: check if inner polygon is real inner polygon of parent:
+// first point is inside parent polygon AND inner polygon's edges does not cross parent polygon's edges
+void polygon::add_inner_polygon(const double (* const points)[2], std::size_t num_points) {
+    _inner_polygons.push_back(new simple_polygon(points, num_points));
+}
+
+void polygon::add_inner_polygon(const double* matrix, std::size_t dim1, std::size_t dim2) {
+    _inner_polygons.push_back(new simple_polygon(matrix, dim1, dim2));
+}
+
+void polygon::add_inner_polygon(const simple_polygon &pol) {
+    _inner_polygons.push_back(new simple_polygon(pol));
+}
+
+// Clip the polygon by a rectangular boundary:
+void polygon::clip_polygon(
+    double left, double right, double bottom, double top) {
+    for(vector<simple_polygon*>::iterator inner_p = _inner_polygons.begin();
+        inner_p != _inner_polygons.end(); ++inner_p)
+    {
+        (*inner_p)->clip_polygon(left, right, bottom, top);
+    }
+    simple_polygon::clip_polygon(left, right, bottom, top);
 }
 
 double polygon::get_area() {
     double parea = simple_polygon::get_area();
-    for(vector<simple_polygon*>::iterator inner_p = _inner_polygons.begin(); inner_p != _inner_polygons.end(); ++inner_p) {
-        parea -= (*inner_p)->get_area(); //all inner polygons must be real inner polygons (i.e. completely inside parent polygon)
+    for(vector<simple_polygon*>::iterator inner_p = _inner_polygons.begin();
+        inner_p != _inner_polygons.end(); ++inner_p)
+    {
+        //all inner polygons must be real inner polygons (i.e. completely inside parent polygon)
+        parea -= (*inner_p)->get_area();
     }
     return parea;
 }
 
-material_stack::material_stack(const double* material_heights,
-                               const double* epsilon_values, const int number_of_layers)
+material_stack::material_stack(
+    const double* layer_thicknesses, const double* layer_epsilons,
+    const int number_of_layers)
 {
-    init_material_stack(material_heights, epsilon_values, number_of_layers);
+    _number_of_layers = number_of_layers;
+    // see if we can remove or join some layers:
+    for (int i = 0; i < number_of_layers; ++i )
+    {
+        if (
+            layer_thicknesses[i] <= 0 ||
+            (i > 0 && layer_epsilons[i] == layer_epsilons[i - 1]))
+            _number_of_layers--;
+    }
+
+    if (_number_of_layers == 0)
+        abort("Please specify at least one layer in material stack.");
+
+    _high_z = new double[_number_of_layers];
+    _epsilon = new double[_number_of_layers];
+    double current_z = 0;
+    int j = 0;
+    for (int i = 0; i < number_of_layers; ++i) {
+        if (layer_thicknesses[i] <= 0) {
+            // don't include empty layer:
+            continue;
+        }
+        if (j > 0 && layer_epsilons[j-1] == layer_epsilons[i]) {
+            // join layers:
+            current_z += layer_thicknesses[i];
+            _high_z[j-1] = current_z;
+            continue;
+        }
+        current_z += layer_thicknesses[i];
+        _high_z[j] = current_z;
+        _epsilon[j] = layer_epsilons[i];
+        j++;
+    }
 };
 
-material_stack::material_stack(const double* material_heights, const int mh_dim,
-                               const double* epsilon_values, const int ev_dim)
-{
-    if (mh_dim != ev_dim)
-        abort("material_heights and epsilon_values must have same length, \
-        i. e. the number of layers in the material stack.");
-    init_material_stack(material_heights, epsilon_values, mh_dim);
-}
-
-void material_stack::init_material_stack(const double* material_heights,
-                                         const double* epsilon_values, const int number_of_layers)
-{
-    if (number_of_layers == 0)
+material_stack::material_stack(const material_stack& stack) :
+        _number_of_layers(stack._number_of_layers)
+    {
+    if (_number_of_layers == 0)
         abort("Please specify at least one layer in material stack.");
 
     // make copy of arrays:
-    // It is really important that the user supplies the right length of the two
-    // arrays with number_of_layers, else some undefined memory outside of the
-    // arrays could be accessed. Unfortunately, this can't be checked here.
-    this->_material_heights = new double[number_of_layers];
-    this->_epsilon_values = new double[number_of_layers];
-    for (int i = 0; i < number_of_layers; ++i) {
-        this->_material_heights[i] = material_heights[i];
-        this->_epsilon_values[i] = epsilon_values[i];
+    _high_z = new double[_number_of_layers];
+    _epsilon = new double[_number_of_layers];
+    for (int i = 0; i < _number_of_layers; ++i) {
+        _high_z[i] = stack._high_z[i];
+        _epsilon[i] = stack._epsilon[i];
     }
-    _number_of_layers = number_of_layers;
 }
 
 material_stack::~material_stack(){
-    delete[] _material_heights;
-    delete[] _epsilon_values;
+    delete[] _high_z;
+    delete[] _epsilon;
 };
 
-bool material_stack::interface_inside_block(
-    double center_z, double half_block_size,
-    double &lower_layer_eps, double &upper_layer_eps,
-    double &percentage_upper_layer) const
-    {
-        if (_number_of_layers == 1) {
-            // no interface
-            lower_layer_eps = _epsilon_values[0];
-            upper_layer_eps = 0.0;
-            percentage_upper_layer = 0.0;
-            return false;
-        }
+double material_stack::chi1p1(const double &z) const
+{
+    // if z <= 0, return epsilon of first layer
+    for (int i = 0; i < _number_of_layers - 1; ++i) {
+        if (z < _high_z[i])
+            return _epsilon[i];
+        // The epsilon value at the exact interface position is the mean
+        // of the two encompassing layer's epsilon values:
+        if (z == _high_z[i]) //TODO just a test; keep or remove?
+            return (_epsilon[i] + _epsilon[i+1])/2;
+    }
+    // if z > total thickness, return epsilon of last layer:
+    return _epsilon[_number_of_layers - 1];
+}
 
-        double lower = center_z - half_block_size;
-        double higher = center_z + half_block_size;
-        double height;
-        double z = 0.0;
-        for (int i = 0; i < _number_of_layers - 1; i++)
-        {
-            z += _material_heights[i];
-            if (lower < z) {
-                lower_layer_eps = _epsilon_values[i];
-                if (higher <= z) {
-                    // no interface
-                    upper_layer_eps = 0.0;
-                    percentage_upper_layer = 0.0;
-                    return false;
+double material_stack::normal(const double &lower_z, const double &higher_z) const
+{
+    double lower_eps, higher_eps;
+    for (int i = 0; i < _number_of_layers - 1; ++i) {
+        if (lower_z <= _high_z[i]) {
+            lower_eps = _epsilon[i];
+            if (higher_z <= _high_z[i]) {
+                // both z values are in same layer:
+                return 0.0;
+            }
+            for (int j = i + 1; j < _number_of_layers - 1; ++j) {
+                if (higher_z <= _high_z[j]) {
+                    higher_eps = _epsilon[j];
+                    return 0.5 * (lower_eps - higher_eps);
+                }
+            }
+            return 0.5 * (lower_eps - _epsilon[_number_of_layers - 1]);
+        }
+    }
+    // both lower_z and higher_z are in topmost layer or above:
+    return 0.0;
+
+}
+
+double material_stack::mean_eps(const double &lower_z, const double &higher_z) const
+{
+    double distance = higher_z - lower_z;
+    double result = 0;
+    for (int i = 0; i < _number_of_layers - 1; ++i) {
+        if (lower_z <= _high_z[i]) {
+            if (higher_z <= _high_z[i]) {
+                // both z values are in same layer:
+                return _epsilon[i];
+            }
+            result += (_high_z[i] - lower_z) * _epsilon[i];
+            for (int j = i + 1; j < _number_of_layers - 1; ++j) {
+                if (higher_z <= _high_z[j]) {
+                    result += (higher_z - _high_z[j - 1]) * _epsilon[j];
+                    return result / distance;
                 }
                 else {
-                    height = higher - z;
-                    if (i < _number_of_layers - 2 && // upmost layer may be thinner than resolution
-                        height > _material_heights[i + 1])
-                        abort("Layer specified in material_stack too thin or resolution too poor.");
-                    upper_layer_eps = _epsilon_values[i + 1];
-                    percentage_upper_layer = height / half_block_size / 2.0;
-                    return true;
+                    // Add the thin layer in between. This should normally not
+                    // occur, only with bad resolution and very thin layers.
+                    result += (_high_z[j] - _high_z[j - 1]) * _epsilon[j];
                 }
             }
+            // higher_z is in topmost layer or above:
+            result += (higher_z - _high_z[_number_of_layers - 2]) * _epsilon[_number_of_layers - 1];
+            return result / distance;
         }
-        // lower > z, i.e. block is in highest layer or above:
-        lower_layer_eps = _epsilon_values[_number_of_layers - 1];
-        upper_layer_eps = 0.0;
-        percentage_upper_layer = 0.0;
-        return false;
     }
+    // both lower_z and higher_z are in topmost layer or above:
+    return _epsilon[_number_of_layers - 1];
+}
 
-    polygons_for_single_material::polygons_for_single_material(
-        material_stack * mat_stack, double block_size, int nx, int ny, int nz)
-    {
-        init_pfsm(mat_stack, 0, block_size, nx, ny, nz);
-    }
-
-    polygons_for_single_material::polygons_for_single_material(
-        double epsilon, double block_size, int nx, int ny)
-    {
-        init_pfsm(0, epsilon, block_size, nx, ny, 0);
-    }
-
-    void polygons_for_single_material::init_pfsm(material_stack * mat_stack,
-                                                    double epsilon, double block_size, int nx, int ny, int nz)
-    {
-        _material_stack = mat_stack;
-        _epsilon = epsilon;
-        _block_size = block_size;
-        _nx = nx;
-        _ny = ny;
-        _nz = nz;
-        splitting_done = false;
-        _areas = new double*[nx];
-        for (int i = 0; i < nx; ++i){
-            _areas[i] = new double[ny];
-            for (int j = 0; j < ny; ++j) {
-                _areas[i][j] = 0;
+double material_stack::mean_inveps(const double &lower_z, const double &higher_z) const
+{
+    double distance = higher_z - lower_z;
+    double result = 0;
+    for (int i = 0; i < _number_of_layers - 1; ++i) {
+        if (lower_z <= _high_z[i]) {
+            if (higher_z <= _high_z[i]) {
+                // both z values are in same layer:
+                return 1.0 / _epsilon[i];
             }
+            result += (_high_z[i] - lower_z) / _epsilon[i];
+            for (int j = i + 1; j < _number_of_layers - 1; ++j) {
+                if (higher_z <= _high_z[j]) {
+                    result += (higher_z - _high_z[j - 1]) / _epsilon[j];
+                    return result / distance;
+                }
+                else {
+                    // Add the thin layer in between. This should normally not
+                    // occur, only with bad resolution or very thin layers.
+                    result += (_high_z[j] - _high_z[j - 1]) / _epsilon[j];
+                }
+            }
+            // higher_z is in topmost layer or above:
+            result += (higher_z - _high_z[_number_of_layers - 2]) / _epsilon[_number_of_layers - 1];
+            return result / distance;
         }
-    };
+    }
+    // both lower_z and higher_z are in topmost layer or above:
+    return 1.0 / _epsilon[_number_of_layers - 1];
+}
 
-    polygons_for_single_material::~polygons_for_single_material() {
-        //delete polygons list:
-        while (!_polygons.empty()){
-            delete _polygons.front(); //delete polygon object
-            _polygons.pop(); //delete pointer to polygon object
+polygonal_material::polygonal_material(
+    const material_stack * mat_stack, double block_size, int nx, int ny, int nz)
+{
+    init_polymat(mat_stack, 0, block_size, nx, ny, nz);
+}
+
+polygonal_material::polygonal_material(
+    double epsilon, double block_size, int nx, int ny)
+{
+    init_polymat(0, epsilon, block_size, nx, ny, 0);
+}
+
+void polygonal_material::init_polymat(
+    const material_stack * mat_stack,
+    double epsilon, double block_size, int nx, int ny, int nz)
+{
+    if (mat_stack) {
+        _material_stack = new material_stack(*mat_stack);
+    }
+    else {
+        _material_stack = 0;
+    }
+    _epsilon = epsilon;
+    _block_size = block_size;
+    _nx = nx;
+    _ny = ny;
+    _nz = nz;
+    splitting_done = false;
+    _areas = new double*[nx];
+    for (int i = 0; i < nx; ++i){
+        _areas[i] = new double[ny];
+        for (int j = 0; j < ny; ++j) {
+            _areas[i][j] = 0;
         }
+    }
+};
 
-        delete _material_stack;
+polygonal_material::~polygonal_material() {
+    //delete polygons list:
+    for (size_t i = 0; i < _polygons.size(); ++i) {
+        //delete polygon object
+        delete _polygons[i];
+    }
+    // remove pointers to deleted polygon objects:
+    _polygons.clear();
 
-        // delete _areas:
-        for (int i = 0; i < _nx; ++i)
-            delete[] _areas[i];
-        delete[] _areas;
-    };
+    delete _material_stack;
 
-    polygon* polygons_for_single_material::add_polygon(polygon* pol) {
-        if (splitting_done)
-            abort("Cannot add polygons after splitting has been done.");
-        _polygons.push(pol);
-        return pol;
-    };
+    // delete _areas:
+    for (int i = 0; i < _nx; ++i)
+        delete[] _areas[i];
+    delete[] _areas;
+};
 
-    bool polygons_for_single_material::is_trivial(const ivec &small_ivec, const ivec &big_ivec)
+void polygonal_material::add_polygon(const polygon& pol)
+{
+    if (splitting_done)
+        abort("Cannot add polygons after splitting has been done.");
+    // make a copy that belongs to this class:
+    polygon *cpol = new polygon(pol);
+    // clip the polygon to the computational domain:
+    cpol->clip_polygon(0, _nx * _block_size, 0, _ny * _block_size);
+    if (cpol->get_number_of_points() > 2)
+        _polygons.push_back(cpol);
+    else {
+        delete cpol;
+    }
+}
+
+bool polygonal_material::is_trivial(const ivec &small_ivec, const ivec &big_ivec)
+{
+    if (!splitting_done)
+        update_splitting();
+    int i2, j2;
+    double val = -2;
+    for (int i = small_ivec.x(); i < big_ivec.x(); ++i)
     {
-        if (!splitting_done)
-            update_splitting();
-        int i2, j2;
-        for (int i = small_ivec.x(); i < big_ivec.x(); ++i)
+        // If pixel is at outer edge, overlapping the undefined area outside
+        // the grid volume, wrap the structure to the opposite side. If a PML
+        // boundary is used, there shouldn't be a structure close to the
+        // boundary anyways, and if periodic boundary conditions are used, we
+        // would want to wrap the structure:
+        i2 = i;
+        if (i2 < 0)
+            i2 += _nx;
+        else if (i2 >= _nx)
+            i2 -= _nx;
+        for (int j = small_ivec.y(); j < big_ivec.y(); ++j)
         {
-            // If pixel is at outer edge, overlapping the undefined area outside
-            // the grid volume, wrap the structure to the opposite side. If a PML
-            // boundary is used, there shouldn't be a structure close to the
-            // boundary anyways, and if periodic boundary conditions are used, we
-            // would want to wrap the structure:
-            i2 = i;
-            if (i2 < 0)
-                i2 += _nx;
-            else if (i2 >= _nx)
-                i2 -= _nx;
-            for (int j = small_ivec.y(); j < big_ivec.y(); ++j)
+            j2 = j;
+            if (j2 < 0)
+                j2 += _ny;
+            else if (j2 >= _ny)
+                j2 -= _ny;
+            if (_areas[i2][j2] != 0 && _areas[i2][j2] != 1)
+                return false;
+            else if (val == -2)
+                val = _areas[i2][j2];
+            else if (val != _areas[i2][j2])
+                return false;
+        }
+    }
+    return true;
+}
+
+vec polygonal_material::normal_vector(const ivec &center)
+{
+    if (!splitting_done)
+        update_splitting();
+
+    // These 4 pointers will point to the 4x4 blocks (=2x2 pixels) that
+    // will be used as parameter in get_2D_gradient:
+    double* area_cols[4];
+    int xi, yi;
+    vec gradient;
+    double inner_area;
+
+    if (center.y() < 2 || center.y() + 1 >= _ny) {
+        /**
+            * If pixel is at outer edge, overlapping the undefined area
+            * outside the grid volume, wrap the structure to the opposite side.
+            * If a PML boundary is used, there shouldn't be a structure close
+            * to the boundary anyways, and if periodic boundary conditions are
+            * used, we would want to wrap the structure.
+            */
+        for (int i = 0; i < 4; ++i)
+        {
+            xi = center.x() - 2 + i;
+            if (xi < 0)
+                xi += _nx;
+            else if (xi >= _nx)
+                xi -= _nx;
+            /**
+                * If the 4x4 area wraps around the grid volume, we cannot
+                * point to the existing memory location, but need to create
+                * new arrays: */
+            area_cols[i] = new double[4];
+            for (int j = 0; j < 4; ++j)
             {
-                j2 = j;
-                if (j2 < 0)
-                    j2 += _ny;
-                else if (j2 >= _ny)
-                    j2 -= _ny;
-                if (_areas[i2][j2] != 0 && _areas[i2][j2] != 1)
-                    return false;
+                yi = center.y() - 2 + j;
+                if (yi < 0)
+                    yi += _ny;
+                else if (yi >= _ny)
+                    yi -= _ny;
+                area_cols[i][j] = _areas[xi][yi];
             }
         }
-        return true;
+        inner_area = (
+            area_cols[1][1] + area_cols[1][2] +
+            area_cols[2][1] + area_cols[2][2]);
+        gradient = get_2D_gradient(area_cols);
+        for (int i = 0; i < 4; ++i)
+        {
+            delete[] area_cols[i];
+        }
+    }
+    else
+    {
+        for (int i = 0; i < 4; ++i) {
+            xi = center.x() - 2 + i;
+            if (xi < 0)
+                xi += _nx;
+            else if (xi >= _nx)
+                xi -= _nx;
+            area_cols[i] = &_areas[xi][center.y() - 2];
+        }
+        inner_area = (
+            area_cols[1][1] + area_cols[1][2] +
+            area_cols[2][1] + area_cols[2][2]);
+        gradient = get_2D_gradient(area_cols);
     }
 
-    vec polygons_for_single_material::normal_vector(const ivec &center)
-    {
-        if (!splitting_done)
-            update_splitting();
-        // Initialize the 4x4 blocks (=2x2 pixels) that will be used as parameter in
-        // calc_gradient_4x4:
-        double** area_cols = new double*[4];
-        bool created_area_cols = false;
-        int xi, yi;
-        vec result;
-        if (center.y() < 2 || center.y() + 1 >= _ny) {
-            // If pixel is at outer edge, overlapping the undefined area outside
-            // the grid volume, wrap the structure to the opposite side. If a PML
-            // boundary is used, there shouldn't be a structure close to the
-            // boundary anyways, and if periodic boundary conditions are used, we
-            // would want to wrap the structure.
-            for (int i = 0; i < 4; ++i)
-            {
-                xi = center.x() - 2 + i;
-                if (xi < 0)
-                    xi += _nx;
-                else if (xi >= _nx)
-                    xi -= _nx;
-                area_cols[i] = new double[4];
-                created_area_cols = true;
-                for (int j = 0; j < 4; ++j)
-                {
-                    yi = center.y() - 2 + j;
-                    if (yi < 0)
-                        yi += _ny;
-                    else if (yi >= _ny)
-                        yi -= _ny;
-                    area_cols[i][j] = _areas[xi][yi];
-                }
-            }
+    // Normalize gradient such that it can be added to gradient of
+    // any neighboring polygonal_material in the same pixel. That is,
+    // the returned gradient must have same length than it would have
+    // if it was calculated with the Lebedev quadrature scheme, or at
+    // least approximately.
+    double meps = is_3D() ? _material_stack->mean_eps(
+        (center.z() - 1) * _block_size,
+        (center.z() + 1) * _block_size) : _epsilon;
+    double len = (meps - 1) * sqrt(fabs((4 - inner_area) * inner_area));
 
-
-            result = calc_gradient_4x4(area_cols);
-            if (center == ivec(216, 0, 0)) {
-                master_printf("singmat normvec: %f, %f, %f; area cols, wrapping: \n", result.x(), result.y(), result.z() );
-                for(int i = 0; i < 4; ++i)
-                    master_printf("%f, %f, %f, %f\n", area_cols[i][0], area_cols[i][1], area_cols[i][2], area_cols[i][3]);
-            }
+    if (is_3D()){
+        double grad_z = _material_stack->normal(
+            (center.z() - 1) * _block_size, (center.z() + 1) * _block_size);
+        if (abs(grad_z) < 1e-8)
+        {
+            // There is no interface in z direction.
+            // The (len / 8)-factor is to make the result comparable with the
+            // Lebedev scheme implementation for gradienQuad below.
+            return gradient * len / 8;
         }
         else
         {
-            for (int i = 0; i < 4; ++i) {
-                xi = center.x() - 2 + i;
-                if (xi < 0)
-                    xi += _nx;
-                else if (xi >= _nx)
-                    xi -= _nx;
-                area_cols[i] = &_areas[xi][center.y() - 2];
+            // There is an interface in z direction
+            if (abs(gradient) < 1e-8) {
+                // there is ONLY an interface in z direction:
+                return vec(0.0, 0.0, grad_z);
             }
-            result = calc_gradient_4x4(area_cols);
-        }
-        if (is_3D()){
-            double lower_layer_eps;
-            double upper_layer_eps;
-            double percentage_upper_layer;
-            double z;
-            if (_material_stack->interface_inside_block(
-                center.z() * _block_size, _block_size,
-                                                        lower_layer_eps, upper_layer_eps,
-                                                        percentage_upper_layer))
+            else
             {
-                z = upper_layer_eps < lower_layer_eps ? 1.0     : -1.0;
-                if (abs(result) < 1e-8)
-                    // interface only in z direction
-                    return vec(0.0, 0.0, z);
-                else
-                {
-                    // Interface in z and transversal direction;
-                    // Need to return approximate vector for corner.
-                    // This is the only time the sign of the normal vector is
-                    // important, because the transversal vector (from polygons)
-                    // and the z vector (from material stack) must be combined,
-                    // and the resulting vector will point in a different direction
-                    // if transversal and z vector have opposite sign than when
-                    // both have same sign.
-                    // This is difficult, because a neigboring polygon (on same
-                    // block) with different material function (= different
-                    // polygons_for_single_material) could have same epsilon on
-                    // different height, e.g. going lower and higher up than the
-                    // currently regarded point, which would mean the transversal
-                    // part of this polygon is actually pointing inward.
-                    // The only possible way to solve this is on a higher level,
-                    // so this problem is moved to
-                    // material_function_for_polygons::normal_vector().
-                    // For now, just return the combined vector ignoring possible
-                    // neighbors, with vector pointing from high to low eps:
-
-
-                    // height of material with higher eps:
-                    double h = upper_layer_eps < lower_layer_eps ?
-                    1 - percentage_upper_layer :
-                    percentage_upper_layer;
-                    // square for better comparability with area:
-                    h *= h;
-                    // area of current 2x2 block (= 1 pixel):
-                    double area = area_cols[1][1] + area_cols[1][2] +
-                    area_cols[2][1] + area_cols[2][2];
-                    // scale transversal vector:
-                    result = result * (h * (1.0 - area));
-                    // add scaled z component:
-                    result.set_direction(Z, area * (1.0 - h) * z);
-                    // normalize:
-                    if (abs(result) != 0.0)
-                        result = result / abs(result);
-                }
+                /**
+                 * There's an interface in z and transversal direction. Such a
+                 * corner cannot be solved exactly, it also isn't clear how to
+                 * calculate the anisotropic averaging here. The best solution
+                 * is to do the same than in material_function::normal_vector:
+                 * That is, integrate chi*r over the unit sphere using the
+                 * Lebedev quadrature scheme:
+                 */
+                return get_gradient_from_sphere_quad(center, gradient);
             }
         }
-        // delete area_cols[] if arrays have been created earlier:
-        if (created_area_cols)
-            for (int i = 0; i < 4; ++i)
-                delete[] area_cols[i];
-            delete[] area_cols;
-        return result;
     }
+    return gradient * len;
+}
 
-    double polygons_for_single_material::get_area(int i, int j) {
-        if (!splitting_done)
-            update_splitting();
-        while (i < 0)
-            i += _nx;
-        while (i >= _nx)
-            i -= _nx;
-        while (j < 0)
-            j += _ny;
-        while (j >= _ny)
-            j -= _ny;
-        return _areas[i][j];
-    }
+double polygonal_material::get_area(int i, int j) {
+    if (!splitting_done)
+        update_splitting();
+    while (i < 0)
+        i += _nx;
+    while (i >= _nx)
+        i -= _nx;
+    while (j < 0)
+        j += _ny;
+    while (j >= _ny)
+        j -= _ny;
+    return _areas[i][j];
+}
 
-    void polygons_for_single_material::message_truncate(double* pt) {
-        if (pt[0] < 0 || pt[0] - 1e-8 > _nx * _block_size || //TODO hardcoded epsilon: yuck!
-            pt[1] < 0 || pt[1] - 1e-8 > _ny * _block_size)
-            // if point is exactly on upper border, this will also be called,
-            // but point will not really be truncated, so check bounds again.
-            master_printf(//"~");
-        "point (%f, %f) outside computational grid (%f, %f) - polygon will be truncated.\n",
-                            pt[0], pt[1], _nx * _block_size, _ny * _block_size);
-    }
+//     void polygonal_material::message_truncate(double* pt) {
+//
+//      I have deactivated this output, since we now clip the polygon to the
+//      computational cell in add_polygon.
+//         if (pt[0] + 1e-8 < 0 || pt[0] - 1e-8 > _nx * _block_size || //hardcoded epsilon: yuck!
+//             pt[1] + 1e-8 < 0 || pt[1] - 1e-8 > _ny * _block_size)
+//             // if point is exactly on upper border, this will also be called,
+//             // but point will not really be truncated, so check bounds again.
+//             master_printf(
+//                 "point (%.8f, %.8f) outside computational grid (%f, %f) - polygon will be truncated.\n",
+//                 pt[0], pt[1], _nx * _block_size, _ny * _block_size);
+//     }
 
-    void polygons_for_single_material::split_in_one_dimension(queue<double*>* arr, int arr_size, queue<double*>* qpol, int axis){
-        if (qpol->empty())
-            return;
-        double *f = qpol->front();
-        double *b = qpol->back();
-        // check if last point equals first point
-        if (f[0] != b[0] || f[1] != b[1]){
-            // add copy of first point to end:
-            b = new double[2];
-            b[0] = f[0];
-            b[1] = f[1];
-            qpol->push(b);
-        }
-        std::size_t pol_size = qpol->size();
-        double** matrix = new double*[pol_size];
-        for (std::size_t i = 0; i < pol_size; ++i) {
-            matrix[i] = qpol->front();
-            qpol->pop();
-        }
-        simple_polygon* pol = new simple_polygon(matrix, pol_size);
-        matrix = 0; //the memory pointed to by matrix is now owned by pol;
-        split_in_one_dimension(arr, arr_size, pol, axis);
-        delete pol;
-    }
-
-    void polygons_for_single_material::split_in_one_dimension(queue<double*>* arr, int arr_size, simple_polygon* pol, int axis){
-        // The split polygons will be added to arr:
-        // (arr item = polygon = queue of points)
-        // arr_size is the length of arr (the number of cols/rows to split the polygon into).
-        // pol will only be split along axis (0 or 1).
-        // The array arr must be initialized before call, but the items (the queues)
-        // must be empty.
-
-        double *pt, *pt2, *ept, *ept2;
-        int col, col2;
-        double u;
-        int other_axis = axis == 0 ? 1 : 0;
-
-        /* Go through all points. Check inside which column
-            *                                                e ach point is, and add the point to the polygon o*f
-            *                                                this column in arr. If column changes from one
-            *                                                point to next, calculate edge point (= intersection of line
-            *                                                connecting the two points and border between columns) and add
-            *                                                this point to polygons in both columns in arr:
-            *                                                arr[n]: (other points, previous point, edge point);
-            *                                                arr[n+1]: (other points, edge point, current point)
-            *                                                Algorithm only works if polygon's first point equals last point,
-            *                                                but this is always true for simple_polygon class.*/
-
-        pt = pol->get_polygon_point(0); //get first point
-        // note: There can't be any empty polygons (with zero points)
-        // at this point, since they have been sorted out in
-        // add_polygon already.
-        col = static_cast<int>(floor(pt[axis] / _block_size)); //TODO: special handling if point is exactly on border:
-        // such a point belongs to current col
-        // compare to col = ceil(pt) - 1
-        // don't add point to neighbouring column - it will happen automatically
-        // if next point is inside neighbouring column.
-        //calculate inside which column pt is
-        if (col >= 0 && col < arr_size) {
-            //add point to last polygon in column:
-            arr[col].push(pt);
-            // steal point (=double* with length 2) from pol,
-            // so it will not be deleted together with pol:
-            pol->take_ownership_of_point(0);
-        }
-        else
-            message_truncate(pt);
-
-        //go through remaining points:
-        for (int i = 1; i < pol->get_number_of_points(); ++i){
-            pt2 = pol->get_polygon_point(i); //get next point
-            //calculate inside which column pt2 is:
-            col2 = static_cast<int>(floor(pt2[axis] / _block_size));//TODO: special handling if point is exactly on border:
-            // such a point belongs to current col
-            // compare to col = ceil(pt) - 1
-            // don't add point to neighbouring column - it will happen automatically
-            // if next point is inside neighbouring column.
-            if (col == col2){
-                // pt2 is in same column than previous point;
-                // add point to last polygon in column :
-                if (col2 >= 0 && col2 < arr_size) {
-                    arr[col2].push(pt2);
-                    // steal point (=double* with length 2) from pol,
-                    // so it will not be deleted together with pol:
-                    pol->take_ownership_of_point(i);
-                }
-                else
-                    message_truncate(pt2);
-                pt = pt2;
-            }
-            else {
-                // pt2 is in different column than previous point ->
-                // add edge point to last polygon in both columns
-                // (and to additional columns in between, if neccessary);
-
-                // calculate slope of line:
-                u = (pt2[other_axis] - pt[other_axis]) / (pt2[axis] - pt[axis]);
-
-                if (col2 > col){ // line is going from left to right
-                    for (int c = col; c < col2; ++c){
-                        // calculate edge point:
-                        ept = new double[2];
-                        ept[axis] = _block_size * (c + 1); //right border
-                        ept[other_axis] = pt[other_axis] + (ept[axis] - pt[axis]) * u;
-                        if (c >= 0 && c < arr_size) {
-                            // add edge_point to right side of current c:
-                            arr[c].push(ept); // TODO: only add if ept differs from previous point
-                            // if previous point was exactly on border, it will not differ
-                            if (c + 1 != arr_size) {
-                                // add copy of edge_point to left side of next c:
-                                ept2 = new double[2];
-                                ept2[0] = ept[0];
-                                ept2[1] = ept[1];
-                                arr[c + 1].push(ept2);
-                            }
-                        }
-                        else if (c == -1)
-                            // add edge_point to left side of leftmost c:
-                            arr[c + 1].push(ept);
-                        else
-                            // both this and next column are outside computational volume
-                            delete[] ept;
-                    }
-                }
-                else { // line is going from right to left
-                    for (int c = col; c > col2; --c){
-                        // calculate edge point:
-                        ept = new double[2];
-                        ept[axis] = _block_size * c; //left border
-                        ept[other_axis] = pt[other_axis] + (ept[axis] - pt[axis]) * u;
-                        if (c >= 0 && c < arr_size) {
-                            // add edge_point to left side of current c:
-                            arr[c].push(ept);  // TODO: only add if ept differs from previous point
-                            // if previous point was exactly on border, it will not differ
-                            if (c != 0) {
-                                // add copy of edge_point to right side of next c:
-                                ept2 = new double[2];
-                                ept2[0] = ept[0];
-                                ept2[1] = ept[1];
-                                arr[c - 1].push(ept2);
-                            }
-                        }
-                        else if (c == arr_size)
-                            // add edge_point to right side of rightmost c:
-                            arr[c - 1].push(ept);
-                        else
-                            // both this and next column are outside computational volume
-                            delete[] ept;
-                    }
-                }
-                //add point2 after last edge point:
-                if (col2 >= 0 && col2 < arr_size) {
-                    arr[col2].push(pt2);
-                    // steal point (=double* with length 2) from pol,
-                    // so it will not be deleted together with pol:
-                    pol->take_ownership_of_point(i);
-                }
-                else
-                    message_truncate(pt2);
-                pt = pt2; // update current point
-                col = col2; // update current column
-            }
-        }
-        // TODO?: remove ghost lines & points: if polpoints enter and leave column again on the same side, start new polygon in that column.
-        // at end, go through first added point, if in same column than last added point - polygons should be merged.
-    }
-
-    double polygons_for_single_material::split_polygon(simple_polygon* pol,
-                                                        bool inner_polygon, queue<double*>* col_arr, queue<double*>* row_arr)
-    {
-        std::size_t pol_size;
-        double** matrix;
-        simple_polygon *spol;
-        double pol_area = 0;
-        double split_area = 0;
-
-        // split polygon into columns and save in col_arr:
-        split_in_one_dimension(col_arr, _nx, pol, 0);
-        // now, go through columns (col_arr) separately and split each
-        // polygon into rows:
-        for (int c = 0; c < _nx; ++c) {
-            if (!col_arr[c].empty()){
-                // split col_arr[c] in rows and save in row_arr:
-                split_in_one_dimension(row_arr, _ny, &col_arr[c], 1);
-                // after the call to split_in_one_dimension, all polygons in
-                // col_arr[c] are empty.
-
-                // go through row_arr, make polygons,
-                // get and save areas, delete polygons again:
-                for (int j = 0; j < _ny; ++j){
-                    pol_size = row_arr[j].size();
-                    if (pol_size > 0) { //don't add empty polygons
-                        double *f = row_arr[j].front();
-                        double *b = row_arr[j].back();
-                        // check if last point equals first point
-                        if (f[0] != b[0] || f[1] != b[1]){
-                            // add copy of first point to end:
-                            b = new double[2];
-                            b[0] = f[0];
-                            b[1] = f[1];
-                            pol_size ++;
-                        }
-                        else
-                            b = 0;
-                        matrix = new double*[pol_size];
-                        for (std::size_t k = 0; k < pol_size - int(b!=0); ++k){
-                            //get first point in queue (double[2] point):
-                            matrix[k] = row_arr[j].front();
-                            //pop this point:
-                            row_arr[j].pop();
-                        }
-                        if (b)
-                            matrix[pol_size - 1] = b;
-
-                        // now, row_arr should be empty
-                        spol = new simple_polygon(matrix, pol_size);
-                        //the memory pointed to by matrix is now owned by spol:
-                        matrix = 0;
-                        pol_area = spol->get_area();
-                        if (inner_polygon)
-                            _areas[c][j] -= pol_area;
-                        else
-                            _areas[c][j] += pol_area;
-                        split_area += pol_area;
-                        delete spol;
-                    }
-                }
-            }
-        }
-        return split_area;
-    }
-
-    void polygons_for_single_material::update_splitting() {
-        /*Splits all _polygons in blocks with size _blocksize x _blocksize.
-         * 
-         *  This is a quick and efficient algorithm, which can be us*ed for both simple
-         *  and for selfintersecting polygons, both convex and concave.
-         *
-         *  It might produce ghost lines in the case of concave polygons (i.e. concave
-         *  polygons will never be split in more than two polygons by one splitting border,
-         *  with ghost lines connecting otherwise seperate polygons). The additional area
-         *  created by these ghost lines is zero, so this will not be an issue for most
-         *  applications.*/
+void polygonal_material::update_splitting()
+{
+    /**
+     * Splits all _polygons into blocks with size _blocksize x _blocksize.
+     *
+     * This is a quick and efficient algorithm, which can be used for both
+     * simple and for selfintersecting polygons, both convex and concave.
+     *
+     * It might produce ghost lines in the case of concave polygons (i.e.
+     * concave polygons will never be split into more than two polygons by one
+     * splitting border, with ghost lines connecting otherwise seperate
+     * polygons). The additional area created by these ghost lines is zero, so
+     * this should not be an issue, as the eps function is solely calculated
+     * from areas. */
 
 
-        // first, split polygons into columns, then afterwards split these columns also in the rows.
-        // If it is not done in this way, blocks completely enclosed by a single polygon will be left out.
+    // First, split polygons into columns, then afterwards split these columns
+    // also into rows. If it is NOT done in this way, blocks completely
+    // enclosed by a single polygon will be left out.
 
-        // the column-wise split polygons will be temporary saved in col_arr,
-        // the row-wise split col_arr elements will be temporary saved in split_arr:
-        // (column item = polygon = queue of points)
-        queue<double*>* col_arr = new queue<double*>[_nx];
-        queue<double*>* row_arr = new queue<double*>[_ny];
+    // The column-wise split polygons will be temporary saved in col_arr,
+    // the row-wise split col_arr elements will be temporary saved in row_arr:
+    // (xxx_arr item = vector of points = polygon)
+    vector<double*>* col_arr = new vector<double*>[_nx];
+    vector<double*>* row_arr = new vector<double*>[_ny];
 
-        polygon* pol;
-        simple_polygon* spol;
-        double area = 0; // area calculated directly from given polygons
-        double area2 = 0; // area calculated from split polygons, for comparison
-        // go through each polygon separately:
-        while (!_polygons.empty()){
-            pol = _polygons.front();
+    polygon* pol;
+    simple_polygon* spol;
+    double area = 0; // area calculated directly from given polygons
+    double area2 = 0; // area calculated from split polygons, for comparison
+    // go through each polygon separately:
+    for (size_t i = 0; i < _polygons.size(); ++i) {
+        pol = _polygons[i];
+        if (pol->get_number_of_points() > 2) {
             area += pol->get_area();
             // split polygon into blocks, save area sizes in _areas:
             area2 += split_polygon(pol, false, col_arr, row_arr);
-            //col_arr and row_arr are empty after split_polygon()
             // repeat for inner polygons:
-            for (int i = 0; i < pol->get_number_inner_polygons(); ++i){
+            for (std::size_t i = 0; i < pol->get_number_inner_polygons(); ++i){
                 spol = pol->get_inner_polygon(i);
-                // split polygon into blocks, save area sizes in _areas:
-                area2 -= split_polygon(spol, true, col_arr, row_arr);
-                //col_arr and row_arr are empty after split_polygon()
+                if (spol->get_number_of_points() > 2) {
+                    // split polygon into blocks, update area sizes in _areas:
+                    area2 -= split_polygon(spol, true, col_arr, row_arr);
+                }
             }
-            delete pol;
-            _polygons.pop();
         }
+        delete pol;
+        _polygons[i] = 0;
+    }
+    _polygons.clear();
 
-        delete[] col_arr; //delete array, free memory
-        delete[] row_arr; //delete array, free memory
-
-        if (fabs(area - area2) > 1e-6) { //TODO: hardcoded epsilon: yuck!
-            master_printf("input polygons area: %f\n", area);
-            master_printf("area after splitting: %f\n", area2);
-            master_printf("WARNING, total polygon area differs after splitting, which could lead to errors in defined structure.\n");
-            master_printf("Please provide only simple, non self-intersecting polygons\n");
+    // Make sure the arr items are empty:
+    for (int i = 0; i < _nx; ++i) {
+        if (!col_arr[i].empty()) {
+            // Not empty yet. Delete leftover points to prevent memory leaks:
+            for (size_t j = 0; j < col_arr[i].size(); ++j) {
+                delete[] col_arr[i][j];
+            }
+            col_arr[i].clear();
         }
+    }
+    delete[] col_arr;
+    for (int i = 0; i < _ny; ++i) {
+        if (!row_arr[i].empty()) {
+            // Not empty yet. Delete leftover points to prevent memory leaks:
+            for (size_t j = 0; j < row_arr[i].size(); ++j) {
+                delete[] row_arr[i][j];
+            }
+            row_arr[i].clear();
+        }
+    }
+    delete[] row_arr;
+    // area is real area, but must be relative area occupied per block
+    // like area2, so normalize with block area:
+    double block_area = _block_size * _block_size;
+    // hardcoded epsilon, but it's okay, since the areas are normalized:
+    if (fabs(area / block_area - area2) > 1e-6) {
+        master_printf("input polygons area: %f\n", area);
+        master_printf("area after splitting: %f\n", area2 * block_area);
+        master_printf("WARNING, total polygon area differs after splitting, which could lead to errors in defined structure.\n");
+        master_printf("Please provide only simple, non self-intersecting polygons\n");
+    }
 
-        bool overlap_message_printed = false;
-        // areas must be relative area occupied per block, so normalize with
-        // block area:
-        double block_area = _block_size * _block_size;
-        for (int i = 0; i < _nx; ++i){
-            for (int j = 0; j < _ny; ++j) {
-                _areas[i][j] /= block_area;
-                // try to round to trivial cases:
-                if (fabs(_areas[i][j]) < 1E-12)
+    // Try to find overlapping polygons and print a warning:
+    bool overlap_message_printed = false;
+    for (int i = 0; i < _nx; ++i){
+        for (int j = 0; j < _ny; ++j) {
+            if ((_areas[i][j] < 0) || (_areas[i][j] > 1)) {
+                if (!overlap_message_printed) {
+                    // print the message only once (per material)
+                    master_printf("WARNING: There are overlapping polygons. Structure will be inexact.\n");
+                    overlap_message_printed = true;
+                }
+                if (_areas[i][j] < 0)
                     _areas[i][j] = 0.0;
-                else if (fabs(1.0 - _areas[i][j]) < 1E-12)
+                else
                     _areas[i][j] = 1.0;
-                // Catch overlapping polygons. This will not catch all overlapping polygons, but at least the user gets a message:
-                if ((_areas[i][j] < 0) || (_areas[i][j] > 1)) {
-                    if (!overlap_message_printed) {
-                        // print the message only once (per material)
-                        master_printf("WARNING: There are overlapping polygons. Structure will be inexact.\n");
-                        overlap_message_printed = true;
-                    }
-                    if (_areas[i][j] < 0)
-                        _areas[i][j] = 0.0;
+            }
+        }
+    }
+    splitting_done = true;
+};
+
+double polygonal_material::split_polygon(
+    simple_polygon* pol, bool inner_polygon,
+    vector<double*>* col_arr, vector<double*>* row_arr)
+{
+    std::size_t pol_size;
+    double pol_area = 0;
+    double split_area = 0;
+
+    // split polygon into columns and save in col_arr:
+    split_in_one_dimension(
+        col_arr, _nx,
+        &pol->get_polygon_point(0), pol->get_number_of_points(), 0);
+
+    // now, go through columns (col_arr) separately and split each
+    // polygon into rows:
+    for (int c = 0; c < _nx; ++c) {
+        if (!col_arr[c].empty()){
+            // split col_arr[c] in rows and save in row_arr:
+            split_in_one_dimension(
+                row_arr, _ny,
+                col_arr[c].data(), col_arr[c].size(), 1);
+
+            // go through row_arr, get and save areas,
+            // delete split polygon points:
+            for (int j = 0; j < _ny; ++j){
+                pol_size = row_arr[j].size();
+                if (pol_size > 3) {
+                    // get area:
+                    pol_area = get_polygon_area(row_arr[j].data(), pol_size, 2);
+                    if (inner_polygon)
+                        _areas[c][j] -= pol_area;
                     else
-                        _areas[i][j] = 1.0;
+                        _areas[c][j] += pol_area;
+                    split_area += pol_area;
+
+                    // delete polygon points:
+                    for (std::size_t k = 0; k < pol_size; ++k){
+                        delete[] row_arr[j].at(k);
+                    }
+                    row_arr[j].clear();
                 }
             }
         }
-        splitting_done = true;
-    };
+    }
+    return split_area;
+}
 
-    vec polygons_for_single_material::rightanglerotate_2Dvec(
-        vec v, int num, bool mirror_x_before, bool mirror_y_before) const
-    {
-        while (num < 0) // modulo works strange for negative numbers
-            num += 4;
-        num %= 4;
-        double x = v.x() * (mirror_x_before ? -1 : 1);
-        double y = v.y() * (mirror_y_before ? -1 : 1);
-        switch (num)
-        {
-            case 0 : v.set_direction(X, x); v.set_direction(Y, y); break;
-            case 1 : v.set_direction(X, -y); v.set_direction(Y, x); break;
-            case 2 : v.set_direction(X, -x); v.set_direction(Y, -y); break;
-            case 3 : v.set_direction(X, y); v.set_direction(Y, -x); break;
-            default : abort("strange error in rightanglerotate_2Dvec");
+void polygonal_material::split_in_one_dimension(
+    std::vector< double* >* arr, int arr_size,
+    double** matrix, int matrix_len, int axis){
+    // The split polygons will be added to arr:
+    // (arr item = polygon = vector of points)
+    // arr_size is the length of arr (the number of cols/rows to split the polygon into).
+
+    double *pt, *pt2, *ept, *ept2;
+    int col, col2;
+    double u;
+    int other_axis = axis == 0 ? 1 : 0;
+
+    // Make sure the arr items are empty:
+    for (int i = 0; i < arr_size; ++i) {
+        if (!arr[i].empty()) {
+            // Not empty yet. Delete leftover points to prevent memory leaks:
+            for (size_t j = 0; j < arr[i].size(); ++j) {
+                delete[] arr[i][j];
+            }
+            arr[i].clear();
         }
-        return v;
-    };
+    }
 
-    vec polygons_for_single_material::calc_grad_case1(const double A1, const double A2) const
-    {
-        double x1 = 2.0 * (sqrt(A1 * (A1 + A2)) - A1);
-        double x2 = 2.0 * A2 - x1;
-        double dy = x2 - x1;
-        double a = sqrt(1.0 + dy * dy);
-        return is_3D() ? vec(1.0 / a, dy / a, 0.0) : vec(1.0 / a, dy / a);
-    };
+    if (matrix_len == 0)
+        return;
 
-    vec polygons_for_single_material::calc_grad_case2(const double A1, const double A2) const
+    // Note: In the following, I will only talk about columns, but think
+    // of them as rows if axis=1.
+
+    // Note 2: The resulting split polygons will be scaled and shifted along
+    // axis to only have values between 0 and 1. The reason for this is that
+    // at the end after both diretions have been split, trivial polygons which
+    // fill a whole block will have an area of exactly one and we don't need
+    // to care about floating point rounding errors which we would have
+    // otherwise.
+
+    // Go through all points. Check inside which column
+    // each point is, and add the point to the polygon of
+    // this column in arr. If column changes from one
+    // point to next, calculate edge point (= intersection of line
+    // connecting the two points and border between columns) and add
+    // this point to polygons in both columns in arr, in this order:
+    // arr[n]: (other points, previous point, edge point);
+    // arr[n+1]: (other points, edge point, current point).
+    // Algorithm only works if polygon's first point equals last point.
+    pt = matrix[0]; //get first point
+    // Calculate inside which column pt is:
+    col = static_cast<int>(floor(pt[axis] / _block_size));
+    if (col >= 0 && col < arr_size) {
+        // Add point to polygon in column:
+        arr[col].push_back(pt);
+        // This point now belongs to arr[col], it should not be
+        // deleted when matrix' items are deleted:
+        matrix[0] = 0;
+    }
+//     else
+//         message_truncate(pt);
+
+    //go through remaining points:
+    for (int i = 1; i < matrix_len; ++i)
     {
-        double y1, y2, dx, a;
-        if (A1 == 0.0) {
-            y1 = 0.0;
-            y2 = 2.0 * (1.0 - A2);
+        pt2 = matrix[i]; //get next point
+        //calculate inside which column pt2 is:
+        col2 = static_cast<int>(floor(pt2[axis] / _block_size));
+        if (col == col2){
+            // pt2 is in same column than previous point;
+            // add point to polygon in column :
+            if (col2 >= 0 && col2 < arr_size) {
+                arr[col2].push_back(pt2);
+                // This point now belongs to arr[col2], it should not be
+                // deleted when matrix' items are deleted:
+                matrix[i] = 0;
+            }
+//             else
+//                 message_truncate(pt2);
         }
         else {
-            y1 = 2.0 * (A1 + sqrt(A1 * (1.0 - A2)));
-            y2 = y1 * (0.5 * y1 / A1 - 1.0);
-        }
-        dx = y1 + y2;
-        a = sqrt(1.0 + dx * dx);
-        return is_3D() ? vec(dx / a, 1.0 / a, 0.0) : vec(dx / a, 1.0 / a);
-    };
+            // pt2 is in different column than previous point ->
+            // add edge point to polygons in both columns
+            // (and to additional columns in between, if neccessary);
 
-    vec polygons_for_single_material::calc_grad_case3(const double A1, const double A2) const
-    {
-        double dy = A2 - A1;
-        double a = sqrt(1.0 + dy * dy);
-        return is_3D() ? vec(1.0 / a, dy / a, 0.0) : vec(1.0 / a, dy / a);
-    };
+            // calculate slope of line:
+            u = (pt2[other_axis] - pt[other_axis]) / (pt2[axis] - pt[axis]);
 
-    vec polygons_for_single_material::calc_gradient_4x4(double** areas) const
-    {
-        double A11, A12, A21, A22, above_left, below_left, left_bottom;
-        double above_right, below_right, right_top;
-        // First, find out which rough position the interface has relative to the
-        // squares, then we know which of the three cases to calculate and which two
-        // squares to use for the calculation.
-        // Since there are many possibilities, first check all possible positions
-        // that are unique for one orientation. If the rough position could not be
-        // found, rotate the whole problem by 90 degrees and try again, rotate the
-        // resulting vector back 90 degrees accordingly if it could be calculated,
-        // otherwise rotate more, and so forth:
-        for (int rotate = 0; rotate < 4; rotate++)
-        {
-            switch (rotate)
-            {
-                case 0:
-                    A11 = areas[1][1];
-                    A12 = areas[1][2];
-                    A21 = areas[2][1];
-                    A22 = areas[2][2];
-                    above_left = areas[1][3];
-                    below_left = areas[1][0];
-                    left_bottom = areas[0][1];
-                    above_right = areas[2][3];
-                    below_right = areas[2][0];
-                    right_top = areas[3][2];
-                    break;
-                case 1: // rotate blocks in anticlockwise-direction:
-                    A11 = areas[2][1];
-                    A12 = areas[1][1];
-                    A21 = areas[2][2];
-                    A22 = areas[1][2];
-                    above_left = areas[0][1];
-                    below_left = areas[3][1];
-                    left_bottom = areas[2][0];
-                    above_right = areas[0][2];
-                    below_right = areas[3][2];
-                    right_top = areas[1][3];
-                    break;
-                case 2: // rotate blocks in anticlockwise-direction:
-                    A11 = areas[2][2];
-                    A12 = areas[2][1];
-                    A21 = areas[1][2];
-                    A22 = areas[1][1];
-                    above_left = areas[2][0];
-                    below_left = areas[2][3];
-                    left_bottom = areas[3][2];
-                    above_right = areas[1][0];
-                    below_right = areas[1][3];
-                    right_top = areas[0][1];
-                    break;
-                default: // rotate == 3: // rotate blocks in anticlockwise-direction:
-                    A11 = areas[1][2];
-                    A12 = areas[2][2];
-                    A21 = areas[1][1];
-                    A22 = areas[2][1];
-                    above_left = areas[3][2];
-                    below_left = areas[0][2];
-                    left_bottom = areas[1][3];
-                    above_right = areas[3][1];
-                    below_right = areas[0][1];
-                    right_top = areas[2][0];
-                    break;
+            if (col2 > col){ // line is going from left to right
+                for (int c = col; c < col2; ++c){
+                    // calculate edge point:
+                    ept = new double[2];
+                    ept[axis] = _block_size * (c + 1); //right border
+                    ept[other_axis] = pt[other_axis] + (ept[axis] - pt[axis]) * u;
+                    ept[axis] = 1; // right border, scaled and shifted to first block
+                    if (c >= 0 && c < arr_size) {
+                        // add edge_point to right side of current c:
+                        arr[c].push_back(ept);
+                        if (c + 1 != arr_size) {
+                            // add copy of edge_point to left side of next c:
+                            ept2 = new double[2];
+                            ept2[axis] = 0; //left border
+                            ept2[other_axis] = ept[other_axis];
+                            arr[c + 1].push_back(ept2);
+                        }
+                    }
+                    else if (c == -1) {
+                        // add edge_point to left side of leftmost c:
+                        ept[axis] = 0;
+                        arr[c + 1].push_back(ept);
+                    }
+                    else {
+                        // both this and next column are outside computational volume
+                        delete[] ept;
+                    }
+                }
             }
-            // check case:
-            if ((A11 == 0 && A12 == 0 && A21 == 0 && A22 == 0) ||
-                (A11 == 1 && A12 == 1 && A21 == 1 && A22 == 1))
-                // no border in center block
-                return vec(D2 + int(is_3D()), 0.0);
-            if ((A11 == 0 && A22 == 0 && A12 != 0 && A21 != 0) ||
-                (A12 == 0 && A21 == 0 && A11 != 0 && A22 != 0))
-                // two separate polygons inside block;
-                // the resolution should be increased
-                return vec(D2 + int(is_3D()), 0.0);
-            if (A12 == 0 && A21 == 0 && A22 == 0) // A11 != 0
+            else { // line is going from right to left
+                for (int c = col; c > col2; --c){
+                    // calculate edge point:
+                    ept = new double[2];
+                    ept[axis] = _block_size * c; //left border
+                    ept[other_axis] = pt[other_axis] + (ept[axis] - pt[axis]) * u;
+                    ept[axis] = 0; //left border, scaled and shifted to first block
+                    if (c >= 0 && c < arr_size) {
+                        // add edge_point to left side of current c:
+                        arr[c].push_back(ept);
+                        // if previous point was exactly on border, it will not differ
+                        if (c != 0) {
+                            // add copy of edge_point to right side of next c:
+                            ept2 = new double[2];
+                            ept2[axis] = 1; // right border
+                            ept2[other_axis] = ept[other_axis];
+                            arr[c - 1].push_back(ept2);
+                        }
+                    }
+                    else if (c == arr_size) {
+                        // add edge_point to right side of rightmost c:
+                        ept[axis] = 1;
+                        arr[c - 1].push_back(ept);
+                    }
+                    else {
+                        // both this and next column are outside computational volume
+                        delete[] ept;
+                    }
+                }
+            }
+            //add point2 after last edge point:
+            if (col2 >= 0 && col2 < arr_size) {
+                // pt2 will be scaled and shifted later, at the end of the
+                // next iteration, but add pointer to it now:
+                arr[col2].push_back(pt2);
+                // This point now belongs to arr[col2], it should not be
+                // deleted when matrix' items are deleted:
+                matrix[i] = 0;
+            }
+//             else
+//                 message_truncate(pt2);
+        }
+        // Scale and shift point to first block:
+        pt[axis] = pt[axis] / _block_size - col;
+        pt = pt2; // update current point
+        col = col2; // update current column
+    }
+    // Scale and shift point to first block:
+    pt[axis] = pt[axis] / _block_size - col;
+
+    // Finalize all new split polygons in arr, i.e. they must all be closed:
+    for (int i = 0; i < arr_size; ++i) {
+        if (arr[i].size() > 0) {
+            pt = arr[i].front();
+            pt2 = arr[i].back();
+            if (pt[0] != pt2[0] || pt[1] != pt2[1]) {
+                pt2 = new double[2];
+                pt2[0] = pt[0];
+                pt2[1] = pt[1];
+                arr[i].push_back(pt2);
+            }
+        }
+    }
+}
+
+vec polygonal_material::rightanglerotate_2Dvec(
+    vec v, int num, bool mirror_x_before, bool mirror_y_before) const
+{
+    while (num < 0)
+        num += 4;
+    num %= 4;
+    double x = v.x() * (mirror_x_before ? -1 : 1);
+    double y = v.y() * (mirror_y_before ? -1 : 1);
+    switch (num)
+    {
+        case 0 : v.set_direction(X, x); v.set_direction(Y, y); break;
+        case 1 : v.set_direction(X, -y); v.set_direction(Y, x); break;
+        case 2 : v.set_direction(X, -x); v.set_direction(Y, -y); break;
+        case 3 : v.set_direction(X, y); v.set_direction(Y, -x); break;
+        default : abort("strange error in rightanglerotate_2Dvec");
+    }
+    return v;
+};
+
+vec polygonal_material::calc_grad_case1(const double A1, const double A2) const
+/*
+ * Calculate the normal of the line intersecting the two 1x1 squares. The line
+ * crosses the squares as shown in the diagram, with the constraints below:
+ * (Note: the aspect ratio is not right, think of the blocks of being square)
+ *
+ *     -|--------------|-
+ *      |              |   A1: area of upper triangle
+ *   y1 |\             |   A2: area of lower trapezoid
+ *      |.\            |   y1: height of upper triangle
+ *      |..\           |   y2 + y1: height of combined triangle A1 + A2
+ *      |A1.\          |   x1: width of upper triangle
+ *     -|----\---------|-  x2: width of combined triangle A1 + A2
+ *      |...x1\        |
+ *      |......\       |   constraints:
+ *   y2 |.......\      |   A1 > 0             A2 > 0
+ *      |..A2....\     |   0 < x1 <= 0.5      0 < x2 <= 1
+ *      |.........\    |   0 < y1 <= 1        y2 == 1
+ *     -|----------\---|-
+ *                x2
+ *
+ * The gradient (unnormalized) is: vec(1, x2 - x1)
+ *
+ *   (I): A1 = 0.5 * x1 * y1      <=>   (I'): y1 = 2*A1 / x1
+ *  (II): A2 = 0.5 * (x1 + x2)    <=>  (II'): x2 = 2*A2 - x1
+ * (III): x2 / x1 = (1 + y1) / y1 <=> (III'): x1 + x1*y1 = x2*y1
+ */
+{
+    // Substitute y1 and x2 in (III') with (I') and (II'), respectively, to
+    // get an equation for x1:
+    double x1 = 2.0 * (sqrt(A1 * (A1 + A2)) - A1);
+    // and get x2 from (II):
+    double x2 = 2.0 * A2 - x1;
+    double dy = x2 - x1;
+    double a = sqrt(1.0 + dy * dy);
+    return is_3D() ? vec(1.0 / a, dy / a, 0.0) : vec(1.0 / a, dy / a);
+};
+
+vec polygonal_material::calc_grad_case2(const double A1, const double A2) const
+/*
+ * Calculate the normal of the line intersecting the two 1x1 squares. The line
+ * crosses the squares as shown in the diagram, with the constraints below:
+ * (Note: the aspect ratio is not right, think of the blocks of being square)
+ *
+ *     -|---------|-       A1: area of upper triangle
+ *      |         |        A2: area of lower trapezoid
+ *      |\        |        y1: height of upper triangle
+ *      |.\       |        y2: height of the lower unfilled triangle (the
+ *   y1 |..\      |            triangle with area (1.0-A2) )
+ *      |A1.\     |        x1: width of upper triangle
+ *     -|----\----|-       x2: width of lower trapezoid (at base)
+ *      |..x1.\   |
+ *      |......\  |y2      constraints:
+ *    1 |..A2...\ |        A1 > 0            A2 > 0.5
+ *      |........\|        0 < x1 < 1        x2 == 1
+ *      |.........|        0 < y1 <= 1       0 < y2 <= 1
+ *     -|---------|-
+ *          x2
+ *
+ * The gradient (unnormalized) is: vec(y1 + y2, 1)
+ *
+ *   (I):      A1 = 0.5 * x1 * y1       <=>   (I'): x1 = 2*A1 / y1
+ *  (II):  1 - A2 = 0.5 * y2 * (1 - x1) <=>  (II'): y2 = 2 * (1-A2) / (1-x1)
+ * (III): y1 / y2 = x1 / (1 - x1)       <=> (III'): y1 * (1-x1) = y2 * x1
+ */
+{
+    double y1, y2, dx, a;
+    if (A1 != 0) {
+        // Substitute y2 in (III') with (II'), then substitute x1 with (I') to
+        // get an equation for y1:
+        y1 = 2.0 * (A1 + sqrt(A1 * (1.0 - A2)));
+        // Now substitute x1 in (III') with (I'):
+        y2 = y1 * (0.5 * y1 / A1 - 1.0);
+    }
+    else {
+        // In get_2D_gradient() it is already made sure that this can never
+        // be called with A1 == 0, but this is just to make double sure we
+        // never get a division by zero.
+        y1 = 0.0;
+        y2 = 2.0 * (1.0 - A2);
+    }
+
+    dx = y1 + y2;
+    a = sqrt(1.0 + dx * dx);
+    return is_3D() ? vec(dx / a, 1.0 / a, 0.0) : vec(dx / a, 1.0 / a);
+};
+
+vec polygonal_material::calc_grad_case3(const double A1, const double A2) const
+/*
+ * Calculate the normal of the line intersecting the two 1x1 squares. The line
+ * crosses the squares as shown in the diagram, with the constraints below:
+ * (Note: the aspect ratio is not right, think of the blocks of being square)
+ *
+ *     -|--\-------------|-  A1: area of upper trapezoid
+ *      |.x0\            |   A2: area of lower trapezoid
+ *      |....\           |   y1: height of upper trapezoid
+ *   y1 |.....\          |   y2: height of lower trapezoid
+ *      |..A1..\         |   x0: width of upper trapezoid (at top)
+ *      |.......\        |   x1: width of upper trapezoid (at base)
+ *     -|--------\-------|-  x2: width of lower trapezoid (at base)
+ *      |.......x1\      |
+ *      |........,,\     |   constraints:
+ *   y2 |....A2....,\    |   A1 > 0         A2 > 0
+ *      |............\   |   0 < x0 <= 1    0 < x1 <= 1    0 < x2 <= 1
+ *      |.............\  |   y1 == 1        y2 == 1
+ *     -|--------------\-|-
+ *                    x2
+ *
+ * The gradient (unnormalized) is: vec(1, x2 - x1)
+ *
+ *   (I): A2 = 0.5 * (x1 + x2)          <=>   (I'): x2 = 2 * A2 - x1
+ *  (II): A1 + A2 = (x0 + x2) = 2 * x1  <=>  (II'): x1 = (A1 + A2) / 2
+ *
+ *          (I')             (II')
+ *  x2 - x1 ==== 2*A2 - 2*x1 ==== 2*A2 - A1 - A2 = A2 - A1
+ */
+{
+    double dy = A2 - A1;
+    double a = sqrt(1.0 + dy * dy);
+    return is_3D() ? vec(1.0 / a, dy / a, 0.0) : vec(1.0 / a, dy / a);
+};
+
+vec polygonal_material::get_2D_gradient(double** areas4x4) const
+/*
+ * These are the three fundamentally different cases how a straight line might
+ * cross two blocks. Every other case can be transformed to one of these by
+ * (90-degree-)rotating and/or flipping the problem and transforming the
+ * resulting gradient back afterwards. (Note: The aspect ratios in these
+ * scetches are not the same and not correct. Think of all blocks being exactly
+ * square). The crucial part here is on which side the line crosses a block's
+ * outer boundary:
+ *
+ *   case 1:                case 2:           case 3:
+ *  -|--------------|-     -|---------|-     -|--\-------------|-
+ *   |              |       |         |       |...\            |
+ *   |\             |       |\        |       |....\           |
+ *   |.\            |       |.\       |       |.....\          |
+ *   |..\           |       |..\      |       |..A1..\         |
+ *   |A1.\          |       |A1.\     |       |.......\        |
+ *  -|----\---------|-     -|----\----|-     -|--------\-------|-
+ *   |.....\        |       |.....\   |       |.........\      |
+ *   |......\       |       |......\  |       |........,,\     |
+ *   |..A2...\      |       |..A2...\ |       |....A2....,\    |
+ *   |........\     |       |........\|       |............\   |
+ *   |.........\    |       |.........|       |.............\  |
+ *  -|----------\---|-     -|---------|-     -|--------------\-|-
+ *
+ * Given only the areas A1 and A2, the exact normal vector on the surface can
+ * be calculated with calc_grad_case1(A1, A2) to calc_grad_case3(A1, A2),
+ * depending on the case.
+ *
+ * In this method, we will start with the following setup of interesting
+ * squares amongst the 4x4 input matrix:
+ *
+ *  ^ y
+ *  |
+ *  |
+ *   ----> x
+ *
+ *  |-------------|-------------|-------------|-------------|
+ *  |             |             |             |             |
+ *  |             |             |             |             |
+ *  |             | above_left  | above_right |             |
+ *  |             |             |             |             |
+ *  |             |             |             |             |
+ *  |-------------|-------------|-------------|-------------|
+ *  |             |             |             |             |
+ *  |             |             |             |             |
+ *  |             |     A12     |     A22     |  right_top  |
+ *  |             |             |             |             |
+ *  |             |             |             |             |
+ *  |-------------|-------------|-------------|-------------|
+ *  |             |             |             |             |
+ *  |             |             |             |             |
+ *  | left_bottom |     A11     |     A21     |             |
+ *  |             |             |             |             |
+ *  |             |             |             |             |
+ *  |-------------|-------------|-------------|-------------|
+ *  |             |             |             |             |
+ *  |             |             |             |             |
+ *  |             | below_left  | below_right |             |
+ *  |             |             |             |             |
+ *  |             |             |             |             |
+ *  |-------------|-------------|-------------|-------------|
+ *
+ * Then, by checking which of the inner squares (A11 - A22) have an interface
+ * (they have one when their area is > 0 and < 1) and also checking the area of
+ * their neighboring squares (that's where we need the outer squares), we can
+ * find out which of the 3 cases and which 2 squares to use for the actual
+ * calculation of the normalized gradient.
+ *
+ * Since there are many possibilities, first check all possible cases
+ * that are unique for one orientation, then rotate the whole problem by 90
+ * degrees and try again (rotate the resulting vector back 90 degrees
+ * accordingly if it could be calculated).
+ *
+ */
+{
+    double A11, A12, A21, A22, above_left, below_left, left_bottom;
+    double above_right, below_right, right_top;
+
+    for (int rotate = 0; rotate < 4; rotate++)
+    {
+        switch (rotate)
+        {
+            case 0:
+                A11 = areas4x4[1][1];
+                A12 = areas4x4[1][2];
+                A21 = areas4x4[2][1];
+                A22 = areas4x4[2][2];
+                above_left = areas4x4[1][3];
+                below_left = areas4x4[1][0];
+                left_bottom = areas4x4[0][1];
+                above_right = areas4x4[2][3];
+                below_right = areas4x4[2][0];
+                right_top = areas4x4[3][2];
+                break;
+            case 1: // rotate blocks in anticlockwise-direction:
+                A11 = areas4x4[2][1];
+                A12 = areas4x4[1][1];
+                A21 = areas4x4[2][2];
+                A22 = areas4x4[1][2];
+                above_left = areas4x4[0][1];
+                below_left = areas4x4[3][1];
+                left_bottom = areas4x4[2][0];
+                above_right = areas4x4[0][2];
+                below_right = areas4x4[3][2];
+                right_top = areas4x4[1][3];
+                break;
+            case 2: // rotate blocks in anticlockwise-direction:
+                A11 = areas4x4[2][2];
+                A12 = areas4x4[2][1];
+                A21 = areas4x4[1][2];
+                A22 = areas4x4[1][1];
+                above_left = areas4x4[2][0];
+                below_left = areas4x4[2][3];
+                left_bottom = areas4x4[3][2];
+                above_right = areas4x4[1][0];
+                below_right = areas4x4[1][3];
+                right_top = areas4x4[0][1];
+                break;
+            default: // rotate == 3: // rotate blocks in anticlockwise-direction:
+                A11 = areas4x4[1][2];
+                A12 = areas4x4[2][2];
+                A21 = areas4x4[1][1];
+                A22 = areas4x4[2][1];
+                above_left = areas4x4[3][2];
+                below_left = areas4x4[0][2];
+                left_bottom = areas4x4[1][3];
+                above_right = areas4x4[3][1];
+                below_right = areas4x4[0][1];
+                right_top = areas4x4[2][0];
+                break;
+        }
+
+        // check case:
+        if ((A11 == 0 && A12 == 0 && A21 == 0 && A22 == 0) ||
+            (A11 == 1 && A12 == 1 && A21 == 1 && A22 == 1)) {
+            // no border in inner 4 blocks
+            return vec(ndim(D2 + int(is_3D())), 0.0);
+        }
+        if ((A11 == 0 && A22 == 0 && A12 != 0 && A21 != 0) ||
+            (A12 == 0 && A21 == 0 && A11 != 0 && A22 != 0) ||
+            (A11 != 1 && A22 != 1 && A12 == 1 && A21 == 1) ||
+            (A12 != 1 && A21 != 1 && A11 == 1 && A22 == 1)) {
+            // These cases can only mean there are multiple separate polygons
+            // inside the 2x2 center block; i.e. the resolution is way too bad.
+            return vec(ndim(D2 + int(is_3D())), 0.0);
+        }
+        if (A12 == 0 && A21 == 0 && A22 == 0) // only A11 != 0
+        {
+            if (left_bottom < below_left) {
+                return rightanglerotate_2Dvec(
+                    calc_grad_case2(A11, below_left),
+                    rotate
+                );
+            }
+            else if (left_bottom == 0) {
+                // which means below_left and left_bottom are zero,
+                // and we have an isolated polygon only inside A11:
+                return vec(ndim(D2 + int(is_3D())), 0.0);
+            }
+            else {
+                return rightanglerotate_2Dvec(
+                    calc_grad_case2(A11, left_bottom),
+                    rotate - 1, true, false
+                );
+            }
+        }
+        if (A11 != 0 && A12 != 0)
+        {
+            if (A21 == 0 && A22 == 0)
             {
-                if (left_bottom < below_left)
+                if ((above_left != 0 && below_left != 0) ||
+                    (above_left == 0 && below_left == 0)) {
+                    // First condition: solution is exact if no corner;
+                    // Second one means there is a corner somewhere,
+                    // then this is just approx. solution
                     return rightanglerotate_2Dvec(
-                        calc_grad_case2(A11, below_left),
-                                                rotate);
-                    else
-                        return rightanglerotate_2Dvec(
-                            calc_grad_case2(A11, left_bottom),
-                                                    rotate - 1, true, false);
-            }
-            if (A11 != 0 && A12 != 0)
-            {
-                if (A21 == 0 && A22 == 0)
-                {
-                    if ((above_left != 0 && below_left != 0) ||
-                        (above_left == 0 && below_left == 0))
-                        // last one means there is a corner somewhere;
-                        // then calculate approx. easy solution
-                        return rightanglerotate_2Dvec(
-                            calc_grad_case3(A12, A11), rotate);
-                        else if (above_left == 0) // below_left != 0
-                            return rightanglerotate_2Dvec(calc_grad_case1(A12, A11),
-                                                        rotate);
-                            else // above_left != 0; below_left == 0
-                                return rightanglerotate_2Dvec(calc_grad_case1(A11, A12),
-                                                            rotate, false, true);
+                        calc_grad_case3(A12, A11), rotate);
                 }
-                else if (A21 != 0 && A22 == 0)
-                {
-                    if (A12 < A21)
-                        return rightanglerotate_2Dvec(
-                            calc_grad_case2(A12, A11),
-                                                    rotate);
-                        else
-                            return rightanglerotate_2Dvec(
-                                calc_grad_case2(A21, A11),
-                                                        rotate - 1, true, false);
+                else if (above_left == 0) { // below_left != 0
+                    return rightanglerotate_2Dvec(
+                        calc_grad_case1(A12, A11),
+                        rotate
+                    );
                 }
-                else if (A21 != 0 && A22 != 0) // all != 0
-                {
-                    if (A11 == 1 && A12 != 1 && A21 != 1 && A22 != 1)
-                    {
-                        if (A12 < A21)
-                            return rightanglerotate_2Dvec(
-                                calc_grad_case2(A22, A21),
-                                                        rotate);
-                            else
-                                return rightanglerotate_2Dvec(
-                                    calc_grad_case2(A22, A12),
-                                                            rotate - 1, true, false);
-                    }
-                    else if (A11 == 1 && A12 == 1 && A21 != 1 && A22 != 1)
-                    {
-                        if ((above_right != 1 && below_right != 1) ||
-                            (above_right == 1 && below_right == 1))
-                            // last one means there is a corner somewhere;
-                            // then calculate approx. easy solution
-                            return rightanglerotate_2Dvec(
-                                calc_grad_case3(A22, A21), rotate);
-                            else if (above_right != 1) // below_right == 1
-                                return rightanglerotate_2Dvec(
-                                    calc_grad_case1(1.0 - A21, 1.0 - A22),
-                                                            rotate);
-                                else // above_right == 1; below_right != 1
-                                    return rightanglerotate_2Dvec(
-                                        calc_grad_case1(1.0 - A22, 1.0 - A21),
-                                                                rotate, false, true);
-                    }
-                    else if (A11 == 1 && A12 == 1 && A21 == 1 && A22 != 1)
-                    {
-                        if (above_right < right_top)
-                            return rightanglerotate_2Dvec(
-                                calc_grad_case2(above_right, A22),
-                                                        rotate);
-                            else
-                                return rightanglerotate_2Dvec(
-                                    calc_grad_case2(right_top, A22),
-                                                            rotate - 1, true, false);
-                    }
+                else { // above_left != 0; below_left == 0
+                    return rightanglerotate_2Dvec(
+                        calc_grad_case1(A11, A12),
+                        rotate, false, true
+                    );
                 }
             }
-        }
-        // if this is reached, it can only mean there is a corner somewhere or even
-        // multiple polygons in one block. To fix this, the resolution must be
-        // increased. For now, an approximate solution based on the Sobel operator
-        // (expanded for 4x4 pixel, to be symmetric around the interesting center
-        // point of v) for edge detection is calculated:
-
-
-        // Define the two kernels of the 'expanded' Sobel operator:
-        int G_avg_weights[4] = {1, 2, 2, 1};
-        int G_diff[4] = {+1, 0, 0, -1};
-        double Gx = 0;
-        double Gy = 0;
-        for (int i = 0; i < 4; ++i)
-            for (int j = 0; j < 4; ++j){
-                Gx += G_avg_weights[j] * G_diff[i] * areas[i][j];
-                Gy += G_avg_weights[i] * G_diff[j] * areas[i][j];
-            }
-            double a = sqrt(Gx * Gx + Gy * Gy);
-        if (a == 0.0)
-            return is_3D() ? vec(0.0, 0.0, 0.0) : vec(0.0, 0.0);
-        else
-            return is_3D() ? vec(Gx / a, Gy / a, 0.0) : vec(Gx / a, Gy / a);
-    };
-
-    bool polygons_for_single_material::index_in_bounds(int x, int y){
-        return (x >= 0 && x < _nx && y >= 0 && y < _ny);
-    }
-
-    material_function_for_polygons::material_function_for_polygons(
-        const grid_volume &thegv)
-    {
-        if ((thegv.dim != D2) && (thegv.dim != D3))
-            abort("material_function_for_polygons only available for 2D and 3D.\n");
-        nx = thegv.nx() * 2;
-        ny = thegv.ny() * 2; // Number of blocks to split polygons into. One block should have halve the size of one pixel
-        // to allow calculating averaged eps for different components (half pixel apart due to yee lattice).
-        // The smooting diameter should stay 1 pixel (Meep default) or be an integer multiple thereof,
-        // in which case material_function_for_polygons::eff_chi1inv_row() must be changed.
-        nz = thegv.nz() * 2;
-
-        block_size = thegv.inva * 0.5;
-    };
-
-    material_function_for_polygons::~material_function_for_polygons() {
-        for (vector<polygons_for_single_material*>::const_iterator it = _polygons.begin();
-            it != _polygons.end();
-        ++it)
+            else if (A21 != 0 && A22 == 0) // only A22 == 0
             {
-                delete (*it); //delete polygons_for_single_material object
-            }
-            _polygons.clear(); //delete all pointers
-    }
-
-    //Adds a material stack to the material function, for use in 3D case. Returns mat_ID, which must
-    //be used for add_polygon(polygon, mat_ID)
-    unsigned int material_function_for_polygons::add_material_stack(
-        double* material_heights, int mh_dim, double* epsilon_values, int ev_dim)
-    {
-        if (!is_3D()) {
-            abort("Specifying material stack is only available in 3D.\n%s",
-                "For 2D, please specify epsilon in add_polygon().\n");
-        }
-        material_stack * mat_stack = new material_stack(material_heights, mh_dim,
-                                                        epsilon_values, ev_dim);
-        _polygons.push_back(new polygons_for_single_material(mat_stack, block_size,
-                                                            nx, ny, nz));
-        //_material_stacks.push_back(new material_stack(material_heights,
-        //              refractive_indices, number_of_layers));
-        //_polygons.push_back(new queue<polygon*>());
-        return _polygons.size() - 1;
-    };
-
-    // Adds a polygon with predefined stack (->mat_ID) to the simulation.
-    // Care must be taken that none of the polygons overlap. Only for 3D simulation.
-    polygon& material_function_for_polygons::add_polygon(polygon* pol, unsigned int mat_ID){
-        // TODO? check if polygon overlaps other already added polygon:
-        // first point is outside other polygon AND polygon's edges does not cross other polygon's edges
-        if (!is_3D()) {
-            abort("Specifying material stack is only available in 3D.\n%s",
-                "For 2D, please specify epsilon in add_polygon().\n");
-        }
-        if (mat_ID >= _polygons.size())
-            abort("Wrong mat_ID specified in add_polygon. Please add material stacks before adding polygons.");
-        polygon* result = 0;
-        if (pol->get_area() > 0){
-            result = _polygons[mat_ID]->add_polygon(pol);
-        }
-        else {
-            master_printf("polygon with zero area not added.\n");
-        }
-        return *result;
-    };
-
-    // Adds a polygon with predefined stack (->mat_ID) to the simulation.
-    // Care must be taken that none of the polygons overlap. Only for 3D simulation.
-    polygon& material_function_for_polygons::add_polygon(double* matrix, int dimX, int dimY, unsigned int mat_ID) {
-        if (!is_3D()) {
-            abort("Specifying material stack is only available in 3D.\n%s",
-                "For 2D, please specify epsilon in add_polygon().\n");
-        }
-        return add_polygon(new polygon(matrix, dimX, dimY), mat_ID);
-    };
-
-    // Adds a polygon with epsilon value eps to the simulation.
-    // Care must be taken that none of the polygons overlap.
-    polygon& material_function_for_polygons::add_polygon(polygon* pol, double eps){
-        // TODO? check if polygon overlaps other already added polygon:
-        // first point is outside other polygon AND polygon's edges does not cross other polygon's edges
-        if (is_3D()) {
-            abort("Specifying polygon with epsilon value is only available in 2D.\n%s",
-                "For 3D, please specify material_stack ID instead.\n");
-        }
-        polygon* result = 0;
-        if (pol->get_area() > 0){
-            // only adds eps if neccessary, else use id
-            // of previously added eps:
-            int id = add_epsilon(eps);
-            result = _polygons[id]->add_polygon(pol);
-        }
-        else {
-            master_printf("polygon with zero area not added.\n");
-        }
-        return *result;
-    };
-
-    // Adds a polygon with epsilon value eps to the simulation.
-    // Care must be taken that none of the polygons overlap.
-    polygon& material_function_for_polygons::add_polygon(double* matrix, int dimX, int dimY, double eps) {
-        if (is_3D()) {
-            abort("Specifying polygon with epsilon value is only available in 2D.\n%s",
-                "For 3D, please specify material_stack ID instead.\n");
-        }
-        return add_polygon(new polygon(matrix, dimX, dimY), eps);
-    };
-
-    vec material_function_for_polygons::normal_vector(const ivec &center)
-    {
-        int debugn = 216; //108;
-        for (vector<polygons_for_single_material*>::const_iterator it = _polygons.begin();
-            it != _polygons.end();
-        ++it)
-            {
-                if ((*it)->is_trivial(center - one_ivec(center.dim),
-                    center + one_ivec(center.dim)))
-                {
-                    if (center == ivec(debugn, 0, 0))
-                        master_printf("pol for single mat is trivial\n");
-                    continue;
+                if (A12 < A21) {
+                    return rightanglerotate_2Dvec(
+                        calc_grad_case2(A12, A11),
+                        rotate
+                    );
                 }
                 else {
-                    if (center == ivec(debugn, 0, 0))
-                        master_printf("pol for single mat is not trivial\n");
-                    // Return normal vector of first material that's non-trivial in v.
-                    // If a second material is non-trivial, it's (absolute) normal
-                    // vector should be the same. If that's not the case, the polygons
-                    // have been defined badly by the user, or the user should increase
-                    // the resolution.
-                    // TODO: This changes slightly in 3D: The sign of the normal vector's
-                    // xy components could change for example in following situation:
-                    // An interface dividing the pixel into two halves left and right,
-                    // both sides with different material-stacks. The left side has
-                    // an interface in z direction (high-eps below, 1 above), the right
-                    // side has no interface, just the whole pixel height with high-eps.
-                    // The resulting surface vector should point to high z and to the
-                    // left, but when only the left side is regarded, it will point to
-                    // high z and to the right. If only the right side is regarded, it
-                    // will only point to the left.
-                    // Possible solution: calculate normal_vector for all non-trivial
-                    // polygons, then logically combine the results.
-                    // Since it is not exactly clear how to handle corners and edges
-                    // (also not in original MEEP-1.2.1), I will postpone the
-                    // implementation until later.
-                    return (*it)->normal_vector(center);
+                    return rightanglerotate_2Dvec(
+                        calc_grad_case2(A21, A11),
+                        rotate - 1, true, false
+                    );
                 }
             }
-            if (!is_3D())
-                // no interface of polygon in volume
-                return vec(D2, 0.0);
-            else
-                // return vector pointing in z direction if on interface of material
-                // stack whose polygon area is one (i.e. not zero):
-                for (vector<polygons_for_single_material*>::const_iterator it = _polygons.begin();
-                    it != _polygons.end();
-                ++it)
-                    {
-                        // polygons must all be trivial (see above), so just check at one
-                        // point whether area == 1:
-                        if ((*it)->get_area(center) == 1) {
-                            if (center == ivec(debugn, 0, 0))
-                                master_printf("found area = 1\n");
-                            double lower_layer_eps;
-                            double upper_layer_eps;
-                            double percentage_upper_layer;
-                            if ((*it)->get_material_stack()->interface_inside_block(
-                                center.z() * block_size, block_size,
-                                                                                    lower_layer_eps, upper_layer_eps,
-                                                                                    percentage_upper_layer))
-                            {
-                                if (center == ivec(debugn, 0, 0))
-                                    master_printf("interface in z\n");
-                                // interface in z only; return vector pointing to lower eps:
-                                return vec(0.0, 0.0,
-                                            upper_layer_eps < lower_layer_eps ? 1.0 : -1.0);
-                            }
-                            else {
-                                if (center == ivec(debugn, 0, 0))
-                                    master_printf("no interface in z\n");
-                                // no interface, also not in z
-                                return vec(D3, 0.0);
-                            }
-                        }
+            else if (A21 != 0 && A22 != 0) // all != 0
+            {
+                if (A11 == 1 && A12 != 1 && A21 != 1 && A22 != 1)
+                {
+                    if (A12 < A21) {
+                        return rightanglerotate_2Dvec(
+                            calc_grad_case2(A22, A21),
+                            rotate
+                        );
                     }
-                    // no interface in block (all areas are trivial and no areas are one):
-                    if (center == ivec(debugn, 0, 0))
-                        master_printf("all blocks zero, i.e no interface\n");
-                    return vec(D3, 0.0);
+                    else {
+                        return rightanglerotate_2Dvec(
+                            calc_grad_case2(A22, A12),
+                            rotate - 1, true, false
+                        );
+                    }
+                }
+                else if (A11 == 1 && A12 == 1 && A21 != 1 && A22 != 1)
+                {
+                    if ((above_right != 1 && below_right != 1) ||
+                        (above_right == 1 && below_right == 1)) {
+                        // First condition: solution is exact if no corner;
+                        // Last one means there is a corner somewhere,
+                        // then this is just approx. solution
+                        return rightanglerotate_2Dvec(
+                            calc_grad_case3(A22, A21), rotate);
+                    }
+                    else if (above_right != 1) { // below_right == 1
+                        return rightanglerotate_2Dvec(
+                            calc_grad_case1(1.0 - A21, 1.0 - A22),
+                            rotate
+                        );
+                    }
+                    else { // above_right == 1; below_right != 1
+                        return rightanglerotate_2Dvec(
+                            calc_grad_case1(1.0 - A22, 1.0 - A21),
+                            rotate, false, true
+                        );
+                    }
+                }
+                else if (A11 == 1 && A12 == 1 && A21 == 1 && A22 != 1)
+                {
+                    if (above_right < right_top) {
+                        return rightanglerotate_2Dvec(
+                            //calc_grad_case2(above_right, A22),
+                            calc_grad_case2(1.0 - A22, 1.0 - above_right),
+                            rotate
+                        );
+                    }
+                    else if (right_top == 1) {
+                        // which means right_top and above_right are both one,
+                        // and we have an isolated hole only inside A22:
+                        return vec(ndim(D2 + int(is_3D())), 0.0);
+                    }
+                    else {
+                        return rightanglerotate_2Dvec(
+                            calc_grad_case2(1.0 - A22, 1.0 - right_top),
+                            rotate - 1, true, false
+                        );
+                    }
+                }
+            } // (A21 != 0 && A22 != 0) // all != 0
+        } // (A11 != 0 && A12 != 0)
+    } // for (int rotate = 0; rotate < 4; rotate++)
+
+    // If this point is reached, it can only mean there is a corner somewhere
+    // or even multiple polygons in one block. To fix this, the resolution must
+    // be increased. For now, an approximate solution based on the Sobel
+    // operator (expanded for 4x4 pixel, to be symmetric around the interesting
+    // center point of v) for edge detection is calculated:
+
+    // Define the two kernels of the 'expanded' Sobel operator:
+    int G_avg_weights[4] = {1, 2, 2, 1};
+    int G_diff[4] = {+1, 0, 0, -1};
+    double Gx = 0;
+    double Gy = 0;
+    for (int i = 0; i < 4; ++i)
+        for (int j = 0; j < 4; ++j){
+            Gx += G_avg_weights[j] * G_diff[i] * areas4x4[i][j];
+            Gy += G_avg_weights[i] * G_diff[j] * areas4x4[i][j];
+        }
+        double a = sqrt(Gx * Gx + Gy * Gy);
+    if (a == 0.0)
+        return is_3D() ? vec(0.0, 0.0, 0.0) : vec(0.0, 0.0);
+    else
+        return is_3D() ? vec(Gx / a, Gy / a, 0.0) : vec(Gx / a, Gy / a);
+};
+
+vec polygonal_material::get_gradient_from_sphere_quad(
+    const ivec &pixel_center, const vec &gradient2D)
+{
+    /**
+     * We want to do the same than in material_function::normal_vector:
+     * That is, integrate chi1*r over the unit sphere using the
+     * Lebedev quadrature scheme.
+     *
+     * Before we can do that, we need to know chi at arbitrary points inside
+     * the pixel: From the 2D-normal and the area occupied by a polygon in the
+     * pixel (=2x2 ivec-pixels), a straight interface can be (re)constructed
+     * and with this (and the stack in 3D) we can quickly determine chi at any
+     * point in the pixel.
+     *
+     * Note: I could just have kept the original polygons before splitting
+     * (after splitting, they will take up too much memory) and use a
+     * winding number search to find out whether a specific point is inside a
+     * polygon, but that takes longer and I need the areas and gradients
+     * anyways.
+     */
+    if (!splitting_done)
+        update_splitting();
+
+    double gx = gradient2D.x();
+    double gy = gradient2D.y();
+    int rot_num = 0;
+    int i2, j2;
+    double slope = 1;
+    double y0 = 0;
+
+    // sum total area in pixel:
+    double total_area = 0;
+    for (int i = pixel_center.x() - 1; i <= pixel_center.x(); ++i)
+    {
+        i2 = i;
+        if (i2 < 0) i2 += _nx;
+        else if (i2 >= _nx) i2 -= _nx;
+        for (int j = pixel_center.y() - 1; j <= pixel_center.y(); ++j)
+        {
+            j2 = j;
+            if (j2 < 0) j2 += _ny;
+            else if (j2 >= _ny) j2 -= _ny;
+            total_area += _areas[i2][j2];
+        }
     }
 
-    double material_function_for_polygons::mean_eps(const ivec &center){
-        // start with complete area/volume, multiplied by 1 (air):
-        double result = is_3D() ? 8.0 : 4.0;
-        for (vector<polygons_for_single_material*>::const_iterator it = _polygons.begin();
-            it != _polygons.end();
-        ++it)
-            {
-                if (center == ivec(216, 0, 0)) {
-                    master_printf("meaneps areas: \n" );
-                    for (int i = center.x() - 1; i <  center.x() + 1; ++i)
-                        master_printf("%f, %f\n", (*it)->get_area(i, center.y() - 1), (*it)->get_area(i, center.y()));
-                }
-                // add up all 4 areas (in xy):
-                for (int i = center.x() - 1; i <  center.x() + 1; ++i)
-                    for (int j = center.y() - 1; j < center.y() + 1; ++j)
-                        if (!is_3D()) {
-                            // add epsilon, weighted by area,
-                            // minus 1 (=air - already added in beginning)
-                            result += (*it)->get_area(i, j) * ((*it)->get_material_epsilon() - 1.0);
-                        }
-                        else // 3D
-                            for (int k = center.z() - 1; k < center.z() + 1; ++k){
-                                double lower_layer_eps;
-                                double upper_layer_eps;
-                                double percentage_upper_layer;
-                                if ((*it)->get_material_stack()->interface_inside_block(
-                                    k * block_size, block_size / 2.0,
-                                    lower_layer_eps, upper_layer_eps,
-                                    percentage_upper_layer))
-                                {
-                                    // add epsilon, weighted by volume,
-                                    // minus 1 (=air - already added in beginning)
-                                    result += (*it)->get_area(i, j) *
-                                    ((1.0 - percentage_upper_layer) * (lower_layer_eps - 1.0)
-                                    + percentage_upper_layer * (upper_layer_eps - 1.0));
-                                }
-                                else {
-                                    result += (*it)->get_area(i, j) * (lower_layer_eps - 1.0);
-                                    if (center == ivec(216, 0, 0))
-                                        master_printf("meps result so far: %f (area %i, %i: %f; eps: %f)\n", result, i, j, (*it)->get_area(i, j), lower_layer_eps);
-                                }
-                            }
-            }
-            return (is_3D() ? result / 8.0 : result / 4.0);
+    // If more than half the area is filled, invert and rotate the whole
+    // problem by 180 degrees (then it's easier to solve later on):
+    bool invert = total_area > 2.0;
+    if (invert) {
+        total_area = 4.0 - total_area;
+        rot_num = 2;
+    }
+
+    bool trivial3D = false;
+    /**
+     * Check into which (rough) direction the normal points, then rotate
+     * everything (the slope of the interface and later the point of interest)
+     * such that we can work with a normal pointing roughly upwards
+     * (slope between -1 and 1):
+     */
+    if ((gy > 0) && (fabs(gx) <= gy)) {
+        // normal points roughly upwards
+        rot_num += 0;
+        slope = -gx / gy;
+    }
+    else if ((gx > 0) && (fabs(gy) <= gx)) {
+        // normal points roughly to the right
+        rot_num += 1;
+        slope = gy / gx;
+    }
+    else if ((gy < 0) && (fabs(gx) <= -gy)) {
+        // normal points roughly downwards
+        rot_num += 2;
+        slope = -gx / gy;
+    }
+    else if ((gx < 0) && (fabs(gy) <= -gx)) {
+        // normal points roughly to the left
+        rot_num += 3;
+        slope = gy / gx;
+    }
+    else {
+        // There is no polygon interface here: ((gx == 0) && (gy == 0))
+        if (!is_3D()) {
+            return zero_vec(gradient2D.dim);
         }
-
-        double material_function_for_polygons::mean_inveps(const ivec &center){
-            // start with complete area/volume, multiplied by 1 (air):
-            double result = is_3D() ? 8.0 : 4.0;
-            for (vector<polygons_for_single_material*>::const_iterator it = _polygons.begin();
-                it != _polygons.end();
-            ++it)
-                {
-                    // add up all 4 areas (in xy):
-                    for (int i = center.x() - 1; i <  center.x() + 1; ++i)
-                        for (int j = center.y() - 1; j < center.y() + 1; ++j)
-                            if (!is_3D())
-                                // add 1/epsilon, weighted by area,
-                                // minus 1 (=air - already added in beginning)
-                                result += (*it)->get_area(i, j) * (1.0 / (*it)->get_material_epsilon() - 1.0);
-                            else // 3D
-                                for (int k = center.z() - 1; k < center.z() + 1; ++k){
-                                    double lower_layer_eps;
-                                    double upper_layer_eps;
-                                    double percentage_upper_layer;
-                                    if ((*it)->get_material_stack()->interface_inside_block(
-                                        k * block_size, block_size / 2.0,
-                                        lower_layer_eps, upper_layer_eps,
-                                        percentage_upper_layer))
-                                    {
-                                        // add 1/epsilon, weighted by volume,
-                                        // minus 1 (=air - already added in beginning)
-                                        result += (*it)->get_area(i, j) *
-                                        ((1.0 - percentage_upper_layer) * (1.0 / lower_layer_eps - 1.0)
-                                        + percentage_upper_layer * (1.0 / upper_layer_eps - 1.0));
-                                    }
-                                    else
-                                        result += (*it)->get_area(i, j) * (1.0 / lower_layer_eps - 1.0);
-                                }
-                }
-                return is_3D() ? result / 8.0 : result / 4.0;
+        else if (!invert) {
+            // total_area <= 2.0, i.e. we are (mostly) outside any polygons:
+            return zero_vec(gradient2D.dim);
         }
-
-        ivec material_function_for_polygons::round_to_block_edge(const vec &v) {
-            ivec iv(v.dim, 0.0);
-            LOOP_OVER_DIRECTIONS(v.dim, d)
-            {
-                iv.set_direction(d,
-                                my_round(v.in_direction(d) / block_size));
-            }
-            return iv;
+        else {
+            // we are completely inside the material
+            trivial3D = true;
+            rot_num = 0;
         }
+    }
 
-        unsigned int material_function_for_polygons::add_epsilon(double eps) {
-            if (!is_3D()){ //2D
-                for (std::size_t i = 0; i < _polygons.size(); ++i){
-                    if (_polygons[i]->get_material_epsilon() == eps) {
-                        //epsilon value already added before. Just return ID.
-                        return i;
-                    }
-                }
-                // add new polygon_for_single_material with epsilon value and return
-                // new ID:
-                _polygons.push_back(new polygons_for_single_material(eps, block_size,
-                                                                    nx, ny));
-                return _polygons.size() - 1;
-            }
-            else { //3D
-                //TODO to be implemented: create a simple material stack with just one eps an no (inf?) thickness
-                return 0;
-            }
-        };
+    if (!trivial3D) {
+        // The interface is a line with the equation y = slope*x + y0. Find y0:
+        if (slope < 0 && total_area <= -2 * slope) {
+            // total_area is a triangle at the lower left edge of the pixel
+            y0 = slope - 1 + sqrt(-2 * slope * total_area);
+        }
+        else if (slope > 0 && total_area <= 2 * slope) {
+            // total_area is a triangle at the lower right edge of the pixel
+            y0 = -slope - 1 + sqrt(2 * slope * total_area);
+        }
+        else {
+            // total_area is a trapezoid at the bottom of the pixel
+            y0 = total_area * 0.5 - 1;
+        }
+    }
 
-        #define UNUSED(x) (void) x // silence compiler warnings
-        void material_function_for_polygons::eff_chi1inv_row(component c,
-                                                            double chi1inv_row[3],
-                                                            const volume &v,
-                                                            double tol, int maxeval)
+    // Slightly increased radius so the pixel corners are also included: TODO keep or remove?
+    const double radius = 1.0; //sqrt(gradient2D.dim + 1);
+    vec zerovec(zero_vec(gradient2D.dim));
+    vec result(zerovec);
+    for (int i = 0;
+         i < num_sphere_quad[number_of_directions(gradient2D.dim) - 1];
+         ++i)
         {
-            UNUSED(tol);
-            ivec center_ivec(round_to_block_edge(v.center()));
-            if (!maxeval) {
-                trivial:
-                chi1inv_row[0] = chi1inv_row[1] = chi1inv_row[2] = 0.0;
-                chi1inv_row[component_direction(c) % 3] = 1.0 / mean_eps(center_ivec);
-                return;
+            double weight, chi1p1;
+            vec pt = sphere_pt(zerovec, radius, i, weight);
+
+            // if pt is below y=slope*x + y0, we are inside the material:
+            if (trivial3D ||
+                (!invert && pt.y() <= slope * pt.x() + y0) ||
+                (invert && pt.y() > slope * pt.x() + y0))
+            {
+                if (is_3D()) {
+                    chi1p1 = _material_stack->chi1p1(
+                        (pt.z() + pixel_center.z()) * _block_size);
+                }
+                else
+                   chi1p1 = _epsilon;
+            }
+            else {
+                chi1p1 = 1;
             }
 
-            if (v.center() == vec(108.0/20, 0.0, 0.0)) {
-                master_printf("ivec: %i, %i, %i", center_ivec.x(), center_ivec.y(), center_ivec.z());
-                master_printf("normalx: %f\n", normal_vector(center_ivec).x());
-            }
+            /**
+             * Note1: chi1 = epsilon-1 instead of epsilon is used so that all
+             * gradients returned from different polygonal_materials in same
+             * pixel can simply be added.
+             *
+             * Note2: Contrary to the implementation in
+             * material_function::normal_vector, here we _substract_
+             * the individual weighted points. The reason is that
+             * the gradients in polygonal_material point away from
+             * the polygons, and therefore also away from areas of
+             * higher eps (background is always air), whereas the
+             * gradients in material_function::normal_vector point
+             * towards areas of higher eps. While the sign doesn't
+             * matter at the end in eff_chi1inv_row, we need to stay
+             * consistent within one material_function.
+             */
+            result -= pt * weight * (chi1p1 - 1);
+        }
 
-            vec gradient(normal_vector(center_ivec));
-            if (abs(gradient) < 1e-8)
-                goto trivial;
+    // Counter the rotation applied to the slope:
+    result = rightanglerotate_2Dvec(result, -rot_num);
 
-            double meps = mean_eps(center_ivec);
-            double minveps = mean_inveps(center_ivec);
+    // Now, we actually only needed the z component, since the input gradient2D
+    // is supposed to be more accurate than the lateral part of the result. So
+    // we fix the result with the better lateral vector:
+    double a = gx * gx + gy * gy;
+    double b = result.x() * result.x() + result.y() * result.y();
+    double c = sqrt(b/a);
+    result.set_direction(X, gx * c);
+    result.set_direction(Y, gy * c);
+    return result;
+}
 
-            double n[3] = {0,0,0};
-            //      double nabsinv = 1.0/abs(gradient);
-            LOOP_OVER_DIRECTIONS(gradient.dim, k)
-            n[k%3] = gradient.in_direction(k);// * nabsinv;
+material_function_for_polygons::material_function_for_polygons(
+    const grid_volume &thegv)
+{
+    if ((thegv.dim != D2) && (thegv.dim != D3))
+        abort("material_function_for_polygons only available for 2D and 3D.\n");
+    // Number of blocks to split polygons into:
+    // (One block should have halve the size of one pixel to allow
+    // calculating averaged eps for different components (half pixel
+    // apart due to yee lattice). The smooting diameter should stay
+    // 1 pixel (Meep default) or be an integer multiple thereof,
+    // in which case material_function_for_polygons::eff_chi1inv_row()
+    // must be changed though.)
+    nx = thegv.nx() * 2;
+    ny = thegv.ny() * 2;
+    nz = thegv.nz() * 2;
 
-            /* get rownum'th row of effective tensor
-            *                                                                                                        P * minveps + (I-P) * 1/meps = P * (minveps-1/mep*s) + I * 1/meps
-            *                                                                                                        where I is the identity and P is the projection matrix
-            *                                                                                                        P_{ij} = n[i] * n[j]. */
-            int rownum = component_direction(c) % 3;
-            for (int i=0; i<3; ++i)
-                chi1inv_row[i] = n[rownum] * n[i] * (minveps - 1/meps);
-            chi1inv_row[rownum] += 1/meps;
-            if (v.center() == vec(108.0/20, 0.0, 0.0)) {
-                master_printf("gradient: %f, %f, %f - ", gradient.x(), gradient.y(), gradient.z());
-                master_printf("meps: %f, minveps: %f, nvec: (%f, %f, %f)\n", meps, minveps, n[0], n[1], n[2]);
+    block_size = thegv.inva * 0.5;
+};
+
+material_function_for_polygons::~material_function_for_polygons() {
+    for (vector<polygonal_material*>::const_iterator it = _polymats.begin();
+            it != _polymats.end();
+    ++it)
+        {
+            delete (*it); //delete polygonal_material object
+        }
+        _polymats.clear(); //delete all pointers
+}
+
+unsigned int material_function_for_polygons::add_material_stack(
+    double* layer_thicknesses, int dim1, double* layer_epsilons, int dim2)
+{
+    if (!is_3D()) {
+        abort("Specifying material stack is only available in 3D.\n%s",
+            "For 2D, please specify epsilon in add_polygon().\n");
+    }
+    if (dim1 != dim2)
+        abort("layer_thicknesses and layer_epsilons must have same length, "
+              "i. e. the number of layers in the material stack.");
+    material_stack mat_stack(layer_thicknesses, layer_epsilons, dim1);
+    _polymats.push_back(
+        new polygonal_material(
+            &mat_stack, block_size, nx, ny, nz));
+    return _polymats.size() - 1;
+};
+
+// TODO? all add_polygon: check if polygon overlaps other already added polygons
+void material_function_for_polygons::add_polygon(const polygon &pol, unsigned int mat_ID){
+    if (!is_3D()) {
+        abort("Specifying material stack is only available in 3D.\n%s",
+            "For 2D, please specify epsilon in add_polygon().\n");
+    }
+    if (mat_ID >= _polymats.size())
+        abort("Wrong mat_ID specified in add_polygon. Please add material stacks before adding polygons.");
+    _polymats[mat_ID]->add_polygon(pol);
+};
+
+void material_function_for_polygons::add_polygon(const polygon &pol, double eps){
+    if (is_3D()) {
+        abort("Specifying polygon with epsilon value is only available in 2D.\n%s",
+            "For 3D, please specify material_stack ID instead.\n");
+    }
+    // try to use id of previously added eps:
+    int id = add_epsilon(eps);
+    _polymats[id]->add_polygon(pol);
+};
+
+vec material_function_for_polygons::normal_vector(const ivec &center)
+{
+    vec result = vec(is_3D()? D3 : D2, 0.0);
+
+    for (
+        vector<polygonal_material*>::const_iterator it = _polymats.begin();
+        it != _polymats.end();
+        ++it)
+    {
+        if (!(*it)->is_trivial(
+            center - one_ivec(center.dim),
+            center + one_ivec(center.dim)))
+        {
+            /**
+             * The gradients returned from polygonal_material::normal_vector
+             * are normalized such that neighboring materials' gradients in
+             * same pixel can simply be added:
+             */
+            result += (*it)->normal_vector(center);
+        }
+        else
+        if (is_3D()) {
+            /**
+             * If the material is trivial in pixel, i.e. the pixel is completely
+             * empty or completely filled, the transversal gradient (gradient
+             * projected onto x-y plane) is (0, 0).
+             * In 3D, we must find out the gradient's z-component, which is
+             * only non-zero if there is an interface in z, which in turn can
+             * only be if the pixel is filled: */
+            if ((*it)->get_area(center) == 1) {
+                double grad_z = (*it)->get_material_stack()->normal(
+                    (center.z() - 1) * block_size,
+                    (center.z() + 1) * block_size);
+                if (abs(grad_z) > 1e-8)
+                {
+                    /**
+                     * There is an interface in z direction. We can directly
+                     * return it, since the structure won't make sense if
+                     * there are any other interfaces in the same pixel:
+                     */
+                    return vec(0, 0, grad_z);
+                }
             }
         }
+    }
+    return result;
+}
+
+double material_function_for_polygons::mean_eps(const ivec &center){
+    // start with complete area (made up of 4 subpixel), multiplied by 1 (air):
+    double result = 4.0;
+    for (
+        vector<polygonal_material*>::const_iterator it = _polymats.begin();
+        it != _polymats.end();
+        ++it)
+    {
+        // epsilon for this block (or stack of blocks in 3D, averaged along z):
+        double eps = (
+            is_3D() ?
+            (*it)->get_material_stack()->mean_eps
+            (
+                (center.z() - 1) * block_size,
+                (center.z() + 1) * block_size
+            ) :
+            (*it)->get_material_epsilon()
+        );
+
+        // add up all 4 areas (in xy):
+        for (int i = center.x() - 1; i <  center.x() + 1; ++i)
+            for (int j = center.y() - 1; j < center.y() + 1; ++j) {
+                // add epsilon, weighted by area,
+                // minus 1 (= air: already added in beginning):
+                result += (*it)->get_area(i, j) * (eps - 1.0);
+            }
+    }
+    return result / 4.0;
+}
+
+double material_function_for_polygons::mean_inveps(const ivec &center){
+    // start with complete area (made up of 4 subpixel), multiplied by 1 (air):
+    double result = 4.0;
+    for (
+        vector<polygonal_material*>::const_iterator it = _polymats.begin();
+        it != _polymats.end();
+        ++it)
+    {
+        // inverse epsilon for this block (or stack of blocks in 3D, averaged along z):
+        double inveps = (
+            is_3D() ?
+            (*it)->get_material_stack()->mean_inveps
+            (
+                (center.z() - 1) * block_size,
+                (center.z() + 1) * block_size
+            ) :
+            1.0 / (*it)->get_material_epsilon()
+        );
+
+        // add up all 4 areas (in xy):
+        for (int i = center.x() - 1; i <  center.x() + 1; ++i)
+            for (int j = center.y() - 1; j < center.y() + 1; ++j) {
+                // add 1/epsilon, weighted by area,
+                // minus 1 (= air: already added in beginning):
+                result += (*it)->get_area(i, j) * (inveps - 1.0);
+            }
+    }
+    return result / 4.0;
+}
+
+ivec material_function_for_polygons::round_to_block_edge(const vec &v) {
+    ivec iv(v.dim, 0.0);
+    LOOP_OVER_DIRECTIONS(v.dim, d)
+    {
+        iv.set_direction(
+            d, my_round(v.in_direction(d) / block_size));
+    }
+    return iv;
+}
+
+unsigned int material_function_for_polygons::add_epsilon(double eps) {
+    if (!is_3D()){ //2D
+        for (std::size_t i = 0; i < _polymats.size(); ++i){
+            if (_polymats[i]->get_material_epsilon() == eps) {
+                //epsilon value already added before. Just return ID.
+                return i;
+            }
+        }
+        // add new polygon_for_single_material with epsilon value and return
+        // new ID:
+        _polymats.push_back(new polygonal_material(
+            eps, block_size, nx, ny));
+        return _polymats.size() - 1;
+    }
+    else { //3D
+        abort("Specifying polygon with epsilon value is only available in 2D.\n%s",
+              "For 3D, please specify material_stack ID instead.\n");
+    }
+};
+
+#define UNUSED(x) (void) x // silence compiler warnings
+void material_function_for_polygons::eff_chi1inv_row(
+    component c, double chi1inv_row[3],
+    const volume &v, double tol, int maxeval)
+{
+    UNUSED(tol);
+
+    ivec center_ivec(round_to_block_edge(v.center()));
+    if (!maxeval) {
+        trivial:
+        chi1inv_row[0] = chi1inv_row[1] = chi1inv_row[2] = 0.0;
+        chi1inv_row[component_direction(c) % 3] = 1.0 / mean_eps(center_ivec);
+        return;
+    }
+
+    vec gradient(normal_vector(center_ivec));
+    if (abs(gradient) < 1e-8) {
+        goto trivial;
+    }
+
+    double meps = mean_eps(center_ivec);
+    double minveps = mean_inveps(center_ivec);
+
+    double n[3] = {0,0,0};
+    double nabsinv = 1.0/abs(gradient);
+    LOOP_OVER_DIRECTIONS(gradient.dim, k)
+    n[k%3] = gradient.in_direction(k) * nabsinv;
+
+    /* get rownum'th row of effective tensor
+    *  P * minveps + (I-P) * 1/meps = P * (minveps-1/meps) + I * 1/meps
+    *  where I is the identity and P is the projection matrix
+    *  P_{ij} = n[i] * n[j]. */
+    int rownum = component_direction(c) % 3;
+    for (int i=0; i<3; ++i)
+        chi1inv_row[i] = n[rownum] * n[i] * (minveps - 1/meps);
+    chi1inv_row[rownum] += 1/meps;
+}
 
 ////////////////////////////////////////////////////////////
 //---- End: defs for polygon-based material functions ----//
 ////////////////////////////////////////////////////////////
-
-void structure_chunk::add_susceptibility(material_function &sigma, 
-					 field_type ft,
-					 const susceptibility &sus)
-{
-  if (ft != E_stuff && ft != H_stuff)
-    abort("susceptibilities must be for E or H fields");
-
-  sigma.set_volume(gv.pad().surroundings());
-
-  susceptibility *newsus = sus.clone();
-  newsus->next = NULL;
-  newsus->ntot = gv.ntot();
-  // get rid of previously allocated sigma, normally not the case here:
-  FOR_COMPONENTS(c) FOR_DIRECTIONS(d) if (newsus->sigma[c][d]) {
-    delete[] newsus->sigma[c][d];
-    newsus->sigma[c][d] = NULL;
-    newsus->trivial_sigma[c][d] = true;
-  }
-  
-  // if we own this chunk, set up the sigma array(s):
-  if (is_mine()) FOR_FT_COMPONENTS(ft,c) if (gv.has_field(c)) {
-    FOR_FT_COMPONENTS(ft,c2) if (gv.has_field(c2)) {
-      direction d = component_direction(c2);
-      if (!newsus->sigma[c][d]) newsus->sigma[c][d] = new realnum[gv.ntot()];
-      if (!newsus->sigma[c][d]) abort("Memory allocation error.\n");
-    }
-    bool trivial[3] = {true, true, true};
-    direction dc = component_direction(c);
-    direction d0 = X, d1 = Y, d2 = Z;
-    if (gv.dim == Dcyl) { d0 = R; d1 = P; }
-    int idiag = component_index(c);
-    realnum *s0 = newsus->sigma[c][d0];
-    realnum *s1 = newsus->sigma[c][d1];
-    realnum *s2 = newsus->sigma[c][d2];
-    vec shift1(gv[unit_ivec(gv.dim,component_direction(c))
-		  * (ft == E_stuff ? 1 : -1)]);
-    LOOP_OVER_VOL(gv, c, i) {
-      double sigrow[3], sigrow_offdiag[3];
-      IVEC_LOOP_LOC(gv, here);
-      sigma.sigma_row(c, sigrow, here);
-      sigma.sigma_row(c, sigrow_offdiag, here - shift1);
-      sigrow[(idiag+1) % 3] = sigrow_offdiag[(idiag+1) % 3];
-      sigrow[(idiag+2) % 3] = sigrow_offdiag[(idiag+2) % 3];
-      if (s0 && (s0[i] = sigrow[0]) != 0.) trivial[0] = false;
-      if (s1 && (s1[i] = sigrow[1]) != 0.) trivial[1] = false;
-      if (s2 && (s2[i] = sigrow[2]) != 0.) trivial[2] = false;
-    }
-
-    direction ds[3]; ds[0] = d0; ds[1] = d1; ds[2] = d2;
-    for (int i = 0; i < 3; ++i) {
-      newsus->trivial_sigma[c][ds[i]] = trivial[i];
-      if (i != idiag && trivial[i]) { // deallocate trivial offdiag
-	delete[] newsus->sigma[c][ds[i]]; 
-	newsus->sigma[c][ds[i]] = 0; 
-      }
-    }
-    // only deallocate trivial diag if entire tensor is trivial
-    if (trivial[0] && trivial[1] && trivial[2]) {
-      delete[] newsus->sigma[c][dc]; 
-      newsus->sigma[c][dc] = 0; 
-    }
-  }
-
-  // finally, add to the beginning of the chiP list:
-  newsus->next = chiP[ft];
-  chiP[ft] = newsus;  
-
-  sigma.unset_volume();
-}
 
 
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -449,7 +449,7 @@ public:
     /* Construct a simple_polygon from the flattened points array matrix.
      * (row-major order: {x0, y0, x1, y1, ...})
      * dim1 is the number of points, dim2 must always be 2.
-     * This constructor is needed for a SWIG interface for python-numpy arrays.
+     * This constructor is needed for easier integration with the SWIG interface.
      * The matrix is copied internally, so can savely be deleted or reused after calling this constructor.
      */
     simple_polygon(const double* matrix, std::size_t dim1, std::size_t dim2 = 2);
@@ -493,7 +493,7 @@ public:
     /* Construct a polygon from the flattened points array matrix.
      * (row-major order: {x0, y0, x1, y1, ...})
      * dim1 is the number of points, dim2 must always be 2.
-     * This constructor is needed for a SWIG interface for python-numpy arrays.
+//      * This constructor is needed for easier integration with the SWIG interface.
      * The matrix is copied internally, so can savely be deleted or reused after calling this constructor. */
     polygon(const double* matrix, std::size_t dim1, std::size_t dim2 = 2) : simple_polygon(matrix, dim1, dim2) {};
 
@@ -842,7 +842,7 @@ public:
 
     // Adds a material stack to the material function, for use in 3D case.
     // Returns mat_ID, which must be used for add_polygon(polygon, mat_ID)
-    // This method is for easier integration with the SWIG interface for python numpy:
+    // This method is for easier integration with the SWIG interface:
     unsigned int add_material_stack(
         double* layer_thicknesses, int dim1,
         double* layer_epsilons, int dim2);

--- a/tests/2D_convergence_polygons.cpp
+++ b/tests/2D_convergence_polygons.cpp
@@ -1,0 +1,164 @@
+// This is a version of 2D_convergence.cpp using a
+// material_function_for_polygons instead of eps function.
+
+#include <meep.hpp>
+using namespace meep;
+#include "config.h"
+using namespace std;
+
+const double diameter = 0.8;
+const double r = diameter*0.5;
+const int num_polygon_points = 1000;
+
+polygon get_round_polygon(
+    double x0, double y0, double radius, int numpts)
+{
+    double (*pts)[2] = new double[numpts][2];
+    for (int i = 0; i < numpts; ++i) {
+        pts[i][0] = radius * cos(2 * pi / numpts * i) + x0;
+        pts[i][1] = radius * sin(2 * pi / numpts * i) + y0;
+    }
+    polygon pol(pts, numpts);
+    delete[] pts;
+
+    return pol;
+}
+
+material_function* polygon_holey_2d(const grid_volume &gv, const vec &shift){
+    double period = 1.0;
+
+    material_function_for_polygons *matfun = new material_function_for_polygons(gv);
+    volume vol(gv.surroundings());
+    vec center = gv.center() - shift;
+    double x0 = center.x();
+    double y0 = center.y();
+    double pts[8] = {
+        vol.in_direction_min(X), vol.in_direction_min(Y),
+        vol.in_direction_max(X), vol.in_direction_min(Y),
+        vol.in_direction_max(X), vol.in_direction_max(Y),
+        vol.in_direction_min(X), vol.in_direction_max(Y)};
+    polygon pol = polygon(pts, 4, 2);
+    while (x0 > vol.in_direction_min(X) - r)
+         x0 -= period;
+    x0 += period;
+    while (y0 > vol.in_direction_min(Y) - r)
+        y0 -= period;
+    y0 += period;
+    double x = x0;
+    double y = y0;
+    while (x <= vol.in_direction_max(X) + r) {
+        while (y <= vol.in_direction_max(Y) + r) {
+            pol.add_inner_polygon(
+                get_round_polygon(x, y, r, num_polygon_points));
+            y += period;
+        }
+        x += period;
+        y = y0;
+    }
+    matfun->add_polygon(pol, 12.0);
+    return matfun;
+}
+
+double get_the_freq(monitor_point *p, component c) {
+  complex<double> *amp, *freqs;
+  int num;
+  p->harminv(c, &amp, &freqs, &num, 0.15, 0.20, 8);
+  if (!num) return 0.0;
+  double best_amp = abs(amp[0]), best_freq = fabs(real(freqs[0]));
+  for (int i=1;i<num;i++)
+    if (abs(amp[i]) > best_amp &&
+        fabs(imag(freqs[i])/real(freqs[i])) < 0.002) {
+      best_amp = abs(amp[i]);
+      best_freq = fabs(real(freqs[i]));
+    }
+  delete[] freqs;
+  delete[] amp;
+  return best_freq;
+}
+
+double freq_at_resolution(
+    material_function *matfun_generator(
+            const grid_volume &gv, const vec &shift),
+        const vec &shift,
+        double a, component c, double beta) {
+  const grid_volume gv = vol2d(2.0,1.0,a);
+  material_function *matfun = matfun_generator(gv, shift);
+  structure s(gv, *matfun);
+  s.set_epsilon(*matfun); // use anisotropic averaging
+
+  fields f(&s, 0, beta);
+  f.use_real_fields();
+  f.use_bloch(vec(0,0));
+  f.add_point_source(c, 0.18, 2.5, 0.0, 6.0, vec(0.5,0.5), 1.0);
+  f.add_point_source(c, 0.18, 2.5, 0.0, 6.0, vec(1.5,0.5),-1.0);
+
+  delete matfun;
+  while (f.time() <= f.last_source_time() + 10.0 && !interrupt) f.step();
+  const double fourier_timesteps = 3000.0;
+  const double ttot = fourier_timesteps/a + f.time();
+  monitor_point *p = NULL;
+  while (f.time() <= ttot) {
+    f.step();
+    p = f.get_new_point(vec(0.52,0.97), p);
+  }
+  const double freq = get_the_freq(p, c);
+  delete p;
+  return freq;
+}
+
+void check_convergence(component c, double best_guess, double beta)
+{
+  const double amin = 5.0, amax = 30.0, adelta = 5.0;
+
+  master_printf("Checking convergence for %s field...\n",
+		component_name(c));
+  if (beta != 0)
+    master_printf("... using exp(i beta z) z-dependence with beta=%g\n", beta);
+  if (best_guess)
+    master_printf("(The correct frequency should be %g.)\n", best_guess);
+
+  for (double a=amax; a >= amin; a-=adelta) {
+    const double freq = freq_at_resolution(
+        polygon_holey_2d, vec(0, 0), a, c, beta);
+    const double freq_shifted = freq_at_resolution(
+        polygon_holey_2d, vec(pi*0.01, 3 - pi)*0.5, a, c, beta);
+
+    // Initialize best guess at the correct freq.
+    if (!best_guess) {
+      best_guess = freq + 0.5*(freq_shifted - freq);
+      master_printf("The frequency is approximately %g\n", best_guess);
+    } else {
+      master_printf("frequency for a=%g is %g, %g (shifted), %g (mean)\n", 
+		    a, freq, freq_shifted, 0.5 * (freq + freq_shifted));
+      master_printf("Unshifted freq error is %g/%g/%g\n",
+                    (freq - best_guess)*a*a, a, a);
+      if (fabs(freq - best_guess)*a*a > 0.4)
+        abort("Frequency doesn't converge properly with a.\n");
+      master_printf("Shifted freq error is %g/%g/%g\n",
+                    (freq_shifted - best_guess)*a*a, a, a);
+      if (fabs(freq_shifted - best_guess)*a*a > 0.4)
+	abort("Frequency doesn't converge properly with a.\n");
+    }    
+    
+    // Check frequency difference...
+    master_printf("Frequency difference with a of %g is %g/%g/%g\n",
+                  a, (freq - freq_shifted)*a*a, a, a);
+    if (fabs(freq - freq_shifted)*a*a > 0.4)
+      abort("Frequency difference = doesn't converge properly with a.\n");
+  }
+  master_printf("Passed 2D resolution convergence test for %s!\n",
+		component_name(c));
+}
+
+int main(int argc, char **argv) {
+  initialize mpi(argc, argv);
+  quiet = true;
+#ifdef HAVE_HARMINV
+  master_printf("Running holes square-lattice resolution convergence test.\n");
+  check_convergence(Ey, 0.179944, 0); // from MPB; correct to >= 4 dec. places
+  check_convergence(Ez, 0.166998, 0); // from MPB; correct to >= 4 dec. places
+  check_convergence(Ez, 0.173605, .1); // from MPB; correct to >= 4 dec. places
+#endif
+
+  return 0;
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,7 +2,7 @@ SRC = aniso_disp.cpp bench.cpp bragg_transmission.cpp			\
 convergence_cyl_waveguide.cpp cylindrical.cpp flux.cpp harmonics.cpp	\
 integrate.cpp known_results.cpp near2far.cpp one_dimensional.cpp	\
 physical.cpp stress_tensor.cpp symmetry.cpp three_d.cpp			\
-two_dimensional.cpp 2D_convergence.cpp h5test.cpp pml.cpp
+two_dimensional.cpp 2D_convergence.cpp h5test.cpp pml.cpp polygons.cpp
 
 EXTRA_DIST = $(SRC)
 
@@ -15,7 +15,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src
 
 .SUFFIXES = .dac .done
 
-check_PROGRAMS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml
+check_PROGRAMS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml polygons
 
 aniso_disp_SOURCES = aniso_disp.cpp
 aniso_disp_LDADD = $(LIBMEEP)
@@ -74,7 +74,10 @@ h5test_LDADD = $(LIBMEEP)
 pml_SOURCES = pml.cpp
 pml_LDADD = $(LIBMEEP)
 
-TESTS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml
+polygons_SOURCES = polygons.cpp
+polygons_LDADD = $(LIBMEEP)
+
+TESTS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml polygons
 
 LOG_COMPILER = $(RUNCODE)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,7 +2,8 @@ SRC = aniso_disp.cpp bench.cpp bragg_transmission.cpp			\
 convergence_cyl_waveguide.cpp cylindrical.cpp flux.cpp harmonics.cpp	\
 integrate.cpp known_results.cpp near2far.cpp one_dimensional.cpp	\
 physical.cpp stress_tensor.cpp symmetry.cpp three_d.cpp			\
-two_dimensional.cpp 2D_convergence.cpp h5test.cpp pml.cpp polygons.cpp
+two_dimensional.cpp 2D_convergence.cpp h5test.cpp pml.cpp polygons.cpp  \
+2D_convergence_polygons.cpp
 
 EXTRA_DIST = $(SRC)
 
@@ -15,7 +16,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src
 
 .SUFFIXES = .dac .done
 
-check_PROGRAMS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml polygons
+check_PROGRAMS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml polygons 2D_convergence_polygons
 
 aniso_disp_SOURCES = aniso_disp.cpp
 aniso_disp_LDADD = $(LIBMEEP)
@@ -77,7 +78,10 @@ pml_LDADD = $(LIBMEEP)
 polygons_SOURCES = polygons.cpp
 polygons_LDADD = $(LIBMEEP)
 
-TESTS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml polygons
+2D_convergence_polygons_SOURCES = 2D_convergence_polygons.cpp
+2D_convergence_polygons_LDADD = $(LIBMEEP)
+
+TESTS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml polygons 2D_convergence_polygons
 
 LOG_COMPILER = $(RUNCODE)
 

--- a/tests/polygons.cpp
+++ b/tests/polygons.cpp
@@ -1,0 +1,524 @@
+// This is a version of 2D_convergence.cpp using a
+// material_function_for_polygons instead of eps function.
+
+#include <meep.hpp>
+using namespace meep;
+#include <stdlib.h>
+using namespace std;
+
+
+void rotate_polygon(double* pts, const int numpts, const double angle)
+{
+    for (int i = 0; i < numpts; ++i) {
+        double x = pts[2 * i];
+        double y = pts[2 * i + 1];
+        pts[2 * i] = x * cos(angle) - y * sin(angle);
+        pts[2 * i + 1] = x * sin(angle) + y * cos(angle);
+    }
+}
+
+void shift_polygon(double* pts, const int numpts, const vec &shift)
+{
+    for (int i = 0; i < numpts; ++i) {
+        pts[2 * i] += shift.x();
+        pts[2 * i + 1] += shift.y();
+    }
+}
+
+// uniform pseudo-random number in [min,max]
+static double urand(double min, double max)
+{
+    return (rand() * ((max - min) / RAND_MAX) + min);
+}
+
+double get_fill_ratio(const double angle, const double xshift, const double yshift)
+{
+    if (angle < -pi || angle > pi)
+        abort("testing angle must be between -pi and +pi");
+    double ta(tan(angle));
+    double x_top, x_bot, y_lft, y_rgt;
+    x_top = (yshift - 0.5) * ta + xshift;
+    x_bot = (yshift + 0.5) * ta + xshift;
+    y_lft = (xshift + 0.5) / ta + yshift;
+    y_rgt = (xshift - 0.5) / ta + yshift;
+
+    double pts[6][2];
+    int numpts = 2;
+
+    if (angle < -pi/2.0) {
+        pts[0][0] = 0.5;
+        pts[0][1] = 0.5;
+        if (x_top >= -0.5) {
+            pts[1][0] = x_top;
+            pts[1][1] = 0.5;
+        }
+        else {
+            numpts++;
+            pts[1][0] = -0.5;
+            pts[1][1] = 0.5;
+            pts[2][0] = -0.5;
+            pts[2][1] = y_lft;
+        }
+        if (x_bot <= 0.5) {
+            pts[numpts][0] = x_bot;
+            pts[numpts][1] = -0.5;
+            numpts++;
+            pts[numpts][0] = 0.5;
+            pts[numpts][1] = -0.5;
+        }
+        else {
+            pts[numpts][0] = 0.5;
+            pts[numpts][1] = y_rgt;
+        }
+        pts[numpts+1][0] = 0.5;
+        pts[numpts+1][1] = 0.5;
+        numpts += 2;
+    }
+    else if (angle < 0.0) {
+        pts[0][0] = -0.5;
+        pts[0][1] = 0.5;
+        if (y_lft >= -0.5) {
+            pts[1][0] = -0.5;
+            pts[1][1] = y_lft;
+        }
+        else {
+            numpts++;
+            pts[1][0] = -0.5;
+            pts[1][1] = -0.5;
+            pts[2][0] = x_bot;
+            pts[2][1] = -0.5;
+        }
+        if (y_rgt <= 0.5) {
+            pts[numpts][0] = 0.5;
+            pts[numpts][1] = y_rgt;
+            numpts++;
+            pts[numpts][0] = 0.5;
+            pts[numpts][1] = 0.5;
+        }
+        else {
+            pts[numpts][0] = x_top;
+            pts[numpts][1] = 0.5;
+        }
+        pts[numpts+1][0] = -0.5;
+        pts[numpts+1][1] = 0.5;
+        numpts += 2;
+    }
+    else if (angle < pi/2.0){
+        pts[0][0] = -0.5;
+        pts[0][1] = -0.5;
+        if (x_bot <= 0.5) {
+            pts[1][0] = x_bot;
+            pts[1][1] = -0.5;
+        }
+        else {
+            numpts++;
+            pts[1][0] = 0.5;
+            pts[1][1] = -0.5;
+            pts[2][0] = 0.5;
+            pts[2][1] = y_rgt;
+        }
+        if (x_top >= -0.5) {
+            pts[numpts][0] = x_top;
+            pts[numpts][1] = 0.5;
+            numpts++;
+            pts[numpts][0] = -0.5;
+            pts[numpts][1] = 0.5;
+        }
+        else {
+            pts[numpts][0] = -0.5;
+            pts[numpts][1] = y_lft;
+        }
+        pts[numpts+1][0] = -0.5;
+        pts[numpts+1][1] = -0.5;
+        numpts += 2;
+    }
+    else {
+        pts[0][0] = 0.5;
+        pts[0][1] = -0.5;
+        if (y_rgt <= 0.5) {
+            pts[1][0] = 0.5;
+            pts[1][1] = y_rgt;
+        }
+        else {
+            numpts++;
+            pts[1][0] = 0.5;
+            pts[1][1] = 0.5;
+            pts[2][0] = x_top;
+            pts[2][1] = 0.5;
+        }
+        if (y_lft >= -0.5) {
+            pts[numpts][0] = -0.5;
+            pts[numpts][1] = y_lft;
+            numpts++;
+            pts[numpts][0] = -0.5;
+            pts[numpts][1] = -0.5;
+        }
+        else {
+            pts[numpts][0] = x_bot;
+            pts[numpts][1] = -0.5;
+        }
+        pts[numpts+1][0] = 0.5;
+        pts[numpts+1][1] = -0.5;
+        numpts += 2;
+    }
+    polygon pol = polygon(pts, numpts);
+    return pol.get_area();
+};
+
+/** Tests the normal direction, mean eps and mean 1/eps of a polygonal
+ *  interface in 2D at multiple randomly chosen angles and offsets. */
+void check_normals_2D(const int num_random_trials = 10000)
+{
+    master_printf("Checking interface of polygonal material with air (2D).\n");
+    const int w = 6;
+    grid_volume gv(voltwo(w, w, 1));
+    volume vol(gv.surroundings());
+    vec center = gv.center();
+    ivec icenter = gv.icenter();
+
+    for (int i = 0; i < num_random_trials; ++i) {
+        double pts[8] = {
+            -w, -w,
+            0, -w,
+            0,  w,
+            -w,  w
+        };
+        double test_angle = urand(-pi, pi);
+        vec test_shift = vec(urand(-0.5, 0.5), urand(-0.5, 0.5));
+
+        rotate_polygon(pts, 4, test_angle);
+        shift_polygon(pts, 4, center + test_shift);
+        polygon pol = polygon(pts, 4, 2);
+        material_function_for_polygons matfun(gv);
+        matfun.add_polygon(pol, 12.0);
+
+        vec grad(matfun.normal_vector(icenter));
+        double grad_ang = atan2(grad.y(), grad.x());
+        double fratio(get_fill_ratio(test_angle, test_shift.x(), test_shift.y()));
+        double test_meps = fratio * 11 + 1;
+        double meps = matfun.mean_eps(icenter);
+        double test_minveps = 1 - fratio * 11./12.;
+        double minveps = matfun.mean_inveps(icenter);
+
+
+        if (fabs(test_angle - grad_ang) > 1e-8 ||
+            fabs(test_minveps - minveps) > 1e-8 ||
+            fabs(test_meps - meps) > 1e-8
+        )
+        {
+            master_printf("error at #%i: test shift: (%.14f, %.14f) ; test angle: %.14f\n",
+                          i, test_shift.x(), test_shift.y(), test_angle * 180 / pi);
+            master_printf("expected angle: %.14f ; mean_eps: %.14f ; mean_inv_eps: %.14f\n",
+                          test_angle * 180 / pi, test_meps, test_minveps);
+            master_printf("     got angle: %.14f ; mean_eps: %.14f ; mean_inv_eps: %.14f\n\n",
+                          grad_ang * 180 / pi, meps, minveps);
+            abort("error");
+        }
+    }
+}
+
+/** Tests the normal direction, mean eps and mean 1/eps of a polygonal
+ *  interface in 2D between 2 different materials at multiple randomly
+ *  chosen angles and offsets. Also tests usage of inner polygons. */
+void check_normals_2D_2materials(const int num_random_trials = 10000)
+{
+    master_printf("Checking interface between two polygonal materials (2D).\n");
+    const int w = 6;
+    grid_volume gv(voltwo(w, w, 1));
+    volume vol(gv.surroundings());
+    vec center = gv.center();
+    ivec icenter = gv.icenter();
+
+    for (int i = 0; i < num_random_trials; ++i) {
+        double test_angle = urand(-pi, pi);
+        vec test_shift = vec(urand(-0.5, 0.5), urand(-0.5, 0.5));
+
+        double pts1[8] = {
+            -w, -w,
+            w, -w,
+            w,  w,
+            -w,  w
+        };
+        double pts2[8] = {
+            w, w,
+            0, w,
+            0,  -w,
+            w,  -w
+        };
+        rotate_polygon(pts2, 4, test_angle);
+        shift_polygon(pts2, 4, center + test_shift);
+
+        material_function_for_polygons matfun(gv);
+        polygon pol(pts1, 4, 2);
+        pol.add_inner_polygon(polygon(pts2, 4, 2));
+        matfun.add_polygon(pol, 12.0);
+        pol = polygon(pts2, 4, 2);
+        matfun.add_polygon(pol, 4.0);
+
+        vec grad(matfun.normal_vector(icenter));
+        double grad_ang = atan2(grad.y(), grad.x());
+        double fratio(get_fill_ratio(test_angle, test_shift.x(), test_shift.y()));
+        double test_meps = fratio * 12 + (1-fratio) * 4;
+        double meps = matfun.mean_eps(icenter);
+        double test_minveps = fratio / 12. + (1 - fratio) / 4.;
+        double minveps = matfun.mean_inveps(icenter);
+
+
+        if (fabs(test_angle - grad_ang) > 1e-8 ||
+            fabs(test_minveps - minveps) > 1e-8 ||
+            fabs(test_meps - meps) > 1e-8
+        )
+        {
+            master_printf("error at #%i: test shift: (%.14f, %.14f) ; test angle: %.14f\n",
+                          i, test_shift.x(), test_shift.y(), test_angle * 180 / pi);
+            master_printf("expected angle: %.14f ; mean_eps: %.14f ; mean_inv_eps: %.14f\n",
+                          test_angle * 180 / pi, test_meps, test_minveps);
+            master_printf("     got angle: %.14f ; mean_eps: %.14f ; mean_inv_eps: %.14f\n\n",
+                          grad_ang * 180 / pi, meps, minveps);
+            abort("error");
+        }
+    }
+}
+
+/** Tests the normal direction, mean eps and mean 1/eps of a polygonal
+ *  interface in 3D between 2 different material stacks at multiple randomly
+ *  chosen angles and offsets. Also tests usage of inner polygons. */
+void check_normals_3D(const int num_random_trials = 10000)
+{
+    master_printf("Checking interface of polygonal material with air (3D) - transversal components\n");
+    const int w = 6;
+    const int sh = int(w/2);
+    grid_volume gv(vol3d(w, w, 4*sh, 1));
+    volume vol(gv.surroundings());
+    vec center = gv.center();
+    ivec icenter = gv.icenter();
+    double maxpd = 0, mpi = 0, mps = 0;
+    vec mpshift = zero_vec(D3);
+
+    for (int i = 0; i < num_random_trials; ++i) {
+        double ptsA[8] = {
+            -w, -w,
+            0, -w,
+            0,  w,
+            -w,  w
+        };
+        double ptsB[8] = {
+            w, w,
+            0, w,
+            0,  -w,
+            w,  -w
+        };
+
+        double test_angle = urand(-pi, pi);
+        vec test_shift = vec(urand(-0.5, 0.5), urand(-0.5, 0.5));
+        double zs = urand(-0.5, 0.5);
+
+        double eps = 12.0;
+        double layer_thicknessA[3] = {sh + zs, 2 * sh, sh - zs};
+        double layer_epsA[3] = {1.0, eps, 1.0};
+        double layer_thicknessB[3] = {sh + zs, sh,  2 * sh - zs};
+        double layer_epsB[3] = {1.0, eps, 1.0};
+        material_function_for_polygons matfun(gv);
+        unsigned int matstack_idA = matfun.add_material_stack(layer_thicknessA, layer_epsA, 3);
+        unsigned int matstack_idB = matfun.add_material_stack(layer_thicknessB, layer_epsB, 3);
+
+        rotate_polygon(ptsA, 4, test_angle);
+        shift_polygon(ptsA, 4, center + test_shift);
+        rotate_polygon(ptsB, 4, test_angle);
+        shift_polygon(ptsB, 4, center + test_shift);
+        polygon pol = polygon(ptsA, 4, 2);
+        matfun.add_polygon(pol, matstack_idA);
+        pol = polygon(ptsB, 4, 2);
+        matfun.add_polygon(pol, matstack_idB);
+
+        /////////////////////////////////////////////////////////////////
+        // position at lower material interface where the two stacks meet:
+        ivec ibottom = icenter - unit_ivec(D3, Z) * (2*sh);
+        vec grad(matfun.normal_vector(ibottom));
+        double fratio = 0.5 - zs;
+        double test_meps = fratio * (eps - 1) + 1;
+        double meps = matfun.mean_eps(ibottom);
+        double test_minveps = 1 - fratio * (eps - 1) / eps;
+        double minveps = matfun.mean_inveps(ibottom);
+        // check that gradient is always pointing downwards at ibottom:
+        if (fabs(grad.x()) > 1e-8 || fabs(grad.y()) > 1e-8 || grad.z() > -1e-8) {
+            master_printf("error at #%i: test shift: (%.14f, %.14f, %.14f) ; test angle: %.14f\n",
+                          i, test_shift.x(), test_shift.y(), zs, test_angle * 180 / pi);
+            master_printf("gradient at %i, %i, %i (bottom): (%.14f, %.14f, %.14f) does not point downwards\n",
+                          ibottom.x(), ibottom.y(), ibottom.z(), grad.x(), grad.y(), grad.z());
+            abort("error");
+        }
+        // check mean epsilon and mean inverse epsilon:
+        if (fabs(test_minveps - minveps) > 1e-8 ||
+            fabs(test_meps - meps) > 1e-8
+        )
+        {
+            master_printf("error at #%i: test shift: (%.14f, %.14f, %.14f) ; test angle: %.14f\n",
+                          i, test_shift.x(), test_shift.y(), zs, test_angle * 180 / pi);
+            master_printf("at %i, %i, %i (bottom):\n",
+                          ibottom.x(), ibottom.y(), ibottom.z());
+            master_printf("expected mean_eps: %.14f ; mean_inv_eps: %.14f\n",
+                          test_meps, test_minveps);
+            master_printf("     got mean_eps: %.14f ; mean_inv_eps: %.14f\n\n",
+                          meps, minveps);
+            abort("error");
+        }
+
+        /////////////////////////////////////////////////////////////////
+        // position at upper material edge where there is only material in one stack:
+        ivec itop = icenter + unit_ivec(D3, Z) * (2*sh);
+        grad = matfun.normal_vector(itop);
+
+        double phi_ang = atan2(grad.y(), grad.x());
+        fratio = (0.5 + zs) * get_fill_ratio(
+            test_angle, test_shift.x(), test_shift.y());
+        test_meps = fratio * (eps - 1) + 1;
+        meps = matfun.mean_eps(itop);
+        test_minveps = 1 - fratio * (eps - 1) / eps;
+        minveps = matfun.mean_inveps(itop);
+
+        if (fabs(test_angle - phi_ang) > 1e-8 ||
+            grad.z() < 1e-8 || // must point upwards
+            fabs(test_minveps - minveps) > 1e-8 ||
+            fabs(test_meps - meps) > 1e-8
+        )
+        {
+            master_printf("error at #%i: test shift: (%.14f, %.14f, %.14f) ; test angle: %.14f\n",
+                          i, test_shift.x(), test_shift.y(), zs, test_angle * 180 / pi);
+            master_printf("gradient at %i, %i, %i (top): (%.14f, %.14f, %.16f)\n",
+                          itop.x(), itop.y(), itop.z(), grad.x(), grad.y(), grad.z());
+            master_printf("expected phi: %.14f ; mean_eps: %.14f ; mean_inv_eps: %.14f ; gradient.z > 0\n",
+                          test_angle * 180 / pi, test_meps, test_minveps);
+            master_printf("     got phi: %.14f ; mean_eps: %.14f ; mean_inv_eps: %.14f ; gradient.z %s 0\n\n",
+                          phi_ang * 180 / pi, meps, minveps, grad.z() < 1e-12 ? "<=" : ">");
+            abort("error");
+        }
+
+        /////////////////////////////////////////////////////////////////
+        // center material edge, where the layers in the two stacks have different heights:
+        grad = matfun.normal_vector(icenter);
+
+        phi_ang = atan2(grad.y(), grad.x());
+        fratio = 0.5 + zs + (0.5 - zs) * get_fill_ratio(
+            test_angle, test_shift.x(), test_shift.y());
+        test_meps = fratio * (eps - 1) + 1;
+        meps = matfun.mean_eps(icenter);
+        test_minveps = 1 - fratio * (eps - 1) / eps;
+        minveps = matfun.mean_inveps(icenter);
+
+        // grad is expected to point in opposite direction:
+        if (fabs(test_angle - phi_ang) - pi > 1e-8 ||
+            grad.z() < 1e-8 || // must point upwards
+            fabs(test_minveps - minveps) > 1e-8 ||
+            fabs(test_meps - meps) > 1e-8
+        )
+        {
+            master_printf("error at #%i: test shift: (%.14f, %.14f, %.14f) ; test angle: %.14f\n",
+                          i, test_shift.x(), test_shift.y(), zs, test_angle * 180 / pi);
+            master_printf("gradient at %i, %i, %i (center): (%.14f, %.14f, %.16f)\n",
+                          icenter.x(), icenter.y(), icenter.z(), grad.x(), grad.y(), grad.z());
+            master_printf("expected phi: %.14f ; mean_eps: %.14f ; mean_inv_eps: %.14f ; gradient.z > 0\n",
+                          test_angle * 180 / pi, test_meps, test_minveps);
+            master_printf("     got phi: %.14f ; mean_eps: %.14f ; mean_inv_eps: %.14f ; gradient.z %s 0\n\n",
+                          phi_ang * 180 / pi, meps, minveps, grad.z() < 1e-12 ? "<=" : ">");
+            abort("error");
+        }
+
+    }
+}
+
+/** Tests the z component of a polygonal interface's normal direction in
+ *  3D between 2 different material stacks for multiple randomly
+ *  chosen angles and z-offsets. */
+void check_z_normals_3D(const int num_random_trials = 10000)
+{
+    master_printf("Checking interface of polygonal material with air (3D) - z component\n");
+    const int w = 6;
+    const int sh = int(w/2);
+    grid_volume gv(vol3d(w, w, 4*sh, 1));
+    volume vol(gv.surroundings());
+    vec center = gv.center();
+    ivec icenter = gv.icenter();
+    double maxpd = 0, mpi = 0, mps = 0;
+    vec mpshift = zero_vec(D3);
+
+    for (int i = 0; i < num_random_trials; ++i) {
+        double ptsA[8] = {
+            -w, -w,
+            0, -w,
+            0,  w,
+            -w,  w
+        };
+        double ptsB[8] = {
+            w, w,
+            0, w,
+            0,  -w,
+            w,  -w
+        };
+        double test_angle = urand(-pi, pi);
+        // in this test case, the lateral shift cannot be random, since we
+        // don't know the analytical solution in those cases:
+        vec test_shift = vec(0, 0);
+        double zs = urand(-0.5, 0.5);
+
+        double eps = 12.0;
+        double layer_thicknessA[3] = {sh + zs, 2 * sh, sh - zs};
+        double layer_epsA[3] = {1.0, eps, 1.0};
+        double layer_thicknessB[3] = {sh + zs, sh,  2 * sh - zs};
+        double layer_epsB[3] = {1.0, eps, 1.0};
+        material_function_for_polygons matfun(gv);
+        unsigned int matstack_idA = matfun.add_material_stack(layer_thicknessA, layer_epsA, 3);
+        unsigned int matstack_idB = matfun.add_material_stack(layer_thicknessB, layer_epsB, 3);
+
+        rotate_polygon(ptsA, 4, test_angle);
+        shift_polygon(ptsA, 4, center + test_shift);
+        rotate_polygon(ptsB, 4, test_angle);
+        shift_polygon(ptsB, 4, center + test_shift);
+        polygon pol = polygon(ptsA, 4, 2);
+        matfun.add_polygon(pol, matstack_idA);
+        pol = polygon(ptsB, 4, 2);
+        matfun.add_polygon(pol, matstack_idB);
+
+        // position at upper material edge where there is only material in one stack:
+        ivec itop = icenter + unit_ivec(D3, Z) * (2*sh);// - unit_ivec(D3, X) * 1;
+        vec grad = matfun.normal_vector(itop);
+        // Also test at center position, where the material from two stacks meet:
+        vec grad2 = matfun.normal_vector(icenter);
+        // expected grad.z(), from analytical integration of -z*chi over the unit sphere:
+        double exp_gz = (eps - 1) / 8.0 * (1 - 4 * pow(zs / sqrt(3), 2));
+        // error, normalized with chi, so this test is independent of changes of eps:
+        double err = fabs(exp_gz - grad.z()) / (eps - 1);
+        double err2 = fabs(exp_gz - grad2.z()) / (eps - 1);
+        // The Lebedev quadrature scheme used in this case in matfun.normal_vector returns
+        // only values at discrete positions, since it cannot distinquish small shifts
+        // in the structure position. So we cannot be too strict on the error, but
+        // still keep a tight upper bound:
+        double maxerr = 0.0158;
+        if (err > maxerr || err2 > maxerr)
+        {
+            master_printf("error at #%i: test shift: (%.14f, %.14f, %.14f) ; test angle: %.14f\n",
+                          i, test_shift.x(), test_shift.y(), zs, test_angle * 180 / pi);
+            master_printf("gradient at %i, %i, %i: (%.14f, %.14f, %.14f), error: %f\n",
+                          itop.x(), itop.y(), itop.z(), grad.x(), grad.y(), grad.z(), err);
+            master_printf("gradient at %i, %i, %i: (%.14f, %.14f, %.14f), error: %f\n",
+                          icenter.x(), icenter.y(), icenter.z(), grad2.x(), grad2.y(), grad2.z(), err2);
+            master_printf("z-component not within allowed margin of expected analytical result: %f\n",
+                          exp_gz);
+            abort("error");
+        }
+    }
+}
+
+int main(int argc, char **argv) {
+  initialize mpi(argc, argv);
+  quiet = true;
+
+  srand(271828); // use fixed random sequence
+
+  check_normals_2D();
+  check_normals_2D_2materials();
+  check_normals_3D();
+  check_z_normals_3D();
+
+  return 0;
+}


### PR DESCRIPTION
Dear Prof. Johnson,

I have added a material function to meep which allows defining the dielectric function with polygons. For 2D simulations, the dielectric function can be freely defined by adding any amount of non-overlapping polygons and their epsilon value. For 3D simulations, instead of an epsilon value, all added polygons must be assigned a material stack, which defines the dielectric function along the z axis, while the polygons describe the regions on the x-y-plane where these stacks are located. 

It all works with the proper anisotropic averaging done in material_function_for_polygons::eff_chi1inv_row. I made some effort that this runs pretty quick.

I hope you find this useful and could eventually add it to the master node if you reckon other users will find it useful as well.

With very best regards,
Jürgen Probst