### PR TITLE
test for near2far with periodic boundaries

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -92,6 +92,7 @@ TESTS =                                   \
     $(MODE_COEFFS_TEST)                   \
     $(MODE_DECOMPOSITION_TEST)            \
     $(TEST_DIR)/multilevel_atom.py        \
+    $(TEST_DIR)/n2f_periodic.py           \
     $(TEST_DIR)/oblique_source.py         \
     $(TEST_DIR)/physical.py               \
     $(TEST_DIR)/pw_source.py              \

--- a/python/tests/n2f_periodic.py
+++ b/python/tests/n2f_periodic.py
@@ -57,7 +57,7 @@ class TestNear2FarPeriodicBoundaries(unittest.TestCase):
             n2f_Ez = sim.get_farfields(n2f_obj, res[j], center=dft_pt, size=mp.Vector3(y=sy))
             dft_Ez = sim.get_dft_array(dft_obj, mp.Ez, 0)
 
-            norm[j] = LA.norm(np.absolute(n2f_Ez['Ez'][0])-np.absolute(dft_Ez[1:-1]))
+            norm[j] = LA.norm(n2f_Ez['Ez']-dft_Ez[1:-1])
             print("norm:, {}, {:.5f}".format(res[j],norm[j]))
             sim.reset_meep()        
 

--- a/python/tests/n2f_periodic.py
+++ b/python/tests/n2f_periodic.py
@@ -1,0 +1,68 @@
+import unittest
+import meep as mp
+import math
+import numpy as np
+from numpy import linalg as LA
+
+class TestNear2FarPeriodicBoundaries(unittest.TestCase):
+
+    def test_nea2far_periodic(self):
+        dpml = 1.0             # PML thickness
+        dsub = 3.0             # substrate thickness
+        dpad = 20.0            # padding between grating and PML
+        gp = 10.0              # grating period
+        gh = 0.5               # grating height
+        gdc = 0.5              # grating duty cycle
+
+        sx = dpml+dsub+gh+dpad+dpml
+        sy = gp
+
+        pml_layers = [mp.PML(thickness=dpml,direction=mp.X)]
+
+        wvl = 0.5              # center wavelength
+        fcen = 1/wvl           # center frequency
+        df = 0.05*fcen         # frequency width
+
+        src_pt = mp.Vector3(-0.5*sx+dpml+0.5*dsub)
+        sources = [mp.Source(mp.GaussianSource(fcen, fwidth=df), component=mp.Ez, center=src_pt, size=mp.Vector3(y=sy))]
+
+        glass = mp.Medium(index=1.5)
+        geometry = [mp.Block(material=glass, size=mp.Vector3(dpml+dsub,mp.inf,mp.inf), center=mp.Vector3(-0.5*sx+0.5*(dpml+dsub))),
+                    mp.Block(material=glass, size=mp.Vector3(gh,gdc*gp,mp.inf), center=mp.Vector3(-0.5*sx+dpml+dsub+0.5*gh))]
+
+        k_point = mp.Vector3(0,0,0)
+
+        symmetries = [mp.Mirror(mp.Y)]
+
+        n2f_pt = mp.Vector3(-0.5*sx+dpml+dsub+gh+1.0)
+        dft_pt = mp.Vector3(0.5*sx-dpml)
+
+        res = [20,25,30]
+        norm = np.empty(3)
+
+        for j in range(3):        
+            sim = mp.Simulation(resolution=res[j],
+                                cell_size=mp.Vector3(sx,sy),
+                                boundary_layers=pml_layers,
+                                geometry=geometry,
+                                k_point=k_point,
+                                sources=sources,
+                                symmetries=symmetries)
+
+            n2f_obj = sim.add_near2far(fcen, 0, 1, mp.Near2FarRegion(center=n2f_pt, size=mp.Vector3(y=sy)), nperiods=10)
+            dft_obj = sim.add_dft_fields([mp.Ez], fcen, fcen, 1, center=dft_pt, size=mp.Vector3(y=sy))
+
+            sim.run(until_after_sources=300)
+
+            n2f_Ez = sim.get_farfields(n2f_obj, res[j], center=dft_pt, size=mp.Vector3(y=sy))
+            dft_Ez = sim.get_dft_array(dft_obj, mp.Ez, 0)
+
+            norm[j] = LA.norm(np.absolute(n2f_Ez['Ez'][0])-np.absolute(dft_Ez[1:-1]))
+            print("norm:, {}, {:.5f}".format(res[j],norm[j]))
+            sim.reset_meep()        
+
+        self.assertGreater(norm[0],norm[1])
+        self.assertGreater(norm[1],norm[2])
+
+if __name__ == '__main__':
+    unittest.main()    

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -983,7 +983,7 @@ cdouble *collapse_empty_dimensions(cdouble *array, int *rank, int dims[3], direc
   for (int nd = 0; nd < full_rank; ++nd) {
     if (dims[nd] == 0) continue;
     if (dft_volume.in_direction(dirs[nd]) == 0.0)
-      reduced_stride[nd - 1] = 0; // degenerate dimension, to be collapsed
+      reduced_stride[nd] = 0; // degenerate dimension, to be collapsed
     else
       reduced_dims[reduced_rank++] = dims[nd];
   }

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -979,6 +979,7 @@ cdouble *collapse_empty_dimensions(cdouble *array, int *rank, int dims[3], volum
 
   int reduced_rank = 0, reduced_dims[3], reduced_stride[3] = {1, 1, 1}, nd = 0;
   LOOP_OVER_DIRECTIONS(dft_volume.dim, d) {
+    nd >= full_rank && break;
     int dim = dims[nd++];
     if (dim == 0) continue;
     if (dft_volume.in_direction(d) == 0.0)

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -979,7 +979,7 @@ cdouble *collapse_empty_dimensions(cdouble *array, int *rank, int dims[3], volum
 
   int reduced_rank = 0, reduced_dims[3], reduced_stride[3] = {1, 1, 1}, nd = 0;
   LOOP_OVER_DIRECTIONS(dft_volume.dim, d) {
-    nd >= full_rank && break;
+    if (nd >= full_rank) break;
     int dim = dims[nd++];
     if (dim == 0) continue;
     if (dft_volume.in_direction(d) == 0.0)

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1695,7 +1695,7 @@ public:
   std::complex<double> process_dft_component(dft_chunk **chunklists, int num_chunklists,
                                              int num_freq, component c, const char *HDF5FileName,
                                              std::complex<double> **field_array = 0, int *rank = 0,
-                                             int *dims = 0, void *mode1_data = 0,
+                                             int *dims = 0, direction *array_dirs=0, void *mode1_data = 0,
                                              void *mode2_data = 0, component c_conjugate = Ex,
                                              bool *first_component = 0, bool retain_interp_weights=true);
 


### PR DESCRIPTION
Adds a test to the `python/tests` suite based on the binary-grating example in #784: verifies that the norm of the difference in the far-fields computed using `add_near2far` and `add_dft_fields` converges to zero with increasing `resolution`. Runs on a single Kaby Lake 4.2Ghz processor in ~`40s`.