### PR TITLE
improve stability of lorentzian susceptibility

### DIFF
--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -214,23 +214,27 @@ void lorentzian_susceptibility::update_P(realnum *W[NUM_FIELD_COMPONENTS][2],
           SWAP(const realnum *, s1, s2);
         }
         if (s1 && s2) { // 3x3 anisotropic
-          LOOP_OVER_VOL_OWNED(gv, c, i)
-	    if (s[i] != 0) {
-	      realnum pcur = p[i];
-	      p[i] =
-                gamma1inv *
-                (pcur * (2 - omega0dtsqr_denom) - gamma1 * pp[i] +
-                 omega0dtsqr * (s[i] * w[i] + OFFDIAG(s1, w1, is1, is) + OFFDIAG(s2, w2, is2, is)));
-	      pp[i] = pcur;
-	    }
+          LOOP_OVER_VOL_OWNED(gv, c, i) {
+            // s[i] != 0 check is a bit of a hack to work around
+            // some instabilities that occur near the boundaries
+            // of materials; see PR #666
+            if (s[i] != 0) {
+              realnum pcur = p[i];
+              p[i] = gamma1inv * (pcur * (2 - omega0dtsqr_denom) - gamma1 * pp[i] +
+                                  omega0dtsqr * (s[i] * w[i] + OFFDIAG(s1, w1, is1, is) +
+                                                 OFFDIAG(s2, w2, is2, is)));
+              pp[i] = pcur;
+            }
+          }
         } else if (s1) { // 2x2 anisotropic
-          LOOP_OVER_VOL_OWNED(gv, c, i)
-	    if (s[i] != 0) {
-	      realnum pcur = p[i];
-	      p[i] = gamma1inv * (pcur * (2 - omega0dtsqr_denom) - gamma1 * pp[i] +
-				  omega0dtsqr * (s[i] * w[i] + OFFDIAG(s1, w1, is1, is)));
-	      pp[i] = pcur;
-	    }
+          LOOP_OVER_VOL_OWNED(gv, c, i) {
+            if (s[i] != 0) { // see above
+              realnum pcur = p[i];
+              p[i] = gamma1inv * (pcur * (2 - omega0dtsqr_denom) - gamma1 * pp[i] +
+                                  omega0dtsqr * (s[i] * w[i] + OFFDIAG(s1, w1, is1, is)));
+              pp[i] = pcur;
+            }
+          }
         } else { // isotropic
           LOOP_OVER_VOL_OWNED(gv, c, i) {
             realnum pcur = p[i];

--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -214,21 +214,23 @@ void lorentzian_susceptibility::update_P(realnum *W[NUM_FIELD_COMPONENTS][2],
           SWAP(const realnum *, s1, s2);
         }
         if (s1 && s2) { // 3x3 anisotropic
-          LOOP_OVER_VOL_OWNED(gv, c, i) {
-            realnum pcur = p[i];
-            p[i] =
+          LOOP_OVER_VOL_OWNED(gv, c, i)
+	    if (s[i] != 0) {
+	      realnum pcur = p[i];
+	      p[i] =
                 gamma1inv *
                 (pcur * (2 - omega0dtsqr_denom) - gamma1 * pp[i] +
                  omega0dtsqr * (s[i] * w[i] + OFFDIAG(s1, w1, is1, is) + OFFDIAG(s2, w2, is2, is)));
-            pp[i] = pcur;
-          }
+	      pp[i] = pcur;
+	    }
         } else if (s1) { // 2x2 anisotropic
-          LOOP_OVER_VOL_OWNED(gv, c, i) {
-            realnum pcur = p[i];
-            p[i] = gamma1inv * (pcur * (2 - omega0dtsqr_denom) - gamma1 * pp[i] +
-                                omega0dtsqr * (s[i] * w[i] + OFFDIAG(s1, w1, is1, is)));
-            pp[i] = pcur;
-          }
+          LOOP_OVER_VOL_OWNED(gv, c, i)
+	    if (s[i] != 0) {
+	      realnum pcur = p[i];
+	      p[i] = gamma1inv * (pcur * (2 - omega0dtsqr_denom) - gamma1 * pp[i] +
+				  omega0dtsqr * (s[i] * w[i] + OFFDIAG(s1, w1, is1, is)));
+	      pp[i] = pcur;
+	    }
         } else { // isotropic
           LOOP_OVER_VOL_OWNED(gv, c, i) {
             realnum pcur = p[i];


### PR DESCRIPTION
This is a simple fix suggested by Felix Schwarz (@fesc3555) a while ago on the [mailing list](https://www.mail-archive.com/meep-discuss@ab-initio.mit.edu/msg05966.html) to improve the stability of the [lorentzian susceptibility](https://meep.readthedocs.io/en/latest/Python_User_Interface/#lorentziansusceptibility).

Replaces and closes #238.

For reference, the original posting is reposted here along with @stevengj's [reply](https://www.mail-archive.com/meep-discuss@ab-initio.mit.edu/msg05967.html).

**original post: 3/15/2018**
```
Dear Meep community,

I sent a problem a couple of days ago and tracked it down a bit. the
problem was, that if you define a non-diagonal sigma in your
lorentzian_susceptibility, the calculation becomes an unstable and
fields and polarizations grow exponentially.

The problem, I think, is a bug in the library and has something to do
with the averaging on the yee-grid. The polarization explodes at the
boundary of the regions where sigma!=0.  To see that in detail, I added
I diagnostic output line inside lorentzian_susceptibility::update_P in
susceptibility.cpp, around line 223. The Line (with a bit of context) is:
LOOP_OVER_VOL_OWNED(gv, c, i) {
          realnum pcur = p[i];
          p[i] = gamma1inv * (pcur * (2 - omega0dtsqr_denom)
                              - gamma1 * pp[i]
                              + omega0dtsqr * (s[i] * w[i]
                                               + OFFDIAG(s1,w1,is1,is)));
          pp[i] = pcur;
          if(p[i] > 1e30){ std::cout << i << " " << s[i] << " " <<
s[i+is1] << " " << s[i-is] << " " << s[i-is+is1] << std::endl; exit(1);}
}

it gets triggered, and the output is all zeros. However, s1 (the
non-diagonal part) is non-zero, which is, I guess, because of the
yee-grid (my material_function sets diagonal and non-diagonal elements
at the same time).

I do not know, why p explodes, though. In principle, even if a p is set
somewhere outside the metal region because of some yee-grid shift, it
should decay as fast as anywhere else, or not?

The whole problem, btw, disappears if you just put
if(s[i] != 0){...
inside the LOOP_OVER_VOL_OWNED, but that seems like a shitty solution
(just ignoring all the nice yee-grid stuff)

If you want to reproduce the Error, a minimal(ish) example is on my github:
https://github.com/fesc3555/meep_nondiagonal_sigma

Any input on this would be apprechiated.

Thanks!
```

**reply: 3/15/2018**
```
> I do not know, why p explodes, though. In principle, even if a p is set
> somewhere outside the metal region because of some yee-grid shift, it
> should decay as fast as anywhere else, or not?
> 
> The whole problem, btw, disappears if you just put
> if(s[i] != 0){...
> inside the LOOP_OVER_VOL_OWNED, but that seems like a shitty solution
> (just ignoring all the nice yee-grid stuff)

I don't really understand why it's unstable at first glance, but I agree that 
the source of the problem here is the Yee grid: you are apparently at a Yee 
grid point that is outside your metal, but an adjacent off-diagonal component 
is inside the metal.

The "if (s[i] != 0)" workaround seems fine; it won't degrade the accuracy since 
we don't have subpixel smoothing for Lorentzian susceptibilities anyway.  If 
you want to submit a pull request with this fix that would be great.

```