### PR TITLE
fix some compiler warnings

### DIFF
--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -476,7 +476,7 @@ void *fields::do_get_array_slice(const volume &where, std::vector<component> com
   size_t dims[3];
   direction dirs[3];
   array_slice_data data;
-  int rank = get_array_slice_dimensions(where, dims, dirs, collapse, snap, 0, &data);
+  get_array_slice_dimensions(where, dims, dirs, collapse, snap, 0, &data);
   size_t slice_size = data.slice_size;
 
   bool complex_data = (rfun == 0);

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -919,7 +919,7 @@ class custom_src_time : public src_time {
 public:
   custom_src_time(std::complex<double> (*func)(double t, void *), void *data, double st = -infinity,
                   double et = infinity, std::complex<double> f = 0)
-      : func(func), data(data), start_time(float(st)), end_time(float(et)), freq(f) {}
+      : func(func), data(data), freq(f), start_time(float(st)), end_time(float(et)) {}
   virtual ~custom_src_time() {}
 
   virtual std::complex<double> current(double time, double dt) const {

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -45,7 +45,7 @@ private:
 #define PRINTF_ATTR(f, a)
 #endif
 
-void abort(const char *fmt, ...) NORETURN_ATTR PRINTF_ATTR(1, 2);
+void abort(const char *fmt, ...) PRINTF_ATTR(1, 2);
 void all_wait();
 int count_processors();
 int my_rank();

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -268,7 +268,7 @@ bool is_metal(meep::field_type ft, const material_type *material) {
         return (md->medium.epsilon_diag.x < 0 || md->medium.epsilon_diag.y < 0 ||
                 md->medium.epsilon_diag.z < 0);
       case material_data::PERFECT_METAL: return true;
-      default: meep::abort("unknown material type");
+      default: meep::abort("unknown material type"); return false;
     }
   else
     switch (md->which_subclass) {
@@ -276,7 +276,7 @@ bool is_metal(meep::field_type ft, const material_type *material) {
         return (md->medium.mu_diag.x < 0 || md->medium.mu_diag.y < 0 || md->medium.mu_diag.z < 0);
       case material_data::PERFECT_METAL:
         return false; // is an electric conductor, but not a magnetic conductor
-      default: meep::abort("unknown material type");
+      default: meep::abort("unknown material type"); return false;
     }
 }
 

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -127,13 +127,15 @@ void abort(const char *fmt, ...) {
   // Make a std::string to support older compilers (std::runtime_error(char *) was added in C++11)
   std::string error_msg(s);
   free(s);
+#ifdef HAVE_MPI
   if (count_processors() == 1) {
     throw runtime_error("meep: " + error_msg);
   }
-#ifdef HAVE_MPI
   fprintf(stderr, "meep: %s", error_msg.c_str());
   if (fmt[strlen(fmt) - 1] != '\n') fputc('\n', stderr); // force newline
   MPI_Abort(MPI_COMM_WORLD, 1);
+#else
+  throw runtime_error("meep: " + error_msg);
 #endif
 }
 

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -447,7 +447,7 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
             case X: cE[0] = ff_EH[1], cE[1] = ff_EH[2], cH[0] = ff_EH[5], cH[1] = ff_EH[4]; break;
             case Y: cE[0] = ff_EH[2], cE[1] = ff_EH[0], cH[0] = ff_EH[3], cH[1] = ff_EH[5]; break;
             case Z: cE[0] = ff_EH[0], cE[1] = ff_EH[1], cH[0] = ff_EH[4], cH[1] = ff_EH[3]; break;
-            case NO_DIRECTION: abort("cannot get flux in NO_DIRECTION");
+            case R: case P: case NO_DIRECTION: abort("invalid flux direction");
           }
           for (int j = 0; j < 2; ++j)
             F_[i] += real(cE[j] * conj(cH[j])) * (1 - 2 * j);

--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -55,6 +55,7 @@ susceptibility *susceptibility::clone() const {
 
 // generic base class definition.
 std::complex<double> susceptibility::chi1(double freq, double sigma) {
+  (void) freq; (void) sigma;
   return std::complex<double>(0,0);
 }
 
@@ -153,6 +154,7 @@ void *lorentzian_susceptibility::copy_internal_data(void *data) const {
   return (void *)dnew;
 }
 
+#if 0
 /* Return true if the discretized Lorentzian ODE is intrinsically unstable,
    i.e. if it corresponds to a filter with a pole z outside the unit circle.
    Note that the pole satisfies the quadratic equation:
@@ -167,6 +169,7 @@ static bool lorentzian_unstable(double omega_0, double gamma, double dt) {
   double b = (1 - w2 / 2) / (1 + g2), c = (1 - g2) / (1 + g2);
   return b * b > c && 2 * b * b - c + 2 * fabs(b) * sqrt(b * b - c) > 1;
 }
+#endif
 
 #define SWAP(t, a, b)                                                                              \
   {                                                                                                \

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -122,7 +122,7 @@ component first_field_component(field_type ft) {
     case H_stuff: return Hx;
     case D_stuff: return Dx;
     case B_stuff: return Bx;
-    default: abort("bug - only E/H/D/B stuff have components");
+    default: abort("bug - only E/H/D/B stuff have components"); return NO_COMPONENT;
   }
 }
 


### PR DESCRIPTION
Note that the `NO_RETURN` attribute for `abort(...)` was apparently no longer correct now that we are throwing exceptions from it. (LLVM complained.)