### PR TITLE
Allow user materials when checking for conductivity

### DIFF
--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1125,7 +1125,10 @@ double geom_epsilon::conductivity(meep::component c, const meep::vec &r) {
   double cond_val;
   material_data *md = material;
   switch (md->which_subclass) {
-    case material_data::MEDIUM: cond_val = get_cnd(c, &(md->medium)); break;
+    case material_data::MEDIUM:
+    case material_data::MATERIAL_USER:
+      cond_val = get_cnd(c, &(md->medium));
+      break;
     default: cond_val = 0;
   }
   material_gc(material);


### PR DESCRIPTION
Fixes #687. I'm not sure if the check for `MATERIAL_USER` was missing for a reason, or if it was just an oversight. With this change, running the script from #687 outputs
```
flux:, 0.018459, 0.746782, 0.234758
slab is absorbing
```
@stevengj @oskooi 