### PR TITLE
remove verbose argument from meepgeom::set_materials_from_geometry

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1627,7 +1627,7 @@ meep::structure *create_structure_and_set_materials(vector3 cell_size,
 
     if (set_materials) {
       meep_geom::set_materials_from_geometry(s, gobj_list, center, use_anisotropic_averaging, tol,
-                                             maxeval, _ensure_periodicity, verbose, _default_material,
+                                             maxeval, _ensure_periodicity, _default_material,
                                              alist, extra_materials);
     }
 

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -358,8 +358,6 @@ public:
   void add_susceptibilities(meep::structure *s);
   void add_susceptibilities(meep::field_type ft, meep::structure *s);
 
-  static bool verbose;
-
 private:
   void get_material_pt(material_type &material, const meep::vec &r);
 
@@ -368,7 +366,6 @@ private:
 };
 
 /***********************************************************************/
-bool geom_epsilon::verbose = false;
 
 geom_epsilon::geom_epsilon(geometric_object_list g, material_type_list mlist,
                            const meep::volume &v) {
@@ -397,7 +394,7 @@ geom_epsilon::geom_epsilon(geometric_object_list g, material_type_list mlist,
   geom_fix_object_list(geometry);
   geom_box box = gv2box(v);
   geometry_tree = create_geom_box_tree0(geometry, box);
-  if (meep::verbosity > 0 && verbose && meep::am_master()) {
+  if (meep::verbosity > 1 && meep::am_master()) {
     master_printf("Geometric-object bounding-box tree:\n");
     display_geom_box_tree(5, geometry_tree);
 
@@ -1475,11 +1472,9 @@ void add_absorbing_layer(absorber_list alist, double thickness, int direction, i
 /***************************************************************/
 void set_materials_from_geometry(meep::structure *s, geometric_object_list g, vector3 center,
                                  bool use_anisotropic_averaging, double tol, int maxeval,
-                                 bool _ensure_periodicity, bool verbose,
+                                 bool _ensure_periodicity,
                                  material_type _default_material, absorber_list alist,
                                  material_type_list extra_materials) {
-  geom_epsilon::verbose = verbose;
-
   // set global variables in libctlgeom based on data fields in s
   geom_initialize();
   geometry_center = center;

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -166,7 +166,7 @@ void set_materials_from_geometry(meep::structure *s, geometric_object_list g,
                                  bool use_anisotropic_averaging = true,
                                  double tol = DEFAULT_SUBPIXEL_TOL,
                                  int maxeval = DEFAULT_SUBPIXEL_MAXEVAL,
-                                 bool ensure_periodicity = false, bool verbose = false,
+                                 bool ensure_periodicity = false,
                                  material_type _default_material = vacuum, absorber_list alist = 0,
                                  material_type_list extra_materials = material_type_list());
 


### PR DESCRIPTION
Removes the `verbose` argument from `set_materials_from_geometry` in `src/meepgeom.cpp` which had been left out of #994 and is no longer necessary. The geometric-object tree information is only displayed when `verbosity = 2`. This should be merged after #997.

Three other places where the `verbose` argument can also be removed:

1. [`geom_epsilon`](https://github.com/NanoComp/meep/blob/master/scheme/structure.cpp#L281) in `scheme/structure.cpp`

2. [`create_structure_and_set_materials`](https://github.com/NanoComp/meep/blob/master/python/meep.i#L1603) in `python/meep.i`

3. `get_eigenmode` and [`get_eigenmode_coefficients`](https://github.com/NanoComp/meep/blob/master/src/mpb.cpp#L866) in `src/mpb.cpp`

 