### PR TITLE
more quiet fixes

### DIFF
--- a/scheme/structure.cpp
+++ b/scheme/structure.cpp
@@ -264,7 +264,8 @@ geom_epsilon::geom_epsilon(geometric_object_list g, material_type_list mlist,
   FOR_DIRECTIONS(d) FOR_SIDES(b) { cond[d][b].prof = NULL; }
 
   if (meep::am_master()) {
-    for (int i = 0; i < geometry.num_items; ++i) {
+    int num_print = meep::verbosity > 2 ? geometry.num_items : std::min(geometry.num_items, meep::verbosity > 0 ? 10 : 0);
+    for (int i = 0; i < num_print; ++i) {
       display_geometric_object_info(5, geometry.items[i]);
 
       if (geometry.items[i].material.which_subclass == MTS::MEDIUM)
@@ -273,6 +274,8 @@ geom_epsilon::geom_epsilon(geometric_object_list g, material_type_list mlist,
                geometry.items[i].material.subclass.medium_data->epsilon_diag.y,
                geometry.items[i].material.subclass.medium_data->epsilon_diag.z);
     }
+    if (num_print < geometry.num_items && meep::verbosity > 0)
+      master_printf("%*s...(+ %d objects not shown)...\n", 5, "", geometry.num_items - num_print);
   }
 
   geom_fix_object_list(geometry);

--- a/src/bicgstab.cpp
+++ b/src/bicgstab.cpp
@@ -158,7 +158,7 @@ ptrdiff_t bicgstabL(const int L, const size_t n, realnum *x, bicgstab_op A, void
   double resid;
   while ((resid = norm2(n, r[0])) > tol * bnrm) {
     ++iter;
-    if (verbosity > 0 && wall_time() > last_output_wall_time + MEEP_MIN_OUTPUT_TIME) {
+    if (!quiet && wall_time() > last_output_wall_time + MEEP_MIN_OUTPUT_TIME) {
       master_printf("residual[%d] = %g\n", iter, resid / bnrm);
       last_output_wall_time = wall_time();
     }
@@ -220,7 +220,7 @@ ptrdiff_t bicgstabL(const int L, const size_t n, realnum *x, bicgstab_op A, void
     }
   }
 
-  if (verbosity > 0) master_printf("final residual = %g\n", norm2(n, r[0]) / bnrm);
+  if (!quiet) master_printf("final residual = %g\n", norm2(n, r[0]) / bnrm);
 
 finish:
   delete[] sigma;


### PR DESCRIPTION
Make scheme interface consistent with #1002 in only showing 10 objects by default.   Fix an incorrect deletion of local `quiet` variable in bicgstab function.