### PR TITLE
contrib: Build bash script for end users

### DIFF
--- a/contrib/build-meep.sh
+++ b/contrib/build-meep.sh
@@ -54,14 +54,6 @@ SUDO=
 mkdir -p ${SRCDIR}
 cd ${SRCDIR}
 
-RPATH_FLAGS="-Wl,-rpath,${DESTDIR}/lib:/usr/lib/x86_64-linux-gnu/hdf5/openmpi"
-LDFLAGS="-L${DESTDIR}/lib -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ${RPATH_FLAGS}"
-CFLAGS="-I${DESTDIR}/include -I/usr/include/hdf5/openmpi"
-CPPFLAGS=${CFLAGS}
-PKG_CONFIG_PATH=${DESDTIR}/pkgconfig
-export PKG_CONFIG_PATH
-export PATH=${DESTDIR}/bin:${PATH}
-
 gitclone ()
 {
     repo=${1##*/}
@@ -117,6 +109,11 @@ if $ubuntu; then
     export HDF5_MPI="ON"
     sudo -H pip3 install --no-binary=h5py h5py
     sudo -H pip3 install matplotlib>3.0.0
+
+    RPATH_FLAGS="-Wl,-rpath,${DESTDIR}/lib:/usr/lib/x86_64-linux-gnu/hdf5/openmpi"
+    LDFLAGS="-L${DESTDIR}/lib -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ${RPATH_FLAGS}"
+    CFLAGS="-I${DESTDIR}/include -I/usr/include/hdf5/openmpi"
+
 fi
 
 if $centos; then
@@ -169,10 +166,19 @@ if $centos; then
     sudo yum -y install    \
         openmpi-devel      \
         hdf5-openmpi-devel \
-        guile-devel
+        guile-devel        \
+        swig
 
     export PATH=${PATH}:/usr/lib64/openmpi/bin
+    RPATH_FLAGS="-Wl,-rpath,${DESTDIR}/lib:/usr/lib64/openmpi/lib"
+    LDFLAGS="-L${DESTDIR}/lib -L/usr/lib64/openmpi/lib ${RPATH_FLAGS}"
+    CFLAGS="-I${DESTDIR}/include -I/usr/include/openmpi-x86_64/"
 fi
+
+CPPFLAGS=${CFLAGS}
+PKG_CONFIG_PATH=${DESDTIR}/pkgconfig
+export PKG_CONFIG_PATH
+export PATH=${DESTDIR}/bin:${PATH}
 
 mkdir -p $SRCDIR
 

--- a/contrib/build-meep.sh
+++ b/contrib/build-meep.sh
@@ -84,7 +84,7 @@ autogensh ()
 
 if $ubuntu; then
 
-    sudo apt-get; update
+    sudo apt-get update
 
     # If building on Ubuntu 18.04LTS, replace libpng16-dev with libpng-dev,
     # and libpython3.5-dev with libpython3-dev.

--- a/contrib/build-meep.sh
+++ b/contrib/build-meep.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# latest version of this script can be found at:
+#   https://github.com/NanoComp/meep/blob/master/contrib/build-meep.sh
+
+# detect if script is in a directory called src/
+DESTDIR=$(pwd)
+[ ${DESTDIR##*/} = src ] && DESTDIR=$(cd $(pwd)/..; pwd)
+SRCDIR=${DESTDIR}/src
+
+cat <<EOF
+
+This sript will download or update sources, compile and install MEEP.
+Please ensure the following final paths fit your needs:
+    '${DESTDIR}/bin/meep'
+    '${DESTDIR}/share/...'
+    '${DESTDIR}/...'
+    '${SRCDIR}/<sources>'
+
+Press return to continue
+EOF
+read junk
+
+set -ex
+
+distrib=$(lsb_release -c -s)
+case "$distrib" in
+    bionic) # ubuntu 18.04
+        libpng=libpng-dev
+        libpython=libpython3-dev
+        ;;
+    xenial) # ubuntu 16.04
+        libpng=libpng16-dev
+        libpython=libpython3.5-dev
+        ;;
+    *)
+        echo "unsupported distribution '$(lsb_release -a)', edit and fix!"
+        false
+        ;;
+esac
+
+# sudo not needed for 'make install'
+#SUDO=sudo
+SUDO=
+
+mkdir -p ${SRCDIR}
+cd ${SRCDIR}
+
+RPATH_FLAGS="-Wl,-rpath,${DESTDIR}/lib:/usr/lib/x86_64-linux-gnu/hdf5/openmpi"
+LDFLAGS="-L${DESTDIR}/lib -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi ${RPATH_FLAGS}"
+CFLAGS="-I${DESTDIR}/include -I/usr/include/hdf5/openmpi"
+CPPFLAGS=${CFLAGS}
+PKG_CONFIG_PATH=${DESDTIR}/pkgconfig
+export PKG_CONFIG_PATH
+export PATH=${DESTDIR}/bin:${PATH}
+
+gitclone ()
+{
+    repo=${1##*/}
+    name=${repo%%.*}
+    echo $repo $name
+    if [ -d $name ]; then
+        ( cd $name; git pull; )
+    else
+        git clone --depth=1 $1
+    fi
+}
+
+autogensh ()
+{
+    sh autogen.sh PKG_CONFIG_PATH="${PKG_CONFIG_PATH}" RPATH_FLAGS="${RPATH_FLAGS}" LDFLAGS="${LDFLAGS}" CFLAGS="${CFLAGS}" CPPFLAGS="${CPPFLAGS}" \
+        --disable-static --enable-shared --prefix="${DESTDIR}" \
+        --with-libctl=${DESTDIR}/share/libctl \
+        "$@"
+}
+
+sudo apt-get update
+
+# If building on Ubuntu 18.04LTS, replace libpng16-dev with libpng-dev,
+# and libpython3.5-dev with libpython3-dev.
+sudo apt-get -y install     \
+    build-essential         \
+    gfortran                \
+    libblas-dev             \
+    liblapack-dev           \
+    libgmp-dev              \
+    swig                    \
+    libgsl-dev              \
+    autoconf                \
+    pkg-config              \
+    $libpng                 \
+    git                     \
+    guile-2.0-dev           \
+    libfftw3-dev            \
+    libhdf5-openmpi-dev     \
+    hdf5-tools              \
+    $libpython              \
+    python3-numpy           \
+    python3-scipy           \
+    python3-pip             \
+    ffmpeg                  \
+
+# The next line is only required on Ubuntu  16.04
+[ "$distrib" = xenial ] && sudo -H pip3 install --upgrade pip
+
+sudo -H pip3 install --no-cache-dir mpi4py
+export HDF5_MPI="ON"
+sudo -H pip3 install --no-binary=h5py h5py
+sudo -H pip3 install matplotlib>3.0.0
+
+mkdir -p $SRCDIR
+
+cd $SRCDIR
+gitclone https://github.com/NanoComp/harminv.git
+cd harminv/
+autogensh
+make -j && $SUDO make install
+
+cd $SRCDIR
+gitclone https://github.com/NanoComp/libctl.git
+cd libctl/
+autogensh
+make -j && $SUDO make install
+
+cd $SRCDIR
+gitclone https://github.com/NanoComp/h5utils.git
+cd h5utils/
+autogensh CC=mpicc
+make -j && $SUDO make install
+
+cd $SRCDIR
+gitclone https://github.com/NanoComp/mpb.git
+cd mpb/
+autogensh CC=mpicc --with-hermitian-eps
+make -j && $SUDO make install
+
+cd $SRCDIR
+gitclone https://github.com/HomerReid/libGDSII.git
+cd libGDSII/
+autogensh
+make -j && $SUDO make install
+
+cd $SRCDIR
+gitclone https://github.com/NanoComp/meep.git
+cd meep/
+autogensh --with-mpi --with-openmp PYTHON=python3
+make -j && $SUDO make install
+
+# all done

--- a/contrib/build-meep.sh
+++ b/contrib/build-meep.sh
@@ -1,18 +1,52 @@
 #!/bin/bash
 
-# latest version of this script can be found at:
+# Latest version of this script can be found at:
 #   https://github.com/NanoComp/meep/blob/master/contrib/build-meep.sh
 
-# detect if script is in a directory called src/
-DESTDIR=$(pwd)
+help ()
+{
+    cat << EOF
+
+$1: Download MEEP sources and dependencies, compile, and install
+
+Usage: $1 [options]
+EOF
+    sed -ne 's,[ \t]*\(-[^ \t]*\))[^#]*#[ \t]*\(.*\),    \1 \2,p' "$1"
+    echo ""
+    exit 1
+}
+
+[ -z "$1" ] && echo "(use -h for help)"
+
+while [ ! -z "$1" ]; do
+    case "$1" in
+        -h)         # help
+            help "$0"
+            ;;
+        -d)         # <installdir>  (default: current directory)
+            DESTDIR="$2"
+            shift
+            ;;
+        *)
+            echo "'$1' ?"
+            help "$0"
+            ;;
+    esac
+    shift
+done
+
+
+# detect wether DESTDIR is ending with src/
+[ -z ${DESTDIR} ] && DESTDIR=$(pwd)
 [ ${DESTDIR##*/} = src ] && DESTDIR=$(cd $(pwd)/..; pwd)
 SRCDIR=${DESTDIR}/src
 
-cat <<EOF
+cat << EOF
 
 This sript will download or update sources, compile and install MEEP.
 Please ensure the following final paths fit your needs:
     '${DESTDIR}/bin/meep'
+    '${DESTDIR}/lib/...'
     '${DESTDIR}/share/...'
     '${DESTDIR}/...'
     '${SRCDIR}/<sources>'

--- a/contrib/build-meep.sh
+++ b/contrib/build-meep.sh
@@ -18,6 +18,8 @@ EOF
 
 [ -z "$1" ] && echo "(use -h for help)"
 
+installdeps=true
+
 while [ ! -z "$1" ]; do
     case "$1" in
         -h)         # help
@@ -29,6 +31,9 @@ while [ ! -z "$1" ]; do
             ;;
         -s)         # use 'sudo' for 'make install'
             SUDO=sudo
+            ;;
+        -n)         # do not check for distribution dependencies
+            installdeps=false
             ;;
         *)
             echo "'$1' ?"
@@ -117,7 +122,7 @@ autogensh ()
         "$@"
 }
 
-if $ubuntu; then
+if $installdeps && $ubuntu; then
 
     sudo apt-get update
 
@@ -155,7 +160,7 @@ if $ubuntu; then
 
 fi
 
-if $centos; then
+if $installdeps && $centos; then
 
     sudo yum -y --enablerepo=extras install epel-release
 

--- a/contrib/build-meep.sh
+++ b/contrib/build-meep.sh
@@ -27,6 +27,9 @@ while [ ! -z "$1" ]; do
             DESTDIR="$2"
             shift
             ;;
+        -s)         # use 'sudo' for 'make install'
+            SUDO=sudo
+            ;;
         *)
             echo "'$1' ?"
             help "$0"
@@ -90,10 +93,6 @@ case "$distrib" in
         false
         ;;
 esac
-
-# sudo not needed for 'make install'
-#SUDO=sudo
-SUDO=
 
 mkdir -p ${SRCDIR}
 cd ${SRCDIR}

--- a/contrib/build-meep.sh
+++ b/contrib/build-meep.sh
@@ -23,15 +23,23 @@ read junk
 
 set -ex
 
-distrib=$(lsb_release -c -s)
+ubuntu=false
+centos=false
+
+distrib=$(lsb_release -r -s)
 case "$distrib" in
-    bionic) # ubuntu 18.04
+    18.04) # ubuntu 18.04 bionic
         libpng=libpng-dev
         libpython=libpython3-dev
+        ubuntu=true
         ;;
-    xenial) # ubuntu 16.04
+    16.04) # ubuntu 16.04 xenal
         libpng=libpng16-dev
         libpython=libpython3.5-dev
+        ubuntu=true
+        ;;
+    7.*) # CentOS 7.x
+        centos=true
         ;;
     *)
         echo "unsupported distribution '$(lsb_release -a)', edit and fix!"
@@ -74,39 +82,97 @@ autogensh ()
         "$@"
 }
 
-sudo apt-get update
+if $ubuntu; then
 
-# If building on Ubuntu 18.04LTS, replace libpng16-dev with libpng-dev,
-# and libpython3.5-dev with libpython3-dev.
-sudo apt-get -y install     \
-    build-essential         \
-    gfortran                \
-    libblas-dev             \
-    liblapack-dev           \
-    libgmp-dev              \
-    swig                    \
-    libgsl-dev              \
-    autoconf                \
-    pkg-config              \
-    $libpng                 \
-    git                     \
-    guile-2.0-dev           \
-    libfftw3-dev            \
-    libhdf5-openmpi-dev     \
-    hdf5-tools              \
-    $libpython              \
-    python3-numpy           \
-    python3-scipy           \
-    python3-pip             \
-    ffmpeg                  \
+    sudo apt-get; update
 
-# The next line is only required on Ubuntu  16.04
-[ "$distrib" = xenial ] && sudo -H pip3 install --upgrade pip
+    # If building on Ubuntu 18.04LTS, replace libpng16-dev with libpng-dev,
+    # and libpython3.5-dev with libpython3-dev.
+    sudo apt-get -y install     \
+        build-essential         \
+        gfortran                \
+        libblas-dev             \
+        liblapack-dev           \
+        libgmp-dev              \
+        swig                    \
+        libgsl-dev              \
+        autoconf                \
+        pkg-config              \
+        $libpng                 \
+        git                     \
+        guile-2.0-dev           \
+        libfftw3-dev            \
+        libhdf5-openmpi-dev     \
+        hdf5-tools              \
+        $libpython              \
+        python3-numpy           \
+        python3-scipy           \
+        python3-pip             \
+        ffmpeg                  \
 
-sudo -H pip3 install --no-cache-dir mpi4py
-export HDF5_MPI="ON"
-sudo -H pip3 install --no-binary=h5py h5py
-sudo -H pip3 install matplotlib>3.0.0
+    # The next line is only required on Ubuntu  16.04
+    [ "$distrib" = xenial ] && sudo -H pip3 install --upgrade pip
+
+    sudo -H pip3 install --no-cache-dir mpi4py
+    export HDF5_MPI="ON"
+    sudo -H pip3 install --no-binary=h5py h5py
+    sudo -H pip3 install matplotlib>3.0.0
+fi
+
+if $centos; then
+
+    sudo yum -y --enablerepo=extras install epel-release
+
+    sudo yum -y install   \
+        bison             \
+        byacc             \
+        cscope            \
+        ctags             \
+        cvs               \
+        diffstat          \
+        oxygen            \
+        flex              \
+        gcc               \
+        gcc-c++           \
+        gcc-gfortran      \
+        gettext           \
+        git               \
+        indent            \
+        intltool          \
+        libtool           \
+        patch             \
+        patchutils        \
+        rcs               \
+        redhat-rpm-config \
+        rpm-build         \
+        subversion        \
+        systemtap         \
+        wget
+
+    sudo yum -y install    \
+        openblas-devel     \
+        fftw3-devel        \
+        libpng-devel       \
+        gsl-devel          \
+        gmp-devel          \
+        pcre-devel         \
+        libtool-ltdl-devel \
+        libunistring-devel \
+        libffi-devel       \
+        gc-devel           \
+        zlib-devel         \
+        openssl-devel      \
+        sqlite-devel       \
+        bzip2-devel        \
+        ffmpeg
+
+    sudo yum -y install    \
+        openmpi-devel      \
+        hdf5-openmpi-devel \
+        guile-devel
+
+    export PATH=${PATH}:/usr/lib64/openmpi/bin
+fi
 
 mkdir -p $SRCDIR
 

--- a/contrib/build-meep.sh
+++ b/contrib/build-meep.sh
@@ -33,7 +33,7 @@ case "$distrib" in
         libpython=libpython3-dev
         ubuntu=true
         ;;
-    16.04) # ubuntu 16.04 xenal
+    16.04) # ubuntu 16.04 xenial
         libpng=libpng16-dev
         libpython=libpython3.5-dev
         ubuntu=true
@@ -78,8 +78,6 @@ if $ubuntu; then
 
     sudo apt-get update
 
-    # If building on Ubuntu 18.04LTS, replace libpng16-dev with libpng-dev,
-    # and libpython3.5-dev with libpython3-dev.
     sudo apt-get -y install     \
         build-essential         \
         gfortran                \
@@ -102,9 +100,7 @@ if $ubuntu; then
         python3-pip             \
         ffmpeg                  \
 
-    # The next line is only required on Ubuntu  16.04
-    [ "$distrib" = xenial ] && sudo -H pip3 install --upgrade pip
-
+    [ "$distrib" = 16.04 ] && sudo -H pip3 install --upgrade pip
     sudo -H pip3 install --no-cache-dir mpi4py
     export HDF5_MPI="ON"
     sudo -H pip3 install --no-binary=h5py h5py

--- a/contrib/build-meep.sh
+++ b/contrib/build-meep.sh
@@ -21,6 +21,16 @@ Press return to continue
 EOF
 read junk
 
+if ! lsb_release; then
+    echo "Minimum requirements:"
+    echo "    Ubuntu:"
+    echo "        sudo apt-get -y install lsb-release sudo git"
+    echo "    CentOS:"
+    echo "        sudo yum -y install redhat-lsb-core sudo git"
+    echo ""
+    exit 1
+fi
+
 set -ex
 
 ubuntu=false

--- a/doc/docs/Build_From_Source.md
+++ b/doc/docs/Build_From_Source.md
@@ -246,6 +246,16 @@ This flag enables some experimental support for [OpenMP](https://en.wikipedia.or
 
 The following instructions are for building parallel PyMeep with all optional features from source on Ubuntu 16.04. The parallel version can still be run serially by running a script with just `python` instead of `mpirun -np 4 python`. If you really don't want to install MPI and parallel HDF5, just replace `libhdf5-openmpi-dev` with `libhdf5-dev`, and remove the `--with-mpi`, `CC=mpicc`, and `CPP=mpicxx` flags. The paths to HDF5 will also need to be adjusted to `/usr/lib/x86_64-linux-gnu/hdf5/serial` and `/usr/include/hdf5/serial`. Note that this script builds with Python 3 by default. If you want to use Python 2, just point the `PYTHON` variable to the appropriate interpreter when calling `autogen.sh` for building Meep, and use `pip` instead of `pip3`.
 
+A contributed script is also available:
+```bash
+mkdir -p /where/to/install/meep
+cd /where/to/install/meep
+wget https://raw.githubusercontent.com/NanoComp/meep/master/contrib/build-meep.sh
+chmod +x build-meep.sh
+./build-meep.sh
+```
+In case of issue, please fix and propose your changes to this script, or report issues.
+
 #### Ubuntu 16.04 and 18.04
 
 There are a few differences in building for 16.04 and 18.04, so be sure to read the script and adjust appropriately.

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -20,6 +20,7 @@
 
 #include <complex>
 #include <stddef.h>
+#include <stdexcept>
 
 namespace meep {
 


### PR DESCRIPTION
Automate full installation to any directory (not only `/usr/local` - *edit4*: now selectable as argument)
    
This script is very useful for
    
- users with electromagnetics skills in the need for the latest MEEP developments but lacking time to get sufficient system knowledge to reach their grail,
    
- system administrators constantly being asked for the latest MEEP versions by their impatient electromagnetics specialist users (sometimes for years)
    
This script has its place right in the source repository, so the (large) audience can improve and adapt it over time.
    
Based on https://github.com/NanoComp/meep/blob/9f68f390f68ecb8a18d98f51c8166c808a1e6f98/doc/docs/Build_From_Source.md#ubuntu-1604-and-1804
Build for ubuntu16.04, 18.04 and CentOS 7

*edit:* documentation update is [visible there](https://github.com/d-a-v/meep/blob/build/doc/docs/Build_From_Source.md#building-from-source)
*edit2:* Centos7 was not finishing the full build, fix included
*edit3:* works with the 3 OSes on a raw docker machine