### PR TITLE
Use fragment_stats to split chunks by cost

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -2287,7 +2287,7 @@ double mode_solver::compute_energy_in_objects(geometric_object_list objects) {
     return 0.0;
   }
 
-  geom_fix_objects0(objects);
+  geom_fix_object_list(objects);
 
   int n1 = mdata->nx;
   int n2 = mdata->ny;

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -471,7 +471,8 @@ class Simulation(object):
                  output_single_precision=False,
                  load_structure='',
                  geometry_center=mp.Vector3(),
-                 force_all_components=False):
+                 force_all_components=False,
+                 split_chunks_evenly=False):
 
         self.cell_size = cell_size
         self.geometry = geometry
@@ -518,6 +519,7 @@ class Simulation(object):
         self._is_initialized = False
         self._fragment_size = 10
         self.force_all_components = force_all_components
+        self.split_chunks_evenly = split_chunks_evenly
 
     # To prevent the user from having to specify `dims` and `is_cylindrical`
     # to Volumes they create, the library will adjust them appropriately based
@@ -823,7 +825,7 @@ class Simulation(object):
 
         return vols1, vols2, vols3
 
-    def _compute_fragment_stats(self, gv):
+    def _make_fragment_lists(self, gv):
 
         def convert_volumes(dft_obj):
             volumes = []
@@ -846,6 +848,12 @@ class Simulation(object):
         pml_vols1, pml_vols2, pml_vols3 = self._boundary_layers_to_vol_list(pmls)
         absorber_vols1, absorber_vols2, absorber_vols3 = self._boundary_layers_to_vol_list(absorbers)
         absorber_vols = absorber_vols1 + absorber_vols2 + absorber_vols3
+
+        return (dft_data_list, pml_vols1, pml_vols2, pml_vols3, absorber_vols)
+
+    def _compute_fragment_stats(self, gv):
+
+        dft_data_list, pml_vols1, pml_vols2, pml_vols3, absorber_vols = self._make_fragment_lists(gv)
 
         stats = mp.compute_fragment_stats(
             self.geometry,
@@ -886,7 +894,6 @@ class Simulation(object):
         gv = self._create_grid_volume(k)
         sym = self._create_symmetries(gv)
         br = _create_boundary_region_from_boundary_layers(self.boundary_layers, gv)
-
         absorbers = [bl for bl in self.boundary_layers if type(bl) is Absorber]
 
         if self.material_function:
@@ -899,22 +906,33 @@ class Simulation(object):
             self.default_material = self.epsilon_input_file
 
         self.fragment_stats = self._compute_fragment_stats(gv) if isinstance(self.default_material, mp.Medium) else []
+        dft_data_list, pml_vols1, pml_vols2, pml_vols3, absorber_vols = self._make_fragment_lists(gv)
 
-        self.structure = mp.structure(gv, None, br, sym, self.num_chunks, self.Courant,
-                                      self.eps_averaging, self.subpixel_tol, self.subpixel_maxeval)
-        self.structure.shared_chunks = True
+        self.structure = mp.create_structure_and_set_materials(
+            self.cell_size,
+            dft_data_list,
+            pml_vols1,
+            pml_vols2,
+            pml_vols3,
+            absorber_vols,
+            gv,
+            br,
+            sym,
+            self.num_chunks,
+            self.Courant,
+            self.eps_averaging,
+            self.subpixel_tol,
+            self.subpixel_maxeval,
+            self.geometry,
+            self.geometry_center,
+            self.ensure_periodicity and not not self.k_point,
+            self.verbose,
+            self.default_material,
+            absorbers,
+            self.extra_materials,
+            self.split_chunks_evenly
+       )
 
-        mp.set_materials_from_geometry(self.structure,
-                                       self.geometry,
-                                       self.geometry_center,
-                                       self.eps_averaging,
-                                       self.subpixel_tol,
-                                       self.subpixel_maxeval,
-                                       self.ensure_periodicity and not not self.k_point,
-                                       False,
-                                       self.default_material,
-                                       absorbers,
-                                       self.extra_materials)
         if self.load_structure_file:
             self.load_structure(self.load_structure_file)
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -472,7 +472,7 @@ class Simulation(object):
                  load_structure='',
                  geometry_center=mp.Vector3(),
                  force_all_components=False,
-                 split_chunks_evenly=False):
+                 split_chunks_evenly=True):
 
         self.cell_size = cell_size
         self.geometry = geometry

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -327,7 +327,8 @@ class TestSimulation(unittest.TestCase):
                             cell_size=cell,
                             boundary_layers=pml_layers,
                             geometry=geometry,
-                            sources=[sources])
+                            sources=[sources],
+                            split_chunks_evenly=True)
 
         sample_point = mp.Vector3(0.12, -0.29)
         ref_field_points = []

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -327,8 +327,7 @@ class TestSimulation(unittest.TestCase):
                             cell_size=cell,
                             boundary_layers=pml_layers,
                             geometry=geometry,
-                            sources=[sources],
-                            split_chunks_evenly=True)
+                            sources=[sources])
 
         sample_point = mp.Vector3(0.12, -0.29)
         ref_field_points = []

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -263,6 +263,8 @@ static meep::vec my_kpoint_func(double freq, int mode, void *user_data) {
 
 %warnfilter(302,325,451,503,509);
 
+%ignore meep_geom::fragment_stats;
+
 %include "meep_renames.i"
 %include "meep_enum_renames.i"
 %include "meep_op_renames.i"

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -985,9 +985,10 @@ public:
   friend grid_volume vol3d(double xsize, double ysize, double zsize, double a);
 
   grid_volume split(size_t num, int which) const;
-  grid_volume split_by_effort(int num, int which, int Ngv = 0, const grid_volume *v = NULL, double *effort = NULL) const;
+  grid_volume split_by_effort(int num, int which, int Ngv = 0, const grid_volume *v = NULL,
+                              double *effort = NULL) const;
   grid_volume split_by_cost(int desired_chunks, int proc_num) const;
-  grid_volume split_at_fraction(bool want_high, int numer, int bestd=-1, int bestlen=1) const;
+  grid_volume split_at_fraction(bool want_high, int numer, int bestd = -1, int bestlen = 1) const;
   grid_volume halve(direction d) const;
   void pad_self(direction d);
   grid_volume pad(direction d) const;

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -987,7 +987,7 @@ public:
   grid_volume split(size_t num, int which) const;
   grid_volume split_by_effort(int num, int which, int Ngv = 0, const grid_volume *v = NULL,
                               double *effort = NULL) const;
-  grid_volume split_by_cost(int desired_chunks, int proc_num) const;
+  grid_volume split_by_cost(int desired_num_chunks, int proc_num, int factor = 2) const;
   grid_volume split_at_fraction(bool want_high, int numer, int bestd = -1, int bestlen = 1) const;
   grid_volume halve(direction d) const;
   void pad_self(direction d);

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -20,6 +20,7 @@
 #define MEEP_VEC_H
 
 #include <complex>
+#include <vector>
 #include <stddef.h>
 
 namespace meep {
@@ -987,8 +988,11 @@ public:
   grid_volume split(size_t num, int which) const;
   grid_volume split_by_effort(int num, int which, int Ngv = 0, const grid_volume *v = NULL,
                               double *effort = NULL) const;
-  grid_volume split_by_cost(int desired_num_chunks, int proc_num, int factor = 2) const;
+  grid_volume split_by_cost(int desired_num_chunks, int proc_num) const;
+  std::vector<grid_volume> split_into_n(int n) const;
+  void split_into_three(std::vector<grid_volume> &result) const;
   grid_volume split_at_fraction(bool want_high, int numer, int bestd = -1, int bestlen = 1) const;
+  double get_cost() const;
   grid_volume halve(direction d) const;
   void pad_self(direction d);
   grid_volume pad(direction d) const;

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -985,9 +985,9 @@ public:
   friend grid_volume vol3d(double xsize, double ysize, double zsize, double a);
 
   grid_volume split(size_t num, int which) const;
-  grid_volume split_by_effort(int num, int which, int Ngv = 0, const grid_volume *v = NULL,
-                              double *effort = NULL) const;
-  grid_volume split_at_fraction(bool want_high, int numer) const;
+  grid_volume split_by_effort(int num, int which, int Ngv = 0, const grid_volume *v = NULL, double *effort = NULL) const;
+  grid_volume split_by_cost(int desired_chunks, int proc_num) const;
+  grid_volume split_at_fraction(bool want_high, int numer, int bestd=-1, int bestlen=1) const;
   grid_volume halve(direction d) const;
   void pad_self(direction d);
   grid_volume pad(direction d) const;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1591,6 +1591,13 @@ double fragment_stats::tol = 0;
 int fragment_stats::maxeval = 0;
 int fragment_stats::resolution = 0;
 meep::ndim fragment_stats::dims = meep::D1;
+geometric_object_list fragment_stats::geom = {};
+std::vector<dft_data> fragment_stats::dft_data_list;
+std::vector<meep::volume> fragment_stats::pml_1d_vols;
+std::vector<meep::volume> fragment_stats::pml_2d_vols;
+std::vector<meep::volume> fragment_stats::pml_3d_vols;
+std::vector<meep::volume> fragment_stats::absorber_vols;
+bool fragment_stats::split_chunks_evenly = false;
 
 inline static bool is_edge_box(double pt, double half_cell, double box_size, double edge_size) {
   return (pt == -half_cell && edge_size != 0) || pt + box_size > half_cell;
@@ -1738,49 +1745,83 @@ static std::vector<fragment_stats> init_fragments(std::vector<geom_box> &boxes, 
 
   for (size_t i = 0; i < boxes.size(); ++i) {
     center_box(&boxes[i]);
-    size_t pixels_in_box = get_pixels_in_box(&boxes[i]);
-    fragments.push_back(fragment_stats(boxes[i], pixels_in_box));
+    fragments.push_back(fragment_stats(boxes[i]));
   }
   return fragments;
 }
 
-static void init_libctl(material_type default_mat, bool ensure_per, meep::grid_volume *gv,
-                        vector3 cell_size, vector3 cell_center, geometric_object_list *geom) {
+std::vector<fragment_stats> compute_fragment_stats(geometric_object_list geom_,
+                                                   meep::grid_volume *gv,
+                                                   vector3 cell_size,
+                                                   vector3 cell_center,
+                                                   material_type default_mat,
+                                                   std::vector<dft_data> dft_data_list_,
+                                                   std::vector<meep::volume> pml_1d_vols_,
+                                                   std::vector<meep::volume> pml_2d_vols_,
+                                                   std::vector<meep::volume> pml_3d_vols_,
+                                                   std::vector<meep::volume> absorber_vols_,
+                                                   double tol,
+                                                   int maxeval,
+                                                   bool ensure_per,
+                                                   double box_size) {
+
+  fragment_stats::geom = geom_;
+  fragment_stats::dft_data_list = dft_data_list_;
+  fragment_stats::pml_1d_vols = pml_1d_vols_;
+  fragment_stats::pml_2d_vols = pml_2d_vols_;
+  fragment_stats::pml_3d_vols = pml_3d_vols_;
+  fragment_stats::absorber_vols = absorber_vols_;
+
+  fragment_stats::init_libctl(default_mat, ensure_per, gv, cell_size, cell_center, &geom_);
+  std::vector<geom_box> boxes = split_cell_into_boxes(gv, box_size, cell_size);
+  std::vector<fragment_stats> fragments = init_fragments(boxes, tol, maxeval, gv);
+
+  for (size_t i = 0; i < fragments.size(); ++i) {
+    fragments[i].compute();
+  }
+  return fragments;
+}
+
+fragment_stats::fragment_stats(geom_box& bx):
+  num_anisotropic_eps_pixels(0),
+  num_anisotropic_mu_pixels(0),
+  num_nonlinear_pixels(0),
+  num_susceptibility_pixels(0),
+  num_nonzero_conductivity_pixels(0),
+  num_1d_pml_pixels(0),
+  num_2d_pml_pixels(0),
+  num_3d_pml_pixels(0),
+  num_dft_pixels(0),
+  num_pixels_in_box(0),
+  box(bx) {
+
+  num_pixels_in_box = get_pixels_in_box(&bx);
+
+}
+
+void fragment_stats::init_libctl(material_type default_mat, bool ensure_per, meep::grid_volume *gv,
+                                 vector3 cell_size, vector3 cell_center, geometric_object_list *geom_) {
   geom_initialize();
   default_material = default_mat;
   ensure_periodicity = ensure_per;
   geometry_center = cell_center;
   dimensions = meep::number_of_directions(gv->dim);
   geometry_lattice.size = cell_size;
-  geom_fix_object_list(*geom);
+  geom_fix_object_list(*geom_);
 }
 
-std::vector<fragment_stats>
-compute_fragment_stats(geometric_object_list geom, meep::grid_volume *gv, vector3 cell_size,
-                       vector3 cell_center, material_type default_mat,
-                       std::vector<dft_data> dft_data_list, std::vector<meep::volume> pml_1d_vols,
-                       std::vector<meep::volume> pml_2d_vols, std::vector<meep::volume> pml_3d_vols,
-                       std::vector<meep::volume> absorber_vols, double tol, int maxeval,
-                       bool ensure_per, double box_size) {
-
-  init_libctl(default_mat, ensure_per, gv, cell_size, cell_center, &geom);
-  std::vector<geom_box> boxes = split_cell_into_boxes(gv, box_size, cell_size);
-  std::vector<fragment_stats> fragments = init_fragments(boxes, tol, maxeval, gv);
-
-  for (size_t i = 0; i < fragments.size(); ++i) {
-    fragments[i].compute_stats(&geom);
-    fragments[i].compute_dft_stats(&dft_data_list);
-    fragments[i].compute_pml_stats(pml_1d_vols, pml_2d_vols, pml_3d_vols);
-    fragments[i].compute_absorber_stats(absorber_vols);
+bool fragment_stats::has_non_medium_material() {
+  for (int i = 0; i < geom.num_items; ++i) {
+    material_type mat = (material_type)geom.items[i].material;
+    if (mat->which_subclass != material_data::MEDIUM) {
+      return true;
+    }
   }
-  return fragments;
+  if (((material_type)default_material)->which_subclass != material_data::MEDIUM) {
+    return true;
+  }
+  return false;
 }
-
-fragment_stats::fragment_stats(geom_box &bx, size_t pixels)
-    : num_anisotropic_eps_pixels(0), num_anisotropic_mu_pixels(0), num_nonlinear_pixels(0),
-      num_susceptibility_pixels(0), num_nonzero_conductivity_pixels(0), num_1d_pml_pixels(0),
-      num_2d_pml_pixels(0), num_3d_pml_pixels(0), num_dft_pixels(0), num_pixels_in_box(pixels),
-      box(bx) {}
 
 void fragment_stats::update_stats_from_material(material_type mat, size_t pixels) {
   switch (mat->which_subclass) {
@@ -1798,15 +1839,15 @@ void fragment_stats::update_stats_from_material(material_type mat, size_t pixels
   }
 }
 
-void fragment_stats::compute_stats(geometric_object_list *geom) {
+void fragment_stats::compute_stats() {
 
-  if (geom->num_items == 0) {
+  if (geom.num_items == 0) {
     // If there is no geometry, count the default material for the whole fragment
     update_stats_from_material((material_type)default_material, num_pixels_in_box);
   }
 
-  for (int i = 0; i < geom->num_items; ++i) {
-    geometric_object *go = &geom->items[i];
+  for (int i = 0; i < geom.num_items; ++i) {
+    geometric_object *go = &geom.items[i];
     double overlap = box_overlap_with_object(box, *go, tol, maxeval);
 
     // Count contributions from material of object
@@ -1876,11 +1917,11 @@ void fragment_stats::count_nonzero_conductivity_pixels(medium_struct *med, size_
   num_nonzero_conductivity_pixels += nonzero_conductivity_elements * pixels;
 }
 
-void fragment_stats::compute_dft_stats(std::vector<dft_data> *dft_data_list) {
+void fragment_stats::compute_dft_stats() {
 
-  for (size_t i = 0; i < dft_data_list->size(); ++i) {
-    for (size_t j = 0; j < (*dft_data_list)[i].vols.size(); ++j) {
-      geom_box dft_box = gv2box((*dft_data_list)[i].vols[j]);
+  for (size_t i = 0; i < dft_data_list.size(); ++i) {
+    for (size_t j = 0; j < dft_data_list[i].vols.size(); ++j) {
+      geom_box dft_box = gv2box(dft_data_list[i].vols[j]);
 
       if (geom_boxes_intersect(&dft_box, &box)) {
         geom_box overlap_box;
@@ -1889,16 +1930,13 @@ void fragment_stats::compute_dft_stats(std::vector<dft_data> *dft_data_list) {
         // Note: Since geom_boxes_intersect returns true if two planes share a line or two volumes
         // share a line or plane, there are cases where some pixels are counted multiple times.
         size_t overlap_pixels = get_pixels_in_box(&overlap_box, 2);
-        num_dft_pixels +=
-            overlap_pixels * (*dft_data_list)[i].num_freqs * (*dft_data_list)[i].num_components;
+        num_dft_pixels += overlap_pixels * dft_data_list[i].num_freqs * dft_data_list[i].num_components;
       }
     }
   }
 }
 
-void fragment_stats::compute_pml_stats(const std::vector<meep::volume> &pml_1d_vols,
-                                       const std::vector<meep::volume> &pml_2d_vols,
-                                       const std::vector<meep::volume> &pml_3d_vols) {
+void fragment_stats::compute_pml_stats() {
 
   const std::vector<meep::volume> *pml_vols[] = {&pml_1d_vols, &pml_2d_vols, &pml_3d_vols};
   size_t *pml_pixels[] = {&num_1d_pml_pixels, &num_2d_pml_pixels, &num_3d_pml_pixels};
@@ -1917,7 +1955,7 @@ void fragment_stats::compute_pml_stats(const std::vector<meep::volume> &pml_1d_v
   }
 }
 
-void fragment_stats::compute_absorber_stats(const std::vector<meep::volume> &absorber_vols) {
+void fragment_stats::compute_absorber_stats() {
 
   for (size_t i = 0; i < absorber_vols.size(); ++i) {
     geom_box absorber_box = gv2box(absorber_vols[i]);
@@ -1931,7 +1969,30 @@ void fragment_stats::compute_absorber_stats(const std::vector<meep::volume> &abs
   }
 }
 
-void fragment_stats::print_stats() {
+void fragment_stats::compute() {
+  compute_stats();
+  compute_dft_stats();
+  compute_pml_stats();
+  compute_absorber_stats();
+}
+
+// Return the estimated time in seconds this fragment will take to run
+// based on a cost function obtained via linear regression on a dataset
+// of random simulations.
+double fragment_stats::cost() const {
+  return (num_anisotropic_eps_pixels * 1.15061674e-04 +
+          num_anisotropic_mu_pixels * 1.26843801e-04 +
+          num_nonlinear_pixels * 1.67029547e-04 +
+          num_susceptibility_pixels * 2.24790864e-04 +
+          num_nonzero_conductivity_pixels * 4.61260934e-05 +
+          num_dft_pixels * 1.47283950e-04 +
+          num_1d_pml_pixels * 9.92955372e-05 +
+          num_2d_pml_pixels * 1.36901107e-03 +
+          num_3d_pml_pixels * 6.63939607e-04 +
+          num_pixels_in_box * 3.46518274e-04);
+}
+
+void fragment_stats::print_stats() const {
   master_printf("Fragment stats\n");
   master_printf("  num_anisotropic_eps_pixels: %zd\n", num_anisotropic_eps_pixels);
   master_printf("  num_anisotropic_mu_pixels: %zd\n", num_anisotropic_mu_pixels);

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1750,20 +1750,12 @@ static std::vector<fragment_stats> init_fragments(std::vector<geom_box> &boxes, 
   return fragments;
 }
 
-std::vector<fragment_stats> compute_fragment_stats(geometric_object_list geom_,
-                                                   meep::grid_volume *gv,
-                                                   vector3 cell_size,
-                                                   vector3 cell_center,
-                                                   material_type default_mat,
-                                                   std::vector<dft_data> dft_data_list_,
-                                                   std::vector<meep::volume> pml_1d_vols_,
-                                                   std::vector<meep::volume> pml_2d_vols_,
-                                                   std::vector<meep::volume> pml_3d_vols_,
-                                                   std::vector<meep::volume> absorber_vols_,
-                                                   double tol,
-                                                   int maxeval,
-                                                   bool ensure_per,
-                                                   double box_size) {
+std::vector<fragment_stats> compute_fragment_stats(
+    geometric_object_list geom_, meep::grid_volume *gv, vector3 cell_size, vector3 cell_center,
+    material_type default_mat, std::vector<dft_data> dft_data_list_,
+    std::vector<meep::volume> pml_1d_vols_, std::vector<meep::volume> pml_2d_vols_,
+    std::vector<meep::volume> pml_3d_vols_, std::vector<meep::volume> absorber_vols_, double tol,
+    int maxeval, bool ensure_per, double box_size) {
 
   fragment_stats::geom = geom_;
   fragment_stats::dft_data_list = dft_data_list_;
@@ -1782,25 +1774,17 @@ std::vector<fragment_stats> compute_fragment_stats(geometric_object_list geom_,
   return fragments;
 }
 
-fragment_stats::fragment_stats(geom_box& bx):
-  num_anisotropic_eps_pixels(0),
-  num_anisotropic_mu_pixels(0),
-  num_nonlinear_pixels(0),
-  num_susceptibility_pixels(0),
-  num_nonzero_conductivity_pixels(0),
-  num_1d_pml_pixels(0),
-  num_2d_pml_pixels(0),
-  num_3d_pml_pixels(0),
-  num_dft_pixels(0),
-  num_pixels_in_box(0),
-  box(bx) {
+fragment_stats::fragment_stats(geom_box &bx)
+    : num_anisotropic_eps_pixels(0), num_anisotropic_mu_pixels(0), num_nonlinear_pixels(0),
+      num_susceptibility_pixels(0), num_nonzero_conductivity_pixels(0), num_1d_pml_pixels(0),
+      num_2d_pml_pixels(0), num_3d_pml_pixels(0), num_dft_pixels(0), num_pixels_in_box(0), box(bx) {
 
   num_pixels_in_box = get_pixels_in_box(&bx);
-
 }
 
 void fragment_stats::init_libctl(material_type default_mat, bool ensure_per, meep::grid_volume *gv,
-                                 vector3 cell_size, vector3 cell_center, geometric_object_list *geom_) {
+                                 vector3 cell_size, vector3 cell_center,
+                                 geometric_object_list *geom_) {
   geom_initialize();
   default_material = default_mat;
   ensure_periodicity = ensure_per;
@@ -1813,13 +1797,9 @@ void fragment_stats::init_libctl(material_type default_mat, bool ensure_per, mee
 bool fragment_stats::has_non_medium_material() {
   for (int i = 0; i < geom.num_items; ++i) {
     material_type mat = (material_type)geom.items[i].material;
-    if (mat->which_subclass != material_data::MEDIUM) {
-      return true;
-    }
+    if (mat->which_subclass != material_data::MEDIUM) { return true; }
   }
-  if (((material_type)default_material)->which_subclass != material_data::MEDIUM) {
-    return true;
-  }
+  if (((material_type)default_material)->which_subclass != material_data::MEDIUM) { return true; }
   return false;
 }
 
@@ -1930,7 +1910,8 @@ void fragment_stats::compute_dft_stats() {
         // Note: Since geom_boxes_intersect returns true if two planes share a line or two volumes
         // share a line or plane, there are cases where some pixels are counted multiple times.
         size_t overlap_pixels = get_pixels_in_box(&overlap_box, 2);
-        num_dft_pixels += overlap_pixels * dft_data_list[i].num_freqs * dft_data_list[i].num_components;
+        num_dft_pixels +=
+            overlap_pixels * dft_data_list[i].num_freqs * dft_data_list[i].num_components;
       }
     }
   }
@@ -1980,16 +1961,11 @@ void fragment_stats::compute() {
 // based on a cost function obtained via linear regression on a dataset
 // of random simulations.
 double fragment_stats::cost() const {
-  return (num_anisotropic_eps_pixels * 1.15061674e-04 +
-          num_anisotropic_mu_pixels * 1.26843801e-04 +
-          num_nonlinear_pixels * 1.67029547e-04 +
-          num_susceptibility_pixels * 2.24790864e-04 +
-          num_nonzero_conductivity_pixels * 4.61260934e-05 +
-          num_dft_pixels * 1.47283950e-04 +
-          num_1d_pml_pixels * 9.92955372e-05 +
-          num_2d_pml_pixels * 1.36901107e-03 +
-          num_3d_pml_pixels * 6.63939607e-04 +
-          num_pixels_in_box * 3.46518274e-04);
+  return (num_anisotropic_eps_pixels * 1.15061674e-04 + num_anisotropic_mu_pixels * 1.26843801e-04 +
+          num_nonlinear_pixels * 1.67029547e-04 + num_susceptibility_pixels * 2.24790864e-04 +
+          num_nonzero_conductivity_pixels * 4.61260934e-05 + num_dft_pixels * 1.47283950e-04 +
+          num_1d_pml_pixels * 9.92955372e-05 + num_2d_pml_pixels * 1.36901107e-03 +
+          num_3d_pml_pixels * 6.63939607e-04 + num_pixels_in_box * 3.46518274e-04);
 }
 
 void fragment_stats::print_stats() const {

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -75,8 +75,9 @@ struct fragment_stats {
   static bool split_chunks_evenly;
 
   static bool has_non_medium_material();
-  static void init_libctl(meep_geom::material_type default_mat, bool ensure_per, meep::grid_volume *gv,
-                          vector3 cell_size, vector3 cell_center, geometric_object_list *geom_list);
+  static void init_libctl(meep_geom::material_type default_mat, bool ensure_per,
+                          meep::grid_volume *gv, vector3 cell_size, vector3 cell_center,
+                          geometric_object_list *geom_list);
 
   size_t num_anisotropic_eps_pixels;
   size_t num_anisotropic_mu_pixels;
@@ -97,7 +98,7 @@ struct fragment_stats {
   geom_box box;
 
   fragment_stats() {}
-  fragment_stats(geom_box& bx);
+  fragment_stats(geom_box &bx);
   void update_stats_from_material(material_type mat, size_t pixels);
   void compute_stats();
   void count_anisotropic_pixels(medium_struct *med, size_t pixels);

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -66,6 +66,17 @@ struct fragment_stats {
   static int maxeval;
   static int resolution;
   static meep::ndim dims;
+  static geometric_object_list geom;
+  static std::vector<dft_data> dft_data_list;
+  static std::vector<meep::volume> pml_1d_vols;
+  static std::vector<meep::volume> pml_2d_vols;
+  static std::vector<meep::volume> pml_3d_vols;
+  static std::vector<meep::volume> absorber_vols;
+  static bool split_chunks_evenly;
+
+  static bool has_non_medium_material();
+  static void init_libctl(meep_geom::material_type default_mat, bool ensure_per, meep::grid_volume *gv,
+                          vector3 cell_size, vector3 cell_center, geometric_object_list *geom_list);
 
   size_t num_anisotropic_eps_pixels;
   size_t num_anisotropic_mu_pixels;
@@ -86,19 +97,19 @@ struct fragment_stats {
   geom_box box;
 
   fragment_stats() {}
-  fragment_stats(geom_box &bx, size_t pixels);
+  fragment_stats(geom_box& bx);
   void update_stats_from_material(material_type mat, size_t pixels);
-  void compute_stats(geometric_object_list *geom);
+  void compute_stats();
   void count_anisotropic_pixels(medium_struct *med, size_t pixels);
   void count_nonlinear_pixels(medium_struct *med, size_t pixels);
   void count_susceptibility_pixels(medium_struct *med, size_t pixels);
   void count_nonzero_conductivity_pixels(medium_struct *med, size_t pixels);
-  void compute_dft_stats(std::vector<dft_data> *dft_data_list);
-  void compute_pml_stats(const std::vector<meep::volume> &pml_1d_vols,
-                         const std::vector<meep::volume> &pml_2d_vols,
-                         const std::vector<meep::volume> &pml_3d_vols);
-  void compute_absorber_stats(const std::vector<meep::volume> &absorber_vols);
-  void print_stats();
+  void compute_dft_stats();
+  void compute_pml_stats();
+  void compute_absorber_stats();
+  void compute();
+  double cost() const;
+  void print_stats() const;
 };
 
 std::vector<fragment_stats>

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -133,12 +133,11 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
 
     grid_volume vi;
     if (meep_geom::fragment_stats::resolution == 0 ||
-        meep_geom::fragment_stats::has_non_medium_material() ||
-        gv.dim == Dcyl || meep_geom::fragment_stats::split_chunks_evenly) {
+        meep_geom::fragment_stats::has_non_medium_material() || gv.dim == Dcyl ||
+        meep_geom::fragment_stats::split_chunks_evenly) {
       // Fall back to split_by_effort method
       vi = gv.split_by_effort(desired_num_chunks, i, num_effort_volumes, effort_volumes, effort);
-    }
-    else {
+    } else {
       vi = gv.split_by_cost(desired_num_chunks, i);
     }
 

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -65,7 +65,6 @@ structure::structure(const grid_volume &thegv, double eps(const vec &), const bo
   shared_chunks = false;
   if (!br.check_ok(thegv)) abort("invalid boundary absorbers for this grid_volume");
   choose_chunkdivision(thegv, num, br, s);
-
   if (eps) {
     simple_material_function epsilon(eps);
     set_materials(epsilon, use_anisotropic_averaging, tol, maxeval);
@@ -95,109 +94,10 @@ static std::vector<int> get_prime_factors(int n) {
   } else if (n >= 2 && n <= 5) {
     result.push_back(n);
   }
-
   return result;
 }
 
-static double get_cost_of_volume(grid_volume gv) {
-  geom_box box = meep_geom::gv2box(gv.surroundings());
-  meep_geom::fragment_stats fstats(box);
-  fstats.compute();
-  return fstats.cost();
-}
-
-static void split_into_three(grid_volume gvol, std::vector<grid_volume> &result) {
-
-  grid_volume best_low, best_mid, best_high;
-  double best_overall_split_measure = 1e20;
-  int best_low_split_point = 0;
-  int best_high_split_point = 0;
-
-  double total_cost = get_cost_of_volume(gvol);
-  double ideal_cost_per_chunk = total_cost / 3;
-
-  direction longest_axis = NO_DIRECTION;
-  int num_in_longest_axis = 0;
-  LOOP_OVER_DIRECTIONS(gvol.dim, d) {
-    if (gvol.num_direction(d) > num_in_longest_axis) {
-      longest_axis = d;
-      num_in_longest_axis = gvol.num_direction(d);
-    }
-  }
-
-  LOOP_OVER_DIRECTIONS(gvol.dim, d) {
-    double best_low_split_measure = 1e20;
-    for (int split_point = 1; split_point < gvol.num_direction(d); ++split_point) {
-      grid_volume v_low = gvol;
-      v_low.set_num_direction(d, split_point);
-      double low_cost = get_cost_of_volume(v_low);
-      double split_measure = fabs(low_cost - ideal_cost_per_chunk);
-
-      if (split_measure < best_low_split_measure) {
-        best_low_split_measure = split_measure;
-        best_low_split_point = split_point;
-      }
-    }
-
-    grid_volume low_gv = gvol.split_at_fraction(false, best_low_split_point, d,
-                                                gvol.num_direction(d));
-    grid_volume high_two_gvs = gvol.split_at_fraction(true, best_low_split_point, d,
-                                                      gvol.num_direction(d));
-
-    double best_high_split_measure = 1e20;
-    for (int split_point = 1; split_point < high_two_gvs.num_direction(d); ++split_point) {
-      grid_volume v_low = high_two_gvs;
-      v_low.set_num_direction(d, split_point);
-      double low_cost = get_cost_of_volume(v_low);
-      double split_measure = fabs(low_cost - ideal_cost_per_chunk);
-
-      if (split_measure < best_high_split_measure) {
-        best_high_split_measure = split_measure;
-        best_high_split_point = split_point;
-      }
-    }
-    grid_volume mid_gv = high_two_gvs.split_at_fraction(false, best_high_split_point, d,
-                                                        high_two_gvs.num_direction(d));
-    grid_volume high_gv = high_two_gvs.split_at_fraction(true, best_high_split_point, d,
-                                                        high_two_gvs.num_direction(d));
-
-    double low_cost = get_cost_of_volume(low_gv);
-    double mid_cost = get_cost_of_volume(mid_gv);
-    double high_cost = get_cost_of_volume(high_gv);
-
-    double overall_split_measure = max(max(low_cost, mid_cost), high_cost);
-    bool within_thirty_percent = (overall_split_measure > best_overall_split_measure * 0.7 &&
-                                  overall_split_measure < best_overall_split_measure * 1.3);
-    bool at_least_thirty_percent_better = overall_split_measure < best_overall_split_measure * 0.7;
-
-    if ((within_thirty_percent && d == longest_axis) || at_least_thirty_percent_better) {
-      best_overall_split_measure = overall_split_measure;
-      best_low = low_gv;
-      best_mid = mid_gv;
-      best_high = high_gv;
-    }
-  }
-  result.push_back(best_low);
-  result.push_back(best_mid);
-  result.push_back(best_high);
-}
-
-static std::vector<grid_volume> make_gvols(grid_volume gvol, int split_num) {
-  std::vector<grid_volume> result;
-
-  if (split_num == 3) {
-    split_into_three(gvol, result);
-  } else {
-    for (int i = 0; i < split_num; ++i) {
-      grid_volume split_gv = gvol.split_by_cost(split_num, i);
-      result.push_back(split_gv);
-    }
-  }
-
-  return result;
-}
-
-static void do_it(std::vector<int> factors, grid_volume gvol, std::vector<grid_volume> &result) {
+static void split_by_cost(std::vector<int> factors, grid_volume gvol, std::vector<grid_volume> &result) {
 
   if (factors.size() == 0) {
     result.push_back(gvol);
@@ -207,12 +107,12 @@ static void do_it(std::vector<int> factors, grid_volume gvol, std::vector<grid_v
   int n = factors.back();
   factors.pop_back();
 
-  std::vector<grid_volume> new_gvs = make_gvols(gvol, n);
+  std::vector<grid_volume> new_gvs = gvol.split_into_n(n);
   if (new_gvs.size() != (size_t)n) {
-    master_printf("Error splitting by cost: %zu != %d", new_gvs.size(), n);
+    abort("Error splitting by cost: expected %d grid_volumes but got %zu", n, new_gvs.size());
   }
   for (int i = 0; i < n; ++i) {
-    do_it(factors, new_gvs[i], result);
+    split_by_cost(factors, new_gvs[i], result);
   }
 }
 
@@ -277,6 +177,7 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
     adjusted_num_chunks *= prime_factors[i];
   }
 
+  // Finally, create the chunks:
   num_chunks = 0;
   chunks = new structure_chunk_ptr[adjusted_num_chunks * num_effort_volumes];
   std::vector<grid_volume> chunk_volumes;
@@ -290,7 +191,7 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
       chunk_volumes.push_back(vi);
     }
   } else {
-    do_it(prime_factors, gv, chunk_volumes);
+    split_by_cost(prime_factors, gv, chunk_volumes);
   }
 
   // Break off PML regions into their own chunks
@@ -304,32 +205,6 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
       }
     }
   }
-
-  // Finally, create the chunks:
-  // num_chunks = 0;
-  // chunks = new structure_chunk_ptr[adjusted_num_chunks * num_effort_volumes];
-  // for (int i = 0; i < adjusted_num_chunks; i++) {
-  //   const int proc = i * count_processors() / adjusted_num_chunks;
-
-  //   grid_volume vi;
-  //   if (meep_geom::fragment_stats::resolution == 0 ||
-  //       meep_geom::fragment_stats::has_non_medium_material() || gv.dim == Dcyl ||
-  //       meep_geom::fragment_stats::split_chunks_evenly) {
-  //     // Fall back to split_by_effort method
-  //     vi = gv.split_by_effort(adjusted_num_chunks, i, num_effort_volumes, effort_volumes, effort);
-  //   } else {
-  //     vi = gv.split_by_cost(adjusted_num_chunks, i);
-  //   }
-
-  //   for (int j = 0; j < num_effort_volumes; j++) {
-  //     grid_volume vc;
-  //     if (vi.intersect_with(effort_volumes[j], &vc)) {
-  //       chunks[num_chunks] = new structure_chunk(vc, v, Courant, proc);
-  //       br.apply(this, chunks[num_chunks++]);
-  //     }
-  //   }
-  // }
-
   check_chunks();
 }
 

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -994,7 +994,14 @@ grid_volume grid_volume::split_by_effort(int n, int which, int Ngv, const grid_v
         .split_by_effort(n - num_low, which - num_low, Ngv, v, effort);
 }
 
-grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num, int factor) const {
+double grid_volume::get_cost() const {
+  geom_box box = meep_geom::gv2box(surroundings());
+  meep_geom::fragment_stats fstats(box);
+  fstats.compute();
+  return fstats.cost();
+}
+
+grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num) const {
   const size_t grid_points_owned = nowned_min();
   if (size_t(desired_chunks) > grid_points_owned) {
     abort("Cannot split %zd grid points into %d parts\n", nowned_min(), desired_chunks);
@@ -1023,14 +1030,8 @@ grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num, int fac
       v_right.set_num_direction(d, num_direction(d) - split_point);
       v_right.shift_origin(d, split_point * 2);
 
-      geom_box left_box = meep_geom::gv2box(v_left.surroundings());
-      geom_box right_box = meep_geom::gv2box(v_right.surroundings());
-      meep_geom::fragment_stats left_stats(left_box);
-      meep_geom::fragment_stats right_stats(right_box);
-      left_stats.compute();
-      right_stats.compute();
-      double left_cost = left_stats.cost();
-      double right_cost = right_stats.cost();
+      double left_cost = v_left.get_cost();
+      double right_cost = v_right.get_cost();
       double total_cost = left_cost + right_cost;
 
       double split_measure = max(left_cost / (desired_chunks / 2),
@@ -1071,6 +1072,98 @@ grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num, int fac
   } else {
     return split_gv.split_by_cost(desired_chunks - num_low, proc_num - num_low);
   }
+}
+
+void grid_volume::split_into_three(std::vector<grid_volume> &result) const {
+
+  grid_volume best_low, best_mid, best_high;
+  double best_overall_split_measure = 1e20;
+  int best_low_split_point = 0;
+  int best_high_split_point = 0;
+
+  double total_cost = get_cost();
+  double ideal_cost_per_chunk = total_cost / 3;
+
+  direction longest_axis = NO_DIRECTION;
+  int num_in_longest_axis = 0;
+  LOOP_OVER_DIRECTIONS(dim, d) {
+    if (num_direction(d) > num_in_longest_axis) {
+      longest_axis = d;
+      num_in_longest_axis = num_direction(d);
+    }
+  }
+
+  LOOP_OVER_DIRECTIONS(dim, d) {
+    double best_low_split_measure = 1e20;
+    for (int split_point = 1; split_point < num_direction(d); ++split_point) {
+      grid_volume v_low = *this;
+      v_low.set_num_direction(d, split_point);
+      double low_cost = v_low.get_cost();
+      double split_measure = fabs(low_cost - ideal_cost_per_chunk);
+
+      if (split_measure < best_low_split_measure) {
+        best_low_split_measure = split_measure;
+        best_low_split_point = split_point;
+      }
+    }
+
+    grid_volume low_gv = split_at_fraction(false, best_low_split_point, d,
+                                           num_direction(d));
+    grid_volume high_two_gvs = split_at_fraction(true, best_low_split_point, d,
+                                                 num_direction(d));
+
+    double best_high_split_measure = 1e20;
+    for (int split_point = 1; split_point < high_two_gvs.num_direction(d); ++split_point) {
+      grid_volume v_low = high_two_gvs;
+      v_low.set_num_direction(d, split_point);
+      double low_cost = v_low.get_cost();
+      double split_measure = fabs(low_cost - ideal_cost_per_chunk);
+
+      if (split_measure < best_high_split_measure) {
+        best_high_split_measure = split_measure;
+        best_high_split_point = split_point;
+      }
+    }
+    grid_volume mid_gv = high_two_gvs.split_at_fraction(false, best_high_split_point, d,
+                                                        high_two_gvs.num_direction(d));
+    grid_volume high_gv = high_two_gvs.split_at_fraction(true, best_high_split_point, d,
+                                                        high_two_gvs.num_direction(d));
+
+    double low_cost = low_gv.get_cost();
+    double mid_cost = mid_gv.get_cost();
+    double high_cost = high_gv.get_cost();
+
+    double overall_split_measure = fabs(ideal_cost_per_chunk - low_cost) +
+                                   fabs(ideal_cost_per_chunk - mid_cost) +
+                                   fabs(ideal_cost_per_chunk - high_cost);
+    bool within_thirty_percent = (overall_split_measure > best_overall_split_measure * 0.7 &&
+                                  overall_split_measure < best_overall_split_measure * 1.3);
+    bool at_least_thirty_percent_better = overall_split_measure < best_overall_split_measure * 0.7;
+
+    if ((within_thirty_percent && d == longest_axis) || at_least_thirty_percent_better) {
+      best_overall_split_measure = overall_split_measure;
+      best_low = low_gv;
+      best_mid = mid_gv;
+      best_high = high_gv;
+    }
+  }
+  result.push_back(best_low);
+  result.push_back(best_mid);
+  result.push_back(best_high);
+}
+
+std::vector<grid_volume> grid_volume::split_into_n(int n) const {
+  std::vector<grid_volume> result;
+
+  if (n == 3) {
+    split_into_three(result);
+  } else {
+    for (int i = 0; i < n; ++i) {
+      grid_volume split_gv = split_by_cost(n, i);
+      result.push_back(split_gv);
+    }
+  }
+  return result;
 }
 
 grid_volume grid_volume::split_at_fraction(bool want_high, int numer, int bestd,

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -21,6 +21,7 @@
 #include <complex>
 
 #include "meep_internals.hpp"
+#include "meepgeom.hpp"
 
 using namespace std;
 
@@ -993,13 +994,77 @@ grid_volume grid_volume::split_by_effort(int n, int which, int Ngv, const grid_v
         .split_by_effort(n - num_low, which - num_low, Ngv, v, effort);
 }
 
-grid_volume grid_volume::split_at_fraction(bool want_high, int numer) const {
-  int bestd = -1, bestlen = 1;
-  for (int i = 0; i < 3; i++)
-    if (num[i] > bestlen) {
-      bestd = i;
-      bestlen = num[i];
+grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num) const {
+  const size_t grid_points_owned = nowned_min();
+  if (size_t(desired_chunks) > grid_points_owned)
+    abort("Cannot split %zd grid points into %d parts\n", nowned_min(), desired_chunks);
+  if (desired_chunks == 1) return *this;
+  double best_split_measure = 1e20, left_effort_fraction = 0;
+  int best_split_point = 0;
+  direction best_split_direction = NO_DIRECTION;
+
+  LOOP_OVER_DIRECTIONS(dim, d) {
+    int biglen = num_direction(d);
+    direction splitdir = d;
+
+    for (int split_point = 1; split_point < biglen; split_point+=1) {
+      grid_volume v_left = *this;
+      v_left.set_num_direction(splitdir, split_point);
+      grid_volume v_right = *this;
+      v_right.set_num_direction(splitdir, num_direction(splitdir) - split_point);
+      v_right.shift_origin(splitdir, split_point*2);
+
+      geom_box left_box = meep_geom::gv2box(v_left.surroundings());
+      geom_box right_box = meep_geom::gv2box(v_right.surroundings());
+
+      meep_geom::fragment_stats left_stats(left_box);
+      meep_geom::fragment_stats right_stats(right_box);
+
+      left_stats.compute();
+      right_stats.compute();
+      double total_left_effort = left_stats.cost();
+      double total_right_effort = right_stats.cost();
+
+      double split_measure = max(total_left_effort/(desired_chunks/2),
+                                 total_right_effort/(desired_chunks-desired_chunks/2));
+      if (split_measure < best_split_measure) {
+        best_split_measure = split_measure;
+        best_split_point = split_point;
+        best_split_direction = d;
+        left_effort_fraction = total_left_effort/(total_left_effort + total_right_effort);
+      }
     }
+  }
+  const int split_point = best_split_point;
+  const int num_in_split_dir = num_direction(best_split_direction);
+
+  const int num_low = (size_t)(left_effort_fraction*desired_chunks + 0.5);
+  // Revert to split() when cost method gives less grid points than chunks
+  if (size_t(num_low) > best_split_point*(grid_points_owned/num_in_split_dir) ||
+      size_t(desired_chunks-num_low) > (grid_points_owned - best_split_point*(grid_points_owned/num_in_split_dir)))
+    return split(desired_chunks, proc_num);
+
+  bool split_low = proc_num < num_low;
+  grid_volume split_gv = split_at_fraction(!split_low, split_point, best_split_direction, num_in_split_dir);
+
+  if (split_low) {
+    return split_gv.split_by_cost(num_low, proc_num);
+  }
+  else {
+    return split_gv.split_by_cost(desired_chunks-num_low, proc_num-num_low);
+  }
+}
+
+grid_volume grid_volume::split_at_fraction(bool want_high, int numer, int bestd, int bestlen) const {
+
+  if (bestd == -1) {
+    for (int i=0;i<3;i++)
+      if (num[i] > bestlen) {
+        bestd = i;
+        bestlen = num[i];
+      }
+  }
+
   if (bestd == -1) {
     for (int i = 0; i < 3; i++)
       master_printf("num[%d] = %d\n", i, num[i]);

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1133,9 +1133,7 @@ void grid_volume::split_into_three(std::vector<grid_volume> &result) const {
     double mid_cost = mid_gv.get_cost();
     double high_cost = high_gv.get_cost();
 
-    double overall_split_measure = fabs(ideal_cost_per_chunk - low_cost) +
-                                   fabs(ideal_cost_per_chunk - mid_cost) +
-                                   fabs(ideal_cost_per_chunk - high_cost);
+    double overall_split_measure = max(max(low_cost, mid_cost), high_cost);
     bool within_thirty_percent = (overall_split_measure > best_overall_split_measure * 0.7 &&
                                   overall_split_measure < best_overall_split_measure * 1.3);
     bool at_least_thirty_percent_better = overall_split_measure < best_overall_split_measure * 0.7;

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1007,12 +1007,12 @@ grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num) const {
     int biglen = num_direction(d);
     direction splitdir = d;
 
-    for (int split_point = 1; split_point < biglen; split_point+=1) {
+    for (int split_point = 1; split_point < biglen; split_point += 1) {
       grid_volume v_left = *this;
       v_left.set_num_direction(splitdir, split_point);
       grid_volume v_right = *this;
       v_right.set_num_direction(splitdir, num_direction(splitdir) - split_point);
-      v_right.shift_origin(splitdir, split_point*2);
+      v_right.shift_origin(splitdir, split_point * 2);
 
       geom_box left_box = meep_geom::gv2box(v_left.surroundings());
       geom_box right_box = meep_geom::gv2box(v_right.surroundings());
@@ -1025,40 +1025,42 @@ grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num) const {
       double total_left_effort = left_stats.cost();
       double total_right_effort = right_stats.cost();
 
-      double split_measure = max(total_left_effort/(desired_chunks/2),
-                                 total_right_effort/(desired_chunks-desired_chunks/2));
+      double split_measure = max(total_left_effort / (desired_chunks / 2),
+                                 total_right_effort / (desired_chunks - desired_chunks / 2));
       if (split_measure < best_split_measure) {
         best_split_measure = split_measure;
         best_split_point = split_point;
         best_split_direction = d;
-        left_effort_fraction = total_left_effort/(total_left_effort + total_right_effort);
+        left_effort_fraction = total_left_effort / (total_left_effort + total_right_effort);
       }
     }
   }
   const int split_point = best_split_point;
   const int num_in_split_dir = num_direction(best_split_direction);
 
-  const int num_low = (size_t)(left_effort_fraction*desired_chunks + 0.5);
+  const int num_low = (size_t)(left_effort_fraction * desired_chunks + 0.5);
   // Revert to split() when cost method gives less grid points than chunks
-  if (size_t(num_low) > best_split_point*(grid_points_owned/num_in_split_dir) ||
-      size_t(desired_chunks-num_low) > (grid_points_owned - best_split_point*(grid_points_owned/num_in_split_dir)))
+  if (size_t(num_low) > best_split_point * (grid_points_owned / num_in_split_dir) ||
+      size_t(desired_chunks - num_low) >
+          (grid_points_owned - best_split_point * (grid_points_owned / num_in_split_dir)))
     return split(desired_chunks, proc_num);
 
   bool split_low = proc_num < num_low;
-  grid_volume split_gv = split_at_fraction(!split_low, split_point, best_split_direction, num_in_split_dir);
+  grid_volume split_gv =
+      split_at_fraction(!split_low, split_point, best_split_direction, num_in_split_dir);
 
   if (split_low) {
     return split_gv.split_by_cost(num_low, proc_num);
-  }
-  else {
-    return split_gv.split_by_cost(desired_chunks-num_low, proc_num-num_low);
+  } else {
+    return split_gv.split_by_cost(desired_chunks - num_low, proc_num - num_low);
   }
 }
 
-grid_volume grid_volume::split_at_fraction(bool want_high, int numer, int bestd, int bestlen) const {
+grid_volume grid_volume::split_at_fraction(bool want_high, int numer, int bestd,
+                                           int bestlen) const {
 
   if (bestd == -1) {
-    for (int i=0;i<3;i++)
+    for (int i = 0; i < 3; i++)
       if (num[i] > bestlen) {
         bestd = i;
         bestlen = num[i];


### PR DESCRIPTION
Closes #536.  Attempts to divide the cell into chunks that take a similar amount of work. The work estimate is produced by `fragment_stats::cost`, which was obtained from running linear regression on training data from random simulations. 

The default is still to use `split_by_effort`, which splits the chunks evenly without taking cost into account, but setting the `Simulation` constructor parameter `split_chunks_evenly=False` will use `split_by_cost`.  Here are some benchmark results from the following simulation (a tall skinny cell with an expensive flux plane at the top):

```python
import argparse
import time
import meep as mp

def main(args):
    sx = 2
    sy = 30
    sz = 1
    fcen = 0.15
    df = 0.1

    src = mp.Source(mp.GaussianSource(fcen, fwidth=df), mp.Ey, mp.Vector3())

    sim = mp.Simulation(cell_size=mp.Vector3(sx, sy, sz),
                        sources=[src],
                        resolution=10,
                        split_chunks_evenly=args.split_evenly)

    flux = sim.add_flux(fcen, df, 500, mp.FluxRegion(center=mp.Vector3(0, 12), size=mp.Vector3(2, 1)))
    start = time.time()
    sim.run(until=200)
    print("bench:{},{},{}".format(args.split_evenly, mp.count_processors(), time.time() - start))

if __name__ == '__main__':
    parser = argparse.ArgumentParser()
    parser.add_argument('-e', '--split-evenly', action='store_true', default=False,
                                        help='Use the old split_by_effort method to create chunks')
    args = parser.parse_args()
    main(args)
```

![bench_results](https://user-images.githubusercontent.com/14114829/51635891-7b05c880-1f1d-11e9-9587-2994af040b5a.png)

The `meep::structure` is now created in C++ (`create_structure_and_set_materials`) instead of Python. Using the geometry in `structure::choose_chunkdivision` would require making copies, or passing it around, both of which would require more significant changes. `create_structure_and_set_materials` allows the Python geometry to be converted to C++ once, then deleted when it returns.

The number of processors is divided into prime factors and the cell is split into chunks starting from the largest prime factor towards the smallest in order to achieve a more even grid split for powers of 3. Here are some examples of the improvement

**Left**: `split_by_effort`                                                  **Right**: `split_by_cost`
## Cell of air with 9 processors
![nine_procs](https://user-images.githubusercontent.com/14114829/51636779-b0abb100-1f1f-11e9-84f5-8c795f144b28.png)
## Cell of air with 9 processors and PML
![nine_procs_pml](https://user-images.githubusercontent.com/14114829/51636784-b43f3800-1f1f-11e9-8a41-0c5eb691f853.png)
## Tall skinny cell with expensive flux plane at the top, 3 processors
(`split_by_effort` puts all the work on 1 processor).
![three_procs_flux_plane](https://user-images.githubusercontent.com/14114829/51636791-b7d2bf00-1f1f-11e9-9f94-166d92cd6593.png)
## Tall skinny cell with expensive flux plane at the top, 9 processors.
![nine_procs_flux_plane](https://user-images.githubusercontent.com/14114829/51636795-ba351900-1f1f-11e9-8ed0-6d59258c197e.png)
This can be improved by splitting in the `X` direction, but the gain is not above the 30% threshold so `split_by_cost` splits in the `Y` direction. Using machine learning to get the actual communication cost should improve this.

### Remaining issues
1. `split_by_cost` doesn't work with cylindrical coordinates yet so it falls back to `split_by_effort`
2. `split_by_cost` breaks the `structure::dump` and `structure::load` features. When you run the initial simulation and dump the structure file, the chunks are split optimally based on the geometry, but when you attempt to load the file, there is no geometry passed in so the chunks are split evenly, resulting in chunk size mismatches. Need to pass a list of volumes to these functions.