### PR TITLE
scheme interface for oblique coefs

### DIFF
--- a/scheme/meep-ctl-swig.hpp
+++ b/scheme/meep-ctl-swig.hpp
@@ -35,7 +35,7 @@ kpoint_list do_get_eigenmode_coefficients(meep::fields *f, meep::dft_flux flux,
                                           int parity, std::complex<double> *coeffs, double *vgrp,
                                           double eig_resolution, double eigensolver_tol,
                                           meep::kpoint_func user_kpoint_func,
-                                          void *user_kpoint_data);
+                                          void *user_kpoint_data, int dir);
 
 ctlio::number_list dft_flux_flux(meep::dft_flux *f);
 ctlio::number_list dft_energy_electric(meep::dft_energy *f);

--- a/scheme/meep.cpp
+++ b/scheme/meep.cpp
@@ -60,14 +60,14 @@ kpoint_list do_get_eigenmode_coefficients(fields *f, dft_flux flux, const volume
                                           std::complex<double> *coeffs, double *vgrp,
                                           double eig_resolution, double eigensolver_tol,
                                           meep::kpoint_func user_kpoint_func,
-                                          void *user_kpoint_data) {
+                                          void *user_kpoint_data, int dir) {
   size_t num_kpoints = num_bands * flux.Nfreq;
   meep::vec *kpoints = new meep::vec[num_kpoints];
   meep::vec *kdom = new meep::vec[num_kpoints];
 
   f->get_eigenmode_coefficients(flux, eig_vol, bands, num_bands, parity, eig_resolution,
                                 eigensolver_tol, coeffs, vgrp, user_kpoint_func, user_kpoint_data,
-                                kpoints, kdom);
+                                kpoints, kdom, false, dir < 0 ? flux.normal_direction : direction(dir));
 
   kpoint_list res = {kpoints, num_kpoints, kdom, num_kpoints};
 

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -1221,7 +1221,7 @@
       (define coeffs (make-typed-array 'c64 '0 num-bands (meep-dft-flux-Nfreq-get flux) 2))
       (define vgrp (make-typed-array 'f64 '0 num-bands (meep-dft-flux-Nfreq-get flux)))
       (define kpoints-and-kdom (do-get-eigenmode-coefficients fields flux eig-vol bands eig-parity coeffs vgrp
-                                                             eig-resolution eig-tolerance kpoint-func))
+                                                             eig-resolution eig-tolerance kpoint-func direction))
       (list coeffs vgrp (first kpoints-and-kdom) (second kpoints-and-kdom)))))
 
 ; ****************************************************************

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -1214,6 +1214,7 @@
         (eig-vol (get-keyword-value args #:eig-vol (meep-dft-flux-where-get flux)))
         (eig-resolution (get-keyword-value args #:eig-resolution 0))
         (eig-tolerance (get-keyword-value args #:eig-tolerance 1e-12))
+        (direction (get-keyword-value args #:direction AUTOMATIC))
         (num-bands (length bands))
         (kpoint-func (get-keyword-value args #:kpoint-func '())))
     (begin


### PR DESCRIPTION
Scheme interface to #940, same as Python (optional `direction` keyword argument to eigenmode coefficients).