### PR TITLE
Fix shape for get_farfields and output_farfields

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -321,32 +321,24 @@ PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v) {
 
     if (!EH) return PyArray_SimpleNew(0, 0, NPY_CDOUBLE);
 
-    // collapse singleton dimensions
-    size_t collapsed_dims[4] = {};
-    int collapsed_rank = 0;
-    for (int i = 0; i < rank; ++i) {
-      if (dims[i] > 1) {
-        collapsed_dims[collapsed_rank++] = dims[i];
-      }
-    }
-
     // frequencies are the last dimension
-    if (n2f->Nfreq > 1) collapsed_dims[collapsed_rank++] = n2f->Nfreq;
+    if (n2f->Nfreq > 1) dims[rank++] = n2f->Nfreq;
 
     // Additional rank to store all 12 E/H x/y/z r/i arrays.
-    collapsed_rank++;
-    npy_intp *arr_dims = new npy_intp[collapsed_rank];
+    rank++;
+    npy_intp *arr_dims = new npy_intp[rank];
     arr_dims[0] = 12;
-    for (int i = 1; i < collapsed_rank; ++i) {
-        arr_dims[i] = collapsed_dims[i - 1];
+    for (int i = 1; i < rank; ++i) {
+        arr_dims[i] = dims[i - 1];
     }
 
-    PyObject *py_arr = PyArray_SimpleNew(collapsed_rank, arr_dims, NPY_DOUBLE);
+    PyObject *py_arr = PyArray_SimpleNew(rank, arr_dims, NPY_DOUBLE);
     memcpy(PyArray_DATA((PyArrayObject*)py_arr), EH, sizeof(meep::realnum) * 2 * N * 6 * n2f->Nfreq);
 
     delete[] arr_dims;
     delete[] EH;
     return py_arr;
+
 }
 
 // Wrapper around meep::dft_ldos::ldos

--- a/python/meep.i
+++ b/python/meep.i
@@ -321,27 +321,32 @@ PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v) {
 
     if (!EH) return PyArray_SimpleNew(0, 0, NPY_CDOUBLE);
 
-    // collapse trailing singleton dimensions
-    while (rank > 0 && dims[rank - 1] == 1) {
-        --rank;
+    // collapse singleton dimensions
+    size_t collapsed_dims[4] = {};
+    int collapsed_rank = 0;
+    for (int i = 0; i < rank; ++i) {
+      if (dims[i] > 1) {
+        collapsed_dims[collapsed_rank++] = dims[i];
+      }
     }
+
     // frequencies are the last dimension
-    if (n2f->Nfreq > 1) dims[rank++] = n2f->Nfreq;
+    if (n2f->Nfreq > 1) collapsed_dims[collapsed_rank++] = n2f->Nfreq;
 
-    rank++;
-    npy_intp *arr_dims = new npy_intp[rank];
+    // Additional rank to store all 12 E/H x/y/z r/i arrays.
+    collapsed_rank++;
+    npy_intp *arr_dims = new npy_intp[collapsed_rank];
     arr_dims[0] = 12;
-    for (int i = 1; i < rank; ++i) {
-        arr_dims[i] = dims[i - 1];
+    for (int i = 1; i < collapsed_rank; ++i) {
+        arr_dims[i] = collapsed_dims[i - 1];
     }
 
-    PyObject *py_arr = PyArray_SimpleNew(rank, arr_dims, NPY_DOUBLE);
+    PyObject *py_arr = PyArray_SimpleNew(collapsed_rank, arr_dims, NPY_DOUBLE);
     memcpy(PyArray_DATA((PyArrayObject*)py_arr), EH, sizeof(meep::realnum) * 2 * N * 6 * n2f->Nfreq);
 
     delete[] arr_dims;
     delete[] EH;
     return py_arr;
-
 }
 
 // Wrapper around meep::dft_ldos::ldos

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -22,7 +22,6 @@
 
 #include <meep.hpp>
 #include <assert.h>
-#include <cstring>
 #include "config.h"
 #include <math.h>
 
@@ -334,16 +333,11 @@ realnum *dft_near2far::get_farfields_array(const volume &where, int &rank, size_
   sum_to_all(EH_, EH, 6 * 2 * N * Nfreq);
 
   /* collapse singleton dimensions */
-  const int ndims = 4;
-  size_t collapsed_dims[ndims] = {};
-  int collapsed_rank = 0;
+  int ireduced = 0;
   for (int i = 0; i < rank; ++i) {
-    if (dims[i] > 1) {
-      collapsed_dims[collapsed_rank++] = dims[i];
-    }
+    if (dims[i] > 1) dims[ireduced++] = dims[i];
   }
-  rank = collapsed_rank;
-  std::memcpy(dims, collapsed_dims, ndims * sizeof(size_t));
+  rank = ireduced;
 
   delete[] EH_;
   delete[] EH1;

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -343,7 +343,7 @@ realnum *dft_near2far::get_farfields_array(const volume &where, int &rank, size_
     }
   }
   rank = collapsed_rank;
-  std::memcpy(dims, collapsed_dims, ndims * sizeof(int));
+  std::memcpy(dims, collapsed_dims, ndims * sizeof(size_t));
 
   delete[] EH_;
   delete[] EH1;


### PR DESCRIPTION
Fixes #842. This issue also existed for `output_farfields` (which calls `dft_near2far::save_farfields`). The documentation states that "dimensions that = 1 are omitted," but only trailing empty dimensions were being removed. Ideally the removal of empty dimensions could be done in `dft_near2far::get_farfields_array` so the collapsing code wouldn't need to be duplicated. Is that doable?
@stevengj @oskooi 