### PR TITLE
Add ability to visualize chunks

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1361,6 +1361,12 @@ Returns a `mp.Volume` read from a GDSII file `fname` on `layer` with `zmin` and 
 fr = mp.FluxRegion(volume=mp.GDSII_vol(fname, layer, zmin, zmax))
 ```
 
+### Data Visualization
+
+**`Simulation.visualize_chunks()`**
+—
+Displays an interactive image of how the cell is divided into chunks. Each rectangular region is a chunk, and each color represents a different processor. Requires [matplotlib](https://matplotlib.org).
+
 Run and Step Functions
 ----------------------
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1917,6 +1917,66 @@ class Simulation(object):
     def get_sfield_p(self):
         return self.get_array(cmplx=True, component=mp.Sp)
 
+    def visualize_chunks(self):
+        if self.structure is None:
+            self.init_sim()
+        try:
+            import matplotlib.pyplot as plt
+            import matplotlib.cm
+            import matplotlib.colors
+            from mpl_toolkits.mplot3d import Axes3D
+            from mpl_toolkits.mplot3d.art3d import Poly3DCollection, Line3DCollection
+        except ImportError:
+            warnings.warn("matplotlib is required for visualize_chunks", ImportWarning)
+            return
+
+        vols = self.structure.get_chunk_volumes()
+        owners = self.structure.get_chunk_owners()
+
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection='3d')
+        chunk_colors = matplotlib.cm.rainbow(np.linspace(0, 1, mp.count_processors()))
+
+        def plot_box(box, proc):
+            low = mp.Vector3(box.low.x, box.low.y, box.low.z)
+            high = mp.Vector3(box.high.x, box.high.y, box.high.z)
+            points = [low, high]
+
+            x_len = mp.Vector3(high.x) - mp.Vector3(low.x)
+            y_len = mp.Vector3(y=high.y) - mp.Vector3(y=low.y)
+            xy_len = mp.Vector3(high.x, high.y) - mp.Vector3(low.x, low.y)
+
+            points += [low + x_len]
+            points += [low + y_len]
+            points += [low + xy_len]
+            points += [high - x_len]
+            points += [high - y_len]
+            points += [high - xy_len]
+            points = np.array([np.array(v) for v in points])
+
+            edges = [
+                [points[0], points[2], points[4], points[3]],
+                [points[1], points[5], points[7], points[6]],
+                [points[0], points[3], points[5], points[7]],
+                [points[1], points[4], points[2], points[6]],
+                [points[3], points[4], points[1], points[5]],
+                [points[0], points[7], points[6], points[2]]
+            ]
+
+            faces = Poly3DCollection(edges, linewidths=1, edgecolors='k')
+            color_with_alpha = matplotlib.colors.to_rgba(chunk_colors[proc], alpha=0.2)
+            faces.set_facecolor(color_with_alpha)
+            ax.add_collection3d(faces)
+
+            # Plot the points themselves to force the scaling of the axes
+            ax.scatter(points[:, 0], points[:, 1], points[:, 2], s=0)
+
+        if mp.am_master():
+            for i, v in enumerate(vols):
+                plot_box(mp.gv2box(v), owners[i])
+            ax.set_aspect('auto')
+            plt.show()
+
 
 def _create_boundary_region_from_boundary_layers(boundary_layers, gv):
     br = mp.boundary_region()

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -708,6 +708,8 @@ public:
 
   bool equal_layout(const structure &) const;
   void print_layout(void) const;
+  std::vector<volume> get_chunk_volumes() const;
+  std::vector<int> get_chunk_owners() const;
 
   // structure_dump.cpp
   void dump(const char *filename);

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -236,7 +236,7 @@ meep::vec vector3_to_vec(const vector3 v3) {
   }
 }
 
-static geom_box gv2box(const meep::volume &v) {
+geom_box gv2box(const meep::volume &v) {
   geom_box box;
   box.low = vec_to_vector3(v.get_min_corner());
   box.high = vec_to_vector3(v.get_max_corner());

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -174,6 +174,7 @@ bool is_medium(material_type md, medium_struct **m);
 bool is_medium(void *md, medium_struct **m);
 bool is_metal(meep::field_type ft, const material_type *material);
 void check_offdiag(medium_struct *m);
+geom_box gv2box(const meep::volume &v);
 
 /***************************************************************/
 /* routines in GDSIIgeom.cc ************************************/

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -940,4 +940,21 @@ void structure::print_layout(void) const {
   }
 }
 
+std::vector<volume> structure::get_chunk_volumes() const {
+  std::vector<volume> result;
+
+  for (int i = 0; i < num_chunks; ++i) {
+    result.push_back(chunks[i]->gv.surroundings());
+  }
+  return result;
+}
+
+std::vector<int> structure::get_chunk_owners() const {
+  std::vector<int> result;
+
+  for (int i = 0; i < num_chunks; ++i) {
+    result.push_back(chunks[i]->n_proc());
+  }
+  return result;
+}
 } // namespace meep


### PR DESCRIPTION
`Simulation.visualize_chunks` shows an interactive plot of the chunk division, with one color per processor.

```python
# 1D
cell = mp.Vector3(10)
sim = mp.Simulation(cell_size=cell, resolution=10, boundary_layers=[mp.PML(1)])
sim.visualize_chunks()
```
Run with 1 processor:
![viz1](https://user-images.githubusercontent.com/14114829/51189961-cfb69d00-18a6-11e9-9058-215ca7401a2e.png)

Run with 4 processors:
![viz2](https://user-images.githubusercontent.com/14114829/51189971-d2b18d80-18a6-11e9-8403-bae0ae979ecb.png)

```python
# 2D
cell = mp.Vector3(10, 10)
sim = mp.Simulation(cell_size=cell, resolution=10)
sim.visualize_chunks()
```
4 processors:
![viz3](https://user-images.githubusercontent.com/14114829/51190199-4fdd0280-18a7-11e9-9436-233661dfc481.png)
With PML:
![viz4](https://user-images.githubusercontent.com/14114829/51190206-51a6c600-18a7-11e9-8b92-505210be3cec.png)
9 processors with PML:
![viz5](https://user-images.githubusercontent.com/14114829/51190267-78fd9300-18a7-11e9-8e74-97f3f15e3720.png)

```python
# 3D
cell = mp.Vector3(10, 10, 10)
sim = mp.Simulation(cell_size=cell, resolution=10, boundary_layers=[mp.PML(1)])
sim.visualize_chunks()
```
4 processors:
![viz6](https://user-images.githubusercontent.com/14114829/51190436-d2fe5880-18a7-11e9-9cdd-909a9471ae93.png)
