### PR TITLE
take fields::beta into account in eigenmode calculations

### DIFF
--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -327,8 +327,6 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
     default: abort("unsupported dimensionality in add_eigenmode_source");
   }
 
-  if (verbosity > 1) master_printf("KPOINT: %g, %g, %g\n", k[0], k[1], k[2]);
-
   double kcart_len = sqrt(dot_product(kcart, kcart));
 
   for (int i = 0; i < 3; ++i) {
@@ -355,6 +353,8 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
     for (int j = 0; j < 3; ++j)
       G[i][j] /= GdotR;
   }
+
+  if (verbosity > 1) master_printf("KPOINT: %g, %g, %g\n", k[0], k[1], k[2]);
 
   maxwell_data *mdata;
   if (!user_mdata || *user_mdata == NULL) {
@@ -404,6 +404,7 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
     if (d == NO_DIRECTION) {
       for (int i = 0; i < 3; ++i)
         k[i] = dot_product(R[i], kdir) * kmatch; // kdir*kmatch in reciprocal basis
+      if (gv.dim == D2) k[2] = beta;
     }
     else {
       k[d - X] = kmatch * R[d - X][d - X]; // convert to reciprocal basis
@@ -497,6 +498,7 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
         if (d == NO_DIRECTION) {
           for (int i = 0; i < 3; ++i)
             k[i] = dot_product(R[i], kdir) * kmatch; // kdir*kmatch in reciprocal basis
+          if (gv.dim == D2) k[2] = beta;
         }
         else {
           k[d - X] = kmatch * R[d - X][d - X];

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -279,6 +279,10 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
     empty_dim[2] = true;
   }
 
+  // special case: in a 2d cell, fields::beta is kz
+  if (gv.dim == D2)
+    kpoint.set_direction(Z, beta);
+
   if (resolution <= 0.0) resolution = 2 * gv.a; // default to twice resolution
   int n[3], local_N, N_start, alloc_N, mesh_size[3] = {1, 1, 1};
   mpb_real k[3] = {0, 0, 0}, kcart[3] = {0, 0, 0};

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -279,10 +279,6 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
     empty_dim[2] = true;
   }
 
-  // special case: in a 2d cell, fields::beta is kz
-  if (gv.dim == D2)
-    kpoint.set_direction(Z, beta);
-
   if (resolution <= 0.0) resolution = 2 * gv.a; // default to twice resolution
   int n[3], local_N, N_start, alloc_N, mesh_size[3] = {1, 1, 1};
   mpb_real k[3] = {0, 0, 0}, kcart[3] = {0, 0, 0};
@@ -319,6 +315,7 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
       s[1] = eig_vol.in_direction(Y);
       kcart[0] = kpoint.in_direction(X);
       kcart[1] = kpoint.in_direction(Y);
+      kcart[2] = beta; // special_kz feature
       empty_dim[2] = true;
       break;
     case D1:
@@ -387,7 +384,12 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
   if (d == NO_DIRECTION) {
     for (int i = 0; i < 3; ++i)
       kdir[i] = kcart[i] / kcart_len;
-    kmatch = kcart_len;
+    if (gv.dim == D2) {
+      kdir[2] = 0; // beta is fixed
+      kmatch = sqrt(kcart[0]*kcart[0] + kcart[1]*kcart[1]);
+    }
+    else
+      kmatch = kcart_len;
   }
   else {
     kmatch = G[d - X][d - X] * k[d - X]; // k[d] in cartesian


### PR DESCRIPTION
This is a bugfix, noted in #1009.

@oskooi, would be good to have a test for this before it is merged: a 2d cell with a multimode waveguide, an eigenmode source, and an eigenmode coefficient plane, checking that it still works (still launches and detects a single mode) when `kz ≠ 0` for `special_kz = True` or `False`.