### PR TITLE
add missing volume member to dft_energy class and Scheme example for computing group velocity

### DIFF
--- a/scheme/examples/group-velocity.ctl
+++ b/scheme/examples/group-velocity.ctl
@@ -1,0 +1,37 @@
+;; compute group velocity of a waveguide mode using two different methods
+;; (1) ratio of Poynting flux to energy density
+;; (2) via MPB from get-eigenmode-coefficients
+
+(set-param! resolution 20)
+
+(set! geometry-lattice (make lattice (size 10 5 no-size)))
+
+(set! geometry (list (make block
+                       (center 0 0 0)
+                       (size infinity 1 infinity)
+                       (material (make medium (epsilon 12))))))
+
+(set! pml-layers (list (make pml (thickness 1))))
+
+(define-param fsrc 0.15)
+
+(set! sources (list (make eigenmode-source
+                      (src (make gaussian-src (frequency fsrc) (fwidth (* 0.2 fsrc))))
+                      (center -3 0 0)
+                      (size 0 5 0)
+                      (eig-band 1)
+                      (eig-parity (+ ODD-Z EVEN-Y))
+                      (eig-match-freq? true))))
+
+(define flux (add-flux fsrc 0 1 (make flux-region (center 3 0 0) (size 0 5 0))))
+(define energy (add-energy fsrc 0 1 (make energy-region (center 3 0 0) (size 0 5 0))))
+(run-sources+ 100)
+
+(define res (get-eigenmode-coefficients flux (list 1) #:eig-parity (+ ODD-Z EVEN-Y)))
+(define mode-vg (array-ref (list-ref res 1) 0 0))
+
+(define poynting-flux (list-ref (get-fluxes flux) 0))
+(define e-energy (list-ref (get-electric-energy energy) 0))
+(define ratio-vg (/ (* 0.5 poynting-flux) e-energy))
+
+(print "group-velocity:, " ratio-vg ", " mode-vg "\n")

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -465,13 +465,13 @@ dft_energy::dft_energy(const dft_energy &f) : where(f.where) {
 
 double *dft_energy::electric() {
   double *F = new double[Nfreq];
-  for (int i = 0; i < Nfreq; ++i) F[i] = 0;
+  for (int i = 0; i < Nfreq; ++i)
+    F[i] = 0;
   for (dft_chunk *curE = E, *curD = D; curE && curD;
        curE = curE->next_in_dft, curD = curD->next_in_dft)
     for (size_t k = 0; k < curE->N; ++k)
       for (int i = 0; i < Nfreq; ++i)
-	F[i] += 0.5*real(conj(curE->dft[k*Nfreq + i])
-			 * curD->dft[k*Nfreq + i]);
+	F[i] += 0.5*real(conj(curE->dft[k * Nfreq + i]) * curD->dft[k * Nfreq + i]);
   double *Fsum = new double[Nfreq];
   sum_to_all(F, Fsum, Nfreq);
   delete[] F;
@@ -480,13 +480,13 @@ double *dft_energy::electric() {
 
 double *dft_energy::magnetic() {
   double *F = new double[Nfreq];
-  for (int i = 0; i < Nfreq; ++i) F[i] = 0;
+  for (int i = 0; i < Nfreq; ++i)
+    F[i] = 0;
   for (dft_chunk *curH = H, *curB = B; curH && curB;
        curH = curH->next_in_dft, curB = curB->next_in_dft)
     for (size_t k = 0; k < curH->N; ++k)
       for (int i = 0; i < Nfreq; ++i)
-	F[i] += 0.5*real(conj(curH->dft[k*Nfreq + i])
-			 * curB->dft[k*Nfreq + i]);
+	F[i] += 0.5*real(conj(curH->dft[k * Nfreq + i]) * curB->dft[k * Nfreq + i]);
   double *Fsum = new double[Nfreq];
   sum_to_all(F, Fsum, Nfreq);
   delete[] F;
@@ -497,7 +497,8 @@ double *dft_energy::total() {
   double *Fe = electric();
   double *Fm = magnetic();
   double *F = new double[Nfreq];
-  for (int i = 0; i < Nfreq; ++i) F[i] = Fe[i]+Fm[i];
+  for (int i = 0; i < Nfreq; ++i)
+    F[i] = Fe[i]+Fm[i];
   delete[] Fe;
   delete[] Fm;
   return F;
@@ -511,19 +512,14 @@ dft_energy fields::add_dft_energy(const volume_list *where_,
 
   dft_chunk *E = 0, *D = 0, *H = 0, *B = 0;
   volume firstvol(where_->v);
-  // volume_list *where = S.reduce(where_);
   volume_list *where = new volume_list(where_);
   volume_list *where_save = where;
   while (where) {
     LOOP_OVER_FIELD_DIRECTIONS(gv.dim, d) {
-      E = add_dft(direction_component(Ex, d), where->v, freq_min, freq_max, Nfreq,
-		  true, 1.0, E);
-      D = add_dft(direction_component(Dx, d), where->v, freq_min, freq_max, Nfreq,
-		  true, 1.0, D);
-      H = add_dft(direction_component(Hx, d), where->v, freq_min, freq_max, Nfreq,
-		  true, 1.0, H);
-      B = add_dft(direction_component(Bx, d), where->v, freq_min, freq_max, Nfreq,
-		  true, 1.0, B);
+      E = add_dft(direction_component(Ex, d), where->v, freq_min, freq_max, Nfreq, true, 1.0, E);
+      D = add_dft(direction_component(Dx, d), where->v, freq_min, freq_max, Nfreq, false, 1.0, D);
+      H = add_dft(direction_component(Hx, d), where->v, freq_min, freq_max, Nfreq, true, 1.0, H);
+      B = add_dft(direction_component(Bx, d), where->v, freq_min, freq_max, Nfreq, false, 1.0, B);
     }
     where = where->next;
   }

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1053,7 +1053,7 @@ public:
 class dft_energy {
 public:
   dft_energy(dft_chunk *E_, dft_chunk *H_, dft_chunk *D_, dft_chunk *B_,
-             double fmin, double fmax, int Nf);
+             double fmin, double fmax, int Nf, const volume &where_);
   dft_energy(const dft_energy &f);
 
   double *electric();
@@ -1082,6 +1082,7 @@ public:
   double freq_min, dfreq;
   int Nfreq;
   dft_chunk *E, *H, *D, *B;
+  volume where;
 };
 
 // stress.cpp (normally created with fields::add_dft_force)


### PR DESCRIPTION
Fixes a bug in the `dft_energy` class from #744 where the `volume` of the `dft` object was not being stored as a class member and therefore not used to normalize the energy density values as part of the quadrature.

Also adds a Scheme example demonstrating the equivalence of computing the group velocity of a waveguide mode (from the [`EigenModeSource` tutorial](https://meep.readthedocs.io/en/latest/Python_Tutorials/Eigenmode_Source/)) using two different methods: (1) as the ratio of the Poynting flux to energy density and (2) directly via `get-eigenmode-coefficients` involving mode decomposition. This example can be ported to Python as part of #747. The test would verify that the relative error in the two values converges monotonically to 0 as the `resolution` is increased (e..g., 10, 20, and 40).