### PR TITLE
bisection search for faster splitting

### DIFF
--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -1030,6 +1030,9 @@ public:
 
 private:
   std::complex<double> get_split_costs(direction d, int split_point) const;
+  grid_volume split_by_cost(int desired_chunks, int proc_num,
+                            int best_split_point, direction best_split_direction, double left_effort_fraction) const;
+  void find_best_split(int desired_chunks, int &best_split_point, direction &best_split_direction, double &left_effort_fraction) const;
   grid_volume(ndim d, double ta, int na, int nb, int nc);
   ivec io;    // integer origin ... always change via set_origin etc.!
   vec origin; // cache of operator[](io), for performance

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -1029,6 +1029,7 @@ public:
   double origin_z() const { return origin.z(); }
 
 private:
+  std::complex<double> get_split_costs(direction d, int split_point) const;
   grid_volume(ndim d, double ta, int na, int nb, int nc);
   ivec io;    // integer origin ... always change via set_origin etc.!
   vec origin; // cache of operator[](io), for performance

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1002,6 +1002,28 @@ double grid_volume::get_cost() const {
   return fstats.cost();
 }
 
+// return complex(left cost, right cost).  Should really be a tuple, but we don't want to require C++11? yet?
+std::complex<double> grid_volume::get_split_costs(direction d, int split_point) const {
+  double left_cost = 0, right_cost = 0;
+  if (split_point > 0) {
+    grid_volume v_left = *this;
+    v_left.set_num_direction(d, split_point);
+    left_cost = v_left.get_cost();
+  }
+  if (split_point < num_direction(d)) {
+    grid_volume v_right = *this;
+    v_right.set_num_direction(d, num_direction(d) - split_point);
+    v_right.shift_origin(d, split_point * 2);
+    right_cost = v_right.get_cost();
+  }
+  return std::complex<double>(left_cost, right_cost);
+}
+
+static double cost_diff(int desired_chunks, std::complex<double> costs) {
+  double left_cost = real(costs), right_cost = imag(costs);
+  return right_cost / (desired_chunks - desired_chunks / 2) - left_cost / (desired_chunks / 2);
+}
+
 grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num) const {
   const size_t grid_points_owned = nowned_min();
   if (size_t(desired_chunks) > grid_points_owned) {
@@ -1024,33 +1046,33 @@ grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num) const {
   }
 
   LOOP_OVER_DIRECTIONS(dim, d) {
-    for (int split_point = 1; split_point < num_direction(d); ++split_point) {
-      grid_volume v_left = *this;
-      v_left.set_num_direction(d, split_point);
-      grid_volume v_right = *this;
-      v_right.set_num_direction(d, num_direction(d) - split_point);
-      v_right.shift_origin(d, split_point * 2);
+    int first = 0, last = num_direction(d);
+    while (first < last) { // bisection search for balanced splitting
+      int mid = (first + last) / 2;
+      double mid_diff = cost_diff(desired_chunks, get_split_costs(d, mid));
+      if (mid_diff > 0) first = mid;
+      else if (mid_diff < 0) last = mid;
+      else break;
+    }
+    int split_point = (first + last) / 2;
+    std::complex<double> costs = get_split_costs(d, split_point);
+    double left_cost = real(costs), right_cost = imag(costs);
+    double total_cost = left_cost + right_cost;
+    double split_measure =
+        max(left_cost / (desired_chunks / 2), right_cost / (desired_chunks - desired_chunks / 2));
+    if (split_measure < best_split_measure) {
+      if (d == longest_axis ||
+          split_measure < (best_split_measure - (0.3 * best_split_measure))) {
+        // Only use this split_measure if we're on the longest_axis, or if the split_measure is
+        // more than 30% better than the best_split_measure. This is a heuristic to prefer lower
+        // communication costs when the split_measure is somewhat close.
+        // TODO: Use machine learning to get a cost function for the communication instead of hard
+        // coding 0.3
 
-      double left_cost = v_left.get_cost();
-      double right_cost = v_right.get_cost();
-      double total_cost = left_cost + right_cost;
-
-      double split_measure =
-          max(left_cost / (desired_chunks / 2), right_cost / (desired_chunks - desired_chunks / 2));
-      if (split_measure < best_split_measure) {
-        if (d == longest_axis ||
-            split_measure < (best_split_measure - (0.3 * best_split_measure))) {
-          // Only use this split_measure if we're on the longest_axis, or if the split_measure is
-          // more than 30% better than the best_split_measure. This is a heuristic to prefer lower
-          // communication costs when the split_measure is somewhat close.
-          // TODO: Use machine learning to get a cost function for the communication instead of hard
-          // coding 0.3
-
-          best_split_measure = split_measure;
-          best_split_point = split_point;
-          best_split_direction = d;
-          left_effort_fraction = left_cost / total_cost;
-        }
+        best_split_measure = split_measure;
+        best_split_point = split_point;
+        best_split_direction = d;
+        left_effort_fraction = left_cost / total_cost;
       }
     }
   }

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1050,7 +1050,10 @@ grid_volume grid_volume::split_by_cost(int desired_chunks, int proc_num) const {
     while (first < last) { // bisection search for balanced splitting
       int mid = (first + last) / 2;
       double mid_diff = cost_diff(desired_chunks, get_split_costs(d, mid));
-      if (mid_diff > 0) first = mid;
+      if (mid_diff > 0) {
+        if (first == mid) break;
+        first = mid;
+      }
       else if (mid_diff < 0) last = mid;
       else break;
     }


### PR DESCRIPTION
This updates the `split_by_cost` function to do a bisection search along each axis to find a balanced splitting, rather than searching every possible splitting, which should speed things up for large simulations.

(In most cases the left and right costs should be monotonic functions of the splitting point, in which cases a bisection search should be equivalent to checking every possible point.)

`split_into_three` should have similar improvements, but that isn't touched by this PR.