### PR TITLE
WIP: periodic green's functions

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1372,11 +1372,8 @@ class Simulation(object):
         mp._get_dft_data(dft_chunk, arr)
         return arr
 
-    def add_near2far(self, fcen, df, nfreq, nperiods=1, *near2fars):
-        # hack around python 2's inability to put keyword args after varargs:
-        if not isinstance(nperiods, int):
-            near2fars = (nperiods,) + near2fars
-            nperiods = 1
+    def add_near2far(self, fcen, df, nfreq, *near2fars, **kwargs):
+        nperiods = kwargs.get('nperiods', 1)
         n2f = DftNear2Far(self._add_near2far, [fcen, df, nfreq, nperiods, near2fars])
         self.dft_objects.append(n2f)
         return n2f

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1117,7 +1117,8 @@ public:
   /* fourier tranforms of tangential E and H field components in a
      medium with the given scalar eps and mu */
   dft_near2far(dft_chunk *F, double fmin, double fmax, int Nf, double eps, double mu,
-               const volume &where_);
+               const volume &where_, const direction periodic_d_[2],
+               const int periodic_n_[2], const double periodic_k_[2], const double period_[2]);
   dft_near2far(const dft_near2far &f);
 
   /* return an array (Ex,Ey,Ez,Hx,Hy,Hz) x Nfreq of the far fields at x */
@@ -1157,6 +1158,9 @@ public:
   dft_chunk *F;
   double eps, mu;
   volume where;
+  direction periodic_d[2];
+  int periodic_n[2];
+  double periodic_k[2], period[2];
 };
 
 /* Class to compute local-density-of-states spectra: the power spectrum

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1733,7 +1733,7 @@ public:
 
   // near2far.cpp
   dft_near2far add_dft_near2far(const volume_list *where, double freq_min, double freq_max,
-                                int Nfreq);
+                                int Nfreq, int Nperiods=1);
   // monitor.cpp
   double get_chi1inv(component, direction, const vec &loc) const;
   double get_inveps(component c, direction d, const vec &loc) const {

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -265,7 +265,7 @@ void dft_near2far::farfield_lowlevel(std::complex<double> *EH, const vec &x) {
               xs.set_direction(periodic_d[1], x0.in_direction(periodic_d[1]) + i1*period[1]);
             double phase = phase0 + i1*periodic_k[1];
             std::complex<double> cphase = std::polar(1.0, phase);
-            green(EH6, x, freq, eps, mu, x0, c0, f->dft[Nfreq * idx_dft + i]);
+            green(EH6, x, freq, eps, mu, xs, c0, f->dft[Nfreq * idx_dft + i]);
             for (int j = 0; j < 6; ++j)
               EH[i * 6 + j] += EH6[j] * cphase;
           }

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -444,7 +444,7 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
 static double approxeq(double a, double b) { return fabs(a - b) < 0.5e-11 * (fabs(a) + fabs(b)); }
 
 dft_near2far fields::add_dft_near2far(const volume_list *where, double freq_min, double freq_max,
-                                      int Nfreq) {
+                                      int Nfreq, int Nperiods) {
   dft_chunk *F = 0; /* E and H chunks*/
   double eps = 0, mu = 0;
   volume everywhere = where->v;
@@ -497,10 +497,9 @@ dft_near2far fields::add_dft_near2far(const volume_list *where, double freq_min,
 
     for (int i = 0; i < 2; ++i) {
       if (has_direction(v.dim, fd[i]) &&
-          boundaries[High][fd[i]] == Periodic && boundaries[Low][fd[i]] == Periodic &&
-          float(w->v.in_direction(fd[i])) == float(v.in_direction(fd[i]))) {
+          boundaries[High][fd[i]] == Periodic && boundaries[Low][fd[i]] == Periodic) {
         periodic_d[i] = fd[i];
-        periodic_n[i] = 10; // just hard-code a 10x10 supercell for now
+        periodic_n[i] = Nperiods;
         period[i] = v.in_direction(fd[i]);
         periodic_k[i] = 2*pi*real(k[fd[i]]) * period[i];
       }

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -495,13 +495,16 @@ dft_near2far fields::add_dft_near2far(const volume_list *where, double freq_min,
       default: abort("invalid normal direction in dft_near2far!");
     }
 
-    for (int i = 0; i < 2; ++i) {
-      if (has_direction(v.dim, fd[i]) &&
-          boundaries[High][fd[i]] == Periodic && boundaries[Low][fd[i]] == Periodic) {
-        periodic_d[i] = fd[i];
-        periodic_n[i] = Nperiods;
-        period[i] = v.in_direction(fd[i]);
-        periodic_k[i] = 2*pi*real(k[fd[i]]) * period[i];
+    if (Nperiods > 1) {
+      for (int i = 0; i < 2; ++i) {
+        if (has_direction(v.dim, fd[i]) &&
+            boundaries[High][fd[i]] == Periodic && boundaries[Low][fd[i]] == Periodic &&
+            float(w->v.in_direction(fd[i])) >= 0.5*float(v.in_direction(fd[i]))) {
+          periodic_d[i] = fd[i];
+          periodic_n[i] = Nperiods;
+          period[i] = v.in_direction(fd[i]);
+          periodic_k[i] = 2*pi*real(k[fd[i]]) * period[i];
+        }
       }
     }
 

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -497,12 +497,13 @@ dft_near2far fields::add_dft_near2far(const volume_list *where, double freq_min,
 
     if (Nperiods > 1) {
       for (int i = 0; i < 2; ++i) {
+        double user_width = user_volume.num_direction(fd[i]) / a;
         if (has_direction(v.dim, fd[i]) &&
             boundaries[High][fd[i]] == Periodic && boundaries[Low][fd[i]] == Periodic &&
-            float(w->v.in_direction(fd[i])) >= 0.5*float(v.in_direction(fd[i]))) {
+            float(w->v.in_direction(fd[i])) >= float(user_width)) {
           periodic_d[i] = fd[i];
           periodic_n[i] = Nperiods;
-          period[i] = v.in_direction(fd[i]);
+          period[i] = user_width;
           periodic_k[i] = 2*pi*real(k[fd[i]]) * period[i];
         }
       }


### PR DESCRIPTION
First attempt (currently untested) to hack in support for periodic Green's functions (closes #763).

That is, it detects whether any directions of the near-to-far surface coincide with a periodic direction of the computational cell.  If so, in that direction it just does a naive Bloch-periodic summation of the Green's function.  Currently, it just sums 10 copies.   For far-away surfaces we may need many more, and in principle should do something like Ewald summation, but for now this is hopefully good enough to experiment with.

*Update*: modulo the bugfix reported below, @oskooi reports that it seems to be working in a quick test.  To do:

- [x] Fix the `x0` typo noted below.
- [ ] A better test.   e.g. the binary grating example, but comparing the near2far fields with the explicitly computed fields (in a sufficiently large computational cell). Can be a separate PR as long as this is undocumented and opt-in.
- [x] The current hack of summing 10 copies is not acceptable in the long run.  Should we do something adaptive?  Or should the lattice sum be a user parameter?  The basic problem is that, the farther away you get, the more copies you need to sum.  The only way around this scaling is to do something fancy like Ewald summation, it seems? *Update: just made it a user parameter for now.*
- [x] Fix the handling of mirror symmetries etc. that chop up the near2far surface, which currently stop the code from working as in @oskooi's example below. 
- [x] In the current PR, the lattice sum turns on automatically if it detects that the near2far surface coincides with a periodic direction.   Since this is currently experimental, my inclination is that it shouldn't turn on by default.   Maybe the best thing is for the lattice sum to be a user parameter that defaults to 1.  In the short term, this will allow users to turn it on and make it sufficiently large for their needs as an option.