### PR TITLE
Fix bug in structure::dump

### DIFF
--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -87,6 +87,7 @@ void sum_to_all(const size_t *in, size_t *out, int size);
 void sum_to_master(const size_t *in, size_t *out, int size);
 bool or_to_all(bool in);
 void or_to_all(const int *in, int *out, int size);
+void bw_or_to_all(const size_t *in, size_t *out, int size);
 bool and_to_all(bool in);
 void and_to_all(const int *in, int *out, int size);
 

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -451,6 +451,14 @@ void or_to_all(const int *in, int *out, int size) {
 #endif
 }
 
+void bw_or_to_all(const size_t *in, size_t *out, int size) {
+#ifdef HAVE_MPI
+  MPI_Allreduce((void*) in, out, size, sizeof(size_t)==4?MPI_UNSIGNED:MPI_UNSIGNED_LONG_LONG, MPI_BOR, mycomm);
+#else
+  memcpy(out, in, sizeof(size_t) * size);
+#endif
+}
+
 bool and_to_all(bool in) {
   int in2 = in, out;
 #ifdef HAVE_MPI

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -206,13 +206,13 @@ void structure::dump(const char *filename) {
           break;
         }
         if (chunks[i]->is_mine()) {
-          susceptibility *sus = chunks[i]->chiP[E_stuff];
+          susceptibility *sus = chunks[i]->chiP[ft];
           if (sus) {
             for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c) {
               for (int d = 0; d < 5; ++d) {
                 if (sus->sigma[c][d]) {
-                  my_sigma_cd[E_stuff][j] = c;
-                  my_sigma_cd[E_stuff][j + 1] = d;
+                  my_sigma_cd[ft][j] = c;
+                  my_sigma_cd[ft][j + 1] = d;
                   j += 2;
                   done = true;
                 }
@@ -222,8 +222,8 @@ void structure::dump(const char *filename) {
         }
       }
     }
-    sum_to_all(my_sigma_cd[E_stuff], sigma_cd[E_stuff], num_E_sigmas * 2);
-    sum_to_all(my_sigma_cd[H_stuff], sigma_cd[H_stuff], num_H_sigmas * 2);
+    bw_or_to_all(my_sigma_cd[E_stuff], sigma_cd[E_stuff], num_E_sigmas * 2);
+    bw_or_to_all(my_sigma_cd[H_stuff], sigma_cd[H_stuff], num_H_sigmas * 2);
   }
 
   // Write location (component and direction) data of non-null sigmas (sigma[c][d])


### PR DESCRIPTION
Ardavan found a bug when dumping dispersive materials.

The code starting at `structure_dump.cpp:200` is trying to find the component and direction for each non-null sigma, which I call `sigma_cd`. Since this data is the same in each chunk that has non-null sigmas, I only need to find the data once, then make sure every processor has access to it. However, if multiple processors find the data, `sum_to_all` will not give us the correct values. Switching the reduce operator to "bitwise or" gives us the desired behavior.

Also fixed a hard-coded `E_stuff` to properly loop through field types.
@stevengj @oskooi 