### PR TITLE
remove verbose argument from geom_epsilon and get_eigenmode

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -25,7 +25,6 @@ class Simulation(object):
                  dimensions=3,
                  boundary_layers=[],
                  symmetries=[],
-                 verbose=False,
                  force_complex_fields=False,
                  default_material=mp.Medium(),
                  m=0,
@@ -1205,7 +1204,7 @@ Scale the Fourier-transformed fields in `flux` by the complex number `s`. e.g. `
 
 Given a structure, Meep can decompose the Fourier-transformed fields into a superposition of its harmonic modes. For a theoretical background, see [Mode Decomposition](Mode_Decomposition.md).
 
-**`get_eigenmode_coefficients(flux, bands, eig_parity=mp.NO_PARITY, eig_vol=None, eig_resolution=0, eig_tolerance=1e-12, kpoint_func=None, verbose=False, direction=mp.AUTOMATIC)`**
+**`get_eigenmode_coefficients(flux, bands, eig_parity=mp.NO_PARITY, eig_vol=None, eig_resolution=0, eig_tolerance=1e-12, kpoint_func=None, direction=mp.AUTOMATIC)`**
 —
 Given a flux object and list of band indices, return a `namedtuple` with the following fields:
 
@@ -1226,7 +1225,7 @@ Similar to `add_flux`, but for use with `get_eigenmode_coefficients`.
 
 `add_mode_monitor` works properly with arbitrary symmetries, but may be suboptimal because the Fourier-transformed region does not exploit the symmetry.  As an optimization, if you have a mirror plane that bisects the mode monitor, you can instead use `add_flux` to gain a factor of two, but in that case you *must* also pass the corresponding `eig_parity` to `get_eigenmode_coefficients` in order to only compute eigenmodes with the corresponding mirror symmetry.
 
-**`get_eigenmode(freq, direction, where, band_num, kpoint, eig_vol=None, match_frequency=True, parity=mp.NO_PARITY, resolution=0, eigensolver_tol=1e-12, verbose=False)`**
+**`get_eigenmode(freq, direction, where, band_num, kpoint, eig_vol=None, match_frequency=True, parity=mp.NO_PARITY, resolution=0, eigensolver_tol=1e-12)`**
 —
 The parameters of this routine are the same as that of `get_eigenmode_coefficients` or `EigenModeSource`, but this function returns an object that can be used to inspect the computed mode.  In particular, it returns an `EigenmodeData` instance with the following fields:
 

--- a/doc/docs/Scheme_User_Interface.md
+++ b/doc/docs/Scheme_User_Interface.md
@@ -772,7 +772,11 @@ Note that the flux is always computed in the *positive* coordinate direction, al
 Miscellaneous Functions
 -----------------------
 
-Here, we describe a number of miscellaneous useful functions provided by Meep.
+### Verbose Output
+
+**`(quiet quietval)`**
+—
+Meep ordinarily prints various diagnostic and progress information to standard output. This output can be suppressed by calling this function with `true`. The output can be enabled again by passing `false`. This sets a global variable, so the value will persist across runs within the same script.
 
 ### Geometry Utilities
 
@@ -976,7 +980,7 @@ Scale the Fourier-transformed fields in `flux` by the complex number `s`. e.g. `
 
 Given a structure, Meep can decompose the Fourier-transformed fields into a superposition of its harmonic modes. For a theoretical background, see [Mode Decomposition](Mode_Decomposition.md).
 
-**`(get-eigenmode-coefficients flux bands eig-parity eig-vol eig-resolution eig-tolerance kpoint-func verbose=False direction=AUTOMATIC)`**
+**`(get-eigenmode-coefficients flux bands eig-parity eig-vol eig-resolution eig-tolerance kpoint-func direction=AUTOMATIC)`**
 —
 Given a flux object and list of band indices, return a list with the following data:
 

--- a/doc/docs/Scheme_User_Interface.md
+++ b/doc/docs/Scheme_User_Interface.md
@@ -776,7 +776,7 @@ Miscellaneous Functions
 
 **`(quiet quietval)`**
 —
-Meep ordinarily prints various diagnostic and progress information to standard output. This output can be suppressed by calling this function with `true`. The output can be enabled again by passing `false`. This sets a global variable, so the value will persist across runs within the same script.
+Meep ordinarily prints various diagnostic and progress information to standard output. This output can be suppressed by calling this function with `true` (the default). The output can be enabled again by passing `false`. This sets a global variable, so the value will persist across runs within the same script.
 
 ### Geometry Utilities
 

--- a/doc/docs/Scheme_User_Interface.md
+++ b/doc/docs/Scheme_User_Interface.md
@@ -774,7 +774,7 @@ Miscellaneous Functions
 
 ### Verbose Output
 
-**`(quiet quietval)`**
+**`(quiet)`** or **`(quiet quietval)`**
 —
 Meep ordinarily prints various diagnostic and progress information to standard output. This output can be suppressed by calling this function with `true` (the default). The output can be enabled again by passing `false`. This sets a global variable, so the value will persist across runs within the same script.
 

--- a/python/meep.i
+++ b/python/meep.i
@@ -492,14 +492,14 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
                                                    int *bands, int num_bands, int parity, double eig_resolution,
                                                    double eigensolver_tol, std::complex<double> *coeffs,
                                                    double *vgrp, meep::kpoint_func user_kpoint_func,
-                                                   void *user_kpoint_data, bool verbose, meep::direction d) {
+                                                   void *user_kpoint_data, meep::direction d) {
 
     size_t num_kpoints = num_bands * flux.Nfreq;
     meep::vec *kpoints = new meep::vec[num_kpoints];
     meep::vec *kdom = new meep::vec[num_kpoints];
 
     f->get_eigenmode_coefficients(flux, eig_vol, bands, num_bands, parity, eig_resolution, eigensolver_tol,
-                                  coeffs, vgrp, user_kpoint_func, user_kpoint_data, kpoints, kdom, verbose, d);
+                                  coeffs, vgrp, user_kpoint_func, user_kpoint_data, kpoints, kdom, d);
 
     kpoint_list res = {kpoints, num_kpoints, kdom, num_kpoints};
 
@@ -523,10 +523,10 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
 meep::eigenmode_data *_get_eigenmode(meep::fields *f, double omega_src, meep::direction d, const meep::volume where,
                                      const meep::volume eig_vol, int band_num, const meep::vec &_kpoint,
                                      bool match_frequency, int parity, double resolution, double eigensolver_tol,
-                                     bool verbose, double kdom[3]) {
+                                     double kdom[3]) {
 
     void *data = f->get_eigenmode(omega_src, d, where, eig_vol, band_num, _kpoint, match_frequency,
-                                  parity, resolution, eigensolver_tol, verbose, kdom);
+                                  parity, resolution, eigensolver_tol, kdom);
     return (meep::eigenmode_data *)data;
 }
 
@@ -542,10 +542,10 @@ PyObject *_get_eigenmode_Gk(meep::eigenmode_data *emdata) {
 void _get_eigenmode(meep::fields *f, double omega_src, meep::direction d, const meep::volume where,
                     const meep::volume eig_vol, int band_num, const meep::vec &_kpoint,
                     bool match_frequency, int parity, double resolution, double eigensolver_tol,
-                    bool verbose, double kdom[3]) {
+                    double kdom[3]) {
     (void) f; (void) omega_src; (void) d; (void) where; (void) eig_vol; (void) band_num; (void) _kpoint;
     (void) match_frequency; (void) parity; (void) resolution; (void) eigensolver_tol;
-    (void) verbose; (void) kdom;
+    (void) kdom;
     meep::abort("Must compile Meep with MPB for get_eigenmode");
 }
 #endif
@@ -1309,7 +1309,7 @@ struct eigenmode_data {
 meep::eigenmode_data *_get_eigenmode(meep::fields *f, double omega_src, meep::direction d, const meep::volume where,
                                      const meep::volume eig_vol, int band_num, const meep::vec &_kpoint,
                                      bool match_frequency, int parity, double resolution, double eigensolver_tol,
-                                     bool verbose, double kdom[3]);
+                                     double kdom[3]);
 PyObject *_get_eigenmode_Gk(meep::eigenmode_data *emdata);
 
 %extend meep::eigenmode_data {
@@ -1322,7 +1322,7 @@ PyObject *_get_eigenmode_Gk(meep::eigenmode_data *emdata);
 void _get_eigenmode(meep::fields *f, double omega_src, meep::direction d, const meep::volume where,
                     const meep::volume eig_vol, int band_num, const meep::vec &_kpoint,
                     bool match_frequency, int parity, double resolution, double eigensolver_tol,
-                    bool verbose, double kdom[3]);
+                    double kdom[3]);
 #endif // HAVE_MPB
 
 // Make omega members of meep::dft_ldos available as 'freq' in python
@@ -1362,7 +1362,7 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
                                                    int parity, double eig_resolution, double eigensolver_tol,
                                                    std::complex<double> *coeffs, double *vgrp,
                                                    meep::kpoint_func user_kpoint_func, void *user_kpoint_data,
-                                                   bool verbose, meep::direction d);
+                                                   meep::direction d);
 PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where, size_t dims[3],
                                       bool collapse_empty_dimensions, bool snap_empty_dimensions);
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -562,7 +562,6 @@ class Simulation(object):
                  dimensions=3,
                  boundary_layers=[],
                  symmetries=[],
-                 verbose=False,
                  force_complex_fields=False,
                  default_material=mp.Medium(),
                  m=0,
@@ -614,7 +613,6 @@ class Simulation(object):
         self.accurate_fields_near_cylorigin = accurate_fields_near_cylorigin
         self.m = m
         self.force_complex_fields = force_complex_fields
-        self.verbose = verbose
         self.progress_interval = progress_interval
         self.init_sim_hooks = []
         self.run_index = 0
@@ -1154,9 +1152,6 @@ class Simulation(object):
         if self.force_all_components and self.dimensions != 1:
             self.fields.require_component(mp.Ez)
             self.fields.require_component(mp.Hz)
-
-        if self.verbose:
-            verbosity(2)
 
         def use_real(self):
             cond1 = self.is_cylindrical and self.m != 0
@@ -1943,7 +1938,7 @@ class Simulation(object):
                                        center=center, size=size, collapse=True)
 
     def get_eigenmode_coefficients(self, flux, bands, eig_parity=mp.NO_PARITY, eig_vol=None,
-                                   eig_resolution=0, eig_tolerance=1e-12, kpoint_func=None, verbose=False, direction=mp.AUTOMATIC):
+                                   eig_resolution=0, eig_tolerance=1e-12, kpoint_func=None, direction=mp.AUTOMATIC):
         if self.fields is None:
             raise ValueError("Fields must be initialized before calling get_eigenmode_coefficients")
         if eig_vol is None:
@@ -1968,14 +1963,13 @@ class Simulation(object):
             coeffs,
             vgrp,
             kpoint_func,
-            verbose,
             direction
         )
 
         return EigCoeffsResult(np.reshape(coeffs, (num_bands, flux.Nfreq, 2)), vgrp, kpoints, kdom)
 
     def get_eigenmode(self, freq, direction, where, band_num, kpoint, eig_vol=None, match_frequency=True,
-                      parity=mp.NO_PARITY, resolution=0, eigensolver_tol=1e-12, verbose=False):
+                      parity=mp.NO_PARITY, resolution=0, eigensolver_tol=1e-12):
 
         if self.fields is None:
             raise ValueError("Fields must be initialized before calling get_eigenmode")
@@ -1989,7 +1983,7 @@ class Simulation(object):
         swig_kpoint = mp.vec(kpoint.x, kpoint.y, kpoint.z)
         kdom = np.zeros(3)
         emdata = mp._get_eigenmode(self.fields, freq, direction, where, eig_vol, band_num, swig_kpoint,
-                                   match_frequency, parity, resolution, eigensolver_tol, verbose, kdom)
+                                   match_frequency, parity, resolution, eigensolver_tol, kdom)
         Gk = mp._get_eigenmode_Gk(emdata)
 
         return EigenmodeData(emdata.band_num, emdata.omega, emdata.group_velocity, Gk,

--- a/python/tests/kdom.py
+++ b/python/tests/kdom.py
@@ -40,7 +40,7 @@ class TestKdom(unittest.TestCase):
     sim.init_sim()
 
     EigenmodeData = sim.get_eigenmode(fcen, mp.X, mp.Volume(center=mp.Vector3(0.3*sx,0,0), size=mp.Vector3(0,sy,0)),
-                                      num_band, k, parity=eig_parity, verbose=True)
+                                      num_band, k, parity=eig_parity)
     kdom = EigenmodeData.kdom
     
     self.assertAlmostEqual(k.y,kdom.y,places=15)

--- a/scheme/meep-ctl.hpp
+++ b/scheme/meep-ctl.hpp
@@ -11,7 +11,7 @@
 
 #include "meep-ctl-swig.hpp"
 
-extern int verbose; // in main.c
+extern int verbosity; // in main.c
 
 /***************************************************************************/
 

--- a/scheme/meep-ctl.hpp
+++ b/scheme/meep-ctl.hpp
@@ -11,7 +11,7 @@
 
 #include "meep-ctl-swig.hpp"
 
-extern int verbosity; // in main.c
+extern int verbose; // in main.c
 
 /***************************************************************************/
 

--- a/scheme/meep.cpp
+++ b/scheme/meep.cpp
@@ -67,8 +67,7 @@ kpoint_list do_get_eigenmode_coefficients(fields *f, dft_flux flux, const volume
 
   f->get_eigenmode_coefficients(flux, eig_vol, bands, num_bands, parity, eig_resolution,
                                 eigensolver_tol, coeffs, vgrp, user_kpoint_func, user_kpoint_data,
-                                kpoints, kdom, false,
-                                dir < 0 ? flux.normal_direction : direction(dir));
+                                kpoints, kdom, dir < 0 ? flux.normal_direction : direction(dir));
 
   kpoint_list res = {kpoints, num_kpoints, kdom, num_kpoints};
 

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -458,7 +458,6 @@
 				(if (and special-kz? k-point)
 				    (vector3-z k-point) 0.0)
 				(not accurate-fields-near-cylorigin?)))
-  (if verbose? (meep-fields-verbose fields))
   (if (not (or force-complex-fields?
 	       (and (= dimensions CYLINDRICAL) (not (zero? m)))
 	       (not (for-all? symmetries
@@ -1201,6 +1200,14 @@
 (define (harminv c pt fcen df . mxbands)
   (harminv! harminv-data harminv-data-dt harminv-results c pt fcen df mxbands))
 
+; ****************************************************************
+; verbosity
+
+(define (quiet quietval)
+  (set! meep-verbosity (or (and (not quietval) 1) 0)))
+
+(define (verbosity verboseval)
+  (set! meep-verbosity verboseval))
 
 ; ****************************************************************
 ; get-eigenmode-coefficients

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -1205,6 +1205,7 @@
 
 (define* (quiet #:optional (quiet? true))
   (verbosity (if quiet? 0 1)))
+(if verbose? (verbosity 2))
 
 ; ****************************************************************
 ; get-eigenmode-coefficients

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -1203,11 +1203,8 @@
 ; ****************************************************************
 ; verbosity
 
-(define (quiet quietval)
-  (set! meep-verbosity (or (and (not quietval) 1) 0)))
-
-(define (verbosity verboseval)
-  (set! meep-verbosity verboseval))
+(define* (quiet #:optional (quiet? true))
+  (verbosity (if quiet? 0 1)))
 
 ; ****************************************************************
 ; get-eigenmode-coefficients

--- a/scheme/structure.cpp
+++ b/scheme/structure.cpp
@@ -278,7 +278,7 @@ geom_epsilon::geom_epsilon(geometric_object_list g, material_type_list mlist,
   geom_fix_object_list(geometry);
   geom_box box = gv2box(v);
   geometry_tree = create_geom_box_tree0(geometry, box);
-  if (meep::verbosity > 0 && verbose && meep::am_master()) {
+  if (meep::verbosity > 2 && meep::am_master()) {
     printf("Geometric-object bounding-box tree:\n");
     display_geom_box_tree(5, geometry_tree);
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1660,7 +1660,7 @@ public:
   // call destroy_eigenmode_data() to deallocate it when finished.
   void *get_eigenmode(double omega_src, direction d, const volume where, const volume eig_vol,
                       int band_num, const vec &kpoint, bool match_frequency, int parity,
-                      double resolution, double eigensolver_tol, bool verbose = false,
+                      double resolution, double eigensolver_tol,
                       double *kdom = 0, void **user_mdata = 0);
 
   void add_eigenmode_source(component c, const src_time &src, direction d, const volume &where,
@@ -1673,12 +1673,12 @@ public:
                                   int parity, double eig_resolution, double eigensolver_tol,
                                   std::complex<double> *coeffs, double *vgrp,
                                   kpoint_func user_kpoint_func, void *user_kpoint_data,
-                                  vec *kpoints, vec *kdom, bool verbose, direction d);
+                                  vec *kpoints, vec *kdom, direction d);
   void get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, int *bands, int num_bands,
                                   int parity, double eig_resolution, double eigensolver_tol,
                                   std::complex<double> *coeffs, double *vgrp,
                                   kpoint_func user_kpoint_func = 0, void *user_kpoint_data = 0,
-                                  vec *kpoints = 0, vec *kdom = 0, bool verbose = false);
+                                  vec *kpoints = 0, vec *kdom = 0);
 
   // initialize.cpp:
   void initialize_field(component, std::complex<double> f(const vec &));

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -253,7 +253,7 @@ static double dot_product(const mpb_real a[3], const mpb_real b[3]) {
 /****************************************************************/
 void *fields::get_eigenmode(double omega_src, direction d, const volume where, const volume eig_vol,
                             int band_num, const vec &_kpoint, bool match_frequency, int parity,
-                            double resolution, double eigensolver_tol, bool verbose, double *kdom,
+                            double resolution, double eigensolver_tol, double *kdom,
                             void **user_mdata) {
   /*--------------------------------------------------------------*/
   /*- part 1: preliminary setup for calling MPB  -----------------*/
@@ -279,7 +279,6 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
     empty_dim[2] = true;
   }
 
-  // bool verbose=true;
   if (resolution <= 0.0) resolution = 2 * gv.a; // default to twice resolution
   int n[3], local_N, N_start, alloc_N, mesh_size[3] = {1, 1, 1};
   mpb_real k[3] = {0, 0, 0}, kcart[3] = {0, 0, 0};
@@ -327,7 +326,7 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
     default: abort("unsupported dimensionality in add_eigenmode_source");
   }
 
-  if (verbosity > 0 && verbose) master_printf("KPOINT: %g, %g, %g\n", k[0], k[1], k[2]);
+  if (verbosity > 1) master_printf("KPOINT: %g, %g, %g\n", k[0], k[1], k[2]);
 
   double kcart_len = sqrt(dot_product(kcart, kcart));
 
@@ -406,7 +405,7 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
           fabs(k[d - X]) > 0.4) // ensure k is well inside the Brillouin zone
         k[d - X] = k[d - X] > 0 ? 0.4 : -0.4;
     }
-    if (verbosity > 0 && verbose) master_printf("NEW KPOINT: %g, %g, %g\n", k[0], k[1], k[2]);
+    if (verbosity > 1) master_printf("NEW KPOINT: %g, %g, %g\n", k[0], k[1], k[2]);
   }
 
   set_maxwell_data_parity(mdata, parity);
@@ -456,7 +455,7 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
 #endif
                   maxwell_preconditioner2, (void *)mdata, evectconstraint_chain_func,
                   (void *)constraints, W, 3, eigensolver_tol, &num_iters,
-                  EIGS_DEFAULT_FLAGS | (am_master() && verbose && verbosity > 0 ? EIGS_VERBOSE : 0));
+                  EIGS_DEFAULT_FLAGS | (am_master() && verbosity > 0 ? EIGS_VERBOSE : 0));
       if (verbosity > 0)
         master_printf("MPB solved for omega_%d(%g,%g,%g) = %g after %d iters\n", band_num,
                       G[0][0] * k[0], G[1][1] * k[1], G[2][2] * k[2], sqrt(eigvals[band_num - 1]),
@@ -482,7 +481,7 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
         // update k via Newton step
         double dkmatch = (sqrt(eigvals[band_num - 1]) - omega_src) / vgrp;
         kmatch = kmatch - dkmatch;
-        if (verbosity > 0 && verbose)
+        if (verbosity > 0)
           master_printf("Newton step: group velocity v=%g, kmatch=%g\n", vgrp, kmatch);
         count_dkmatch_increase += fabs(dkmatch) > fabs(dkmatch_prev);
         if (count_dkmatch_increase > 4) {
@@ -750,7 +749,7 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
                                         double eigensolver_tol, std::complex<double> *coeffs,
                                         double *vgrp, kpoint_func user_kpoint_func,
                                         void *user_kpoint_data, vec *kpoints, vec *kdom_list,
-                                        bool verbose, direction d) {
+                                        direction d) {
   double freq_min = flux.freq_min;
   double dfreq = flux.dfreq;
   int num_freqs = flux.Nfreq;
@@ -778,7 +777,7 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
       am_now_working_on(MPBTime);
       void *mode_data =
           get_eigenmode(freq, d, flux.where, eig_vol, band_num, kpoint, match_frequency, parity,
-                        eig_resolution, eigensolver_tol, verbose, kdom, (void **)&mdata);
+                        eig_resolution, eigensolver_tol, kdom, (void **)&mdata);
       finished_working();
       if (!mode_data) { // mode not found, assume evanescent
         coeffs[2 * nb * num_freqs + 2 * nf] = coeffs[2 * nb * num_freqs + 2 * nf + 1] = 0;
@@ -818,7 +817,7 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
 #else // #ifdef HAVE_MPB
 void *fields::get_eigenmode(double omega_src, direction d, const volume where, const volume eig_vol,
                             int band_num, const vec &kpoint, bool match_frequency, int parity,
-                            double resolution, double eigensolver_tol, bool verbose, double *kdom,
+                            double resolution, double eigensolver_tol, double *kdom,
                             void **user_mdata) {
 
   (void)omega_src;
@@ -831,7 +830,6 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
   (void)parity;
   (void)resolution;
   (void)eigensolver_tol;
-  (void)verbose;
   (void)kdom;
   (void)user_mdata;
   abort("Meep must be configured/compiled with MPB for get_eigenmode");
@@ -863,7 +861,7 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
                                         double eigensolver_tol, std::complex<double> *coeffs,
                                         double *vgrp, kpoint_func user_kpoint_func,
                                         void *user_kpoint_data, vec *kpoints, vec *kdom,
-                                        bool verbose, direction d) {
+                                        direction d) {
   (void)flux;
   (void)eig_vol;
   (void)bands;
@@ -877,7 +875,6 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
   (void)user_kpoint_func;
   (void)user_kpoint_data;
   (void)kdom;
-  (void)verbose;
   (void)d;
   abort("Meep must be configured/compiled with MPB for get_eigenmode_coefficient");
 }
@@ -912,11 +909,10 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
                                         int num_bands, int parity, double eig_resolution,
                                         double eigensolver_tol, std::complex<double> *coeffs,
                                         double *vgrp, kpoint_func user_kpoint_func,
-                                        void *user_kpoint_data, vec *kpoints, vec *kdom,
-                                        bool verbose) {
+                                        void *user_kpoint_data, vec *kpoints, vec *kdom) {
   get_eigenmode_coefficients(flux, eig_vol, bands, num_bands, parity, eig_resolution,
                              eigensolver_tol, coeffs, vgrp, user_kpoint_func, user_kpoint_data,
-                             kpoints, kdom, verbose, flux.normal_direction);
+                             kpoints, kdom, flux.normal_direction);
 }
 
 } // namespace meep

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -455,7 +455,7 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
 #endif
                   maxwell_preconditioner2, (void *)mdata, evectconstraint_chain_func,
                   (void *)constraints, W, 3, eigensolver_tol, &num_iters,
-                  EIGS_DEFAULT_FLAGS | (am_master() && verbosity > 0 ? EIGS_VERBOSE : 0));
+                  EIGS_DEFAULT_FLAGS | (am_master() && verbosity > 1 ? EIGS_VERBOSE : 0));
       if (verbosity > 0)
         master_printf("MPB solved for omega_%d(%g,%g,%g) = %g after %d iters\n", band_num,
                       G[0][0] * k[0], G[1][1] * k[1], G[2][2] * k[2], sqrt(eigvals[band_num - 1]),
@@ -481,7 +481,7 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
         // update k via Newton step
         double dkmatch = (sqrt(eigvals[band_num - 1]) - omega_src) / vgrp;
         kmatch = kmatch - dkmatch;
-        if (verbosity > 0)
+        if (verbosity > 1)
           master_printf("Newton step: group velocity v=%g, kmatch=%g\n", vgrp, kmatch);
         count_dkmatch_increase += fabs(dkmatch) > fabs(dkmatch_prev);
         if (count_dkmatch_increase > 4) {


### PR DESCRIPTION
Removes the deprecated `verbose` argument from (1) `geom_epsilon` in `scheme/structure.cpp` and (2) `get_eigenmode`/`get_eigenmode_coefficients` in `src/mpb.cpp`. The documentation is also updated.

Scheme versions of the [`quiet`](https://github.com/NanoComp/meep/blob/master/python/simulation.py#L2924-L2925) ~~and [`verbosity`](https://github.com/NanoComp/meep/blob/master/python/simulation.py#L2927-L2928)~~ functions from the Python interface are added to `scheme/meep.scm.in`. ~~However, these functions don't seem to be actually setting the global [`verbosity`](https://github.com/NanoComp/meep/blob/master/src/meep.hpp#L47) variable in the Meep namespace. What is the correct way to do this?~~