### PR TITLE
Fine-grained timing statistics for structure class

### DIFF
--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -714,6 +714,7 @@ public:
   grid_volume *effort_volumes;
   double *effort;
   int num_effort_volumes;
+  double t_setepsilon, t_setconductivity, t_chunkdivision, t_addsusceptibility;
 
   ~structure();
   structure();

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1351,8 +1351,11 @@ static pol *add_pols(pol *pols, const susceptibility_list slist) {
 }
 
 void geom_epsilon::add_susceptibilities(meep::structure *s) {
+  double tstart = meep::wall_time();
   add_susceptibilities(meep::E_stuff, s);
   add_susceptibilities(meep::H_stuff, s);
+  s->t_addsusceptibility = meep::wall_time() - tstart;
+  if (!meep::quiet) master_printf("time for add_susceptibility = %g s\n", s->t_addsusceptibility);
 }
 
 void geom_epsilon::add_susceptibilities(meep::field_type ft, meep::structure *s) {


### PR DESCRIPTION
The `structure` class contains four routines &mdash; `set_epsilon`, `set_conductivity`, `choose_chunkdivision`, and `add_susceptibility` &mdash; which in certain situations require non-negligible runtimes. This PR times these four routines separately and stores the results in a public variable which can be used for e.g. improving performance, debugging, etc.