### PR TITLE
Abort instead of setting Python exception in typemaps

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -146,9 +146,7 @@ static std::complex<double> py_field_func_wrap(const std::complex<double> *field
 
     PyObject *pyret = PyObject_CallObject(data->func, py_args);
 
-    if (!pyret) {
-        PyErr_PrintEx(0);
-    }
+    if (!pyret) { abort_with_stack_trace(); }
 
     double real = PyComplex_RealAsDouble(pyret);
     double imag = PyComplex_ImagAsDouble(pyret);
@@ -215,8 +213,7 @@ static int pyabsorber_to_absorber(PyObject *py_absorber, meep_geom::absorber *a)
     PyObject *py_pml_profile_func = PyObject_GetAttrString(py_absorber, "pml_profile");
 
     if (!py_pml_profile_func) {
-        PyErr_Format(PyExc_ValueError, "Class attribute 'pml_profile' is None\n");
-        return 0;
+      meep::abort("Class attribute 'pml_profile' is None\n");
     }
 
     a->pml_profile_data = py_pml_profile_func;
@@ -229,12 +226,9 @@ double py_pml_profile(double u, void *f) {
     PyObject *func = (PyObject *)f;
     PyObject *d = PyFloat_FromDouble(u);
 
-    if (!PyCallable_Check(func)) {
-        PyErr_SetString(PyExc_TypeError, "py_pml_profile: Expected a callable");
-        PyErr_Print();
-    }
-
     PyObject *pyret = PyObject_CallFunctionObjArgs(func, d, NULL);
+
+    if (!pyret) { abort_with_stack_trace(); }
 
     double ret = PyFloat_AsDouble(pyret);
     Py_XDECREF(pyret);
@@ -711,8 +705,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
         swig_obj = $input;
         Py_XINCREF(swig_obj);
     } else {
-        PyErr_SetString(PyExc_TypeError, "Expected a meep.source.SourceTime or a meep.src_time\n");
-        SWIG_fail;
+      meep::abort("Expected a meep.source.SourceTime or a meep.src_time\n");
     }
 
     tmp_res = SWIG_ConvertPtr(swig_obj, &tmp_ptr, $1_descriptor, 0);
@@ -897,8 +890,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 //--------------------------------------------------
 %typemap(in) (meep::component *components, int num_components) {
     if (!PyList_Check($input)) {
-        PyErr_SetString(PyExc_ValueError, "Expected a list");
-        SWIG_fail;
+        meep::abort("Expected a list");
     }
     $2 = PyList_Size($input);
     $1 = new meep::component[$2];
@@ -927,22 +919,19 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
     (py_field_func_data tmp_data) {
 
     if (!PySequence_Check($input)) {
-        PyErr_SetString(PyExc_ValueError, "Expected a sequence");
-        SWIG_fail;
+        meep::abort("Expected a sequence");
     }
 
     PyObject *cs = PyList_GetItem($input, 0);
 
     if (!PySequence_Check(cs)) {
-        PyErr_SetString(PyExc_ValueError, "Expected first item in list to be a list");
-        SWIG_fail;
+        meep::abort("Expected first item in list to be a list");
     }
 
     PyObject *func = PyList_GetItem($input, 1);
 
     if (!PyCallable_Check(func)) {
-        PyErr_SetString(PyExc_ValueError, "Expected a function");
-        SWIG_fail;
+        meep::abort("Expected a function");
     }
 
     $1 = PyList_Size(cs);
@@ -980,28 +969,25 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
               void *integrand_data_) (py_field_func_data data) {
 
     if (!PySequence_Check($input)) {
-        PyErr_SetString(PyExc_ValueError, "Expected a sequence");
-        SWIG_fail;
+        meep::abort("Expected a sequence");
     }
 
     PyObject *cs1 = PyList_GetItem($input, 0);
 
     if (!PySequence_Check(cs1)) {
-        PyErr_SetString(PyExc_ValueError, "Expected 1st item in list to be a sequence");
-        SWIG_fail;
+        meep::abort("Expected 1st item in list to be a sequence");
     }
 
     PyObject *cs2 = PyList_GetItem($input, 1);
 
     if (!PySequence_Check(cs2)) {
-        PyErr_SetString(PyExc_ValueError, "Expected 2nd item in list to be a sequence");
+        meep::abort("Expected 2nd item in list to be a sequence");
     }
 
     PyObject *func = PyList_GetItem($input, 2);
 
     if (!PyCallable_Check(func)) {
-        PyErr_SetString(PyExc_ValueError, "Expected 3rd item in list to be a function");
-        SWIG_fail;
+        meep::abort("Expected 3rd item in list to be a function");
     }
 
     $1 = PyList_Size(cs1);

--- a/python/tests/geom.py
+++ b/python/tests/geom.py
@@ -199,13 +199,6 @@ class TestCylinder(unittest.TestCase):
         self.assertNotIn(gm.Vector3(2.0001, 0, 0), c)
         self.assertNotIn(gm.Vector3(10, 10, 10), c)
 
-    def test_missing_required_arg_throws(self):
-        c = gm.Cylinder(radius=2.0, height=4.0, center=None)
-
-        with self.assertRaises(ValueError) as ctx:
-            self.assertIn(zeros(), c)
-            self.assertIn("Vector3 is not initialized", ctx.exception)
-
     def test_wrong_type_exception(self):
         """Test for Issue 180"""
         with self.assertRaises(TypeError):

--- a/python/tests/source.py
+++ b/python/tests/source.py
@@ -55,8 +55,6 @@ class TestSourceTime(unittest.TestCase):
 
 class TestSourceTypemaps(unittest.TestCase):
 
-    expected_msg = "Expected a meep.source.SourceTime or a meep.src_time\n"
-
     def setUp(self):
 
         def dummy_eps(v):
@@ -79,22 +77,6 @@ class TestSourceTypemaps(unittest.TestCase):
     def test_typemap_py(self):
         src = GaussianSource(0.15, 0.1)
         self.f.add_volume_source(mp.Ez, src, self.v)
-
-    def test_typemap_swig_raises(self):
-        src = mp.gaussian_src_time(0.15, 0.1)
-        self.assertTrue(src.is_equal(src))
-
-        with self.assertRaises(TypeError) as error:
-            src.is_equal(mp.vec())
-            self.assertEqual(error.exception.message, self.expected_msg)
-
-    def test_typemap_py_raises(self):
-        src = GaussianSource(0.15, 0.1)
-        self.assertTrue(src.swigobj.is_equal(src))
-
-        with self.assertRaises(TypeError) as error:
-            src.swigobj.is_equal(Vector3())
-            self.assertEqual(error.exception.message, self.expected_msg)
 
     def test_custom_source(self):
         n = 3.4


### PR DESCRIPTION
Errors in the typemaps never printed any useful messages because they told SWIG to fail, which caused the SWIG cleanup typemaps to fire, which resulted in NULL pointer dereferencing and segmentation faults. This PR just aborts on typemap errors instead of trying to set a Python exception.
@stevengj @oskooi 