### PR TITLE
Add option to use fallback integration for user material functions

### DIFF
--- a/python/geom.py
+++ b/python/geom.py
@@ -22,6 +22,10 @@ def check_nonnegative(prop, val):
     else:
         raise ValueError("{} cannot be negative. Got {}".format(prop, val))
 
+def init_do_averaging(mat_func):
+    if not hasattr(mat_func, 'do_averaging'):
+        mat_func.do_averaging = False
+
 
 class Vector3(object):
 
@@ -303,8 +307,10 @@ class GeometricObject(object):
 
     def __init__(self, material=Medium(), center=Vector3(), epsilon_func=None):
         if type(material) is not Medium and callable(material):
+            init_do_averaging(material)
             material.eps = False
         elif epsilon_func:
+            init_do_averaging(epsilon_func)
             epsilon_func.eps = True
             material = epsilon_func
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -15,7 +15,7 @@ from collections import Sequence
 import numpy as np
 
 import meep as mp
-from meep.geom import Vector3
+from meep.geom import Vector3, init_do_averaging
 from meep.source import EigenModeSource, check_positive
 
 
@@ -945,9 +945,11 @@ class Simulation(object):
         absorbers = [bl for bl in self.boundary_layers if type(bl) is Absorber]
 
         if self.material_function:
+            init_do_averaging(self.material_function)
             self.material_function.eps = False
             self.default_material = self.material_function
         elif self.epsilon_func:
+            init_do_averaging(self.epsilon_func)
             self.epsilon_func.eps = True
             self.default_material = self.epsilon_func
         elif self.epsilon_input_file:

--- a/python/solver.py
+++ b/python/solver.py
@@ -12,8 +12,8 @@ import h5py
 import numpy as np
 import meep as mp
 from . import mode_solver, with_hermitian_epsilon
+from meep.geom import init_do_averaging
 from meep.simulation import get_num_args
-
 try:
     basestring
 except NameError:
@@ -123,6 +123,7 @@ class ModeSolver(object):
         grid_size = self._adjust_grid_size()
 
         if type(self.default_material) is not mp.Medium and callable(self.default_material):
+            init_do_averaging(self.default_material)
             self.default_material.eps = False
 
         self.mode_solver = mode_solver(

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -405,13 +405,18 @@ static int pymaterial_to_material(PyObject *po, material_type *mt) {
     if (!pymedium_to_medium(po, &md->medium)) { return 0; }
   } else if (PyFunction_Check(po)) {
     PyObject *eps = PyObject_GetAttrString(po, "eps");
-    if (!eps) { return 0; }
-    if (eps == Py_True) {
-      md = make_user_material(py_epsilon_func_wrap, po);
-    } else {
-      md = make_user_material(py_user_material_func_wrap, po);
+    PyObject *py_do_averaging = PyObject_GetAttrString(po, "do_averaging");
+    bool do_averaging = false;
+    if (py_do_averaging) {
+      do_averaging = PyObject_IsTrue(py_do_averaging);
     }
-    Py_DECREF(eps);
+    if (eps && eps == Py_True) {
+      md = make_user_material(py_epsilon_func_wrap, po, do_averaging);
+    } else {
+      md = make_user_material(py_user_material_func_wrap, po, do_averaging);
+    }
+    Py_XDECREF(eps);
+    Py_XDECREF(py_do_averaging);
   } else if (IsPyString(po)) {
     const char *eps_input_file = PyObject_ToCharPtr(po);
     md = make_file_material(eps_input_file);

--- a/src/material_data.hpp
+++ b/src/material_data.hpp
@@ -171,6 +171,7 @@ struct material_data {
   // these fields used only if which_subclass==MATERIAL_USER
   user_material_func user_func;
   void *user_data;
+  bool do_averaging;
 
   // these fields used only if which_subclass==MATERIAL_FILE
   meep::realnum *epsilon_data;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -913,11 +913,12 @@ void geom_epsilon::fallback_chi1inv_row(meep::component c, double chi1inv_row[3]
 
   symmetric_matrix chi1p1, chi1p1_inv;
   material_type material;
+  meep::vec gradient(normal_vector(meep::type(c), v));
   get_material_pt(material, v.center());
   material_epsmu(meep::type(c), material, &chi1p1, &chi1p1_inv);
   material_gc(material);
   if (chi1p1.m01 != 0 || chi1p1.m02 != 0 || chi1p1.m12 != 0 || chi1p1.m00 != chi1p1.m11 ||
-      chi1p1.m11 != chi1p1.m22 || chi1p1.m00 != chi1p1.m22) {
+      chi1p1.m11 != chi1p1.m22 || chi1p1.m00 != chi1p1.m22 || meep::abs(gradient) == 0) {
     int rownum = meep::component_direction(c) % 3;
     if (rownum == 0) {
       chi1inv_row[0] = chi1p1.m00;
@@ -982,7 +983,6 @@ void geom_epsilon::fallback_chi1inv_row(meep::component c, double chi1inv_row[3]
     minveps = 1.0 / (meps = eps(v.center()));
 
   {
-    meep::vec gradient(normal_vector(meep::type(c), v));
     double n[3] = {0, 0, 0};
     double nabsinv = 1.0 / meep::abs(gradient);
     LOOP_OVER_DIRECTIONS(gradient.dim, k) { n[k % 3] = gradient.in_direction(k) * nabsinv; }

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -166,7 +166,7 @@ void set_materials_from_geometry(meep::structure *s, geometric_object_list g,
                                  material_type_list extra_materials = material_type_list());
 
 material_type make_dielectric(double epsilon);
-material_type make_user_material(user_material_func user_func, void *user_data);
+material_type make_user_material(user_material_func user_func, void *user_data, bool do_averaging);
 material_type make_file_material(const char *eps_input_file);
 
 vector3 vec_to_vector3(const meep::vec &pt);

--- a/tests/user-defined-material.cpp
+++ b/tests/user-defined-material.cpp
@@ -189,7 +189,7 @@ int main(int argc, char *argv[]) {
   data.rOuter = R2;
 
   meep_geom::material_type my_material =
-      meep_geom::make_user_material(my_material_func, (void *)&data);
+      meep_geom::make_user_material(my_material_func, (void *)&data, false);
 
   geometric_object_list g = {0, 0};
   vector3 center = {0, 0, 0};


### PR DESCRIPTION
Fixes #764.

Allows setting a `do_averaging` property on a user material function to `True` (defaults to `False`) to use `fallback_chi1inv_row`.
```py
def my_func(p):
  return mp.Medium()

my_func.do_averaging = True
sim = mp.Simulation(default_material=my_func, ...)
```
This was a little more complicated than the fix described in #764. `get_front_object` *always* returns `false` for a material function, so the `if (material_type_equal(mat, mat_behind))` line is never reached.

~~### TODO~~
~~Running the script in issue #764 performs subpixel-averaging when setting `do_averaging` to `True`, but fails in the harminv step with~~
```
On entry to ZGEBAL parameter number 3 had an illegal value
```
~~I traced this back to `chi1inv_row` getting filled in with `nan`s in `geom_epsilon::fallback_chi1inv_row` due to a divide by zero [here](https://github.com/NanoComp/meep/blob/master/src/meepgeom.cpp#L977). How should we handle this?~~