### PR TITLE
Add %newobject to create_structure_and_set_materials

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1577,7 +1577,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
     import atexit
     atexit.register(report_elapsed_time)
 %}
-
+%newobject create_structure_and_set_materials;
 %inline %{
 
 size_t get_realnum_size() {


### PR DESCRIPTION
Without this decorator the memory allocated in meep::structure
is never recovered, because ~structure is never run.

Fixes #1038.