### PR TITLE
Fix python medium evals

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -301,11 +301,11 @@ List of dispersive susceptibilities (see below) added to the permeability μ in 
 Transforms `epsilon`, `mu`, and `sigma` of any [susceptibilities](#susceptibility) by the 3×3 matrix `M`. If `M` is a [rotation matrix](https://en.wikipedia.org/wiki/Rotation_matrix), then the principal axes of the susceptibilities are rotated by `M`.  More generally, the susceptibilities χ are transformed to MχMᵀ/|det M|, which corresponds to [transformation optics](http://math.mit.edu/~stevenj/18.369/coordinate-transform.pdf) for an arbitrary curvilinear coordinate transformation with Jacobian matrix M. The absolute value of the determinant is to prevent inadvertent construction of left-handed materials, which are [problematic in nondispersive media](FAQ.md#why-does-my-simulation-diverge-if-0).
 
 **`epsilon(freq` [ scalar, list, or `numpy` array, ]`)`**
--
+—
 Calculates the medium's permittivity tensor as a 3x3 `numpy` array at the specified frequency, `freq`. Either a scalar, list, or `numpy` array of frequencies may be supplied. In the case `N` frequency points, a `numpy` array size Nx3x3 is returned.
 
 **`mu(freq` [ scalar, list, or `numpy` array, ]`)`**
--
+—
 Calculates the medium's permeability tensor as a 3x3 `numpy` array at the specified frequency, `freq`. Either a scalar, list, or `numpy` array of frequencies may be supplied. In the case `N` frequency points, a `numpy` array size Nx3x3 is returned.
 
 **material functions**

--- a/python/materials.py
+++ b/python/materials.py
@@ -233,7 +233,7 @@ Si3N4_NIR = mp.Medium(epsilon=1.0, E_susceptibilities=Si3N4_NIR_susc, valid_freq
 # elemental metals from A.D. Rakic et al., Applied Optics, Vol. 37, No. 22, pp. 5271-83, 1998
 # wavelength range: 0.2 - 12.4 um
 
-metal_range = mp.FreqRange(min=um_scale/12.4, max=um_scale/0.2)
+metal_range = mp.FreqRange(min=um_scale/12.398, max=um_scale/.24797)
 
 # silver (Ag)
 
@@ -275,6 +275,8 @@ Ag = mp.Medium(epsilon=1.0, E_susceptibilities=Ag_susc, valid_freq_range=metal_r
 #------------------------------------------------------------------
 # gold (Au)
 
+metal_range = mp.FreqRange(min=um_scale/6.1992, max=um_scale/.24797)
+
 Au_plasma_frq = 9.03*eV_um_scale
 Au_f0 = 0.760
 Au_frq0 = 1e-10
@@ -312,6 +314,8 @@ Au = mp.Medium(epsilon=1.0, E_susceptibilities=Au_susc, valid_freq_range=metal_r
 
 #------------------------------------------------------------------
 # copper (Cu)
+
+metal_range = mp.FreqRange(min=um_scale/12.398, max=um_scale/.20664)
 
 Cu_plasma_frq = 10.83*eV_um_scale
 Cu_f0 = 0.575

--- a/python/tests/medium_evaluations.py
+++ b/python/tests/medium_evaluations.py
@@ -17,30 +17,51 @@ import numpy as np
 class TestMediumEvaluations(unittest.TestCase):
 
     def test_medium_evaluations(self):
-        from meep.materials import Si, Au, LiNbO3
+        from meep.materials import Si, Ag, LiNbO3, fused_quartz
+
+        # Check that scalars work
+        w0 = LiNbO3.valid_freq_range.min
+        eps = LiNbO3.epsilon(w0)
+        self.assertAlmostEqual(np.real(np.sqrt(eps[0,0])), 2.0508, places=4)
+
+        # Check numpy arrays
+        try:
+            w0 = Si.valid_freq_range.min
+            w1 = Si.valid_freq_range.max
+            eps = Si.epsilon(np.linspace(w0,w1,100))
+        except ExceptionType:
+            self.fail("myFunc() raised ExceptionType unexpectedly!")
+
+        # Check that regions outside of domain don't work
+        self.assertRaises(ValueError,LiNbO3.epsilon,-1.0)
+        self.assertRaises(ValueError,LiNbO3.epsilon,10000.0)
+
+        # Check complex vs non complex numbers
+        self.assertTrue(np.iscomplex(Ag.epsilon(1.0)[0,0]))
+        self.assertFalse(np.iscomplex(fused_quartz.epsilon(1.0)[0,0]))
 
         # Check Silicon
-        w0 = 1/1.357
-        w1 = 1/11.04
+        w0 = Si.valid_freq_range.min
+        w1 = Si.valid_freq_range.max
         eps = Si.epsilon([w0,w1])
-        self.assertAlmostEqual(np.real(np.sqrt(eps[0,0,0])), 3.4975134228247, places=6)
-        self.assertAlmostEqual(np.real(np.sqrt(eps[1,0,0])), 3.4175012372164, places=6)
+        self.assertAlmostEqual(np.real(np.sqrt(eps[0,0,0])), 3.4175, places=4)
+        self.assertAlmostEqual(np.real(np.sqrt(eps[1,0,0])), 3.4971, places=4)
 
-        # Check Gold
-        w0 = 1/0.24797
-        w1 = 1/6.1992
-        eps = Au.epsilon([w0,w1])
-        self.assertAlmostEqual(np.real(np.sqrt(eps[0,0,0])), 1.0941, places=4)
-        self.assertAlmostEqual(np.real(np.sqrt(eps[1,0,0])), 5.0974, places=4)
+        # Check Silver
+        w0 = Ag.valid_freq_range.min
+        w1 = Ag.valid_freq_range.max
+        eps = Ag.epsilon([w0,w1])
+        self.assertAlmostEqual(np.real(np.sqrt(eps[0,0,0])), 17.485, places=2)
+        self.assertAlmostEqual(np.real(np.sqrt(eps[1,0,0])), 0.44265, places=4)
 
         # Check Lithium Niobate
-        w0 = 1/0.4
-        w1 = 1/5.0
+        w0 = LiNbO3.valid_freq_range.min
+        w1 = LiNbO3.valid_freq_range.max
         eps = LiNbO3.epsilon([w0,w1])
-        self.assertAlmostEqual(np.real(np.sqrt(eps[0,0,0])), 2.4392710888511, places=6)
-        self.assertAlmostEqual(np.real(np.sqrt(eps[1,0,0])), 2.0508048794821, places=6)
-        self.assertAlmostEqual(np.real(np.sqrt(eps[0,2,2])), 2.332119801394, places=6)
-        self.assertAlmostEqual(np.real(np.sqrt(eps[1,2,2])), 2.0025312699385, places=6)
+        self.assertAlmostEqual(np.real(np.sqrt(eps[0,0,0])), 2.0508, places=4)
+        self.assertAlmostEqual(np.real(np.sqrt(eps[1,0,0])), 2.4393, places=4)
+        self.assertAlmostEqual(np.real(np.sqrt(eps[0,2,2])), 2.0025, places=4)
+        self.assertAlmostEqual(np.real(np.sqrt(eps[1,2,2])), 2.3321, places=4)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #877.

1.) The functions now properly work with scalars, `numpy` arrays, and lists. The test script `medium_evaluations.py` now checks for this.
```python
>>> import meep as mp
>>> from meep.materials import fused_quartz
>>> fused_quartz.epsilon(1.0)
array([[2.10371066, 0.        , 0.        ],
       [0.        , 2.10371066, 0.        ],
       [0.        , 0.        , 2.10371066]])
```
2.) As seen above, it will return a purely real array if it expects no imaginary components. The complex cases still work. This was also added to the test script.

```python
>>> from meep.materials import Au
>>> Au.epsilon(1)
array([[-35.77233774+3.06147023j,   0.        +0.j        ,
          0.        +0.j        ],
       [  0.        +0.j        , -35.77233774+3.06147023j,
          0.        +0.j        ],
       [  0.        +0.j        ,   0.        +0.j        ,
        -35.77233774+3.06147023j]])
```

3.) The functions now raise a `ValueError` if the user's frequency is outside of the specified band. Also added to the test script.
```python
>>> Au.epsilon(-1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/site-packages/meep/geom.py", line 243, in epsilon
    return self._get_epsmu(self.epsilon_diag, self.epsilon_offdiag, self.E_susceptibilities, self.D_conductivity_diag, self.D_conductivity_offdiag, freq)
  File "/usr/local/lib/python3.6/site-packages/meep/geom.py", line 258, in _get_epsmu
    raise ValueError('User specified frequency {} is below the Medium\'s limit, {}.'.format(np.min(np.squeeze(freqs)),self.valid_freq_range.min))
ValueError: User specified frequency -1 is below the Medium's limit, 0.16131113692089302.
>>>
```

4.) I updated some of the band limits for the metals as specified in the literature.

5.) I fixed the docs formatting for `epsilon()` and `mu()`.