### PR TITLE
Prevent infinite loop when fragment size divides cell perfectly

### DIFF
--- a/python/tests/fragment_stats.py
+++ b/python/tests/fragment_stats.py
@@ -854,6 +854,11 @@ class TestPMLToVolList(unittest.TestCase):
         self.checkcyl(v2[2], mp.Vector3(-5, 0, -5), mp.Vector3(-4, 0, -4))
         self.checkcyl(v2[3], mp.Vector3(4, 0, -5), mp.Vector3(5, 0, -4))
 
+    def test_edge_size_zero(self):
+        # Issue #736
+        sim = mp.Simulation(resolution=100, cell_size=mp.Vector3(1.50, 0.1, 0))
+        sim.init_sim()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1611,6 +1611,7 @@ static std::vector<geom_box> split_cell_1d(double box_size, vector3 cell_size) {
   double half_box = box_size / 2;
   double half_z = cell_size.z / 2;
   double edge_size_z = fmod(half_z + half_box, box_size);
+  if (edge_size_z == 0) edge_size_z = box_size;
   std::vector<geom_box> boxes;
 
   for (double z = -half_z; z < half_z;) {
@@ -1632,7 +1633,9 @@ static std::vector<geom_box> split_cell_2d(double box_size, vector3 cell_size) {
   double half_x = cell_size.x / 2;
   double half_y = cell_size.y / 2;
   double edge_size_x = fmod(half_x + half_box, box_size);
+  if (edge_size_x == 0) edge_size_x = box_size;
   double edge_size_y = fmod(half_y + half_box, box_size);
+  if (edge_size_y == 0) edge_size_y = box_size;
   std::vector<geom_box> boxes;
 
   for (double x = -half_x; x < half_x;) {
@@ -1660,8 +1663,11 @@ static std::vector<geom_box> split_cell_3d(double box_size, vector3 cell_size) {
   double half_y = cell_size.y / 2;
   double half_z = cell_size.z / 2;
   double edge_size_x = fmod(half_x + half_box, box_size);
+  if (edge_size_x == 0) edge_size_x = box_size;
   double edge_size_y = fmod(half_y + half_box, box_size);
+  if (edge_size_y == 0) edge_size_y = box_size;
   double edge_size_z = fmod(half_z + half_box, box_size);
+  if (edge_size_z == 0) edge_size_z = box_size;
   std::vector<geom_box> boxes;
 
   for (double x = -half_x; x < half_x;) {


### PR DESCRIPTION
Fixes #736.
@stevengj @oskooi 