### PR TITLE
Remove need for user to access swigobj in near2far.flux

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -321,9 +321,8 @@ class DftNear2Far(DftObj):
     def mu(self):
         return self.swigobj_attr('mu')
 
-    @property
-    def flux(self):
-        return self.swigobj_attr('flux')
+    def flux(self, direction, where, resolution):
+        return self.swigobj_attr('flux')(direction, where.swigobj, resolution)
 
 class DftFields(DftObj):
 

--- a/python/tests/antenna_radiation.py
+++ b/python/tests/antenna_radiation.py
@@ -69,10 +69,10 @@ class TestAntennaRadiation(unittest.TestCase):
         far_flux_circle = np.sum(Pr)*2*np.pi*r/len(Pr)
 
         rr = 20/fcen      # length of far field square box
-        far_flux_square = (nearfield_box.flux(mp.Y, mp.Volume(center=mp.Vector3(y=0.5*rr), size=mp.Vector3(rr)).swigobj, resolution)[0]
-                           - nearfield_box.flux(mp.Y, mp.Volume(center=mp.Vector3(y=-0.5*rr), size=mp.Vector3(rr)).swigobj, resolution)[0]
-                           + nearfield_box.flux(mp.X, mp.Volume(center=mp.Vector3(0.5*rr), size=mp.Vector3(y=rr)).swigobj, resolution)[0]
-                           - nearfield_box.flux(mp.X, mp.Volume(center=mp.Vector3(-0.5*rr), size=mp.Vector3(y=rr)).swigobj, resolution)[0])
+        far_flux_square = (nearfield_box.flux(mp.Y, mp.Volume(center=mp.Vector3(y=0.5*rr), size=mp.Vector3(rr)), resolution)[0]
+                           - nearfield_box.flux(mp.Y, mp.Volume(center=mp.Vector3(y=-0.5*rr), size=mp.Vector3(rr)), resolution)[0]
+                           + nearfield_box.flux(mp.X, mp.Volume(center=mp.Vector3(0.5*rr), size=mp.Vector3(y=rr)), resolution)[0]
+                           - nearfield_box.flux(mp.X, mp.Volume(center=mp.Vector3(-0.5*rr), size=mp.Vector3(y=rr)), resolution)[0])
 
         print("flux:, {:.6f}, {:.6f}, {:.6f}".format(near_flux,far_flux_circle,far_flux_square))
 


### PR DESCRIPTION
Adds a wrapper that accesses the SWIG object of `where` so the user doesn't have to do it manually.
@stevengj @oskooi 