### PR TITLE
Guard config.h in HAVE_CONFIG_H.

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -4,7 +4,9 @@
 #include <cstddef>
 #include <iostream>
 
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 #include "pympb.hpp"
 #include "mpb/scalar.h"
 #include "meep/mympi.hpp"

--- a/scheme/meep-ctl.hpp
+++ b/scheme/meep-ctl.hpp
@@ -6,7 +6,9 @@
 
 #include "meep-ctl-const.hpp"
 
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 #include "ctl-io.h"
 
 #include "meep-ctl-swig.hpp"

--- a/src/bands.cpp
+++ b/src/bands.cpp
@@ -22,7 +22,9 @@
 #include "meep.hpp"
 #include "meep_internals.hpp"
 
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 #ifdef HAVE_HARMINV
 #  include <harminv.h>
 #endif

--- a/src/bicgstab.cpp
+++ b/src/bicgstab.cpp
@@ -21,7 +21,9 @@
 #include "meep/mympi.hpp"
 #include "bicgstab.hpp"
 
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 /* bicgstab() implements an iterative solver for non-symmetric linear
    operators, using the algorithm described in:

--- a/src/casimir.cpp
+++ b/src/casimir.cpp
@@ -28,7 +28,9 @@
 
 #include "meep.hpp"
 
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 #if defined(HAVE_LIBFFTW)
 #  include <fftw.h>

--- a/src/h5file.cpp
+++ b/src/h5file.cpp
@@ -28,7 +28,9 @@
      } \
 } while (0)
 
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 #ifdef HAVE_HDF5
 

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -22,7 +22,9 @@
 
 #include "meep.hpp"
 #include "meep_internals.hpp"
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 // Cylindrical coordinates:
 

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -22,7 +22,9 @@
 #include "meep.hpp"
 #include "meep_internals.hpp"
 
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 #if defined(HAVE_LIBFFTW3)
 #  include <fftw3.h>
 #elif defined(HAVE_LIBDFFTW)

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -19,7 +19,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "meep.hpp"
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 #ifdef HAVE_MPB
 #  include <mpb.h>

--- a/src/multilevel-atom.cpp
+++ b/src/multilevel-atom.cpp
@@ -21,7 +21,9 @@
 #include <string.h>
 #include "meep.hpp"
 #include "meep_internals.hpp"
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 namespace meep {
 

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -20,7 +20,9 @@
 #include <stdlib.h>
 
 #include "meep.hpp"
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 #ifdef HAVE_MPI
 #  ifdef NEED_UNDEF_SEEK_FOR_MPI

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -22,7 +22,9 @@
 
 #include <meep.hpp>
 #include <assert.h>
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 using namespace std;
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -16,7 +16,9 @@
  */
 
 #include "meep.hpp"
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 #ifdef HAVE_LIBGSL
 #  include <gsl/gsl_randist.h>

--- a/src/step.cpp
+++ b/src/step.cpp
@@ -22,7 +22,9 @@
 #include "meep.hpp"
 #include "meep_internals.hpp"
 
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 #define RESTRICT
 

--- a/src/step_generic.cpp
+++ b/src/step_generic.cpp
@@ -1,6 +1,8 @@
 #include "meep.hpp"
 #include "meep_internals.hpp"
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 #define DPR double * restrict
 #define RPR realnum * restrict

--- a/src/update_pols.cpp
+++ b/src/update_pols.cpp
@@ -21,7 +21,9 @@
 
 #include "meep.hpp"
 #include "meep_internals.hpp"
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 using namespace std;
 

--- a/tests/2D_convergence.cpp
+++ b/tests/2D_convergence.cpp
@@ -1,6 +1,8 @@
 #include <meep.hpp>
 using namespace meep;
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 using namespace std;
 
 const double diameter = 0.8;

--- a/tests/convergence_cyl_waveguide.cpp
+++ b/tests/convergence_cyl_waveguide.cpp
@@ -1,7 +1,9 @@
 #include <stdio.h>
 #include <meep.hpp>
 using namespace meep;
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 using namespace std;
 
 double eps(const vec &pt) { return ((pt.r() < 0.5+1e-6) ? 9.0 : 1.0); }

--- a/tests/h5test.cpp
+++ b/tests/h5test.cpp
@@ -6,7 +6,9 @@
 
 #include <meep.hpp>
 #include "meep_internals.hpp"
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 using namespace meep;
 using namespace std;
 

--- a/tests/known_results.cpp
+++ b/tests/known_results.cpp
@@ -22,7 +22,9 @@
 using namespace meep;
 using namespace std;
 
-#include "config.h"
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
 
 double one(const vec &) { return 1.0; }
 


### PR DESCRIPTION
When we cannot run `configure.sh` to generate `config.h`, this will
allow us to build by providing the defines via CXXFLAGS and friends.