### PR TITLE
stop simulation if NaN or Inf encountered

### DIFF
--- a/src/step.cpp
+++ b/src/step.cpp
@@ -94,7 +94,7 @@ void fields::step() {
     synchronized_magnetic_fields = save_synchronized_magnetic_fields;
   }
 
-  if (!std::isfinite(get_field(EnergyDensity, gv.center())))
+  if (!std::isfinite(get_field(D_EnergyDensity, gv.center())))
     abort("simulation fields are NaN or Inf");
 }
 

--- a/src/step.cpp
+++ b/src/step.cpp
@@ -93,6 +93,9 @@ void fields::step() {
     synchronize_magnetic_fields();
     synchronized_magnetic_fields = save_synchronized_magnetic_fields;
   }
+
+  if (!std::isfinite(get_field(EnergyDensity, gv.center())))
+    abort("simulation fields are NaN or Inf");
 }
 
 double fields_chunk::peek_field(component c, const vec &where) {


### PR DESCRIPTION
Fixes #916.

It should suffice to check a single point in the center of the computational cell, because once the simulation blows up anywhere it soon blows up everywhere.   And since checking a single point is so cheap, we might as well do it at every timestep.