### PR TITLE
add fields::reset_timers

### DIFF
--- a/src/fields.cpp
+++ b/src/fields.cpp
@@ -47,13 +47,8 @@ fields::fields(structure *s, double m, double beta, bool zero_fields_near_cylori
   sources = NULL;
   fluxes = NULL;
   // Time stuff:
-  for (int i = 0; i < MEEP_TIMING_STACK_SZ; ++i)
-    was_working_on[i] = Other;
-  working_on = Other;
-  for (int i = 0; i <= Other; i++)
-    times_spent[i] = 0.0;
-  last_wall_time = last_step_output_wall_time = -1;
-  am_now_working_on(Other);
+  reset_timers();
+  last_step_output_wall_time = -1;
 
   num_chunks = s->num_chunks;
   typedef fields_chunk *fields_chunk_ptr;
@@ -109,13 +104,8 @@ fields::fields(const fields &thef)
   sources = NULL;
   fluxes = NULL;
   // Time stuff:
-  for (int i = 0; i < MEEP_TIMING_STACK_SZ; ++i)
-    was_working_on[i] = Other;
-  working_on = Other;
-  for (int i = 0; i <= Other; i++)
-    times_spent[i] = 0.0;
-  last_wall_time = -1;
-  am_now_working_on(Other);
+  reset_timers();
+  last_step_output_wall_time = -1;
 
   num_chunks = thef.num_chunks;
   typedef fields_chunk *fields_chunk_ptr;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1889,6 +1889,7 @@ public:
   // time.cpp
   void am_now_working_on(time_sink);
   void finished_working();
+  void reset_timers();
 };
 
 class flux_vol {

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -41,6 +41,16 @@ void fields::am_now_working_on(time_sink s) {
   working_on = s;
 }
 
+void fields::reset_timers() {
+  for (int i = 0; i < MEEP_TIMING_STACK_SZ; ++i)
+    was_working_on[i] = Other;
+  working_on = Other;
+  for (int i = 0; i <= Other; ++i)
+    times_spent[i] = 0;
+  last_wall_time = -1;
+  am_now_working_on(Other);
+}
+
 double fields::time_spent_on(time_sink s) { return times_spent[s]; }
 
 double fields::mean_time_spent_on(time_sink s) {


### PR DESCRIPTION
Allows the timing statistics to be restarted, e.g. to exclude the startup time for the first timestep.