### PR TITLE
time chunk synchronization separately from time stepping

### DIFF
--- a/src/boundaries.cpp
+++ b/src/boundaries.cpp
@@ -314,7 +314,7 @@ void fields::connect_the_chunks() {
     FOR_H_AND_B(hc, bc) {
       B_redundant[5 * (num_chunks + i) + bc - Bx] = chunks[i]->f[hc][0] == chunks[i]->f[bc][0];
     }
-  am_now_working_on(Other);
+  am_now_working_on(MpiTime);
   and_to_all(B_redundant + 5 * num_chunks, B_redundant, 5 * num_chunks);
   finished_working();
 

--- a/src/boundaries.cpp
+++ b/src/boundaries.cpp
@@ -121,6 +121,11 @@ void fields::disconnect_chunks() {
 }
 
 void fields::connect_chunks() {
+  /* make sure all processes agree on chunk_connections_valid to avoid deadlocks */
+  am_now_working_on(MpiTime);
+  chunk_connections_valid = and_to_all(chunk_connections_valid);
+  finished_working();
+
   if (!chunk_connections_valid) {
     am_now_working_on(Connecting);
     disconnect_chunks();

--- a/src/boundaries.cpp
+++ b/src/boundaries.cpp
@@ -314,7 +314,9 @@ void fields::connect_the_chunks() {
     FOR_H_AND_B(hc, bc) {
       B_redundant[5 * (num_chunks + i) + bc - Bx] = chunks[i]->f[hc][0] == chunks[i]->f[bc][0];
     }
+  am_now_working_on(Other);
   and_to_all(B_redundant + 5 * num_chunks, B_redundant, 5 * num_chunks);
+  finished_working();
 
   /* Figure out whether we need the notowned W field (== E/H in
      non-PML regions) in update_pols, e.g. if we have an anisotropic

--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -33,11 +33,6 @@ void fields::step_db(field_type ft) {
   for (int i = 0; i < num_chunks; i++)
     if (chunks[i]->is_mine())
       if (chunks[i]->step_db(ft)) chunk_connections_valid = false;
-
-  /* synchronize to avoid deadlocks in connect_the_chunks */
-  am_now_working_on(Other);
-  chunk_connections_valid = and_to_all(chunk_connections_valid);
-  finished_working();
 }
 
 bool fields_chunk::step_db(field_type ft) {

--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -35,7 +35,9 @@ void fields::step_db(field_type ft) {
       if (chunks[i]->step_db(ft)) chunk_connections_valid = false;
 
   /* synchronize to avoid deadlocks in connect_the_chunks */
+  am_now_working_on(Other);
   chunk_connections_valid = and_to_all(chunk_connections_valid);
+  finished_working();
 }
 
 bool fields_chunk::step_db(field_type ft) {

--- a/src/update_eh.cpp
+++ b/src/update_eh.cpp
@@ -30,12 +30,6 @@ void fields::update_eh(field_type ft, bool skip_w_components) {
     if (chunks[i]->is_mine())
       if (chunks[i]->update_eh(ft, skip_w_components))
         chunk_connections_valid = false; // E/H allocated - reconnect chunks
-
-  /* synchronize to avoid deadlocks if one process decides it needs
-     to allocate E or H ... */
-  am_now_working_on(Other);
-  chunk_connections_valid = and_to_all(chunk_connections_valid);
-  finished_working();
 }
 
 bool fields_chunk::needs_W_prev(component c) const {

--- a/src/update_eh.cpp
+++ b/src/update_eh.cpp
@@ -33,7 +33,9 @@ void fields::update_eh(field_type ft, bool skip_w_components) {
 
   /* synchronize to avoid deadlocks if one process decides it needs
      to allocate E or H ... */
+  am_now_working_on(Other);
   chunk_connections_valid = and_to_all(chunk_connections_valid);
+  finished_working();
 }
 
 bool fields_chunk::needs_W_prev(component c) const {

--- a/src/update_pols.cpp
+++ b/src/update_pols.cpp
@@ -31,12 +31,6 @@ void fields::update_pols(field_type ft) {
   for (int i = 0; i < num_chunks; i++)
     if (chunks[i]->is_mine())
       if (chunks[i]->update_pols(ft)) chunk_connections_valid = false;
-
-  /* synchronize to avoid deadlocks if one process decides it needs
-     to allocate E or H ... */
-  am_now_working_on(Other);
-  chunk_connections_valid = and_to_all(chunk_connections_valid);
-  finished_working();
 }
 
 bool fields_chunk::update_pols(field_type ft) {

--- a/src/update_pols.cpp
+++ b/src/update_pols.cpp
@@ -34,7 +34,9 @@ void fields::update_pols(field_type ft) {
 
   /* synchronize to avoid deadlocks if one process decides it needs
      to allocate E or H ... */
+  am_now_working_on(Other);
   chunk_connections_valid = and_to_all(chunk_connections_valid);
+  finished_working();
 }
 
 bool fields_chunk::update_pols(field_type ft) {


### PR DESCRIPTION
There are four separate occurrences of *chunk synchronization* to avoid deadlocks via `and_to_all` throughout the time stepping. Rather than include this idle time which a given chunks spends just waiting for other chunks as part of its `time stepping` statistics (the current setup), the idle time should be stored separately in the `Other` category (which is a generic bin for *all* idle time).

As demonstrated below for a test case involving a tall, skinny 2d cell with a `Block` of aluminum involving four Lorentzian polarization terms which fills up exactly 1/3 of the cell, the current setup results in all chunks always reporting (nearly) the same `time stepping` time. For example, with `split_chunks_evenly=True` and 3 processors/chunks, one of the chunks (on the "right" side) should have a time-stepping time which is larger than the other two chunks due to the additional polarization fields. This is enabled by this PR.

```py
import meep as mp
from meep.materials import Al

sx = 30
sy = 5
fcen = 1.5
df = 0.1

src = [mp.Source(mp.GaussianSource(fcen,fwidth=df),
                 component=mp.Ez,
                 center=mp.Vector3())]

geometry = [mp.Block(material=Al,
                     center=mp.Vector3(10),
                     size=mp.Vector3(9,mp.inf,mp.inf))]

sim = mp.Simulation(cell_size=mp.Vector3(sx,sy),
                    sources=src,
                    geometry=geometry,
                    resolution=53,
                    verbose=True,
                    split_chunks_evenly=True)

sim.run(until=100)
```
**master**
```
Elapsed run time = 36.9808 s

Field time usage:
        connecting chunks: 0.00587344 s +/- 0.000171029 s
            time stepping: 35.5819 s +/- 0.0197658 s
            communicating: 0.571517 s +/- 0.0433773 s
     Fourier transforming: 0.00129107 s +/- 0.00102239 s
          everything else: 0.284321 s +/- 0.0248078 s


Field time usage for all processes:
        connecting chunks: 0.0057615, 0.00607031, 0.00578852
            time stepping: 35.5997, 35.5607, 35.5853
          copying borders: 0, 0, 0
            communicating: 0.524009, 0.609013, 0.581529
        outputting fields: 0, 0, 0
     Fourier transforming: 0.00246251, 0.000832106, 0.000578588
                      MPB: 0, 0, 0
        getting farfields: 0, 0, 0
          everything else: 0.312899, 0.268338, 0.271725
```
**this PR**
```
Elapsed run time = 36.7467 s

Field time usage:
        connecting chunks: 0.00591236 s +/- 0.000257231 s
            time stepping: 25.959 s +/- 6.82591 s
            communicating: 0.593137 s +/- 0.0521093 s
     Fourier transforming: 0.00131831 s +/- 0.00110191 s
          everything else: 9.68494 s +/- 6.84187 s


Field time usage for all processes:
        connecting chunks: 0.0057769, 0.00620901, 0.00575117
            time stepping: 21.9879, 22.0483, 33.8408
          copying borders: 0, 0, 0
            communicating: 0.534211, 0.633143, 0.612056
        outputting fields: 0, 0, 0
     Fourier transforming: 0.00257974, 0.000831769, 0.000543413
                      MPB: 0, 0, 0
        getting farfields: 0, 0, 0
          everything else: 13.7138, 13.5559, 1.78515
```