### PR TITLE
Don't bother splitting cell into fragments when collecting statistics

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -520,7 +520,6 @@ class Simulation(object):
         self.load_structure_file = load_structure
         self.dft_objects = []
         self._is_initialized = False
-        self._fragment_size = 10
         self.force_all_components = force_all_components
         self.split_chunks_evenly = split_chunks_evenly
         self.chunk_layout = chunk_layout
@@ -873,21 +872,19 @@ class Simulation(object):
             self.subpixel_tol,
             self.subpixel_maxeval,
             self.ensure_periodicity,
-            self._fragment_size
         )
 
         mirror_symmetries = [sym for sym in self.symmetries if isinstance(sym, Mirror)]
         for sym in mirror_symmetries:
-            for fs in stats:
-                fs.num_anisotropic_eps_pixels //= 2
-                fs.num_anisotropic_mu_pixels //= 2
-                fs.num_nonlinear_pixels //= 2
-                fs.num_susceptibility_pixels //= 2
-                fs.num_nonzero_conductivity_pixels //= 2
-                fs.num_1d_pml_pixels //= 2
-                fs.num_2d_pml_pixels //= 2
-                fs.num_3d_pml_pixels //= 2
-                fs.num_pixels_in_box //= 2
+            stats.num_anisotropic_eps_pixels //= 2
+            stats.num_anisotropic_mu_pixels //= 2
+            stats.num_nonlinear_pixels //= 2
+            stats.num_susceptibility_pixels //= 2
+            stats.num_nonzero_conductivity_pixels //= 2
+            stats.num_1d_pml_pixels //= 2
+            stats.num_2d_pml_pixels //= 2
+            stats.num_3d_pml_pixels //= 2
+            stats.num_pixels_in_box //= 2
 
         return stats
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -475,7 +475,8 @@ class Simulation(object):
                  geometry_center=mp.Vector3(),
                  force_all_components=False,
                  split_chunks_evenly=True,
-                 chunk_layout=None):
+                 chunk_layout=None,
+                 collect_stats=False):
 
         self.cell_size = cell_size
         self.geometry = geometry
@@ -523,6 +524,7 @@ class Simulation(object):
         self.force_all_components = force_all_components
         self.split_chunks_evenly = split_chunks_evenly
         self.chunk_layout = chunk_layout
+        self.collect_stats = collect_stats
 
     # To prevent the user from having to specify `dims` and `is_cylindrical`
     # to Volumes they create, the library will adjust them appropriately based
@@ -906,7 +908,9 @@ class Simulation(object):
         elif self.epsilon_input_file:
             self.default_material = self.epsilon_input_file
 
-        self.fragment_stats = self._compute_fragment_stats(gv) if isinstance(self.default_material, mp.Medium) else []
+        if self.collect_stats and isinstance(self.default_material, mp.Medium):
+            self.fragment_stats = self._compute_fragment_stats(gv)
+
         dft_data_list, pml_vols1, pml_vols2, pml_vols3, absorber_vols = self._make_fragment_lists(gv)
 
         self.structure = mp.create_structure_and_set_materials(

--- a/python/tests/fragment_stats.py
+++ b/python/tests/fragment_stats.py
@@ -62,10 +62,9 @@ class TestFragmentStats(unittest.TestCase):
         return stats
 
     def _test_1d(self, sym, pml=[]):
-        # A z=30 cell, split into three fragments of size 10 each, with a block
-        # covering the middle fragment.
+        # A z=30 cell, with a size 10 block in the middle.
 
-        # flux covering first fragment, near2far covering second, force covering third
+        # flux covering first 10 units, near2far covering second 10, and force covering third
         dft_vecs = make_dft_vecs(
             [mp.FluxRegion(mp.Vector3(z=-10), size=mp.Vector3(z=10))],
             [mp.Near2FarRegion(mp.Vector3(), size=mp.Vector3(z=10))],
@@ -74,15 +73,8 @@ class TestFragmentStats(unittest.TestCase):
 
         fs = self.get_fragment_stats(mp.Vector3(z=10), mp.Vector3(z=30), 1, dft_vecs=dft_vecs, sym=sym, pml=pml)
 
-        self.assertEqual(len(fs), 3)
-
-        # First and last fragments have no geometry, only default_material
-        for i in [0, 2]:
-            self.check_stats(fs[i], 0, 0, 0, 0, 0)
-
-        # Second fragment contains entire block
         sym_factor = 2 if sym else 1
-        self.check_stats(fs[1],
+        self.check_stats(fs,
                          a_eps=100 / sym_factor,
                          a_mu=100 / sym_factor,
                          nonlin=300 / sym_factor,
@@ -90,10 +82,7 @@ class TestFragmentStats(unittest.TestCase):
                          cond=300 / sym_factor)
 
         # Check DFT regions
-        self.assertEqual(fs[0].num_dft_pixels, 8224)
-        self.assertEqual(fs[1].num_dft_pixels, 11792)
-        self.assertEqual(fs[2].num_dft_pixels, 21824)
-
+        self.assertEqual(fs.num_dft_pixels, 40800)
         self.fs = fs
 
     def test_1d(self):
@@ -104,111 +93,48 @@ class TestFragmentStats(unittest.TestCase):
 
     def test_1d_with_pml(self):
         self._test_1d([], pml=[mp.PML(1)])
-
-        for i in range(3):
-            self.assertEqual(self.fs[i].num_2d_pml_pixels, 0)
-            self.assertEqual(self.fs[i].num_3d_pml_pixels, 0)
-
-        self.assertEqual(self.fs[0].num_1d_pml_pixels, 10)
-        self.assertEqual(self.fs[1].num_1d_pml_pixels, 0)
-        self.assertEqual(self.fs[2].num_1d_pml_pixels, 10)
+        self.assertEqual(self.fs.num_2d_pml_pixels, 0)
+        self.assertEqual(self.fs.num_3d_pml_pixels, 0)
+        self.assertEqual(self.fs.num_1d_pml_pixels, 20)
 
     def test_1d_with_overlap(self):
-        # A z=30 cell split into three fragments of size 10 each, with a block
-        # covering the middle fragment, and half of the two outer fragments.
-
+        # A z=30 cell, with a block covering the middle 20 units.
         mat = mp.Medium(H_susceptibilities=[mp.DrudeSusceptibility()])
         fs = self.get_fragment_stats(mp.Vector3(z=20), mp.Vector3(z=30), 1, def_mat=mat)
-
-        self.assertEqual(len(fs), 3)
-
-        # Middle fragment is completely covered by the block
-        self.check_stats(fs[1], a_eps=100, a_mu=100, nonlin=300, susc=300, cond=300)
-
-        # Outer two fragments are half covered by the block, and half covered by default_material 'mat'
-        for i in [0, 2]:
-            self.check_stats(fs[i], a_eps=50, a_mu=50, nonlin=150, susc=200, cond=150)
+        self.check_stats(fs, a_eps=200, a_mu=200, nonlin=600, susc=700, cond=600)
 
     def test_1d_with_partial_fragment(self):
-        # A cell with z=26, with a 16 unit block in the center, split into 3 fragments,
-        # with the first and last fragment of length 8, and 3/8 covered by the block,
-        # and the middle fragment completely covered.
+        # A cell with z=26, with a 16 unit block in the center
 
-        # dft_flux with 2 volumes, 1 covering the first fragment and one covering
-        # half of the second fragment
+        # dft_flux with 2 volumes, 1 covering the first 10 units and one covering
+        # half of the second 10
         dft_vecs = make_dft_vecs(flx_reg=[
             mp.FluxRegion(mp.Vector3(z=-9), mp.Vector3(z=8)),
             mp.FluxRegion(mp.Vector3(z=-2.5), mp.Vector3(z=5))
         ])
         fs = self.get_fragment_stats(mp.Vector3(z=16), mp.Vector3(z=26), 1, dft_vecs=dft_vecs)
 
-        self.assertEqual(len(fs), 3)
-        # Check first and last box sizes
-        self.assertEqual(fs[0].box.low.z, -13)
-        self.assertEqual(fs[0].box.high.z, -5)
-        self.assertEqual(fs[2].box.low.z, 5)
-        self.assertEqual(fs[2].box.high.z, 13)
-
-        # Middle fragment is completely covered by block
-        self.check_stats(fs[1], a_eps=100, a_mu=100, nonlin=300, susc=300, cond=300)
-        # Outer fragments are 3/8 covered
-        for i in [0, 2]:
-            self.check_stats(fs[i], a_eps=30, a_mu=30, nonlin=90, susc=90, cond=90)
-
+        self.check_stats(fs, a_eps=160, a_mu=160, nonlin=480, susc=480, cond=480)
         # Check dft stats
-        self.assertEqual(fs[0].num_dft_pixels, 6560)
-        self.assertEqual(fs[1].num_dft_pixels, 4160)
-        self.assertEqual(fs[2].num_dft_pixels, 0)
-
-    def test_1d_with_shifted_center(self):
-        # A cell with z=26, with a 16 unit block shifted so that the right side is flush,
-        # with the right side of the cell, split into 3 fragments, with the first and last
-        # fragments of length 8, the first uncovered and the last completely covered by the
-        # block, and the middle fragment 80% covered by the block.
-        fs = self.get_fragment_stats(mp.Vector3(z=16), mp.Vector3(z=26), 1, mp.Vector3(z=5))
-
-        self.assertEqual(len(fs), 3)
-        # Check first and last box sizes
-        self.assertEqual(fs[0].box.low.z, -13)
-        self.assertEqual(fs[0].box.high.z, -5)
-        self.assertEqual(fs[2].box.low.z, 5)
-        self.assertEqual(fs[2].box.high.z, 13)
-
-        # First fragment is uncovered
-        self.check_stats(fs[0], 0, 0, 0, 0, 0)
-
-        # Middel fragment is 80% covered
-        self.check_stats(fs[1], a_eps=80, a_mu=80, nonlin=240, susc=240, cond=240)
-
-        # Last fragment is completely covered, but only 8 units long
-        self.check_stats(fs[2], a_eps=80, a_mu=80, nonlin=240, susc=240, cond=240)
+        self.assertEqual(fs.num_dft_pixels, 10400)
 
     def test_1d_dft_fields(self):
-        # A z=30 cell, split into three fragments of size 10 each, with a block
-        # covering the middle fragment.
+        # A z=30 cell with a block covering the middle 10 units.
 
-        # dft_fields covering first fragment
+        # dft_fields covering first 10 units
         dft_vecs = make_dft_vecs(fldc=mp.Vector3(z=-10), flds=mp.Vector3(z=10), fld_cmp=[mp.X, mp.Y])
         fs = self.get_fragment_stats(mp.Vector3(z=10), mp.Vector3(z=30), 1, dft_vecs=dft_vecs)
-
-        self.assertEqual(len(fs), 3)
-
-        self.assertEqual(fs[0].num_dft_pixels, 4000)
-        self.assertEqual(fs[1].num_dft_pixels, 80)
-        self.assertEqual(fs[2].num_dft_pixels, 0)
+        self.assertEqual(fs.num_dft_pixels, 4000)
 
         # Same test with volume instead of center and size
         dft_vecs = make_dft_vecs(fldw=mp.Volume(mp.Vector3(z=-10), mp.Vector3(z=10)), fld_cmp=[mp.X, mp.Y])
         fs = self.get_fragment_stats(mp.Vector3(z=10), mp.Vector3(z=30), 1, dft_vecs=dft_vecs)
-
-        self.assertEqual(fs[0].num_dft_pixels, 4000)
-        self.assertEqual(fs[1].num_dft_pixels, 80)
-        self.assertEqual(fs[2].num_dft_pixels, 0)
+        self.assertEqual(fs.num_dft_pixels, 4000)
 
     def _test_2d(self, sym, pml=[]):
-        # A 30 x 30 cell, with a 10 x 10 block in the middle, split into 9 10 x 10 fragments.
+        # A 30 x 30 cell, with a 10 x 10 block in the middle
 
-        # flux covering top-left fragment, near2far covering top-middle, force covering top-right
+        # flux covering top-left 10x10, near2far covering top-middle 10x10, force covering top-right
         dft_vecs = make_dft_vecs(
             [mp.FluxRegion(mp.Vector3(-10, 10), size=mp.Vector3(10, 10))],
             [mp.Near2FarRegion(mp.Vector3(0, 10), size=mp.Vector3(10, 10))],
@@ -217,32 +143,15 @@ class TestFragmentStats(unittest.TestCase):
         fs = self.get_fragment_stats(mp.Vector3(10, 10), mp.Vector3(30, 30), 2,
                                      dft_vecs=dft_vecs, sym=sym, pml=pml)
 
-        self.assertEqual(len(fs), 9)
-
         # Check fragment boxes
-        self.assertEqual(fs[0].box.low.x, -15)
-        self.assertEqual(fs[0].box.low.y, -15)
-        self.assertEqual(fs[0].box.high.x, -5)
-        self.assertEqual(fs[0].box.high.y, -5)
-
-        self.assertEqual(fs[1].box.low.x, -15)
-        self.assertEqual(fs[1].box.low.y, -5)
-        self.assertEqual(fs[1].box.high.x, -5)
-        self.assertEqual(fs[1].box.high.y, 5)
-
-        self.assertEqual(fs[2].box.low.x, -15)
-        self.assertEqual(fs[2].box.low.y, 5)
-        self.assertEqual(fs[2].box.high.x, -5)
-        self.assertEqual(fs[2].box.high.y, 15)
-
-        # All fragments besides the middle one have no geometry, only default_material
-        for i in [0, 1, 2, 3, 5, 6, 7, 8]:
-            self.check_stats(fs[i], 0, 0, 0, 0, 0)
+        self.assertEqual(fs.box.low.x, -15)
+        self.assertEqual(fs.box.low.y, -15)
+        self.assertEqual(fs.box.high.x, 15)
+        self.assertEqual(fs.box.high.y, 15)
 
         # Middle fragment contains entire block
-        idx = 4
         sym_factor = 4 if sym else 1
-        self.check_stats(fs[idx],
+        self.check_stats(fs,
                          a_eps=10000 / sym_factor,
                          a_mu=10000 / sym_factor,
                          nonlin=30000 / sym_factor,
@@ -250,17 +159,7 @@ class TestFragmentStats(unittest.TestCase):
                          cond=30000 / sym_factor)
 
         # Check DFT regions
-        for i in [0, 3, 6]:
-            self.assertEqual(fs[i].num_dft_pixels, 0)
-
-        self.assertEqual(fs[1].num_dft_pixels, 8224)
-        self.assertEqual(fs[4].num_dft_pixels, 11792)
-        self.assertEqual(fs[7].num_dft_pixels, 21824)
-
-        self.assertEqual(fs[2].num_dft_pixels, 411200)
-        self.assertEqual(fs[5].num_dft_pixels, 589600)
-        self.assertEqual(fs[8].num_dft_pixels, 1091200)
-
+        self.assertEqual(fs.num_dft_pixels, 2040000)
         self.fs = fs
 
     def test_2d(self):
@@ -271,111 +170,20 @@ class TestFragmentStats(unittest.TestCase):
 
     def test_2d_with_pml_all_sides(self):
         self._test_2d([], pml=[mp.PML(1, mp.Y), mp.PML(2, mp.X, mp.Low), mp.PML(3, mp.X, mp.High)])
-
-        # Center fragment has no PML pixels
-        self.assertEqual(self.fs[4].num_1d_pml_pixels, 0)
-        self.assertEqual(self.fs[4].num_2d_pml_pixels, 0)
-        self.assertEqual(self.fs[4].num_3d_pml_pixels, 0)
-
-        for i in range(len(self.fs)):
-            # No regions where 3 PMLs overlap
-            self.assertEqual(self.fs[i].num_3d_pml_pixels, 0)
-
-        for i in [1, 3, 5, 7]:
-            # No regions where 2 PMLs overlap
-            self.assertEqual(self.fs[i].num_2d_pml_pixels, 0)
-
-        for i in [0, 2]:
-            # Lower left and top left
-            self.assertEqual(self.fs[i].num_1d_pml_pixels, 2600)
-            self.assertEqual(self.fs[i].num_2d_pml_pixels, 200)
-
-        for i in [6, 8]:
-            # Lower right and top right
-            self.assertEqual(self.fs[i].num_1d_pml_pixels, 3400)
-            self.assertEqual(self.fs[i].num_2d_pml_pixels, 300)
-
-        for i in [3, 5]:
-            # bottom center, top center
-            self.assertEqual(self.fs[i].num_1d_pml_pixels, 1000)
-
-        # Right center
-        self.assertEqual(self.fs[7].num_1d_pml_pixels, 3000)
-        # Left center
-        self.assertEqual(self.fs[1].num_1d_pml_pixels, 2000)
+        self.assertEqual(self.fs.num_1d_pml_pixels, 19000)
+        self.assertEqual(self.fs.num_2d_pml_pixels, 1000)
+        self.assertEqual(self.fs.num_3d_pml_pixels, 0)
 
     def test_2d_with_absorbers(self):
         fs = self.get_fragment_stats(mp.Vector3(10, 10), mp.Vector3(30, 30), 2,
                                      geom=[], pml=[mp.Absorber(1)])
-
-        total_nonzero_cond_pixels = 0
-        for i in range(len(fs)):
-            self.assertEqual(fs[i].num_1d_pml_pixels, 0)
-            self.assertEqual(fs[i].num_2d_pml_pixels, 0)
-            self.assertEqual(fs[i].num_3d_pml_pixels, 0)
-            total_nonzero_cond_pixels += fs[i].num_nonzero_conductivity_pixels
-
-        self.assertEqual(total_nonzero_cond_pixels, 11600)
-
-    def test_2d_with_overlap(self):
-        # A 30 x 30 cell, with a 20 x 20 block in the middle, split into 9 10 x 10 fragments.
-
-        mat = mp.Medium(H_susceptibilities=[mp.DrudeSusceptibility()])
-        fs = self.get_fragment_stats(mp.Vector3(20, 20), mp.Vector3(30, 30), 2, def_mat=mat)
-
-        self.assertEqual(len(fs), 9)
-
-        # Middle fragment contains entire block
-        idx = 4
-        self.check_stats(fs[idx], a_eps=10000, a_mu=10000, nonlin=30000, susc=30000, cond=30000)
-
-        # Top-middle, bottom-middle, left-middle, and right-middle fragments are half
-        # covered by the block, and half covered by default_material 'mat'.
-        for i in [1, 3, 5, 7]:
-            self.check_stats(fs[i], a_eps=5000, a_mu=5000, nonlin=15000, susc=20000, cond=15000)
-
-        # The four corner fragments are quarter-filled by the block, and 3/4 filled by
-        # default_material 'mat'
-        for i in [0, 2, 6, 8]:
-            self.check_stats(fs[i], a_eps=2500, a_mu=2500, nonlin=7500, susc=15000, cond=7500)
-
-    def test_2d_with_partial_fragments_and_shifted_center(self):
-        # A 26 x 26 cell with a 18 x 18 Block in the lower right corner
-
-        fs = self.get_fragment_stats(mp.Vector3(18, 18), mp.Vector3(26, 26), 2, mp.Vector3(4, -4))
-
-        self.assertEqual(len(fs), 9)
-
-        # Middle fragment is 10 x 10 and covered by block
-        self.check_stats(fs[4], a_eps=10000, a_mu=10000, nonlin=30000, susc=30000, cond=30000)
-
-        for i in [0, 1, 2, 5, 8]:
-            # Air
-            self.check_stats(fs[i], 0, 0, 0, 0, 0)
-
-        # 10 x 8 fragment, covered by block
-        self.assertEqual(fs[3].box.low.x, -5)
-        self.assertEqual(fs[3].box.low.y, -13)
-        self.assertEqual(fs[3].box.high.x, 5)
-        self.assertEqual(fs[3].box.high.y, -5)
-        self.check_stats(fs[3], a_eps=8000, a_mu=8000, nonlin=24000, susc=24000, cond=24000)
-
-        # 8 x 10 fragment, covered by block
-        self.assertEqual(fs[7].box.low.x, 5)
-        self.assertEqual(fs[7].box.low.y, -5)
-        self.assertEqual(fs[7].box.high.x, 13)
-        self.assertEqual(fs[7].box.high.y, 5)
-        self.check_stats(fs[7], a_eps=8000, a_mu=8000, nonlin=24000, susc=24000, cond=24000)
-
-        # 8 x 8 fragment covered by block
-        self.assertEqual(fs[6].box.low.x, 5)
-        self.assertEqual(fs[6].box.low.y, -13)
-        self.assertEqual(fs[6].box.high.x, 13)
-        self.assertEqual(fs[6].box.high.y, -5)
-        self.check_stats(fs[6], a_eps=6400, a_mu=6400, nonlin=19200, susc=19200, cond=19200)
+        self.assertEqual(fs.num_1d_pml_pixels, 0)
+        self.assertEqual(fs.num_2d_pml_pixels, 0)
+        self.assertEqual(fs.num_3d_pml_pixels, 0)
+        self.assertEqual(fs.num_nonzero_conductivity_pixels, 11600)
 
     def test_2d_dft_fields(self):
-        # A 30 x 30 cell, with a 10 x 10 block in the middle, split into 9 10 x 10 fragments.
+        # A 30 x 30 cell, with a 10 x 10 block in the middle
 
         # dft_fields covering 20 by 20 area in center of cell. Test with volume, and center/size
         cmpts = [mp.Ex, mp.Ey, mp.Ez]
@@ -384,44 +192,21 @@ class TestFragmentStats(unittest.TestCase):
 
         for dft_vec in [dft_fields_size_center, dft_fields_where]:
             fs = self.get_fragment_stats(mp.Vector3(10, 10), mp.Vector3(30, 30), 2, dft_vecs=dft_vec)
-
-            # Middle fragment is fully covered
-            self.assertEqual(fs[4].num_dft_pixels, 300000)
-
-            # 4 corners are 1/4 covered
-            for i in [0, 2, 6, 8]:
-                self.assertEqual(fs[i].num_dft_pixels, 75000)
-
-            # The rest are half covered
-            for i in [1, 3, 5, 7]:
-                self.assertEqual(fs[i].num_dft_pixels, 150000)
+            self.assertEqual(fs.num_dft_pixels, 300000 + 4*75000 + 4*150000)
 
     def test_2d_pml_and_absorber(self):
         blayers = [mp.PML(1, mp.Y, mp.High), mp.PML(2, mp.Y, mp.Low),
                    mp.Absorber(1, mp.X, mp.High), mp.Absorber(3, mp.X, mp.Low)]
-        fragments = self.get_fragment_stats(mp.Vector3(), mp.Vector3(30, 30), 2, pml=blayers, geom=[])
-
-        num_nonzero_cond = 0
-        num_pml_1d = 0
-        num_pml_2d = 0
-        num_pml_3d = 0
-
-        for f in fragments:
-            num_nonzero_cond += f.num_nonzero_conductivity_pixels
-            num_pml_1d += f.num_1d_pml_pixels
-            num_pml_2d += f.num_2d_pml_pixels
-            num_pml_3d += f.num_3d_pml_pixels
-
-        self.assertEqual(num_nonzero_cond, 12000)
-        self.assertEqual(num_pml_1d, 9000)
-        self.assertEqual(num_pml_2d, 0)
-        self.assertEqual(num_pml_3d, 0)
+        fs = self.get_fragment_stats(mp.Vector3(), mp.Vector3(30, 30), 2, pml=blayers, geom=[])
+        self.assertEqual(fs.num_nonzero_conductivity_pixels, 12000)
+        self.assertEqual(fs.num_1d_pml_pixels, 9000)
+        self.assertEqual(fs.num_2d_pml_pixels, 0)
+        self.assertEqual(fs.num_3d_pml_pixels, 0)
 
     def _test_3d(self, sym, pml=[]):
-        # A 30 x 30 x 30 cell with a 10 x 10 x 10 block placed at the center, split
-        # into 27 10 x 10 x 10 fragments
+        # A 30 x 30 x 30 cell with a 10 x 10 x 10 block placed at the center
 
-        # flux covering lower-front-left fragment, near2far covering lower-middle-left,
+        # flux covering lower-front-left 10x10x10, near2far covering lower-middle-left,
         # force covering lower-back-left
         dft_vecs = make_dft_vecs(
             [mp.FluxRegion(mp.Vector3(-10, -10, -10), size=mp.Vector3(10, 10, 10))],
@@ -431,18 +216,8 @@ class TestFragmentStats(unittest.TestCase):
         fs = self.get_fragment_stats(mp.Vector3(10, 10, 10), mp.Vector3(30, 30, 30), 3,
                                      dft_vecs=dft_vecs, sym=sym, pml=pml)
 
-        self.assertEqual(len(fs), 27)
-
-        # All fragments besides the middle one have no geometry, only default_material
-        for i in range(27):
-            if i == 13:
-                continue
-            self.check_stats(fs[i], 0, 0, 0, 0, 0)
-
-        # Middle fragments contains entire block
-        idx = 13
         sym_factor = 8 if sym else 1
-        self.check_stats(fs[idx],
+        self.check_stats(fs,
                          a_eps=1000000 / sym_factor,
                          a_mu=1000000 / sym_factor,
                          nonlin=3000000 / sym_factor,
@@ -450,10 +225,7 @@ class TestFragmentStats(unittest.TestCase):
                          cond=3000000 / sym_factor)
 
         # Check DFT regions
-        self.assertEqual(fs[0].num_dft_pixels, 20560000)
-        self.assertEqual(fs[1].num_dft_pixels, 29480000)
-        self.assertEqual(fs[2].num_dft_pixels, 54560000)
-
+        self.assertEqual(fs.num_dft_pixels, 102000000)
         self.fs = fs
 
     def test_3d(self):
@@ -466,52 +238,20 @@ class TestFragmentStats(unittest.TestCase):
         self._test_3d([], pml=[mp.PML(1, mp.Y, mp.High), mp.PML(2, mp.Y, mp.Low), mp.PML(3, mp.X),
                                mp.PML(1, mp.Z, mp.High), mp.PML(2, mp.Z, mp.Low)])
 
-        # bottom left near
-        self.assertEqual(self.fs[0].num_1d_pml_pixels, 416000)
-        self.assertEqual(self.fs[0].num_2d_pml_pixels, 124000)
-        self.assertEqual(self.fs[0].num_3d_pml_pixels, 12000)
+        self.assertEqual(self.fs.num_1d_pml_pixels, 8262000)
+        self.assertEqual(self.fs.num_2d_pml_pixels, 1188000)
+        self.assertEqual(self.fs.num_3d_pml_pixels, 54000)
 
     def test_3d_with_absorbers(self):
         fs = self.get_fragment_stats(mp.Vector3(), mp.Vector3(30, 30, 30), 3,
                                      geom=[], pml=[mp.Absorber(1)])
-
-        total_nonzero_cond_pixels = 0
-        for i in range(len(fs)):
-            self.assertEqual(fs[i].num_1d_pml_pixels, 0)
-            self.assertEqual(fs[i].num_2d_pml_pixels, 0)
-            self.assertEqual(fs[i].num_3d_pml_pixels, 0)
-            total_nonzero_cond_pixels += fs[i].num_nonzero_conductivity_pixels
-
-        self.assertEqual(total_nonzero_cond_pixels, 5048000)
-
-    def test_3d_with_overlap(self):
-        # A 30 x 30 x 30 cell with a 20 x 20 x 20 block placed at the center, split
-        # into 27 10 x 10 x 10 fragments
-
-        mat = mp.Medium(E_susceptibilities=[mp.DrudeSusceptibility()])
-        fs = self.get_fragment_stats(mp.Vector3(20, 20, 20), mp.Vector3(30, 30, 30), 3, def_mat=mat)
-
-        self.assertEqual(len(fs), 27)
-
-        # Middle fragment contains entire block
-        idx = 13
-        self.check_stats(fs[idx], a_eps=1000000, a_mu=1000000, nonlin=3000000, susc=3000000, cond=3000000)
-
-        # Six fragments adjacent to the middle fragment faces will be half covered by the block,
-        # and half covered by default_material 'mat'
-        for i in [4, 10, 12, 14, 16, 22]:
-            self.check_stats(fs[i], a_eps=500000, a_mu=500000, nonlin=1500000, susc=2000000, cond=1500000)
-
-        # The corners will be 1/8 covered by the block and 7/8 covered by default_material 'mat'
-        for i in [0, 2, 6, 8, 18, 20, 24, 26]:
-            self.check_stats(fs[i], a_eps=125000, a_mu=125000, nonlin=375000, susc=1250000, cond=375000)
-
-        # The rest will be 1/4 covered by the block and 3/4 covered by default_material 'mat'
-        for i in [1, 3, 5, 7, 9, 11, 15, 17, 19, 21, 23, 25]:
-            self.check_stats(fs[i], a_eps=250000, a_mu=250000, nonlin=750000, susc=1500000, cond=750000)
+        self.assertEqual(fs.num_1d_pml_pixels, 0)
+        self.assertEqual(fs.num_2d_pml_pixels, 0)
+        self.assertEqual(fs.num_3d_pml_pixels, 0)
+        self.assertEqual(fs.num_nonzero_conductivity_pixels, 5048000)
 
     def test_cyl(self):
-        # A 30 x 30 cell, with a 10 x 10 block in the middle, split into 9 10 x 10 fragments.
+        # A 30 x 30 cell, with a 10 x 10 block in the middle
 
         # flux covering top-left fragment, near2far covering top-middle, force covering top-right
         dft_vecs = make_dft_vecs(
@@ -521,44 +261,12 @@ class TestFragmentStats(unittest.TestCase):
         )
         fs = self.get_fragment_stats(mp.Vector3(10, 0, 10), mp.Vector3(30, 0, 30),
                                      mp.CYLINDRICAL, dft_vecs=dft_vecs)
-
-        self.assertEqual(len(fs), 9)
-
-        # Check fragment boxes
-        self.assertEqual(fs[0].box.low.x, -15)
-        self.assertEqual(fs[0].box.low.z, -15)
-        self.assertEqual(fs[0].box.high.x, -5)
-        self.assertEqual(fs[0].box.high.z, -5)
-
-        self.assertEqual(fs[1].box.low.x, -15)
-        self.assertEqual(fs[1].box.low.z, -5)
-        self.assertEqual(fs[1].box.high.x, -5)
-        self.assertEqual(fs[1].box.high.z, 5)
-
-        self.assertEqual(fs[2].box.low.x, -15)
-        self.assertEqual(fs[2].box.low.z, 5)
-        self.assertEqual(fs[2].box.high.x, -5)
-        self.assertEqual(fs[2].box.high.z, 15)
-
-        # All fragments besides the middle one have no geometry, only default_material
-        for i in [0, 1, 2, 3, 5, 6, 7, 8]:
-            self.check_stats(fs[i], 0, 0, 0, 0, 0)
-
-        # Middle fragment contains entire block
-        idx = 4
-        self.check_stats(fs[idx], a_eps=10000, a_mu=10000, nonlin=30000, susc=30000, cond=30000)
-
-        # Check DFT regions
-        for i in [0, 3, 6]:
-            self.assertEqual(fs[i].num_dft_pixels, 0)
-
-        self.assertEqual(fs[1].num_dft_pixels, 8224)
-        self.assertEqual(fs[4].num_dft_pixels, 11792)
-        self.assertEqual(fs[7].num_dft_pixels, 21824)
-
-        self.assertEqual(fs[2].num_dft_pixels, 411200)
-        self.assertEqual(fs[5].num_dft_pixels, 589600)
-        self.assertEqual(fs[8].num_dft_pixels, 1091200)
+        self.assertEqual(fs.box.low.x, -15)
+        self.assertEqual(fs.box.low.z, -15)
+        self.assertEqual(fs.box.high.x, 15)
+        self.assertEqual(fs.box.high.z, 15)
+        self.check_stats(fs, a_eps=10000, a_mu=10000, nonlin=30000, susc=30000, cond=30000)
+        self.assertEqual(fs.num_dft_pixels, 2040000)
 
     def test_no_geometry(self):
         mat = mp.Medium(
@@ -573,39 +281,31 @@ class TestFragmentStats(unittest.TestCase):
             B_conductivity_diag=mp.Vector3(x=1, z=1)
         )
         fs = self.get_fragment_stats(mp.Vector3(), mp.Vector3(10, 10), 2, def_mat=mat, geom=[])
-
-        self.assertEqual(len(fs), 1)
-        self.check_stats(fs[0], a_eps=10000, a_mu=10000, nonlin=30000, susc=30000, cond=30000)
+        self.check_stats(fs, a_eps=10000, a_mu=10000, nonlin=30000, susc=30000, cond=30000)
 
     def test_1d_cell_smaller_than_minimum_fragment_size(self):
         fs = self.get_fragment_stats(mp.Vector3(z=1), mp.Vector3(z=1), 1)
-        self.assertEqual(len(fs), 1)
-        stats = fs[0]
-        self.assertEqual(stats.box.low.z, -0.5)
-        self.assertEqual(stats.box.high.z, 0.5)
-        self.assertEqual(stats.num_pixels_in_box, 10)
+        self.assertEqual(fs.box.low.z, -0.5)
+        self.assertEqual(fs.box.high.z, 0.5)
+        self.assertEqual(fs.num_pixels_in_box, 10)
 
     def test_2d_cell_smaller_than_minimum_fragment_size(self):
         fs = self.get_fragment_stats(mp.Vector3(1, 1), mp.Vector3(1, 1), 2)
-        self.assertEqual(len(fs), 1)
-        stats = fs[0]
-        self.assertEqual(stats.box.low.x, -0.5)
-        self.assertEqual(stats.box.low.y, -0.5)
-        self.assertEqual(stats.box.high.x, 0.5)
-        self.assertEqual(stats.box.high.y, 0.5)
-        self.assertEqual(stats.num_pixels_in_box, 100)
+        self.assertEqual(fs.box.low.x, -0.5)
+        self.assertEqual(fs.box.low.y, -0.5)
+        self.assertEqual(fs.box.high.x, 0.5)
+        self.assertEqual(fs.box.high.y, 0.5)
+        self.assertEqual(fs.num_pixels_in_box, 100)
 
     def test_3d_cell_smaller_than_minimum_fragment_size(self):
         fs = self.get_fragment_stats(mp.Vector3(1, 1, 1), mp.Vector3(1, 1, 1), 3)
-        self.assertEqual(len(fs), 1)
-        stats = fs[0]
-        self.assertEqual(stats.box.low.x, -0.5)
-        self.assertEqual(stats.box.low.y, -0.5)
-        self.assertEqual(stats.box.low.z, -0.5)
-        self.assertEqual(stats.box.high.x, 0.5)
-        self.assertEqual(stats.box.high.y, 0.5)
-        self.assertEqual(stats.box.high.z, 0.5)
-        self.assertEqual(stats.num_pixels_in_box, 1000)
+        self.assertEqual(fs.box.low.x, -0.5)
+        self.assertEqual(fs.box.low.y, -0.5)
+        self.assertEqual(fs.box.low.z, -0.5)
+        self.assertEqual(fs.box.high.x, 0.5)
+        self.assertEqual(fs.box.high.y, 0.5)
+        self.assertEqual(fs.box.high.z, 0.5)
+        self.assertEqual(fs.num_pixels_in_box, 1000)
 
 
 class TestPMLToVolList(unittest.TestCase):

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1602,122 +1602,15 @@ std::vector<meep::volume> fragment_stats::pml_3d_vols;
 std::vector<meep::volume> fragment_stats::absorber_vols;
 bool fragment_stats::split_chunks_evenly = false;
 
-inline static bool is_edge_box(double pt, double half_cell, double box_size, double edge_size) {
-  return (pt == -half_cell && edge_size != 0) || pt + box_size > half_cell;
-}
+static geom_box make_box_from_cell(vector3 cell_size) {
+  double edgex = cell_size.x / 2;
+  double edgey = cell_size.y / 2;
+  double edgez = cell_size.z / 2;
+  vector3 low = {-edgex, -edgey, -edgez};
+  vector3 high = {edgex, edgey, edgez};
+  geom_box result = {low, high};
 
-static std::vector<geom_box> split_cell_1d(double box_size, vector3 cell_size) {
-  if (cell_size.z < box_size) { box_size = cell_size.z; }
-  double half_box = box_size / 2;
-  double half_z = cell_size.z / 2;
-  double edge_size_z = fmod(half_z + half_box, box_size);
-  std::vector<geom_box> boxes;
-
-  for (double z = -half_z; z < half_z;) {
-    double z_increment = is_edge_box(z, half_z, box_size, edge_size_z) ? edge_size_z : box_size;
-    vector3 low = {0.0, 0.0, z};
-    vector3 high = {0.0, 0.0, z + z_increment};
-    geom_box b = {low, high};
-    boxes.push_back(b);
-    z += z_increment;
-  }
-  return boxes;
-}
-
-static std::vector<geom_box> split_cell_2d(double box_size, vector3 cell_size) {
-  if (cell_size.x < box_size || cell_size.y < box_size) {
-    box_size = MIN(cell_size.x, cell_size.y);
-  }
-  double half_box = box_size / 2;
-  double half_x = cell_size.x / 2;
-  double half_y = cell_size.y / 2;
-  double edge_size_x = fmod(half_x + half_box, box_size);
-  double edge_size_y = fmod(half_y + half_box, box_size);
-  std::vector<geom_box> boxes;
-
-  for (double x = -half_x; x < half_x;) {
-    double x_increment = is_edge_box(x, half_x, box_size, edge_size_x) ? edge_size_x : box_size;
-    for (double y = -half_y; y < half_y;) {
-      double y_increment = is_edge_box(y, half_y, box_size, edge_size_y) ? edge_size_y : box_size;
-      vector3 low = {x, y, 0.0};
-      vector3 high = {x + x_increment, y + y_increment, 0.0};
-      geom_box b = {low, high};
-      boxes.push_back(b);
-      y += y_increment;
-    }
-    x += x_increment;
-  }
-  return boxes;
-}
-
-static std::vector<geom_box> split_cell_3d(double box_size, vector3 cell_size) {
-  if (cell_size.x < box_size || cell_size.y < box_size || cell_size.z < box_size) {
-    box_size = MIN(cell_size.x, cell_size.y);
-    box_size = MIN(box_size, cell_size.z);
-  }
-  double half_box = box_size / 2;
-  double half_x = cell_size.x / 2;
-  double half_y = cell_size.y / 2;
-  double half_z = cell_size.z / 2;
-  double edge_size_x = fmod(half_x + half_box, box_size);
-  double edge_size_y = fmod(half_y + half_box, box_size);
-  double edge_size_z = fmod(half_z + half_box, box_size);
-  std::vector<geom_box> boxes;
-
-  for (double x = -half_x; x < half_x;) {
-    double x_increment = is_edge_box(x, half_x, box_size, edge_size_x) ? edge_size_x : box_size;
-    for (double y = -half_y; y < half_y;) {
-      double y_increment = is_edge_box(y, half_y, box_size, edge_size_y) ? edge_size_y : box_size;
-      for (double z = -half_z; z < half_z;) {
-        double z_increment = is_edge_box(z, half_z, box_size, edge_size_z) ? edge_size_z : box_size;
-        vector3 low = {x, y, z};
-        vector3 high = {x + x_increment, y + y_increment, z + z_increment};
-        geom_box b = {low, high};
-        boxes.push_back(b);
-        z += z_increment;
-      }
-      y += y_increment;
-    }
-    x += x_increment;
-  }
-  return boxes;
-}
-
-static std::vector<geom_box> split_cell_cyl(double box_size, vector3 cell_size) {
-  if (cell_size.x < box_size || cell_size.z < box_size) {
-    box_size = MIN(cell_size.x, cell_size.z);
-  }
-  double half_box = box_size / 2;
-  double half_x = cell_size.x / 2;
-  double half_z = cell_size.z / 2;
-  double edge_size_x = fmod(half_x + half_box, box_size);
-  double edge_size_z = fmod(half_z + half_box, box_size);
-  std::vector<geom_box> boxes;
-
-  for (double x = -half_x; x < half_x;) {
-    double x_increment = is_edge_box(x, half_x, box_size, edge_size_x) ? edge_size_x : box_size;
-    for (double z = -half_z; z < half_z;) {
-      double z_increment = is_edge_box(z, half_z, box_size, edge_size_z) ? edge_size_z : box_size;
-      vector3 low = {x, 0.0, z};
-      vector3 high = {x + x_increment, 0.0, z + z_increment};
-      geom_box b = {low, high};
-      boxes.push_back(b);
-      z += z_increment;
-    }
-    x += x_increment;
-  }
-  return boxes;
-}
-
-static std::vector<geom_box> split_cell_into_boxes(meep::grid_volume *gv, double box_size,
-                                                   vector3 cell_size) {
-  switch (gv->dim) {
-    case meep::D1: return split_cell_1d(box_size, cell_size);
-    case meep::D2: return split_cell_2d(box_size, cell_size);
-    case meep::D3: return split_cell_3d(box_size, cell_size);
-    case meep::Dcyl: return split_cell_cyl(box_size, cell_size); break;
-    default: return std::vector<geom_box>();
-  }
+  return result;
 }
 
 static size_t get_pixels_in_box(geom_box *b, int empty_pixel = 1) {
@@ -1738,27 +1631,23 @@ static void center_box(geom_box *b) {
   b->high = vector3_plus(geometry_center, b->high);
 }
 
-static std::vector<fragment_stats> init_fragments(std::vector<geom_box> &boxes, double tol,
-                                                  int maxeval, meep::grid_volume *gv) {
-  std::vector<fragment_stats> fragments;
+static fragment_stats init_stats(geom_box &box, double tol, int maxeval, meep::grid_volume *gv) {
   fragment_stats::tol = tol;
   fragment_stats::maxeval = maxeval;
   fragment_stats::resolution = gv->a;
   fragment_stats::dims = gv->dim;
 
-  for (size_t i = 0; i < boxes.size(); ++i) {
-    center_box(&boxes[i]);
-    fragments.push_back(fragment_stats(boxes[i]));
-  }
-  return fragments;
+  center_box(&box);
+  fragment_stats result(box);
+  return result;
 }
 
-std::vector<fragment_stats> compute_fragment_stats(
+fragment_stats compute_fragment_stats(
     geometric_object_list geom_, meep::grid_volume *gv, vector3 cell_size, vector3 cell_center,
     material_type default_mat, std::vector<dft_data> dft_data_list_,
     std::vector<meep::volume> pml_1d_vols_, std::vector<meep::volume> pml_2d_vols_,
     std::vector<meep::volume> pml_3d_vols_, std::vector<meep::volume> absorber_vols_, double tol,
-    int maxeval, bool ensure_per, double box_size) {
+    int maxeval, bool ensure_per) {
 
   fragment_stats::geom = geom_;
   fragment_stats::dft_data_list = dft_data_list_;
@@ -1768,13 +1657,10 @@ std::vector<fragment_stats> compute_fragment_stats(
   fragment_stats::absorber_vols = absorber_vols_;
 
   fragment_stats::init_libctl(default_mat, ensure_per, gv, cell_size, cell_center, &geom_);
-  std::vector<geom_box> boxes = split_cell_into_boxes(gv, box_size, cell_size);
-  std::vector<fragment_stats> fragments = init_fragments(boxes, tol, maxeval, gv);
-
-  for (size_t i = 0; i < fragments.size(); ++i) {
-    fragments[i].compute();
-  }
-  return fragments;
+  geom_box box = make_box_from_cell(cell_size);
+  fragment_stats stats = init_stats(box, tol, maxeval, gv);
+  stats.compute();
+  return stats;
 }
 
 fragment_stats::fragment_stats(geom_box &bx)

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -113,13 +113,13 @@ struct fragment_stats {
   void print_stats() const;
 };
 
-std::vector<fragment_stats>
+fragment_stats
 compute_fragment_stats(geometric_object_list geom, meep::grid_volume *gv, vector3 cell_size,
                        vector3 cell_center, material_type default_mat,
                        std::vector<dft_data> dft_data_list, std::vector<meep::volume> pml_1d_vols,
                        std::vector<meep::volume> pml_2d_vols, std::vector<meep::volume> pml_3d_vols,
                        std::vector<meep::volume> absorber_vols, double tol, int maxeval,
-                       bool ensure_per, double box_size = 10);
+                       bool ensure_per);
 
 /***************************************************************/
 /* these routines create and append absorbing layers to an     */


### PR DESCRIPTION
Replaces and closes #737. Fixes #736. Originally we thought we would do load balancing by dividing small fragments of the cell across processors, but it turns out that the load balancing implementation does its own computations to find the optimal splitting into fragments. That means we no longer need to split the cell at all when collecting statistics; we simply create one `fragment_stats` instance using the entire cell. This greatly simplifies the code. Additionally, I've added a `collect_stats` parameter to `Simulation()` that disables collection by default, since it's not useful to users.
@stevengj @oskooi 