### PR TITLE
libmeepgeom: Fix build failure.

### DIFF
--- a/tests/ring-ll.cpp
+++ b/tests/ring-ll.cpp
@@ -136,7 +136,8 @@ int main(int argc, char *argv[])
   int ref_bands=3;
   double ref_freq_re[3] = {  1.1807e-01, 1.4716e-01,  1.7525e-01  };
   double ref_freq_im[3] = { -7.6133e-04, -2.1156e-04, -5.2215e-05 };
-  cdouble ref_amp[3]    = { -8.28e-04-1.34e-03i, +1.23e-03-1.25e-02i, +2.83e-03-6.52e-04i};
+  cdouble ref_amp[3]    = { cdouble(-8.28e-04,-1.34e-03),
+    cdouble(1.23e-03,-1.25e-02), cdouble(2.83e-03,-6.52e-04) };
   if (bands!=3)
    abort("harminv found only %i/%i bands\n",bands,ref_bands);
   for(int nb=0; nb<bands; nb++)


### PR DESCRIPTION
Updating meep to 1.7.0 on openSUSE Tumbleweed leaded to some compiling errors:
```
CXX      ring-ll.o
ring-ll.cpp: In function 'int main(int, char**)':
ring-ll.cpp:139:39: error: unable to find numeric literal operator 'operator""i'
    cdouble ref_amp[3]    = { -8.28e-04-1.34e-03i, +1.23e-03-1.25e-02i, +2.83e-03-6.52e-04i};
                                        ^~~~~~~~~
ring-ll.cpp:139:39: note: add 'using namespace std::complex_literals' (from <complex>) to enable the C++14 user-defined literal suffixes
ring-ll.cpp:139:60: error: unable to find numeric literal operator 'operator""i'
    cdouble ref_amp[3]    = { -8.28e-04-1.34e-03i, +1.23e-03-1.25e-02i, +2.83e-03-6.52e-04i};
                                                            ^~~~~~~~~
ring-ll.cpp:139:60: note: add 'using namespace std::complex_literals' (from <complex>) to enable the C++14 user-defined literal suffixes
ring-ll.cpp:139:81: error: unable to find numeric literal operator 'operator""i'
    cdouble ref_amp[3]    = { -8.28e-04-1.34e-03i, +1.23e-03-1.25e-02i, +2.83e-03-6.52e-04i};
                                                                                  ^~~~~~~~~
ring-ll.cpp:139:81: note: add 'using namespace std::complex_literals' (from <complex>) to enable the C++14 user-defined literal suffixes
make[2]: *** [Makefile:812: ring-ll.o] Error 1
```

Adding the commit from this PR resolves the compiling issue. Could you merge this?

Jonathan