### PR TITLE
added print_chunk_costs

### DIFF
--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -786,9 +786,6 @@ public:
 
   friend class boundary_region;
 
-  double chunk_cost(int i) const;
-  void print_estimated_costs() const;
-
 private:
   void use_pml(direction d, boundary_side b, double dx);
   void add_to_effort_volumes(const grid_volume &new_effort_volume, double extra_effort);

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -787,7 +787,7 @@ public:
   friend class boundary_region;
 
   double chunk_cost(int i) const;
-  void print_chunk_costs() const;
+  void print_estimated_costs() const;
 
 private:
   void use_pml(direction d, boundary_side b, double dx);

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -786,6 +786,9 @@ public:
 
   friend class boundary_region;
 
+  double chunk_cost(int i) const;
+  void print_chunk_costs() const;
+
 private:
   void use_pml(direction d, boundary_side b, double dx);
   void add_to_effort_volumes(const grid_volume &new_effort_volume, double extra_effort);

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -216,6 +216,25 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
   check_chunks();
 }
 
+double structure::chunk_cost(int i) const {
+  return i < 0 || i > num_chunks ? 0.0 : chunks[i]->gv.get_cost();
+}
+
+void structure::print_chunk_costs() const {
+  double sum = 0, sumsq = 0;
+  master_printf("chunk costs: ");
+  for (int i = 0; i < num_chunks; i++) {
+    double cost = chunk_cost(i);
+    sum += cost;
+    sumsq += cost*cost;
+    master_printf("%g%s", cost, i == num_chunks - 1 ? "\n" : ", ");
+  }
+  double mean = sum / num_chunks;
+  double stddev = sumsq - num_chunks * mean * mean;
+  stddev = num_chunks == 1 || stddev <= 0 ? 0.0 : sqrt(stddev / (num_chunks - 1));
+  master_printf("chunk cost mean = %g, stddev = %g\n", mean, stddev);
+}
+
 void boundary_region::apply(structure *s) const {
   if (has_direction(s->gv.dim, d) && s->user_volume.has_boundary(side, d) &&
       s->user_volume.num_direction(d) > 1) {

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -217,7 +217,7 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
 }
 
 double structure::chunk_cost(int i) const {
-  return i < 0 || i > num_chunks ? 0.0 : chunks[i]->gv.get_cost();
+  return i < 0 || i >= num_chunks ? 0.0 : chunks[i]->gv.get_cost();
 }
 
 void structure::print_estimated_costs() const {

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -214,31 +214,27 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
     }
   }
   check_chunks();
-}
 
-double structure::chunk_cost(int i) const {
-  return i < 0 || i >= num_chunks ? 0.0 : chunks[i]->gv.get_cost();
-}
-
-void structure::print_estimated_costs() const {
-  double *costs = new double[count_processors()];
-  for (int i = 0; i < count_processors(); i++)
-    costs[i] = 0;
-  for (int i = 0; i < num_chunks; i++)
-    costs[chunks[i]->n_proc()] += chunk_cost(i);
-  double sum = 0, sumsq = 0;
-  master_printf("estimated costs per process: ");
-  for (int i = 0; i < count_processors(); i++) {
-    double cost = costs[i];
-    sum += cost;
-    sumsq += cost*cost;
-    master_printf("%g%s", cost, i == count_processors() - 1 ? "\n" : ", ");
+  if (!quiet) {
+    double *costs = new double[count_processors()];
+    for (int i = 0; i < count_processors(); i++)
+      costs[i] = 0;
+    for (int i = 0; i < num_chunks; i++)
+      costs[chunks[i]->n_proc()] += chunks[i]->gv.get_cost();
+    double sum = 0, sumsq = 0;
+    master_printf("estimated costs per process: ");
+    for (int i = 0; i < count_processors(); i++) {
+      double cost = costs[i];
+      sum += cost;
+      sumsq += cost*cost;
+      master_printf("%g%s", cost, i == count_processors() - 1 ? "\n" : ", ");
+    }
+    delete[] costs;
+    double mean = sum / count_processors();
+    double stddev = sumsq - num_chunks * mean * mean;
+    stddev = count_processors() == 1 || stddev <= 0 ? 0.0 : sqrt(stddev / (count_processors() - 1));
+    master_printf("estimated cost mean = %g, stddev = %g\n", mean, stddev);
   }
-  delete[] costs;
-  double mean = sum / count_processors();
-  double stddev = sumsq - num_chunks * mean * mean;
-  stddev = count_processors() == 1 || stddev <= 0 ? 0.0 : sqrt(stddev / (count_processors() - 1));
-  master_printf("estimated cost mean = %g, stddev = %g\n", mean, stddev);
 }
 
 void boundary_region::apply(structure *s) const {

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -185,6 +185,7 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
   chunks = new structure_chunk_ptr[adjusted_num_chunks * num_effort_volumes];
   std::vector<grid_volume> chunk_volumes;
 
+  bool by_cost = false;
   if (meep_geom::fragment_stats::resolution == 0 ||
       meep_geom::fragment_stats::has_non_medium_material() ||
       meep_geom::fragment_stats::split_chunks_evenly) {
@@ -200,6 +201,7 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
     if (!quiet && adjusted_num_chunks > 1)
       master_printf("Splitting into %d chunks by cost\n", adjusted_num_chunks);
     split_by_cost(prime_factors, gv, chunk_volumes);
+    by_cost = true;
   }
 
   // Break off PML regions into their own chunks
@@ -215,7 +217,7 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
   }
   check_chunks();
 
-  if (!quiet) {
+  if (!quiet && by_cost) {
     double *costs = new double[count_processors()];
     for (int i = 0; i < count_processors(); i++)
       costs[i] = 0;

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -222,6 +222,8 @@ double structure::chunk_cost(int i) const {
 
 void structure::print_estimated_costs() const {
   double *costs = new double[count_processors()];
+  for (int i = 0; i < count_processors(); i++)
+    costs[i] = 0;
   for (int i = 0; i < num_chunks; i++)
     costs[chunks[i]->n_proc()] += chunk_cost(i);
   double sum = 0, sumsq = 0;


### PR DESCRIPTION
Add a routine to print the estimated chunk costs.   Run it with ~~`sim.structure.print_chunk_costs()`~~ `sim.structure.print_estimated_costs()`.

*Update:* now prints as part of `choose_chunkdivision` if `!quiet`