### PR TITLE
Fix memory leak

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1578,6 +1578,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
     atexit.register(report_elapsed_time)
 %}
 
+%newobject create_structure_and_set_materials;
 %inline %{
 
 size_t get_realnum_size() {

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1097,6 +1097,16 @@ class Simulation(object):
 
         absorbers = [bl for bl in self.boundary_layers if type(bl) is Absorber]
 
+        # Since we are about to overwrite self.structure, SWIG will garbage
+        # collect it. However, that's not what we want because we're just
+        # passing self.structure into create_structure_and_set_materials for
+        # the "set_materials" half of that function. The return value will be
+        # the same structure we passed in. We tell SWIG to disown (and not
+        # delete) the current self.structure. SWIG will properly take ownership
+        # of the returned self.structure (which is the same structure as
+        # before).
+        self.structure.this.disown()
+
         self.structure = mp.create_structure_and_set_materials(
             self.cell_size,
             self.dft_data_list,


### PR DESCRIPTION
Replaces #1039. Along with #1041, fixes #1038. The fix from #1039 wasn't working for simulations that pass in a `chunk_layout`. A couple tests (`chunks.py` and `simulation.py`) were failing.
@stevengj @oskooi @jeinarsson