### PR TITLE
Split chunks based on costs obtained from fragment_stats

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -2287,7 +2287,7 @@ double mode_solver::compute_energy_in_objects(geometric_object_list objects) {
     return 0.0;
   }
 
-  geom_fix_objects0(objects);
+  geom_fix_object_list(objects);
 
   int n1 = mdata->nx;
   int n2 = mdata->ny;

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -471,7 +471,8 @@ class Simulation(object):
                  output_single_precision=False,
                  load_structure='',
                  geometry_center=mp.Vector3(),
-                 force_all_components=False):
+                 force_all_components=False,
+                 split_chunks_evenly=False):
 
         self.cell_size = cell_size
         self.geometry = geometry
@@ -518,6 +519,7 @@ class Simulation(object):
         self._is_initialized = False
         self._fragment_size = 10
         self.force_all_components = force_all_components
+        self.split_chunks_evenly = split_chunks_evenly
 
     # To prevent the user from having to specify `dims` and `is_cylindrical`
     # to Volumes they create, the library will adjust them appropriately based
@@ -823,7 +825,7 @@ class Simulation(object):
 
         return vols1, vols2, vols3
 
-    def _compute_fragment_stats(self, gv):
+    def _make_fragment_lists(self, gv):
 
         def convert_volumes(dft_obj):
             volumes = []
@@ -846,6 +848,12 @@ class Simulation(object):
         pml_vols1, pml_vols2, pml_vols3 = self._boundary_layers_to_vol_list(pmls)
         absorber_vols1, absorber_vols2, absorber_vols3 = self._boundary_layers_to_vol_list(absorbers)
         absorber_vols = absorber_vols1 + absorber_vols2 + absorber_vols3
+
+        return (dft_data_list, pml_vols1, pml_vols2, pml_vols3, absorber_vols)
+
+    def _compute_fragment_stats(self, gv):
+
+        dft_data_list, pml_vols1, pml_vols2, pml_vols3, absorber_vols = self._make_fragment_lists(gv)
 
         stats = mp.compute_fragment_stats(
             self.geometry,
@@ -886,7 +894,6 @@ class Simulation(object):
         gv = self._create_grid_volume(k)
         sym = self._create_symmetries(gv)
         br = _create_boundary_region_from_boundary_layers(self.boundary_layers, gv)
-
         absorbers = [bl for bl in self.boundary_layers if type(bl) is Absorber]
 
         if self.material_function:
@@ -899,22 +906,33 @@ class Simulation(object):
             self.default_material = self.epsilon_input_file
 
         self.fragment_stats = self._compute_fragment_stats(gv) if isinstance(self.default_material, mp.Medium) else []
+        dft_data_list, pml_vols1, pml_vols2, pml_vols3, absorber_vols = self._make_fragment_lists(gv)
 
-        self.structure = mp.structure(gv, None, br, sym, self.num_chunks, self.Courant,
-                                      self.eps_averaging, self.subpixel_tol, self.subpixel_maxeval)
-        self.structure.shared_chunks = True
+        self.structure = mp.create_structure_and_set_materials(
+            self.cell_size,
+            dft_data_list,
+            pml_vols1,
+            pml_vols2,
+            pml_vols3,
+            absorber_vols,
+            gv,
+            br,
+            sym,
+            self.num_chunks,
+            self.Courant,
+            self.eps_averaging,
+            self.subpixel_tol,
+            self.subpixel_maxeval,
+            self.geometry,
+            self.geometry_center,
+            self.ensure_periodicity and not not self.k_point,
+            self.verbose,
+            self.default_material,
+            absorbers,
+            self.extra_materials,
+            self.split_chunks_evenly
+       )
 
-        mp.set_materials_from_geometry(self.structure,
-                                       self.geometry,
-                                       self.geometry_center,
-                                       self.eps_averaging,
-                                       self.subpixel_tol,
-                                       self.subpixel_maxeval,
-                                       self.ensure_periodicity and not not self.k_point,
-                                       False,
-                                       self.default_material,
-                                       absorbers,
-                                       self.extra_materials)
         if self.load_structure_file:
             self.load_structure(self.load_structure_file)
 

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -327,7 +327,8 @@ class TestSimulation(unittest.TestCase):
                             cell_size=cell,
                             boundary_layers=pml_layers,
                             geometry=geometry,
-                            sources=[sources])
+                            sources=[sources],
+                            split_chunks_evenly=True)
 
         sample_point = mp.Vector3(0.12, -0.29)
         ref_field_points = []

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -263,6 +263,8 @@ static meep::vec my_kpoint_func(double freq, int mode, void *user_data) {
 
 %warnfilter(302,325,451,503,509);
 
+%ignore meep_geom::fragment_stats;
+
 %include "meep_renames.i"
 %include "meep_enum_renames.i"
 %include "meep_op_renames.i"

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -985,9 +985,10 @@ public:
   friend grid_volume vol3d(double xsize, double ysize, double zsize, double a);
 
   grid_volume split(size_t num, int which) const;
-  grid_volume split_by_effort(int num, int which, int Ngv = 0, const grid_volume *v = NULL, double *effort = NULL) const;
+  grid_volume split_by_effort(int num, int which, int Ngv = 0, const grid_volume *v = NULL,
+                              double *effort = NULL) const;
   grid_volume split_by_cost(int desired_chunks, int proc_num) const;
-  grid_volume split_at_fraction(bool want_high, int numer, int bestd=-1, int bestlen=1) const;
+  grid_volume split_at_fraction(bool want_high, int numer, int bestd = -1, int bestlen = 1) const;
   grid_volume halve(direction d) const;
   void pad_self(direction d);
   grid_volume pad(direction d) const;

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -985,9 +985,9 @@ public:
   friend grid_volume vol3d(double xsize, double ysize, double zsize, double a);
 
   grid_volume split(size_t num, int which) const;
-  grid_volume split_by_effort(int num, int which, int Ngv = 0, const grid_volume *v = NULL,
-                              double *effort = NULL) const;
-  grid_volume split_at_fraction(bool want_high, int numer) const;
+  grid_volume split_by_effort(int num, int which, int Ngv = 0, const grid_volume *v = NULL, double *effort = NULL) const;
+  grid_volume split_by_cost(int desired_chunks, int proc_num) const;
+  grid_volume split_at_fraction(bool want_high, int numer, int bestd=-1, int bestlen=1) const;
   grid_volume halve(direction d) const;
   void pad_self(direction d);
   grid_volume pad(direction d) const;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -236,8 +236,7 @@ meep::vec vector3_to_vec(const vector3 v3) {
   }
 }
 
-geom_box gv2box(const meep::volume &v)
-{
+geom_box gv2box(const meep::volume &v) {
   geom_box box;
   box.low = vec_to_vector3(v.get_min_corner());
   box.high = vec_to_vector3(v.get_max_corner());
@@ -1751,20 +1750,12 @@ static std::vector<fragment_stats> init_fragments(std::vector<geom_box> &boxes, 
   return fragments;
 }
 
-std::vector<fragment_stats> compute_fragment_stats(geometric_object_list geom_,
-                                                   meep::grid_volume *gv,
-                                                   vector3 cell_size,
-                                                   vector3 cell_center,
-                                                   material_type default_mat,
-                                                   std::vector<dft_data> dft_data_list_,
-                                                   std::vector<meep::volume> pml_1d_vols_,
-                                                   std::vector<meep::volume> pml_2d_vols_,
-                                                   std::vector<meep::volume> pml_3d_vols_,
-                                                   std::vector<meep::volume> absorber_vols_,
-                                                   double tol,
-                                                   int maxeval,
-                                                   bool ensure_per,
-                                                   double box_size) {
+std::vector<fragment_stats> compute_fragment_stats(
+    geometric_object_list geom_, meep::grid_volume *gv, vector3 cell_size, vector3 cell_center,
+    material_type default_mat, std::vector<dft_data> dft_data_list_,
+    std::vector<meep::volume> pml_1d_vols_, std::vector<meep::volume> pml_2d_vols_,
+    std::vector<meep::volume> pml_3d_vols_, std::vector<meep::volume> absorber_vols_, double tol,
+    int maxeval, bool ensure_per, double box_size) {
 
   fragment_stats::geom = geom_;
   fragment_stats::dft_data_list = dft_data_list_;
@@ -1783,25 +1774,17 @@ std::vector<fragment_stats> compute_fragment_stats(geometric_object_list geom_,
   return fragments;
 }
 
-fragment_stats::fragment_stats(geom_box& bx):
-  num_anisotropic_eps_pixels(0),
-  num_anisotropic_mu_pixels(0),
-  num_nonlinear_pixels(0),
-  num_susceptibility_pixels(0),
-  num_nonzero_conductivity_pixels(0),
-  num_1d_pml_pixels(0),
-  num_2d_pml_pixels(0),
-  num_3d_pml_pixels(0),
-  num_dft_pixels(0),
-  num_pixels_in_box(0),
-  box(bx) {
+fragment_stats::fragment_stats(geom_box &bx)
+    : num_anisotropic_eps_pixels(0), num_anisotropic_mu_pixels(0), num_nonlinear_pixels(0),
+      num_susceptibility_pixels(0), num_nonzero_conductivity_pixels(0), num_1d_pml_pixels(0),
+      num_2d_pml_pixels(0), num_3d_pml_pixels(0), num_dft_pixels(0), num_pixels_in_box(0), box(bx) {
 
   num_pixels_in_box = get_pixels_in_box(&bx);
-
 }
 
 void fragment_stats::init_libctl(material_type default_mat, bool ensure_per, meep::grid_volume *gv,
-                                 vector3 cell_size, vector3 cell_center, geometric_object_list *geom_) {
+                                 vector3 cell_size, vector3 cell_center,
+                                 geometric_object_list *geom_) {
   geom_initialize();
   default_material = default_mat;
   ensure_periodicity = ensure_per;
@@ -1814,13 +1797,9 @@ void fragment_stats::init_libctl(material_type default_mat, bool ensure_per, mee
 bool fragment_stats::has_non_medium_material() {
   for (int i = 0; i < geom.num_items; ++i) {
     material_type mat = (material_type)geom.items[i].material;
-    if (mat->which_subclass != material_data::MEDIUM) {
-      return true;
-    }
+    if (mat->which_subclass != material_data::MEDIUM) { return true; }
   }
-  if (((material_type)default_material)->which_subclass != material_data::MEDIUM) {
-    return true;
-  }
+  if (((material_type)default_material)->which_subclass != material_data::MEDIUM) { return true; }
   return false;
 }
 
@@ -1931,7 +1910,8 @@ void fragment_stats::compute_dft_stats() {
         // Note: Since geom_boxes_intersect returns true if two planes share a line or two volumes
         // share a line or plane, there are cases where some pixels are counted multiple times.
         size_t overlap_pixels = get_pixels_in_box(&overlap_box, 2);
-        num_dft_pixels += overlap_pixels * dft_data_list[i].num_freqs * dft_data_list[i].num_components;
+        num_dft_pixels +=
+            overlap_pixels * dft_data_list[i].num_freqs * dft_data_list[i].num_components;
       }
     }
   }
@@ -1981,16 +1961,11 @@ void fragment_stats::compute() {
 // based on a cost function obtained via linear regression on a dataset
 // of random simulations.
 double fragment_stats::cost() const {
-  return (num_anisotropic_eps_pixels * 1.15061674e-04 +
-          num_anisotropic_mu_pixels * 1.26843801e-04 +
-          num_nonlinear_pixels * 1.67029547e-04 +
-          num_susceptibility_pixels * 2.24790864e-04 +
-          num_nonzero_conductivity_pixels * 4.61260934e-05 +
-          num_dft_pixels * 1.47283950e-04 +
-          num_1d_pml_pixels * 9.92955372e-05 +
-          num_2d_pml_pixels * 1.36901107e-03 +
-          num_3d_pml_pixels * 6.63939607e-04 +
-          num_pixels_in_box * 3.46518274e-04);
+  return (num_anisotropic_eps_pixels * 1.15061674e-04 + num_anisotropic_mu_pixels * 1.26843801e-04 +
+          num_nonlinear_pixels * 1.67029547e-04 + num_susceptibility_pixels * 2.24790864e-04 +
+          num_nonzero_conductivity_pixels * 4.61260934e-05 + num_dft_pixels * 1.47283950e-04 +
+          num_1d_pml_pixels * 9.92955372e-05 + num_2d_pml_pixels * 1.36901107e-03 +
+          num_3d_pml_pixels * 6.63939607e-04 + num_pixels_in_box * 3.46518274e-04);
 }
 
 void fragment_stats::print_stats() const {

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -75,8 +75,9 @@ struct fragment_stats {
   static bool split_chunks_evenly;
 
   static bool has_non_medium_material();
-  static void init_libctl(meep_geom::material_type default_mat, bool ensure_per, meep::grid_volume *gv,
-                          vector3 cell_size, vector3 cell_center, geometric_object_list *geom_list);
+  static void init_libctl(meep_geom::material_type default_mat, bool ensure_per,
+                          meep::grid_volume *gv, vector3 cell_size, vector3 cell_center,
+                          geometric_object_list *geom_list);
 
   size_t num_anisotropic_eps_pixels;
   size_t num_anisotropic_mu_pixels;
@@ -97,7 +98,7 @@ struct fragment_stats {
   geom_box box;
 
   fragment_stats() {}
-  fragment_stats(geom_box& bx);
+  fragment_stats(geom_box &bx);
   void update_stats_from_material(material_type mat, size_t pixels);
   void compute_stats();
   void count_anisotropic_pixels(medium_struct *med, size_t pixels);

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -66,6 +66,17 @@ struct fragment_stats {
   static int maxeval;
   static int resolution;
   static meep::ndim dims;
+  static geometric_object_list geom;
+  static std::vector<dft_data> dft_data_list;
+  static std::vector<meep::volume> pml_1d_vols;
+  static std::vector<meep::volume> pml_2d_vols;
+  static std::vector<meep::volume> pml_3d_vols;
+  static std::vector<meep::volume> absorber_vols;
+  static bool split_chunks_evenly;
+
+  static bool has_non_medium_material();
+  static void init_libctl(meep_geom::material_type default_mat, bool ensure_per, meep::grid_volume *gv,
+                          vector3 cell_size, vector3 cell_center, geometric_object_list *geom_list);
 
   size_t num_anisotropic_eps_pixels;
   size_t num_anisotropic_mu_pixels;
@@ -86,19 +97,19 @@ struct fragment_stats {
   geom_box box;
 
   fragment_stats() {}
-  fragment_stats(geom_box &bx, size_t pixels);
+  fragment_stats(geom_box& bx);
   void update_stats_from_material(material_type mat, size_t pixels);
-  void compute_stats(geometric_object_list *geom);
+  void compute_stats();
   void count_anisotropic_pixels(medium_struct *med, size_t pixels);
   void count_nonlinear_pixels(medium_struct *med, size_t pixels);
   void count_susceptibility_pixels(medium_struct *med, size_t pixels);
   void count_nonzero_conductivity_pixels(medium_struct *med, size_t pixels);
-  void compute_dft_stats(std::vector<dft_data> *dft_data_list);
-  void compute_pml_stats(const std::vector<meep::volume> &pml_1d_vols,
-                         const std::vector<meep::volume> &pml_2d_vols,
-                         const std::vector<meep::volume> &pml_3d_vols);
-  void compute_absorber_stats(const std::vector<meep::volume> &absorber_vols);
-  void print_stats();
+  void compute_dft_stats();
+  void compute_pml_stats();
+  void compute_absorber_stats();
+  void compute();
+  double cost() const;
+  void print_stats() const;
 };
 
 std::vector<fragment_stats>
@@ -174,6 +185,7 @@ bool is_medium(material_type md, medium_struct **m);
 bool is_medium(void *md, medium_struct **m);
 bool is_metal(meep::field_type ft, const material_type *material);
 void check_offdiag(medium_struct *m);
+geom_box gv2box(const meep::volume &v);
 
 /***************************************************************/
 /* routines in GDSIIgeom.cc ************************************/

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -133,12 +133,11 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
 
     grid_volume vi;
     if (meep_geom::fragment_stats::resolution == 0 ||
-        meep_geom::fragment_stats::has_non_medium_material() ||
-        gv.dim == Dcyl || meep_geom::fragment_stats::split_chunks_evenly) {
+        meep_geom::fragment_stats::has_non_medium_material() || gv.dim == Dcyl ||
+        meep_geom::fragment_stats::split_chunks_evenly) {
       // Fall back to split_by_effort method
       vi = gv.split_by_effort(desired_num_chunks, i, num_effort_volumes, effort_volumes, effort);
-    }
-    else {
+    } else {
       vi = gv.split_by_cost(desired_num_chunks, i);
     }
 

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -21,6 +21,7 @@
 #include <complex>
 
 #include "meep_internals.hpp"
+#include "meepgeom.hpp"
 
 using namespace std;
 
@@ -993,13 +994,77 @@ grid_volume grid_volume::split_by_effort(int n, int which, int Ngv, const grid_v
         .split_by_effort(n - num_low, which - num_low, Ngv, v, effort);
 }
 
-grid_volume grid_volume::split_at_fraction(bool want_high, int numer) const {
-  int bestd = -1, bestlen = 1;
-  for (int i = 0; i < 3; i++)
-    if (num[i] > bestlen) {
-      bestd = i;
-      bestlen = num[i];
+grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num) const {
+  const size_t grid_points_owned = nowned_min();
+  if (size_t(desired_chunks) > grid_points_owned)
+    abort("Cannot split %zd grid points into %d parts\n", nowned_min(), desired_chunks);
+  if (desired_chunks == 1) return *this;
+  double best_split_measure = 1e20, left_effort_fraction = 0;
+  int best_split_point = 0;
+  direction best_split_direction = NO_DIRECTION;
+
+  LOOP_OVER_DIRECTIONS(dim, d) {
+    int biglen = num_direction(d);
+    direction splitdir = d;
+
+    for (int split_point = 1; split_point < biglen; split_point+=1) {
+      grid_volume v_left = *this;
+      v_left.set_num_direction(splitdir, split_point);
+      grid_volume v_right = *this;
+      v_right.set_num_direction(splitdir, num_direction(splitdir) - split_point);
+      v_right.shift_origin(splitdir, split_point*2);
+
+      geom_box left_box = meep_geom::gv2box(v_left.surroundings());
+      geom_box right_box = meep_geom::gv2box(v_right.surroundings());
+
+      meep_geom::fragment_stats left_stats(left_box);
+      meep_geom::fragment_stats right_stats(right_box);
+
+      left_stats.compute();
+      right_stats.compute();
+      double total_left_effort = left_stats.cost();
+      double total_right_effort = right_stats.cost();
+
+      double split_measure = max(total_left_effort/(desired_chunks/2),
+                                 total_right_effort/(desired_chunks-desired_chunks/2));
+      if (split_measure < best_split_measure) {
+        best_split_measure = split_measure;
+        best_split_point = split_point;
+        best_split_direction = d;
+        left_effort_fraction = total_left_effort/(total_left_effort + total_right_effort);
+      }
     }
+  }
+  const int split_point = best_split_point;
+  const int num_in_split_dir = num_direction(best_split_direction);
+
+  const int num_low = (size_t)(left_effort_fraction*desired_chunks + 0.5);
+  // Revert to split() when cost method gives less grid points than chunks
+  if (size_t(num_low) > best_split_point*(grid_points_owned/num_in_split_dir) ||
+      size_t(desired_chunks-num_low) > (grid_points_owned - best_split_point*(grid_points_owned/num_in_split_dir)))
+    return split(desired_chunks, proc_num);
+
+  bool split_low = proc_num < num_low;
+  grid_volume split_gv = split_at_fraction(!split_low, split_point, best_split_direction, num_in_split_dir);
+
+  if (split_low) {
+    return split_gv.split_by_cost(num_low, proc_num);
+  }
+  else {
+    return split_gv.split_by_cost(desired_chunks-num_low, proc_num-num_low);
+  }
+}
+
+grid_volume grid_volume::split_at_fraction(bool want_high, int numer, int bestd, int bestlen) const {
+
+  if (bestd == -1) {
+    for (int i=0;i<3;i++)
+      if (num[i] > bestlen) {
+        bestd = i;
+        bestlen = num[i];
+      }
+  }
+
   if (bestd == -1) {
     for (int i = 0; i < 3; i++)
       master_printf("num[%d] = %d\n", i, num[i]);

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1007,12 +1007,12 @@ grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num) const {
     int biglen = num_direction(d);
     direction splitdir = d;
 
-    for (int split_point = 1; split_point < biglen; split_point+=1) {
+    for (int split_point = 1; split_point < biglen; split_point += 1) {
       grid_volume v_left = *this;
       v_left.set_num_direction(splitdir, split_point);
       grid_volume v_right = *this;
       v_right.set_num_direction(splitdir, num_direction(splitdir) - split_point);
-      v_right.shift_origin(splitdir, split_point*2);
+      v_right.shift_origin(splitdir, split_point * 2);
 
       geom_box left_box = meep_geom::gv2box(v_left.surroundings());
       geom_box right_box = meep_geom::gv2box(v_right.surroundings());
@@ -1025,40 +1025,42 @@ grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num) const {
       double total_left_effort = left_stats.cost();
       double total_right_effort = right_stats.cost();
 
-      double split_measure = max(total_left_effort/(desired_chunks/2),
-                                 total_right_effort/(desired_chunks-desired_chunks/2));
+      double split_measure = max(total_left_effort / (desired_chunks / 2),
+                                 total_right_effort / (desired_chunks - desired_chunks / 2));
       if (split_measure < best_split_measure) {
         best_split_measure = split_measure;
         best_split_point = split_point;
         best_split_direction = d;
-        left_effort_fraction = total_left_effort/(total_left_effort + total_right_effort);
+        left_effort_fraction = total_left_effort / (total_left_effort + total_right_effort);
       }
     }
   }
   const int split_point = best_split_point;
   const int num_in_split_dir = num_direction(best_split_direction);
 
-  const int num_low = (size_t)(left_effort_fraction*desired_chunks + 0.5);
+  const int num_low = (size_t)(left_effort_fraction * desired_chunks + 0.5);
   // Revert to split() when cost method gives less grid points than chunks
-  if (size_t(num_low) > best_split_point*(grid_points_owned/num_in_split_dir) ||
-      size_t(desired_chunks-num_low) > (grid_points_owned - best_split_point*(grid_points_owned/num_in_split_dir)))
+  if (size_t(num_low) > best_split_point * (grid_points_owned / num_in_split_dir) ||
+      size_t(desired_chunks - num_low) >
+          (grid_points_owned - best_split_point * (grid_points_owned / num_in_split_dir)))
     return split(desired_chunks, proc_num);
 
   bool split_low = proc_num < num_low;
-  grid_volume split_gv = split_at_fraction(!split_low, split_point, best_split_direction, num_in_split_dir);
+  grid_volume split_gv =
+      split_at_fraction(!split_low, split_point, best_split_direction, num_in_split_dir);
 
   if (split_low) {
     return split_gv.split_by_cost(num_low, proc_num);
-  }
-  else {
-    return split_gv.split_by_cost(desired_chunks-num_low, proc_num-num_low);
+  } else {
+    return split_gv.split_by_cost(desired_chunks - num_low, proc_num - num_low);
   }
 }
 
-grid_volume grid_volume::split_at_fraction(bool want_high, int numer, int bestd, int bestlen) const {
+grid_volume grid_volume::split_at_fraction(bool want_high, int numer, int bestd,
+                                           int bestlen) const {
 
   if (bestd == -1) {
-    for (int i=0;i<3;i++)
+    for (int i = 0; i < 3; i++)
       if (num[i] > bestlen) {
         bestd = i;
         bestlen = num[i];


### PR DESCRIPTION
Closes #536. Adds `grid_volume::split_by_cost` which attempts to divide the cell into chunks that take a similar amount of work. The work estimate is produced by `fragment_stats::cost`, which was obtained from running linear regression on training data from random simulations. Scheme will fall back to the old `grid_volume::split_by_effort` method. Additionally, there is a `Simulation` constructor parameter for Python, `split_chunks_evenly`, that will force the use of `split_by_effort`.  Here are some benchmark results from the following simulation (a tall skinny cell with an expensive flux plane at the top):

```python
import argparse
import time
import meep as mp

def main(args):
    sx = 2
    sy = 30
    sz = 1
    fcen = 0.15
    df = 0.1

    src = mp.Source(mp.GaussianSource(fcen, fwidth=df), mp.Ey, mp.Vector3())

    sim = mp.Simulation(cell_size=mp.Vector3(sx, sy, sz),
                        sources=[src],
                        resolution=10,
                        split_chunks_evenly=args.split_evenly)

    flux = sim.add_flux(fcen, df, 500, mp.FluxRegion(center=mp.Vector3(0, 12), size=mp.Vector3(2, 1)))
    start = time.time()
    sim.run(until=200)
    print("bench:{},{},{}".format(args.split_evenly, mp.count_processors(), time.time() - start))

if __name__ == '__main__':
    parser = argparse.ArgumentParser()
    parser.add_argument('-e', '--split-evenly', action='store_true', default=False,
                                        help='Use the old split_by_effort method to create chunks')
    args = parser.parse_args()
    main(args)
```

![split_by_cost_results](https://user-images.githubusercontent.com/14114829/50986489-952aba00-14cc-11e9-839b-fb75060286bb.png)

The `meep::structure` is now created in C++ (`create_structure_and_set_materials`) instead of Python. Using the geometry in `structure::choose_chunkdivision` would require making copies, or passing it around, both of which would require more significant changes. `create_structure_and_set_materials` allows the Python geometry to be converted to C++ once, then deleted when it returns.

### Remaining issues
1. `split_by_cost` doesn't work with cylindrical coordinates yet so it falls back to `split_by_effort`
2. `split_by_cost` breaks the `structure::dump` and `structure::load` features. When you run the initial simulation and dump the structure file, the chunks are split optimally based on the geometry, but when you attempt to load the file, there is no geometry passed in so the chunks are split evenly, resulting in chunk size mismatches. My temporary solution to this is to pass `split_chunks_evenly=True` to a `Simulation` when you know you want to dump and reuse a structure file. I guess `structure::load` needs to recreate the chunks with the correct sizes.