### PR TITLE
Streamline array slice interface

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1688,7 +1688,7 @@ class Simulation(object):
         else:
             v = self._volume_from_kwargs(vol, center, size)
         dims = np.zeros(3, dtype=np.uintp)
-        rank, dirs = mp._get_array_slice_dimensions(self.fields, v, dims, True)
+        rank, dirs = mp._get_array_slice_dimensions(self.fields, v, dims, bool(dft))
 
         nxyz = np.ones(3, dtype=np.intp)
         for r in range(0,rank):
@@ -1698,7 +1698,7 @@ class Simulation(object):
         ytics=np.zeros(nxyz[1],dtype=np.float64)
         ztics=np.zeros(nxyz[2],dtype=np.float64)
         weights=np.zeros(nw,dtype=np.float64)
-        self.fields.get_array_metadata(v, xtics, ytics, ztics, weights, True)
+        self.fields.get_array_metadata(v, xtics, ytics, ztics, weights, bool(dft))
         return (xtics,ytics,ztics,np.reshape(weights,dims[np.nonzero(dims)]))
 
     def get_dft_array_metadata(self, dft_cell=None, vol=None, center=None, size=None):

--- a/python/tests/cavity_arrayslice.py
+++ b/python/tests/cavity_arrayslice.py
@@ -59,27 +59,27 @@ class TestCavityArraySlice(unittest.TestCase):
     def test_1d_slice(self):
         self.sim.run(until_after_sources=0)
         vol = mp.Volume(center=self.center_1d, size=self.size_1d)
-        hl_slice1d = self.sim.get_array(vol, component=mp.Hz)
+        hl_slice1d = self.sim.get_array(mp.Hz, vol)
         np.testing.assert_allclose(self.expected_1d, hl_slice1d)
 
     def test_2d_slice(self):
         self.sim.run(until_after_sources=0)
         vol = mp.Volume(center=self.center_2d, size=self.size_2d)
-        hl_slice2d = self.sim.get_array(vol, component=mp.Hz)
+        hl_slice2d = self.sim.get_array(mp.Hz, vol)
         np.testing.assert_allclose(self.expected_2d, hl_slice2d)
 
     def test_1d_slice_user_array(self):
         self.sim.run(until_after_sources=0)
         arr = np.zeros(126, dtype=np.float64)
         vol = mp.Volume(center=self.center_1d, size=self.size_1d)
-        self.sim.get_array(vol, component=mp.Hz, arr=arr)
+        self.sim.get_array(mp.Hz, vol, arr=arr)
         np.testing.assert_allclose(self.expected_1d, arr)
 
     def test_2d_slice_user_array(self):
         self.sim.run(until_after_sources=0)
         arr = np.zeros((126, 38), dtype=np.float64)
         vol = mp.Volume(center=self.center_2d, size=self.size_2d)
-        self.sim.get_array(vol, component=mp.Hz, arr=arr)
+        self.sim.get_array(mp.Hz, vol, arr=arr)
         np.testing.assert_allclose(self.expected_2d, arr)
 
     def test_illegal_user_array(self):
@@ -88,29 +88,29 @@ class TestCavityArraySlice(unittest.TestCase):
         with self.assertRaises(ValueError):
             arr = np.zeros(128)
             vol = mp.Volume(center=self.center_1d, size=self.size_1d)
-            self.sim.get_array(vol, component=mp.Hz, arr=arr)
+            self.sim.get_array(mp.Hz, vol, arr=arr)
 
         with self.assertRaises(ValueError):
             arr = np.zeros((126, 39))
             vol = mp.Volume(center=self.center_2d, size=self.size_2d)
-            self.sim.get_array(vol, component=mp.Hz, arr=arr)
+            self.sim.get_array(mp.Hz, vol, arr=arr)
 
         with self.assertRaises(ValueError):
             arr = np.zeros((126, 38))
             vol = mp.Volume(center=self.center_2d, size=self.size_2d)
-            self.sim.get_array(vol, component=mp.Hz, cmplx=True, arr=arr)
+            self.sim.get_array(mp.Hz, vol, cmplx=True, arr=arr)
 
     def test_1d_complex_slice(self):
         self.sim.run(until_after_sources=0)
         vol = mp.Volume(center=self.center_1d, size=self.size_1d)
-        hl_slice1d = self.sim.get_array(vol, component=mp.Hz, cmplx=True)
+        hl_slice1d = self.sim.get_array(mp.Hz, vol, cmplx=True)
         self.assertTrue(hl_slice1d.dtype == np.complex128)
         self.assertTrue(hl_slice1d.shape[0] == 126)
 
     def test_2d_complex_slice(self):
         self.sim.run(until_after_sources=0)
         vol = mp.Volume(center=self.center_2d, size=self.size_2d)
-        hl_slice2d = self.sim.get_array(vol, component=mp.Hz, cmplx=True)
+        hl_slice2d = self.sim.get_array(mp.Hz, vol, cmplx=True)
         self.assertTrue(hl_slice2d.dtype == np.complex128)
         self.assertTrue(hl_slice2d.shape[0] == 126 and hl_slice2d.shape[1] == 38)
 

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -274,12 +274,10 @@ class TestSimulation(unittest.TestCase):
         eps = {'arr1': None, 'arr2': None}
 
         def get_arr1(sim):
-            eps['arr1'] = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(10, 10)),
-                                        component=mp.Dielectric)
+            eps['arr1'] = sim.get_array(mp.Dielectric, mp.Volume(mp.Vector3(), mp.Vector3(10, 10)))
 
         def get_arr2(sim):
-            eps['arr2'] = sim.get_array(mp.Volume(mp.Vector3(), mp.Vector3(10, 10)),
-                                        component=mp.Dielectric)
+            eps['arr2'] = sim.get_array(mp.Dielectric, mp.Volume(mp.Vector3(), mp.Vector3(10, 10)))
 
         sim.run(mp.at_time(50, get_arr1), mp.at_time(100, change_geom),
                 mp.at_end(get_arr2), until=200)


### PR DESCRIPTION
Closes #670. Closes #661.
* `get_array` takes `component` as first argument (remains a keyword to keep as much backward compatibility as possible).
* `get_dft_array_metadata` is deprecated.
* Removed `collapse` parameter from `get_array_metadata` (defaults to `True`).
* Deprecated `get_source_slice` and added `get_source`. 

@HomerReid may want to review the changes.
@stevengj @oskooi  