### PR TITLE
workaround for swig 4.0 bug

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -149,12 +149,12 @@ HPPFILES=                                    \
  $(top_srcdir)/src/material_data.hpp
 
 meep-python.cxx: $(MEEP_SWIG_SRC) $(HPPFILES)
-	$(SWIG) -Wextra $(AM_CPPFLAGS) -outdir $(builddir) -c++ -python -o $@ $(srcdir)/meep.i
+	$(SWIG) -Wextra $(AM_CPPFLAGS) -outdir $(builddir) -c++ -nofastunpack -python -o $@ $(srcdir)/meep.i
 
 if WITH_MPB
 MPB_SWIG_SRC = mpb.i
 mpb-python.cxx: $(MPB_SWIG_SRC) $(top_srcdir)/libpympb/pympb.hpp
-	$(SWIG) -Wextra $(AM_CPPFLAGS) $(PYMPBINCLUDE) -outdir $(builddir) -c++ -python -o $@ $(srcdir)/mpb.i
+	$(SWIG) -Wextra $(AM_CPPFLAGS) $(PYMPBINCLUDE) -outdir $(builddir) -c++ -nofastunpack -python -o $@ $(srcdir)/mpb.i
 mpb.py: mpb-python.cxx
 MPB_PY = mpb.py
 endif # WITH_MPB


### PR DESCRIPTION
Workaround similar to google/or-tools#1247.

Without this, I was getting errors like
```
meep-python.cxx:46511:8: error: no matching function for call to
      'PyObject_IsInstance'
    if(PyObject_IsInstance(swig_obj[0], py_source_time_object())) {
       ^~~~~~~~~~~~~~~~~~~
/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7/abstract.h:1374:17: note: 
      candidate function not viable: no known conversion from 'PyObject'
      (aka '_object') to 'PyObject *' (aka '_object *') for 1st argument; take
      the address of the argument with &
PyAPI_FUNC(int) PyObject_IsInstance(PyObject *object, PyObject *typeorclass);
```
where swig was generating clearly incorrect code like:
```cxx
SWIGINTERN PyObject *_wrap_new_src_time__SWIG_1(PyObject *SWIGUNUSEDPARM(self), Py_ssize_t nobjs, PyObject **swig_obj) {
  PyObject *resultobj = 0;
  meep::src_time *arg1 = 0 ;
  meep::src_time *result = 0 ;
  
  if ((nobjs < 1) || (nobjs > 1)) SWIG_fail;
  {
    PyObject *swig_obj = NULL;
    void *tmp_ptr = 0;
    int tmp_res = 0;
    
    if(PyObject_IsInstance(swig_obj[0], py_source_time_object())) {
      swig_obj = PyObject_GetAttrString(swig_obj[0], "swigobj");
```
(Notice that `PyObject *swig_obj = NULL` shadows the `PyObject **swig_obj` parameter, leading to the wrong type being passed for `swig_obj[0]` to `PyObject_IsInstance`.)
