### PR TITLE
change normalization of eigenmode sources to yield unit input power

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -450,10 +450,10 @@ struct py_eigenmode_data {
 
 py_eigenmode_data _get_eigenmode(meep::fields *f, double omega_src, meep::direction d, const meep::volume where,
                                  const meep::volume eig_vol, int band_num, const meep::vec &_kpoint,
-                                 bool match_frequency, int parity, double resolution, double eigensolver_tol,
-                                 bool verbose) {
+                                 bool match_frequency, int parity, double resolution, double eigensolver_tol, 
+                                 double width, bool verbose) {
     void *data = f->get_eigenmode(omega_src, d, where, eig_vol, band_num, _kpoint, match_frequency,
-                                    parity, resolution, eigensolver_tol, verbose);
+                                    parity, resolution, eigensolver_tol, width, verbose);
     meep::eigenmode_data *emdata = (meep::eigenmode_data *)data;
 
     py_eigenmode_data result = {};
@@ -1166,7 +1166,7 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
 py_eigenmode_data _get_eigenmode(meep::fields *f, double omega_src, meep::direction d, const meep::volume where,
                                  const meep::volume eig_vol, int band_num, const meep::vec &_kpoint,
                                  bool match_frequency, int parity, double resolution, double eigensolver_tol,
-                                 bool verbose);
+                                 double width, bool verbose);
 
 %ignore eps_func;
 %ignore inveps_func;

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1378,7 +1378,7 @@ class Simulation(object):
         return np.reshape(coeffs, (num_bands, flux.Nfreq, 2)), vgrp, kpoints
 
     def get_eigenmode(self, omega_src, direction, where, band_num, kpoint, eig_vol=None, match_frequency=True,
-                      parity=mp.NO_PARITY, resolution=0, eigensolver_tol=1e-7, verbose=False):
+                      parity=mp.NO_PARITY, resolution=0, eigensolver_tol=1e-7, verbose=False, width=0.0):
 
         if self.fields is None:
             raise ValueError("Fields must be initialized before calling get_eigenmode")
@@ -1391,7 +1391,7 @@ class Simulation(object):
 
         swig_kpoint = mp.vec(kpoint.x, kpoint.y, kpoint.z)
         emdata = mp._get_eigenmode(self.fields, omega_src, direction, where, eig_vol, band_num, swig_kpoint,
-                                   match_frequency, parity, resolution, eigensolver_tol, verbose)
+                                   match_frequency, parity, resolution, eigensolver_tol, width, verbose)
 
         return EigenmodeData(emdata.band_num, emdata.omega, emdata.group_velocity, emdata.Gk, emdata.data)
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -741,6 +741,7 @@ class src_time {
   virtual bool is_equal(const src_time &t) const { (void)t; return 1; }
   virtual std::complex<double> frequency() const { return 0.0; }
   virtual void set_frequency(std::complex<double> f) { (void) f; }
+  virtual double get_width() const { return 0.0; }
 
  private:
   double current_time;
@@ -762,6 +763,7 @@ class gaussian_src_time : public src_time {
   virtual bool is_equal(const src_time &t) const;
   virtual std::complex<double> frequency() const { return freq; }
   virtual void set_frequency(std::complex<double> f) { freq = real(f); }
+  virtual double get_width() const { return width; }
 
  private:
   double freq, width, peak_time, cutoff;
@@ -782,6 +784,7 @@ class continuous_src_time : public src_time {
   virtual bool is_equal(const src_time &t) const;
   virtual std::complex<double> frequency() const { return freq; }
   virtual void set_frequency(std::complex<double> f) { freq = f; }
+  virtual double get_width() const { return width; }
 
  private:
   std::complex<double> freq;
@@ -1496,7 +1499,8 @@ class fields {
                       const volume eig_vol, int band_num,
                       const vec &kpoint, bool match_frequency,
                       int parity, double resolution,
-                      double eigensolver_tol, bool verbose=false);
+                      double eigensolver_tol, double width=0.0,
+                      bool verbose=false);
 
   void add_eigenmode_source(component c, const src_time &src,
 	  		    direction d, const volume &where,
@@ -1514,7 +1518,6 @@ class fields {
                                   std::complex<double> *coeffs, double *vgrp,
                                   kpoint_func user_kpoint_func=0,
                                   void *user_kpoint_data=0, vec *kpoints=0);
-
 
   // initialize.cpp:
   void initialize_field(component, std::complex<double> f(const vec &));


### PR DESCRIPTION
Fixes #470. Renormalize the amplitude of eigenmode sources to yield unit power flux.

The power flux depends on the frequency width of the source. I added a `width` parameter to `fields::get_eigenmode` with a default value of 0. (If `width==0` the amplitude renormalization is skipped.) This requires updating calling conventions in a couple of other places: 

(1) Within `add_eigenmode_source,` the frequency width can in principle be fetched from the existing `src` input parameter, so the calling convention doesn't need to change. However, the frequency width is a private data field in `gaussian_src_time` and `continuous_src_time,` and there were no getter functions. I added a virtual getter routine `get_width()` to the parent `src_time` class, which returns 0 by default and is overridden by `gaussian_src_time` and `continuous_src_time`.

(2) I updated the `_get_eigenmode` python routine to accept a new optional `width=0.0` argument. (Again, passing `width=0.0` to `get_eigenmode` yields behavior unchanged from before this PR.) If a user calls `get_eigenmode` directly from python and wants the amplitude renormalization` the user must specify a nonzero value for `width`. 

(3) No modification is needed for `get_eigenmode_coefficients.` The overall normalization of the eigenmodes cancels out of this calculation anyway, so it suffices to pass `width=0.0` yielding behavior equivalent to before.