### PR TITLE
Allow any callable object for user material function

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -763,7 +763,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 
 %typecheck(SWIG_TYPECHECK_POINTER) material_type {
     int py_material = PyObject_IsInstance($input, py_material_object());
-    int user_material = PyFunction_Check($input);
+    int user_material = PyCallable_Check($input);
     int file_material = IsPyString($input);
     int numpy_material = PyArray_Check($input);
 

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -422,7 +422,7 @@ static int pymaterial_to_material(PyObject *po, material_type *mt) {
   if (PyObject_IsInstance(po, py_material_object())) {
     md = make_dielectric(1);
     if (!pymedium_to_medium(po, &md->medium)) { return 0; }
-  } else if (PyFunction_Check(po)) {
+  } else if (PyCallable_Check(po)) {
     PyObject *eps = PyObject_GetAttrString(po, "eps");
     if (!eps) { return 0; }
     if (eps == Py_True) {


### PR DESCRIPTION
Requested by Ian Sage on the mailing list. Allows passing a class instance to the `material_function` parameter of the `Simulation` constructor, provided the class's `__call__` method is implemented.
@stevengj @oskooi 