### PR TITLE
Visualization python test bug fixes for Ubuntu 16

### DIFF
--- a/python/tests/visualization.py
+++ b/python/tests/visualization.py
@@ -153,19 +153,14 @@ class TestVisualization(unittest.TestCase):
         animation = mp.Animate2D(sim,mp.Ez,realtime=False,normalize=True)
         sim.run(mp.at_every(1),until=25)
 
-        from distutils.version import LooseVersion
-        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.1.0"):
-            # Check mp4 output
-            Animate.to_mp4(10,'test.mp4')
+        # Check mp4 output
+        Animate.to_mp4(10,'test.mp4')
 
-            # Check gif output
-            Animate.to_gif(10,'test.gif')
+        # Check gif output
+        Animate.to_gif(10,'test.gif')
 
-            # Check jshtml output
-            Animate.to_jshtml(10)
-        else:
-            import warnings
-            warnings.warn("Warning: Animation export is not supported with the current version of matplotlib. Consider upgrading.")
+        # Check jshtml output
+        Animate.to_jshtml(10)
     '''
     Travis does not play well with Mayavi
     def test_3D_mayavi(self):

--- a/python/tests/visualization.py
+++ b/python/tests/visualization.py
@@ -153,14 +153,19 @@ class TestVisualization(unittest.TestCase):
         animation = mp.Animate2D(sim,mp.Ez,realtime=False,normalize=True)
         sim.run(mp.at_every(1),until=25)
 
-        # Check mp4 output
-        Animate.to_mp4(10,'test.mp4')
+        from distutils.version import LooseVersion
+        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.1.0"):
+            # Check mp4 output
+            Animate.to_mp4(10,'test.mp4')
 
-        # Check gif output
-        Animate.to_gif(10,'test.gif')
+            # Check gif output
+            Animate.to_gif(10,'test.gif')
 
-        # Check jshtml output
-        Animate.to_jshtml(10)
+            # Check jshtml output
+            Animate.to_jshtml(10)
+        else:
+            import warnings
+            warnings.warn("Warning: Animation export is not supported with the current version of matplotlib. Consider upgrading.")
     '''
     Travis does not play well with Mayavi
     def test_3D_mayavi(self):

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -766,6 +766,7 @@ class Animate2D(object):
         
         # Only works with Python3 and matplotlib > 3.1.0
         from distutils.version import LooseVersion
+        import matplotlib
         if LooseVersion(matplotlib.__version__) < LooseVersion("3.1.0"):
             warnings.warn('JSHTML output is not supported with your current matplotlib build. Consider upgrading to 3.1.0+')
             return ""

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -764,10 +764,10 @@ class Animate2D(object):
         # ready for jupyter notebook embedding.
         # modified from matplotlib/animation.py code.
         
-        # Only works with Python3
-        import sys
-        if sys.version_info[0] < 3:
-            warnings.warn('JSHTML output is not supported with python2 builds.')
+        # Only works with Python3 and matplotlib > 3.1.0
+        from distutils.version import LooseVersion
+        if LooseVersion(matplotlib.__version__) < LooseVersion("3.1.0"):
+            warnings.warn('JSHTML output is not supported with your current matplotlib build. Consider upgrading to 3.1.0+')
             return ""
 
         from uuid import uuid4

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -652,16 +652,12 @@ class Animate2D(object):
     plot_modifiers=None,**customization_args):
         self.fields = fields
 
-        from matplotlib import pyplot as plt
-        from matplotlib import animation
-
         if f:
             self.f = f
             self.ax = self.f.gca()
         else:
             self.f = None
-
-        self.ax = None
+            self.ax = None
 
         self.realtime = realtime
         self.normalize = normalize
@@ -768,9 +764,11 @@ class Animate2D(object):
         from distutils.version import LooseVersion
         import matplotlib
         if LooseVersion(matplotlib.__version__) < LooseVersion("3.1.0"):
-            warnings.warn('JSHTML output is not supported with your current matplotlib build. Consider upgrading to 3.1.0+')
-            return ""
-
+            print('-------------------------------')
+            print('Warning: JSHTML output is not supported with your current matplotlib build. Consider upgrading to 3.1.0+')
+            print('-------------------------------')
+            return
+        
         from uuid import uuid4
         from matplotlib._animation_data import (DISPLAY_TEMPLATE, INCLUDED_FRAMES, JS_INCLUDE, STYLE_INCLUDE)
 


### PR DESCRIPTION
Minor bug fixes for any build that does not have a sufficient version of matplotlib to do jshtml output (i.e. the current Ubuntu 16 build).

@oskooi 