### PR TITLE
GDSII layers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -432,8 +432,16 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctlgeom.h>]], [ctl_printf_callbac
 ##############################################################################
 # check for libGDSII
 AC_CHECK_HEADER(libGDSII.h, [have_gdsii=maybe], [have_gdsii=no])
-if test $have_gdsii = maybe; then
+if test "x$have_gdsii" = xmaybe; then
   AC_CHECK_LIB(GDSII, libGDSIIExists)
+  if test "x$ac_cv_lib_GDSII_libGDSIIExists" = xyes; then
+    AC_MSG_CHECKING([for libGDSII::GetLayers])
+    have_gdsii_getlayers=no
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <libGDSII.h>]], [libGDSII::GetLayers("foo")])],
+      [have_gdsii_getlayers=yes
+       AC_DEFINE([HAVE_GDSII_GETLAYERS], [1], [If we have libGDSII::GetLayers])])
+    AC_MSG_RESULT($have_gdsii_getlayers)
+  fi
 fi
 
 ##############################################################################

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1485,6 +1485,16 @@ After `solve_cw` completes, it should be as if you had just run the simulation f
 
 This feature is only available if Meep is built with [libGDSII](Build_From_Source.md#libgdsii).
 
+**`mp.GDSII_layers(gdsii_filename)`**
+
+Returns a list of integer-valued layer indices for the layers present in
+the specified GDSII file.
+
+```python 
+mp.GDSII_layers('python/examples/coupler.gds')
+Out[2]: [0, 1, 2, 3, 4, 5, 31, 32]
+```
+
 **`mp.get_GDSII_prisms(material, gdsii_filename, layer)`**
 —
 Returns a list of `GeometricObject`s with `material` (`mp.Medium`) on layer number `layer` of a GDSII file `gdsii_filename`.

--- a/python/meep.i
+++ b/python/meep.i
@@ -1429,6 +1429,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         dft_ldos,
         display_progress,
         during_sources,
+        GDSII_layers,
         GDSII_vol,
         get_center_and_size,
         get_eigenmode_freqs,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2763,6 +2763,8 @@ def get_center_and_size(v):
     size = v3rmax - v3rmin
     return center, size
 
+def GDSII_layers(fname):
+    return list(mp.get_GDSII_layers(fname))
 
 def GDSII_vol(fname, layer, zmin, zmax):
     meep_vol = mp.get_GDSII_volume(fname, layer, zmin, zmax)

--- a/src/GDSIIgeom.cpp
+++ b/src/GDSIIgeom.cpp
@@ -205,10 +205,6 @@ meep::volume get_GDSII_volume(const char *GDSIIFile, int Layer, double zmin, dou
   return get_GDSII_volume(GDSIIFile, 0, Layer, zmin, zmax);
 }
 
-std::vector<int> get_GDSII_layers(const char *GDSIIFile) {
- return libGDSII::GetLayers(GDSIIFile);
-}
-
 /***************************************************************/
 /* stubs for compilation without libGDSII **********************/
 /***************************************************************/
@@ -293,12 +289,18 @@ meep::volume get_GDSII_volume(const char *GDSIIFile, int Layer, double zmin, dou
   GDSIIError("get_GDSII_volume");
   return meep::volume(meep::vec());
 }
-std::vector<int> get_GDSII_layers(const char *GDSIIFile)
-{ GDSIIError("get_GDSII_layers");
-  std::vector<int> layers;
-  return layers;
-}
 
 #endif // HAVE_LIBGDSII
+
+std::vector<int> get_GDSII_layers(const char *GDSIIFile)
+{
+#if defined(HAVE_LIBGDSII) && defined(HAVE_GDSII_GETLAYERS)
+  return libGDSII::GetLayers(GDSIIFile);
+#else
+  GDSIIError("get_GDSII_layers");
+  std::vector<int> layers;
+  return layers;
+#endif
+}
 
 } // namespace meep_geom

--- a/src/GDSIIgeom.cpp
+++ b/src/GDSIIgeom.cpp
@@ -205,6 +205,10 @@ meep::volume get_GDSII_volume(const char *GDSIIFile, int Layer, double zmin, dou
   return get_GDSII_volume(GDSIIFile, 0, Layer, zmin, zmax);
 }
 
+std::vector<int> get_GDSII_layers(const char *GDSIIFile) {
+ return libGDSII::GetLayers(GDSIIFile);
+}
+
 /***************************************************************/
 /* stubs for compilation without libGDSII **********************/
 /***************************************************************/
@@ -288,6 +292,11 @@ meep::volume get_GDSII_volume(const char *GDSIIFile, int Layer, double zmin, dou
   (void)zmax;
   GDSIIError("get_GDSII_volume");
   return meep::volume(meep::vec());
+}
+std::vector<int> get_GDSII_layers(const char *GDSIIFile)
+{ GDSIIError("get_GDSII_layers");
+  std::vector<int> layers;
+  return layers;
 }
 
 #endif // HAVE_LIBGDSII

--- a/src/GDSIIgeom.cpp
+++ b/src/GDSIIgeom.cpp
@@ -297,7 +297,7 @@ std::vector<int> get_GDSII_layers(const char *GDSIIFile)
 #if defined(HAVE_LIBGDSII) && defined(HAVE_GDSII_GETLAYERS)
   return libGDSII::GetLayers(GDSIIFile);
 #else
-  GDSIIError("get_GDSII_layers");
+  GDSIIError("get_GDSII_layers (needs libGDSII version 0.21 or later)");
   std::vector<int> layers;
   return layers;
 #endif

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -206,6 +206,7 @@ meep::volume get_GDSII_volume(const char *GDSIIFile, const char *Text, int Layer
                               double zmin = 0.0, double zmax = 0.0);
 meep::volume get_GDSII_volume(const char *GDSIIFile, int Layer, double zmin = 0.0,
                               double zmax = 0.0);
+std::vector<int> get_GDSII_layers(const char *GDSIIFile);
 
 }; // namespace meep_geom
 


### PR DESCRIPTION
Fixes #514. Requires most recent repository version of `libGDSII.`

````python
>>> mp.GDSII_layers('python/examples/coupler.gds')              
Out[2]: [0, 1, 2, 3, 4, 5, 31, 32]
```