### PR TITLE
Correctly print chunk costs when using chunk layout

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1046,15 +1046,21 @@ class Simulation(object):
             print("STATS: num_cores: {}".format(mp.count_processors()))
             sys.exit(0)
 
-        dft_data_list, pml_vols1, pml_vols2, pml_vols3, absorber_vols = self._make_fragment_lists(gv)
+        fragment_vols = self._make_fragment_lists(gv)
+        self.dft_data_list = fragment_vols[0]
+        self.pml_vols1 = fragment_vols[1]
+        self.pml_vols2 = fragment_vols[2]
+        self.pml_vols3 = fragment_vols[3]
+        self.absorber_vols = fragment_vols[4]
+        self.gv = gv
 
         self.structure = mp.create_structure_and_set_materials(
             self.cell_size,
-            dft_data_list,
-            pml_vols1,
-            pml_vols2,
-            pml_vols3,
-            absorber_vols,
+            self.dft_data_list,
+            self.pml_vols1,
+            self.pml_vols2,
+            self.pml_vols3,
+            self.absorber_vols,
             gv,
             br,
             sym,
@@ -1070,7 +1076,8 @@ class Simulation(object):
             absorbers,
             self.extra_materials,
             self.split_chunks_evenly,
-            False if self.chunk_layout else True
+            False if self.chunk_layout else True,
+            None
        )
 
         if self.chunk_layout:
@@ -1086,17 +1093,30 @@ class Simulation(object):
 
         absorbers = [bl for bl in self.boundary_layers if type(bl) is Absorber]
 
-        mp.set_materials_from_geometry(
-            self.structure,
-            geometry if geometry is not None else self.geometry,
-            self.geometry_center,
+        self.structure = mp.create_structure_and_set_materials(
+            self.cell_size,
+            self.dft_data_list,
+            self.pml_vols1,
+            self.pml_vols2,
+            self.pml_vols3,
+            self.absorber_vols,
+            self.gv,
+            mp.boundary_region(),
+            mp.symmetry(),
+            self.num_chunks,
+            self.Courant,
             self.eps_averaging,
             self.subpixel_tol,
             self.subpixel_maxeval,
-            self.ensure_periodicity,
+            geometry if geometry is not None else self.geometry,
+            self.geometry_center,
+            self.ensure_periodicity and not not self.k_point,
             default_material if default_material else self.default_material,
             absorbers,
-            self.extra_materials
+            self.extra_materials,
+            self.split_chunks_evenly,
+            True,
+            self.structure
         )
 
     def dump_structure(self, fname):


### PR DESCRIPTION
Fixes #988.

1. Move printing of chunk costs to `create_structure_and_set_materials`.
2. `Simulation.set_materials` now goes through `create_structure_and_set_materials`.
    a. If we don't have a chunk layout, then the structure is created and the materials are set.
    b. If we do have a chunk layout, then `create_structure_and_set_materials` is called twice: first it creates the structure (without setting the materials), then the structure is passed to the second call and the materials are set.

Output from script in #988 (with boundary region removed).

### Empty Cell
```
estimated costs per process: 126.493, 126.493, 126.493, 126.493, 126.493
estimated cost mean = 126.493, stddev = 0
```

### Oled with empty cell layout
```
estimated costs per process: 357.119, 396.911, 408.676, 396.911, 357.119
estimated cost mean = 383.347, stddev = 24.4197
```

### Oled with split_by_cost layout
```
estimated costs per process: 370.927, 383.089, 380.858, 385.785, 396.062
estimated cost mean = 383.344, stddev = 9.05726
```

If you want to keep the boundary region, just add it to the initial empty layout.

@stevengj @oskooi 
