### PR TITLE
Fix scipy warning in MPB tutorial

### DIFF
--- a/python/examples/mpb_tutorial.py
+++ b/python/examples/mpb_tutorial.py
@@ -73,7 +73,7 @@ def first_tm_gap(r):
 ms.num_bands = 2
 ms.mesh_size = 7
 
-result = minimize_scalar(first_tm_gap, method='bounded', bounds=[0.1, 0.5], tol=0.1)
+result = minimize_scalar(first_tm_gap, method='bounded', bounds=[0.1, 0.5], options={'xatol': 0.1})
 print("radius at maximum: {}".format(result.x))
 print("gap size at maximum: {}".format(result.fun * -1))
 

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -553,7 +553,7 @@ class TestModeSolver(unittest.TestCase):
         ms.num_bands = 2
         ms.mesh_size = 7
 
-        result = minimize_scalar(first_tm_gap, method='bounded', bounds=[0.1, 0.5], tol=0.1)
+        result = minimize_scalar(first_tm_gap, method='bounded', bounds=[0.1, 0.5], options={'xatol': 0.1})
         expected = 39.10325687542367
         self.assertAlmostEqual(expected, result.fun * -1, places=2)
 


### PR DESCRIPTION
This doesn't change the behavior, but fixes the warning:
```
RuntimeWarning: Method 'bounded' does not support relative tolerance in x; defaulting to absolute tolerance.
```
@stevengj @oskooi 