### PR TITLE
rm redundant mpb includes

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -6,7 +6,6 @@
 
 #include "config.h"
 #include "pympb.hpp"
-#include "mpb/scalar.h"
 #include "meep/mympi.hpp"
 
 // xyz_loop.h
@@ -29,7 +28,7 @@
           int xyz_index = ((i2_ * n1 + i1) * n3 + i3);
 #  endif /* HAVE_MPI */
 
-typedef  mpb_real real;
+typedef  mpb_real real; // needed for the CASSIGN macros below
 
 // TODO: Support MPI
 #define mpi_allreduce(sb, rb, n, ctype, t, op, comm) { \

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -5,7 +5,6 @@
 
 #include "ctlgeom.h"
 #include "mpb.h"
-#include "mpb/maxwell.h"
 #include "meepgeom.hpp"
 
 namespace py_mpb {


### PR DESCRIPTION
These files are already included via `mpb.h`, so there is no need to include them explicitly.

(May be related to the intermittent #664 failures I'm seeing on some commits?)