### PR TITLE
test and documentation for special_kz

### DIFF
--- a/doc/docs/FAQ.md
+++ b/doc/docs/FAQ.md
@@ -481,9 +481,9 @@ Yes. You can use the [`set_boundary`](Python_User_Interface.md#field-computation
 
 ### How do I model a 2d structure involving an out-of-plane wavevector?
 
-To model e.g., fiber waveguides with 2d claddings, diffractive binary gratings with arbitrary incident planewaves in 3d, etc. in Cartesian coordinates, you would create a 2d cell in the $xy$ plane and specify a `k_point` with *non-zero* component in $z$. The resulting 3d simulation involves all electromagnetic fields (rather than a 2d simulation which involves a subset of the fields determined by the polarization of the current source).
+To model e.g., fiber waveguides with 2d claddings, diffractive binary gratings with arbitrary incident planewaves in 3d, etc. in Cartesian coordinates, you would create a 2d cell in the $xy$ plane and specify a `k_point` with *non-zero* component in $z$. The resulting 3d simulation involves all electromagnetic fields (rather than a 2d simulation which involves a subset of the fields determined by the polarization of the current source). Performance can be improved by specifying `special_kz=True` in the `Simulation` constructor; this results in a 2d simulation with real rather than complex fields (as long as the $x$ and $y$ components of `k_point` are zero).
 
-Note: [mode decomposition](Python_Tutorials/Mode_Decomposition.md) is *not* currently supported for this use case (Issues [#291](https://github.com/NanoComp/meep/issues/291), [#604](https://github.com/NanoComp/meep/issues/604)).
+Note: [mode decomposition](Python_Tutorials/Mode_Decomposition.md) is *not* yet currently supported for this use case (Issues [#291](https://github.com/NanoComp/meep/issues/291), [#604](https://github.com/NanoComp/meep/issues/604)).
 
 ### Can Meep model electrostatic effects?
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -29,6 +29,7 @@ class Simulation(object):
                  default_material=mp.Medium(),
                  m=0,
                  k_point=False,
+                 special_kz=False,
                  extra_materials=[],
                  material_function=None,
                  epsilon_func=None,
@@ -111,6 +112,10 @@ Specifies the computational grid resolution in pixels per distance unit. Require
 **`k_point` [`False` or `Vector3`]**
 —
 If `False` (the default), then the boundaries are perfect metallic (zero electric field). If a `Vector3`, then the boundaries are Bloch-periodic: the fields at one side are $\exp(i\mathbf{k}\cdot\mathbf{R})$ times the fields at the other side, separated by the lattice vector $\mathbf{R}$. A non-zero `Vector3` will produce complex fields. The `k_point` vector is specified in Cartesian coordinates in units of 2π/distance. Note: this is *different* from [MPB](https://mpb.readthedocs.io), equivalent to taking MPB's `k_points` through its function `reciprocal->cartesian`.
+
+**`special_kz` [`boolean`]**
+—
+By default, a 2d cell (i.e., `dimensions=2`) combined with a `k_point` that has a *non-zero* component in $z$ results in a 3d simulation with complex fields. However, by setting `special_kz` to `True`, Meep will use a 2d cell and real fields (if the $x$ and $y$ components of `k_point` are zero) which improves performance.
 
 **`ensure_periodicity` [`boolean`]**
 —
@@ -1775,7 +1780,7 @@ Output the relative permeability function μ. Note that this only outputs the re
 
 **`Simulation.output_dft(dft_fields, fname, where=None, center=None, size=None)`**
 —
-Output the Fourier-transformed fields in `dft_fields` (created by `add_dft_fields`) to an HDF5 file with name `fname` (does *not* include the `.h5` suffix). The `Volume` `where` defaults to the entire cell. The volume can also be specified via the `center` and `size` arguments. Method of the `Simulation` class.
+Output the Fourier-transformed fields in `dft_fields` (created by `add_dft_fields`) to an HDF5 file with name `fname` (does *not* include the `.h5` suffix). The `Volume` `where` defaults to the entire cell. The volume can also be specified via the `center` and `size` arguments.
 
 **`output_poynting()`**
 —

--- a/doc/docs/Scheme_User_Interface.md
+++ b/doc/docs/Scheme_User_Interface.md
@@ -64,6 +64,10 @@ Specifies the computational grid resolution in pixels per distance unit. Default
 —
 If `false` (the default), then the boundaries are perfect metallic (zero electric field). If a `vector3`, then the boundaries are Bloch-periodic: the fields at one side are $\exp(i\mathbf{k}\cdot\mathbf{R})$ times the fields at the other side, separated by the lattice vector $\mathbf{R}$. A non-zero `vector3` will produce complex fields. The `k-point` vector is specified in Cartesian coordinates in units of 2π/distance. Note: this is *different* from [MPB](https://mpb.readthedocs.io), equivalent to taking MPB's `k-points` through its function `reciprocal->cartesian`.
 
+**`special-kz?` [`boolean`]**
+—
+By default, a 2d cell (i.e., `dimensions` is `2`) combined with a `k-point` that has a *non-zero* component in $z$ results in a 3d simulation with complex fields. However, by setting `special-kz?` to `true`, Meep will use a 2d cell and real fields (if the $x$ and $y$ components of `k-point` are zero) which improves performance.
+
 **`ensure-periodicity` [`boolean`]**
 —
 If `true` (the default) *and* if the boundary conditions are periodic (`k-point` is not `false`), then the geometric objects are automatically repeated periodically according to the lattice vectors which define the size of the cell.

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -70,6 +70,7 @@ TESTS =                                   \
     $(TEST_DIR)/ring.py                   \
     $(TEST_DIR)/ring_cyl.py               \
     $(TEST_DIR)/simulation.py             \
+    $(TEST_DIR)/special_kz.py             \
     $(TEST_DIR)/source.py                 \
     $(TEST_DIR)/user_defined_material.py  \
     $(TEST_DIR)/visualization.py          \

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -566,6 +566,7 @@ class Simulation(object):
                  default_material=mp.Medium(),
                  m=0,
                  k_point=False,
+                 special_kz=False,
                  extra_materials=[],
                  material_function=None,
                  epsilon_func=None,
@@ -606,7 +607,7 @@ class Simulation(object):
         self.Courant = Courant
         self.global_d_conductivity = 0
         self.global_b_conductivity = 0
-        self.special_kz = False
+        self.special_kz = special_kz
         self.k_point = k_point
         self.fields = None
         self.structure = None

--- a/python/tests/cavity_farfield.py
+++ b/python/tests/cavity_farfield.py
@@ -49,7 +49,7 @@ class TestCavityFarfield(unittest.TestCase):
                             resolution=resolution)
 
         nearfield = sim.add_near2far(
-            fcen, 0.1, nfreqs,
+            fcen, 0 if nfreqs == 1 else 0.1, nfreqs,
             mp.Near2FarRegion(mp.Vector3(0, 0.5 * w + d1), size=mp.Vector3(2 * dpml - sx)),
             mp.Near2FarRegion(mp.Vector3(-0.5 * sx + dpml, 0.5 * w + 0.5 * d1), size=mp.Vector3(0, d1), weight=-1.0),
             mp.Near2FarRegion(mp.Vector3(0.5 * sx - dpml, 0.5 * w + 0.5 * d1), size=mp.Vector3(0, d1))

--- a/python/tests/special_kz.py
+++ b/python/tests/special_kz.py
@@ -1,0 +1,96 @@
+from __future__ import division
+
+import unittest
+import meep as mp
+import math
+from time import time
+
+class TestSpecialKz(unittest.TestCase):
+
+    def refl_planar(self, theta, special_kz):
+        resolution = 100  # pixels/um
+
+        dpml = 1.0
+        sx = 3+2*dpml
+        sy = 1/resolution
+        cell_size = mp.Vector3(sx,sy)
+        pml_layers = [mp.PML(dpml,direction=mp.X)]
+
+        fcen = 1.0 # source wavelength = 1 um
+
+        k_point = mp.Vector3(z=math.sin(theta)).scale(fcen)
+
+        sources = [mp.Source(mp.GaussianSource(fcen,fwidth=0.2*fcen),
+                             component=mp.Ez,
+                             center=mp.Vector3(-0.5*sx+dpml),
+                             size=mp.Vector3(y=sy))]
+
+        sim = mp.Simulation(cell_size=cell_size,
+                            boundary_layers=pml_layers,
+                            sources=sources,
+                            k_point=k_point,
+                            special_kz=special_kz,
+                            resolution=resolution)
+
+        refl_fr = mp.FluxRegion(center=mp.Vector3(-0.25*sx),
+                                size=mp.Vector3(y=sy))
+        refl = sim.add_flux(fcen,0,1,refl_fr)
+
+        sim.run(until_after_sources=mp.stop_when_fields_decayed(50,mp.Ez,mp.Vector3(),1e-9))
+
+        empty_flux = mp.get_fluxes(refl)
+        empty_data = sim.get_flux_data(refl)
+        sim.reset_meep()
+
+        geometry = [mp.Block(material=mp.Medium(index=3.5),
+                             size=mp.Vector3(0.5*sx,mp.inf,mp.inf),
+                             center=mp.Vector3(0.25*sx))]
+
+        sim = mp.Simulation(cell_size=cell_size,
+                            boundary_layers=pml_layers,
+                            geometry=geometry,
+                            sources=sources,
+                            k_point=k_point,
+                            special_kz=special_kz,
+                            resolution=resolution)
+
+        refl = sim.add_flux(fcen,0,1,refl_fr)
+        sim.load_minus_flux_data(refl,empty_data)
+
+        sim.run(until_after_sources=mp.stop_when_fields_decayed(50,mp.Ez,mp.Vector3(),1e-9))
+
+        refl_flux = mp.get_fluxes(refl)
+
+        Rmeep = -refl_flux[0]/empty_flux[0]
+        return Rmeep
+
+    def test_special_kz(self):
+        n1 = 1
+        n2 = 3.5
+
+        # compute angle of refracted planewave in medium n2
+        # for incident planewave in medium n1 at angle theta_in
+        theta_out = lambda theta_in: math.asin(n1*math.sin(theta_in)/n2)
+
+        # compute Fresnel reflectance for P-polarization in medium n2
+        # for incident planewave in medium n1 at angle theta_in
+        Rfresnel = lambda theta_in: math.fabs((n1*math.cos(theta_out(theta_in))-n2*math.cos(theta_in))/(n1*math.cos(theta_out(theta_in))+n2*math.cos(theta_in)))**2
+
+        theta = math.radians(23)
+
+        start = time()
+        Rmeep_no_kz = self.refl_planar(theta, False)
+        t_no_kz = time() - start
+
+        start = time()
+        Rmeep_kz = self.refl_planar(theta, True)
+        t_kz = time() - start
+
+        Rfres = Rfresnel(theta)
+
+        self.assertAlmostEqual(Rmeep_no_kz,Rfres,places=2)
+        self.assertAlmostEqual(Rmeep_kz,Rfres,places=2)
+        self.assertLess(t_kz,t_no_kz)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a test to the Python `make check` suite based on the example described in #1007:[comment](https://github.com/NanoComp/meep/pull/1007#issuecomment-527747292). Documentation is provided  for both the Python and Scheme interface.

Also, `special_kz` can now be defined directly in the `Simulation` constructor (default: `False`). As @stevengj [proposed](https://github.com/NanoComp/meep/pull/1007#issuecomment-527858908), we may want to turn this feature on by default.