### PR TITLE
fix minor typos of docs

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1744,13 +1744,9 @@ The results are stored in the list `Harminv.modes`, which is a list of tuples ho
 
 **`freq`**
 —
-The complex frequency ω (in the usual Meep 2πc units).
+The real part of frequency ω (in the usual Meep 2πc units).
 
-**`freq.real`**
-—
-The real part of the frequency ω.
-
-**`freq.decay`**
+**`decay`**
 —
 The imaginary part of the frequency ω.
 


### PR DESCRIPTION
In my case,
```
print(harminv_instance.modes)
```
return 
```
[Mode(freq=0.11680245319740999, decay=-0.0006834209964856166, Q=85.45424694152504, amp=(0.022364090007081165-0.05966479702405166j), err=(1.943059072730648e-08+0j))]
```
So, the component of freq.real, freq.decay and freq.decay don't exist.
They should be freq and decay.