### PR TITLE
remove aspect ratios for 3d layout plots from visualize_chunks

### DIFF
--- a/python/visualization.py
+++ b/python/visualization.py
@@ -657,12 +657,21 @@ def visualize_chunks(sim):
 
         for i, v in enumerate(vols):
             plot_box(mp.gv2box(v.surroundings()), owners[i], fig, ax)
-        ax.set_aspect('equal')
-        plt.autoscale(tight=True)
+
         ax.set_xlabel('x')
         ax.set_ylabel('y')
+
+        cell_box = mp.gv2box(sim.structure.gv.surroundings())
         if sim.structure.gv.dim == 2:
+            ax.set_xlim3d(left=cell_box.low.x,right=cell_box.high.x)
+            ax.set_ylim3d(bottom=cell_box.low.y,top=cell_box.high.y)
+            ax.set_zlim3d(bottom=cell_box.low.z,top=cell_box.high.z)
             ax.set_zlabel('z')
+        else:
+            ax.set_xlim(left=cell_box.low.x,right=cell_box.high.x)
+            ax.set_ylim(bottom=cell_box.low.y,top=cell_box.high.y)
+            ax.set_aspect('equal')
+
         plt.tight_layout()
         plt.show()
 


### PR DESCRIPTION
Matplotlib `3.1.0` [disabled support for equal aspect axes in 3d plots](https://matplotlib.org/3.1.0/api/api_changes.html#mplot3d-changes) which was then causing [`visualize_chunks`](https://meep.readthedocs.io/en/latest/Python_User_Interface/#data-visualization) to abort with an error. This PR modifies `visualize_chunks` to include equal aspect axes for only 2d layout plots (which is still supported). Also, the axes limits are set manually to exactly fit the grid cell which removes unused space but more importantly corrects an artifact that was causing the cell grid to be offset from the origin as shown below.

**master**

![random_sim_chunks_offset](https://user-images.githubusercontent.com/7152530/63973955-babb0280-ca60-11e9-9a20-146f939033c2.png)

**this PR**

![chunks_axes_set2](https://user-images.githubusercontent.com/7152530/63974007-d1615980-ca60-11e9-8fe0-27ba20fe6841.png)

It would still be useful to enable equal aspect axes for 3d layout plots but this does not currently seem to possible.