### PR TITLE
Bisection search for split_into_three

### DIFF
--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1073,7 +1073,7 @@ void grid_volume::find_best_split(int desired_chunks, int &best_split_point,
     double left_cost = real(costs), right_cost = imag(costs);
     double total_cost = left_cost + right_cost;
     double split_measure =
-      split_measure to max(left_cost * (desired_chunks-1), right_cost);
+      split_measure = max(left_cost * (desired_chunks-1), right_cost);
     if (split_measure < best_split_measure) {
       if (d == longest_axis || split_measure < (best_split_measure - (0.3 * best_split_measure))) {
         // Only use this split_measure if we're on the longest_axis, or if the split_measure is

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1029,7 +1029,7 @@ std::complex<double> grid_volume::get_split_costs(direction d, int split_point) 
 
 static double cost_diff(int desired_chunks, std::complex<double> costs) {
   double left_cost = real(costs), right_cost = imag(costs);
-  return right_cost / (desired_chunks - desired_chunks / 2) - left_cost / (desired_chunks / 2);
+  return right_cost - left_cost * (desired_chunks-1);
 }
 
 void grid_volume::find_best_split(int desired_chunks, int &best_split_point,
@@ -1073,7 +1073,7 @@ void grid_volume::find_best_split(int desired_chunks, int &best_split_point,
     double left_cost = real(costs), right_cost = imag(costs);
     double total_cost = left_cost + right_cost;
     double split_measure =
-        max(left_cost / (desired_chunks / 2), right_cost / (desired_chunks - desired_chunks / 2));
+      split_measure to max(left_cost * (desired_chunks-1), right_cost);
     if (split_measure < best_split_measure) {
       if (d == longest_axis || split_measure < (best_split_measure - (0.3 * best_split_measure))) {
         // Only use this split_measure if we're on the longest_axis, or if the split_measure is

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1072,8 +1072,7 @@ void grid_volume::find_best_split(int desired_chunks, int &best_split_point,
     std::complex<double> costs = get_split_costs(d, split_point);
     double left_cost = real(costs), right_cost = imag(costs);
     double total_cost = left_cost + right_cost;
-    double split_measure =
-      split_measure = max(left_cost * (desired_chunks-1), right_cost);
+    double split_measure = max(left_cost * (desired_chunks-1), right_cost);      
     if (split_measure < best_split_measure) {
       if (d == longest_axis || split_measure < (best_split_measure - (0.3 * best_split_measure))) {
         // Only use this split_measure if we're on the longest_axis, or if the split_measure is


### PR DESCRIPTION
Extends the bisection search approach of #966 to `grid_volume::split_into_three` which was missing.