### PR TITLE
Flush stdout after each step

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1248,6 +1248,7 @@ class Simulation(object):
             for func in step_funcs:
                 _eval_step_func(self, func, 'step')
             self.fields.step()
+            sys.stdout.flush()
 
         # Translating the recursive scheme version of run-until into an iterative version
         # (because python isn't tail-call-optimized) means we need one extra iteration to


### PR DESCRIPTION
Since `master_printf` sends output to Python's `stdout` (as of #785), we need to do the flush from Python that `master_printf` used to do. Otherwise users can't see the progress (this is especially pronounced when using MPI). 
@stevengj @oskooi 