### PR TITLE
Only check for mpb_printf_callback if we are building with MPB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -187,9 +187,11 @@ if test $have_mpb = maybe; then
 fi
 
 AM_CONDITIONAL(WITH_MPB, test "x$have_mpb" = "xyes")
-# check for mpb_printf_callback
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <mpb.h>]], [mpb_printf_callback = 0;])],
-  AC_DEFINE([HAVE_MPB_PRINTF_CALLBACK], [1], [If we have the mpb_printf_callback variable]))
+if test "x$have_mpb" = "xyes"; then
+  # check for mpb_printf_callback
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <mpb.h>]], [mpb_printf_callback = 0;])],
+    AC_DEFINE([HAVE_MPB_PRINTF_CALLBACK], [1], [If we have the mpb_printf_callback variable]))
+fi
 
 ##############################################################################
 # GNU Scientific Library


### PR DESCRIPTION
Travis didn't catch this because CI for #891 ran before NanoComp/mpb#102 was merged.
@stevengj @oskooi 