### PR TITLE
include interpolation weights in DFT slice output

### DIFF
--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -731,7 +731,7 @@ cdouble dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corne
      a copy of these with the weights for non-empty dimensions set to 1. */
   vec s0i(s0), s1i(s1), e0i(e0), e1i(e1);
   LOOP_OVER_DIRECTIONS(fc->gv.dim, d) {
-    if (empty_dim[d]) {
+    if (!empty_dim[d]) {
       s0i.set_direction(d, 1.0);
       s1i.set_direction(d, 1.0);
       e0i.set_direction(d, 1.0);

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -998,6 +998,7 @@ public:
   ivec is, ie;
   vec s0, s1, e0, e1;
   double dV0, dV1;
+  bool empty_dim[5]; // which directions correspond to empty dimensions in original volume
   std::complex<double> scale; // scale factor * phase from shift and symmetry
   ivec shift;
   symmetry S;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -943,7 +943,7 @@ public:
                                              ivec max_corner, int num_freq, h5file *file,
                                              double *buffer, int reim,
                                              std::complex<double> *field_array, void *mode1_data,
-                                             void *mode2_data, component c_conjugate);
+                                             void *mode2_data, component c_conjugate, bool retain_interp_weights);
 
   void operator-=(const dft_chunk &chunk);
 
@@ -1696,7 +1696,7 @@ public:
                                              std::complex<double> **field_array = 0, int *rank = 0,
                                              int *dims = 0, void *mode1_data = 0,
                                              void *mode2_data = 0, component c_conjugate = Ex,
-                                             bool *first_component = 0);
+                                             bool *first_component = 0, bool retain_interp_weights=true);
 
   // output DFT fields to HDF5 file
   void output_dft_components(dft_chunk **chunklists, int num_chunklists, volume dft_volume,


### PR DESCRIPTION
This ensures that empty dimensions are collapsed correctly.  I think this should fix #784 — what was happening is that at "unlucky" resolutions where the DFT slice fell between two pixels, the `collapse_empty_dims` was summing over two pixels in the empty direction, but without the interpolation weights this effectively doubled the field value, resulting in the factor-of-two oscillation observed in #784.

~~One downside of this PR is that, at the edges of the output volume, the edge pixels might be multiplied by an integration weight factor (between 0 and 1).   It might be nice to only include the interpolation weights for empty dimensions, but not for edge pixels, but that would require some additional work (e.g. a different `IVEC_LOOP_WEIGHT` function or a modified `loop_in_chunks`).~~ *Update:* Now the PR only includes the empty-dimension interpolation weights, and not the edge integration weights.