### PR TITLE
add function to return mean time spent on given task

### DIFF
--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1513,6 +1513,7 @@ public:
 
   // time.cpp
   double time_spent_on(time_sink);
+  double mean_time_spent_on(time_sink);
   void print_times();
   // boundaries.cpp
   void set_boundary(boundary_side, direction, boundary_condition);

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -43,6 +43,12 @@ void fields::am_now_working_on(time_sink s) {
 
 double fields::time_spent_on(time_sink s) { return times_spent[s]; }
 
+double fields::mean_time_spent_on(time_sink s) {
+  int n = count_processors();
+  double total_time_spent = sum_to_master(times_spent[s]);
+  return total_time_spent/n;
+}
+
 static const char *ts2n(time_sink s) {
   switch (s) {
     case Stepping: return "time stepping";


### PR DESCRIPTION
The `verbose=True` parameter of the `Simulation` object outputs the timing statistics and it is also useful to be able to access these statistics directly (i.e. to compute various performance metrics at the end of a run). The existing `time_spent_on` function does this for only a single processor (often just the `master`). This PR adds a new function `mean_time_spent_on` which returns the mean value for a given task across all processors.