### PR TITLE
Fix bug in get_array_slice_dimensions

### DIFF
--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -352,8 +352,8 @@ int fields::get_array_slice_dimensions(const volume &where, size_t dims[3], dire
   array_slice_data *data = (array_slice_data *)caller_data;
   if (data == 0) data = &local_data;
 
-  data->min_corner = gv.round_vec(where.get_max_corner()) + one_ivec(gv.dim);
-  data->max_corner = gv.round_vec(where.get_min_corner()) - one_ivec(gv.dim);
+  data->min_corner = gv.round_vec(where.get_min_corner()) - one_ivec(gv.dim);
+  data->max_corner = gv.round_vec(where.get_max_corner()) + one_ivec(gv.dim);
   data->num_chunks = 0;
 
   loop_in_chunks(get_array_slice_dimensions_chunkloop, (void *)data, where, Centered, true, true);


### PR DESCRIPTION
I believe this fixes the `get_array` collapsing issue we see in #661. `data->min_corner` referred to the max_corner, and vice versa. With this change, the output of the last script in #661 is now
```
Using MPI version 2.2, 1 processes
-----------
Initializing structure...
Working in 2D dimensions.
Computational cell is 16 x 16 x 0 with resolution 20
     cylinder, center = (0,0,0)
          radius 2, height 1e+20, axis (0, 0, 1)
          dielectric constant epsilon diagonal = (11.56,11.56,11.56)
     cylinder, center = (0,0,0)
          radius 1, height 1e+20, axis (0, 0, 1)
          dielectric constant epsilon diagonal = (1,1,1)
time for set_epsilon = 0.675024 s
-----------
Meep progress: 42.775000000000006/225.0 = 19.0% done in 4.0s, 17.0s to go
on time step 1711 (time=42.775), 0.00233871 s/step
Meep progress: 88.775/225.0 = 39.5% done in 8.0s, 12.3s to go
on time step 3551 (time=88.775), 0.00217478 s/step
Meep progress: 135.1/225.0 = 60.0% done in 12.0s, 8.0s to go
on time step 5404 (time=135.1), 0.00215914 s/step
Meep progress: 181.65/225.0 = 80.7% done in 16.0s, 3.8s to go
on time step 7266 (time=181.65), 0.00214842 s/step
run 0 finished at t = 225.0 (9000 timesteps)
3.0426567097628787 (2, 242) (242, 2)
0.8681129431515568 (2, 242) (242, 2)
5.416862222330615 (2, 242) (242, 2)
5.8797900292783165 (2, 242) (242, 2)
7.289513610781202 (2, 242) (242, 2)
7.79303785198777 (2, 242) (242, 2)
5.030252175792953 (2, 242) (242, 2)
1.8845842010217666 (2, 242) (242, 2)
1.5690314102814025 (2, 242) (242, 2)
1.555558347024217 (2, 242) (242, 2)

Elapsed run time = 20.4165 s

Field time usage:
     connecting chunks: 0.235678 s
         time stepping: 18.1292 s
         communicating: 1.21502 s
     outputting fields: 0.00275898 s
    Fourier transforming: 0.00547528 s
       everything else: 0.150497 s
```
If this looks correct, I'll update the failing tests.
@stevengj @HomerReid @oskooi 