### PR TITLE
Use HL interface in dft_fields test and fix h5py deprecation warnings

### DIFF
--- a/python/solver.py
+++ b/python/solver.py
@@ -481,7 +481,7 @@ class ModeSolver(object):
 
     def load_eigenvectors(self, filename):
         with h5py.File(filename, 'r') as f:
-            ev = f['rawdata'].value
+            ev = f['rawdata'][()]
             self.set_eigenvectors(ev, 1)
             self.mode_solver.curfield_reset()
 

--- a/python/tests/cavity_farfield.py
+++ b/python/tests/cavity_farfield.py
@@ -64,12 +64,12 @@ class TestCavityFarfield(unittest.TestCase):
 
         with h5py.File(ref_file, 'r') as f:
             # Get reference data into memory
-            ref_ex = mp.complexarray(f['ex.r'].value, f['ex.i'].value)
-            ref_ey = mp.complexarray(f['ey.r'].value, f['ey.i'].value)
-            ref_ez = mp.complexarray(f['ez.r'].value, f['ez.i'].value)
-            ref_hx = mp.complexarray(f['hx.r'].value, f['hx.i'].value)
-            ref_hy = mp.complexarray(f['hy.r'].value, f['hy.i'].value)
-            ref_hz = mp.complexarray(f['hz.r'].value, f['hz.i'].value)
+            ref_ex = mp.complexarray(f['ex.r'][()], f['ex.i'][()])
+            ref_ey = mp.complexarray(f['ey.r'][()], f['ey.i'][()])
+            ref_ez = mp.complexarray(f['ez.r'][()], f['ez.i'][()])
+            ref_hx = mp.complexarray(f['hx.r'][()], f['hx.i'][()])
+            ref_hy = mp.complexarray(f['hy.r'][()], f['hy.i'][()])
+            ref_hz = mp.complexarray(f['hz.r'][()], f['hz.i'][()])
 
             np.testing.assert_allclose(ref_ex, result['Ex'])
             np.testing.assert_allclose(ref_ey, result['Ey'])

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -222,9 +222,9 @@ class TestModeSolver(unittest.TestCase):
         with h5py.File(ref_path, 'r') as ref:
             # Reshape the reference data into a component-wise 1d array like
             # [x1,y1,z1,x2,y2,z2,etc.]
-            ref_x = mp.complexarray(ref["x.r{}".format(suffix)].value, ref["x.i{}".format(suffix)].value)
-            ref_y = mp.complexarray(ref["y.r{}".format(suffix)].value, ref["y.i{}".format(suffix)].value)
-            ref_z = mp.complexarray(ref["z.r{}".format(suffix)].value, ref["z.i{}".format(suffix)].value)
+            ref_x = mp.complexarray(ref["x.r{}".format(suffix)][()], ref["x.i{}".format(suffix)][()])
+            ref_y = mp.complexarray(ref["y.r{}".format(suffix)][()], ref["y.i{}".format(suffix)][()])
+            ref_z = mp.complexarray(ref["z.r{}".format(suffix)][()], ref["z.i{}".format(suffix)][()])
 
             ref_arr = np.zeros(np.prod(field.shape), dtype=np.complex128)
             ref_arr[0::3] = ref_x.ravel()
@@ -238,9 +238,9 @@ class TestModeSolver(unittest.TestCase):
             with h5py.File(res_path, 'r') as res:
                 for k in ref.keys():
                     if k == 'description':
-                        self.assertEqual(ref[k].value, res[k].value)
+                        self.assertEqual(ref[k][()], res[k][()])
                     else:
-                        compare_arrays(self, ref[k].value, res[k].value, tol=tol)
+                        compare_arrays(self, ref[k][()], res[k][()], tol=tol)
 
     def test_update_band_range_data(self):
         brd = []
@@ -734,7 +734,7 @@ class TestModeSolver(unittest.TestCase):
         ref_fn = 'converted-diamond-dpwr.k06.b05.h5'
         ref_path = os.path.join(self.data_dir, ref_fn)
         with h5py.File(ref_path, 'r') as f:
-            expected = f['data-new'].value
+            expected = f['data-new'][()]
 
         compare_arrays(self, expected, converted_dpwr[-1])
 
@@ -985,8 +985,8 @@ class TestModeSolver(unittest.TestCase):
 
         # Test MPBData
         with h5py.File(ref_path, 'r') as f:
-            efield_re = f['z.r'].value
-            efield_im = f['z.i'].value
+            efield_re = f['z.r'][()]
+            efield_im = f['z.i'][()]
             efield = np.vectorize(complex)(efield_re, efield_im)
 
         # rectangularize
@@ -998,8 +998,8 @@ class TestModeSolver(unittest.TestCase):
         ref_path = os.path.join(self.data_dir, ref_fn)
 
         with h5py.File(ref_path, 'r') as f:
-            expected_re = f['z.r-new'].value
-            expected_im = f['z.i-new'].value
+            expected_re = f['z.r-new'][()]
+            expected_im = f['z.i-new'][()]
             expected = np.vectorize(complex)(expected_re, expected_im)
             compare_arrays(self, expected, new_efield)
 
@@ -1034,7 +1034,7 @@ class TestModeSolver(unittest.TestCase):
         ref_path = os.path.join(self.data_dir, ref_fn)
 
         with h5py.File(ref_path, 'r') as f:
-            ref = f['data-new'].value
+            ref = f['data-new'][()]
             compare_arrays(self, ref, new_eps, tol=1e-3)
 
     def test_subpixel_averaging(self):
@@ -1109,7 +1109,7 @@ class TestModeSolver(unittest.TestCase):
 
         mu = ms.get_mu()
         with h5py.File(data_path, 'r') as f:
-            data = f['data'].value
+            data = f['data'][()]
             compare_arrays(self, data, mu)
 
     def test_output_tot_pwr(self):
@@ -1126,7 +1126,7 @@ class TestModeSolver(unittest.TestCase):
         # Test get_tot_pwr
         arr = ms.get_tot_pwr(8)
         with h5py.File(ref_path, 'r') as f:
-            expected = f['data'].value
+            expected = f['data'][()]
 
         compare_arrays(self, expected, arr)
 
@@ -1136,7 +1136,7 @@ class TestModeSolver(unittest.TestCase):
 
         def compare_eigenvectors(ref_fn, start, cols):
             with h5py.File(os.path.join(self.data_dir, ref_fn), 'r') as f:
-                expected = f['rawdata'].value
+                expected = f['rawdata'][()]
                 # Reshape the last dimension of 2 reals into one complex
                 expected = np.vectorize(complex)(expected[..., 0], expected[..., 1])
                 ev = ms.get_eigenvectors(start, cols)

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -242,7 +242,7 @@ class TestSimulation(unittest.TestCase):
         eps_input_path = os.path.join(eps_input_dir, eps_input_fname)
 
         with h5py.File(eps_input_path, 'r') as f:
-            sim.default_material = f['eps'].value
+            sim.default_material = f['eps'][()]
 
         sim.run(until=200)
         fp = sim.get_field_point(mp.Ez, mp.Vector3(x=1))
@@ -403,18 +403,18 @@ class TestSimulation(unittest.TestCase):
         fname_fmt = "test_get_array_output-{}-000020.00.h5"
 
         with h5py.File(fname_fmt.format('eps'), 'r') as f:
-            eps = f['eps'].value
+            eps = f['eps'][()]
 
         with h5py.File(fname_fmt.format('ez'), 'r') as f:
-            efield_z = f['ez'].value
+            efield_z = f['ez'][()]
 
         with h5py.File(fname_fmt.format('energy'), 'r') as f:
-            energy = f['energy'].value
+            energy = f['energy'][()]
 
         with h5py.File(fname_fmt.format('e'), 'r') as f:
-            ex = f['ex'].value
-            ey = f['ey'].value
-            ez = f['ez'].value
+            ex = f['ex'][()]
+            ey = f['ey'][()]
+            ez = f['ez'][()]
             efield = np.stack([ex, ey, ez], axis=-1)
 
         np.testing.assert_allclose(eps, eps_arr)


### PR DESCRIPTION
* The `.value` syntax has been deprecated since h5py 2.1.0, which came out in 2013.
* Changed `tests/dft_fields.py` to go through `sim.add_dft_fields` instead of lower level `sim.fields.add_dft_fields`.

@stevengj @oskooi 