### PR TITLE
compute Poynting flux of far fields in dft_near2far

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -321,6 +321,9 @@ class DftNear2Far(DftObj):
     def mu(self):
         return self.swigobj_attr('mu')
 
+    @property
+    def flux(self):
+        return self.swigobj_attr('flux')
 
 class DftFields(DftObj):
 

--- a/python/tests/antenna_radiation.py
+++ b/python/tests/antenna_radiation.py
@@ -76,9 +76,10 @@ class TestAntennaRadiation(unittest.TestCase):
                            - nearfield_box.flux(mp.X, mp.Volume(center=mp.Vector3(-0.5*rr), size=mp.Vector3(y=rr)).swigobj, resolution)[0]) * 1/resolution
 
         print("flux:, {:.6f}, {:.6f}, {:.6f}".format(near_flux,far_flux_circle,far_flux_square))
+
         self.assertAlmostEqual(near_flux, far_flux_circle, places=2)
-        self.assertAlmostEqual(near_flux, far_flux_square, places=2)
         self.assertAlmostEqual(far_flux_circle, far_flux_square, places=2)
+        self.assertAlmostEqual(far_flux_square, far_flux_circle, places=2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/antenna_radiation.py
+++ b/python/tests/antenna_radiation.py
@@ -79,7 +79,7 @@ class TestAntennaRadiation(unittest.TestCase):
 
         self.assertAlmostEqual(near_flux, far_flux_circle, places=2)
         self.assertAlmostEqual(far_flux_circle, far_flux_square, places=2)
-        self.assertAlmostEqual(far_flux_square, far_flux_circle, places=2)
+        self.assertAlmostEqual(far_flux_square, near_flux, places=2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/antenna_radiation.py
+++ b/python/tests/antenna_radiation.py
@@ -73,7 +73,7 @@ class TestAntennaRadiation(unittest.TestCase):
         far_flux_square = (nearfield_box.flux(mp.Y, mp.Volume(center=mp.Vector3(y=0.5*rr), size=mp.Vector3(rr)).swigobj, resolution)[0]
                            - nearfield_box.flux(mp.Y, mp.Volume(center=mp.Vector3(y=-0.5*rr), size=mp.Vector3(rr)).swigobj, resolution)[0]
                            + nearfield_box.flux(mp.X, mp.Volume(center=mp.Vector3(0.5*rr), size=mp.Vector3(y=rr)).swigobj, resolution)[0]
-                           - nearfield_box.flux(mp.X, mp.Volume(center=mp.Vector3(-0.5*rr), size=mp.Vector3(y=rr)).swigobj, resolution)[0]) * 1/resolution
+                           - nearfield_box.flux(mp.X, mp.Volume(center=mp.Vector3(-0.5*rr), size=mp.Vector3(y=rr)).swigobj, resolution)[0])
 
         print("flux:, {:.6f}, {:.6f}, {:.6f}".format(near_flux,far_flux_circle,far_flux_square))
 

--- a/python/tests/antenna_radiation.py
+++ b/python/tests/antenna_radiation.py
@@ -52,7 +52,7 @@ class TestAntennaRadiation(unittest.TestCase):
 
         near_flux = mp.get_fluxes(flux_box)[0]
 
-        r = 1000/fcen      # circle of radius 1000 wavelengths
+        r = 1000/fcen      # radius of far field circle
         npts = 100         # number of points in [0,2*pi) range of angles
         E = np.zeros((npts,3),dtype=np.complex128)
         H = np.zeros((npts,3),dtype=np.complex128)
@@ -65,11 +65,10 @@ class TestAntennaRadiation(unittest.TestCase):
 
         Px = np.real(np.multiply(E[:,1],H[:,2])-np.multiply(E[:,2],H[:,1]))
         Py = np.real(np.multiply(E[:,2],H[:,0])-np.multiply(E[:,0],H[:,2]))
-        Pz = np.real(np.multiply(E[:,0],H[:,1])-np.multiply(E[:,1],H[:,0]))
         Pr = np.sqrt(np.square(Px)+np.square(Py))
         far_flux_circle = np.sum(Pr)*2*np.pi*r/len(Pr)
 
-        rr = 20/fcen      # square of side length 20 wavelengths
+        rr = 20/fcen      # length of far field square box
         far_flux_square = (nearfield_box.flux(mp.Y, mp.Volume(center=mp.Vector3(y=0.5*rr), size=mp.Vector3(rr)).swigobj, resolution)[0]
                            - nearfield_box.flux(mp.Y, mp.Volume(center=mp.Vector3(y=-0.5*rr), size=mp.Vector3(rr)).swigobj, resolution)[0]
                            + nearfield_box.flux(mp.X, mp.Volume(center=mp.Vector3(0.5*rr), size=mp.Vector3(y=rr)).swigobj, resolution)[0]

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -685,6 +685,9 @@
   (meep-dft-near2far-save-farfields near2far fname (get-filename-prefix)
                                     where resolution))
 
+(define (output-farflux near2far df where resolution)
+  (meep-dft-near2far-flux near2far df where resolution))
+
 (define (load-near2far fname near2far)
   (if (null? fields) (init-fields))
   (meep-dft-near2far-load-hdf5 near2far fields fname "" (get-filename-prefix)))

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1093,6 +1093,9 @@ public:
   void save_farfields(const char *fname, const char *prefix, const volume &where,
                       double resolution);
 
+  /* output Poynting flux of far fields */
+  double *flux(direction df, const volume &where, double resolution);
+
   void save_hdf5(h5file *file, const char *dprefix = 0);
   void load_hdf5(h5file *file, const char *dprefix = 0);
 

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -336,15 +336,15 @@ void dft_near2far::save_farfields(const char *fname, const char *prefix, const v
 }
 
 double *dft_near2far::flux(direction df, const volume &where, double resolution) {
+    if (coordinate_mismatch(where.dim, df) || where.dim == Dcyl)
+      abort("cannot get flux for near2far: co-ordinate mismatch");
+
     /* compute output grid size etc. */
     int dims[4] = {1,1,1,1};
     double dx[3] = {0,0,0};
     direction dirs[3] = {X,Y,Z};
     int rank = 0, N = 1;
     double vol = 1;
-
-    if (coordinate_mismatch(where.dim, df) || where.dim == Dcyl)
-      abort("cannot get flux for near2far: co-ordinate mismatch");
 
     LOOP_OVER_DIRECTIONS(where.dim, d) {
       dims[rank] = int(floor(where.in_direction(d) * resolution));
@@ -398,7 +398,7 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
 
     delete[] EH1_;
     delete[] EH1;
-    
+
     for (int i = 0; i < Nfreq; ++i)
       F_[i] *= vol;
 

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -23,6 +23,7 @@
 #include <meep.hpp>
 #include <assert.h>
 #include "config.h"
+#include <math.h>
 
 using namespace std;
 
@@ -332,6 +333,79 @@ void dft_near2far::save_farfields(const char *fname, const char *prefix, const v
   }
 
   delete[] EH;
+}
+
+double *dft_near2far::flux(direction df, const volume &where, double resolution) {
+    /* compute output grid size etc. */
+    int dims[4] = {1,1,1,1};
+    double dx[3] = {0,0,0};
+    direction dirs[3] = {X,Y,Z};
+    int rank = 0, N = 1;
+    LOOP_OVER_DIRECTIONS(where.dim, d) {
+      dims[rank] = int(floor(where.in_direction(d) * resolution));
+      if (dims[rank] <= 1) {
+	dims[rank] = 1;
+	dx[rank] = 0;
+      }
+      else
+	dx[rank] = where.in_direction(d) / (dims[rank] - 1);
+      N *= dims[rank];
+      dirs[rank++] = d;
+    }
+
+    /* 6 x N x Nfreq array of fields in row-major order */
+    std::complex<double> *EH = new std::complex<double>[6*N*Nfreq];
+    std::complex<double> *EH_ = new std::complex<double>[6*N*Nfreq]; // temp array for sum_to_master
+
+    /* fields for farfield_lowlevel for a single output point x */
+    std::complex<double> *EH1 = new std::complex<double>[6*Nfreq];
+
+    vec x(where.dim);
+    for (int i0 = 0; i0 < dims[0]; ++i0) {
+      x.set_direction(dirs[0], where.in_direction_min(dirs[0]) + i0*dx[0]);
+      for (int i1 = 0; i1 < dims[1]; ++i1) {
+	x.set_direction(dirs[1], where.in_direction_min(dirs[1]) + i1*dx[1]);
+	for (int i2 = 0; i2 < dims[2]; ++i2) {
+	  x.set_direction(dirs[2], where.in_direction_min(dirs[2]) + i2*dx[2]);
+	  farfield_lowlevel(EH1, x);
+	  int idx = (i0 * dims[1] + i1) * dims[2] + i2;
+	  for (int i = 0; i < Nfreq; ++i)
+	    for (int k = 0; k < 6; ++k)
+	      EH_[(k * N + idx) + (6 * N * i)] = EH1[i * 6 + k];
+	}
+      }
+    }
+
+    delete[] EH1;
+    sum_to_master(EH_, EH, 6*N*Nfreq);
+    delete[] EH_;
+
+    if (coordinate_mismatch(where.dim, df) || where.dim == Dcyl)
+      abort("cannot get flux for near2far: co-ordinate mismatch");
+
+    double *F = new double[Nfreq];
+    std::complex<double> *ff_EH[6];
+    std::complex<double> *cE[2], *cH[2];
+    for (int i = 0; i < Nfreq; ++i) {
+      for (int k = 0; k < 6; ++k)
+	ff_EH[k] = EH + (k * N) + (6 * N * i);
+      switch (df) {
+      case X: cE[0] = ff_EH[1], cE[1] = ff_EH[2], cH[0] = ff_EH[5], cH[1] = ff_EH[4]; break;
+      case Y: cE[0] = ff_EH[2], cE[1] = ff_EH[0], cH[0] = ff_EH[3], cH[1] = ff_EH[5]; break;
+      case Z: cE[0] = ff_EH[0], cE[1] = ff_EH[1], cH[0] = ff_EH[4], cH[1] = ff_EH[3]; break;
+      case NO_DIRECTION: abort("cannot get flux in NO_DIRECTION");
+      }
+      F[i] = 0;
+      for (int j = 0; j < 2; ++j) {
+        double flux_sum = 0;
+	for (int p = 0; p < N; ++p)
+	  flux_sum += real(cE[j][p]*conj(cH[j][p]));
+	F[i] += flux_sum * (1 - 2*j);
+      }
+      master_printf("near2far-flux:, %0.2g, %0.5g\n",freq_min+i*dfreq,F[i]);
+    }
+    delete[] EH;
+    return F;
 }
 
 static double approxeq(double a, double b) { return fabs(a - b) < 0.5e-11 * (fabs(a) + fabs(b)); }

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -362,9 +362,10 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
 
     /* fields for farfield_lowlevel for a single output point x */
     std::complex<double> *EH1 = new std::complex<double>[6*Nfreq];
+    std::complex<double> *EH1_ = new std::complex<double>[6*Nfreq];
 
     double *F_ = new double[Nfreq];
-    std::complex<double> ff_EH[6], ff_EH_[6];
+    std::complex<double> ff_EH[6];
     std::complex<double> cE[2], cH[2];
 
     for (int i = 0; i < Nfreq; ++i)
@@ -377,11 +378,11 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
 	x.set_direction(dirs[1], where.in_direction_min(dirs[1]) + i1*dx[1]);
 	for (int i2 = 0; i2 < dims[2]; ++i2) {
 	  x.set_direction(dirs[2], where.in_direction_min(dirs[2]) + i2*dx[2]);
-	  farfield_lowlevel(EH1, x);
+	  farfield_lowlevel(EH1_, x);
+          sum_to_master(EH1_, EH1, 6*Nfreq);          
           for (int i = 0; i < Nfreq; ++i) {
             for (int k = 0; k < 6; ++k)
-              ff_EH_[k] = EH1[i * 6 + k];
-            sum_to_master(ff_EH_, ff_EH, 6);
+              ff_EH[k] = EH1[i * 6 + k];
             switch (df) {
             case X: cE[0] = ff_EH[1], cE[1] = ff_EH[2], cH[0] = ff_EH[5], cH[1] = ff_EH[4]; break;
             case Y: cE[0] = ff_EH[2], cE[1] = ff_EH[0], cH[0] = ff_EH[3], cH[1] = ff_EH[5]; break;
@@ -395,6 +396,9 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
       }
     }
 
+    delete[] EH1_;
+    delete[] EH1;
+    
     for (int i = 0; i < Nfreq; ++i)
       F_[i] *= vol;
 

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -383,7 +383,7 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
     if (coordinate_mismatch(where.dim, df) || where.dim == Dcyl)
       abort("cannot get flux for near2far: co-ordinate mismatch");
 
-    double *F = new double[Nfreq];
+    double *F_ = new double[Nfreq];
     std::complex<double> *ff_EH[6];
     std::complex<double> *cE[2], *cH[2];
     for (int i = 0; i < Nfreq; ++i) {
@@ -395,16 +395,18 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
       case Z: cE[0] = ff_EH[0], cE[1] = ff_EH[1], cH[0] = ff_EH[4], cH[1] = ff_EH[3]; break;
       case NO_DIRECTION: abort("cannot get flux in NO_DIRECTION");
       }
-      F[i] = 0;
+      F_[i] = 0;
       for (int j = 0; j < 2; ++j) {
         double flux_sum = 0;
 	for (int p = 0; p < N; ++p)
 	  flux_sum += real(cE[j][p]*conj(cH[j][p]));
-	F[i] += flux_sum * (1 - 2*j);
+	F_[i] += flux_sum * (1 - 2*j);
       }
-      master_printf("near2far-flux:, %0.2g, %0.5g\n",freq_min+i*dfreq,F[i]);
     }
     delete[] EH;
+    double *F = new double[Nfreq];
+    sum_to_all(F_, F, Nfreq);
+    delete[] F_;
     return F;
 }
 


### PR DESCRIPTION
Replaces and closes #27.

A test of this new feature has been made a part of the revised `python/tests/antenna-radiation.py` which computes the Poynting flux of an E<sub>z</sub>-polarized dipole source from the fields in three different arrangements and verifies that they are equivalent.

We still need to add a high-level Python interface as well as documentation.