### PR TITLE
Improvements to GeometricObject '+' operators

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -492,7 +492,7 @@ Methods:
 
 **`shift`(vec [`Vector3`])**
 —
-Shifts the objects `center` by `vec`. This can also be accomplished via the `+` operator: `geometric_obj + Vector3(10,10,10)`.
+Shifts the object's `center` by `vec`, returning a new object. This can also be accomplished via the `+` operator: `geometric_obj + Vector3(10,10,10)`. Using `+=` will shift the object in place.
 
 **`info`(indent_by [`integer`])**
 —

--- a/python/geom.py
+++ b/python/geom.py
@@ -41,6 +41,9 @@ class Vector3(object):
         return not self == other
 
     def __add__(self, other):
+        if isinstance(other, GeometricObject):
+            return NotImplemented
+
         x = self.x + other.x
         y = self.y + other.y
         z = self.z + other.z
@@ -324,7 +327,14 @@ class GeometricObject(object):
         return mp.is_point_in_object(point, self)
 
     def __add__(self, vec):
+        return self.shift(vec)
+
+    def __radd__(self, vec):
+        return self.shift(vec)
+
+    def __iadd__(self, vec):
         self.center += vec
+        return self
 
     def shift(self, vec):
         c = deepcopy(self)

--- a/python/tests/geom.py
+++ b/python/tests/geom.py
@@ -164,6 +164,20 @@ class TestSphere(unittest.TestCase):
         shifted = s.shift(gm.Vector3(-10, -10))
         self.assertEqual(shifted.center, gm.Vector3())
 
+        s = gm.Sphere(center=zeros(), radius=2.0)
+        s += mp.Vector3(5, 5)
+        self.assertEqual(s.center, mp.Vector3(5, 5))
+
+        s = gm.Sphere(center=zeros(), radius=2.0)
+        new_sphere = s + mp.Vector3(5, 5)
+        self.assertEqual(new_sphere.center, mp.Vector3(5, 5))
+        self.assertEqual(s.center, zeros())
+
+        s = gm.Sphere(center=zeros(), radius=2.0)
+        new_sphere = mp.Vector3(5, 5) + s
+        self.assertEqual(new_sphere.center, mp.Vector3(5, 5))
+        self.assertEqual(s.center, zeros())
+
     def test_info(self):
         # Sanity test to ensure that display_geometric_object_info is callable
         s = gm.Sphere(2)


### PR DESCRIPTION
Fixes #815. `GeometricObject + Vector3` now returns a copy of `GeometricObject` and is commutative. `GeometricObject += Vector3` updates the object in place.
@stevengj @oskooi 