### PR TITLE
Add progress bar for notebooks

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2607,7 +2607,7 @@ def display_progress(t0, t, dt):
 
     def _disp(sim):
         t1 = mp.wall_time()
-        if t1 - closure['tlast'] >= dt and mp.cvar.verbosity > 0:
+        if t1 - closure['tlast'] >= dt:
             msg_fmt = "Meep progress: {}/{} = {:.1f}% done in {:.1f}s, {:.1f}s to go"
             val1 = sim.meep_time() - t0
             val2 = val1 / (0.01 * t)
@@ -2618,8 +2618,10 @@ def display_progress(t0, t, dt):
                 sim.progress.value = val1
                 sim.progress.description = "{}% done ".format(int(val2))
 
-            print(msg_fmt.format(val1, t, val2, val3, val4))
+            if mp.cvar.verbosity > 0:
+                print(msg_fmt.format(val1, t, val2, val3, val4))
             closure['tlast'] = t1
+
     return _disp
 
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -26,6 +26,14 @@ try:
 except NameError:
     basestring = str
 
+try:
+    from ipywidgets import FloatProgress
+    from IPython.display import display
+    do_progress = True
+except ImportError:
+    do_progress = False
+
+
 # Send output from Meep, ctlgeom, and MPB to Python's stdout
 mp.cvar.master_printf_callback = mp.py_master_printf_wrap
 mp.set_ctl_printf_callback(mp.py_master_printf_wrap)
@@ -1371,6 +1379,10 @@ class Simulation(object):
 
                 step_funcs = list(step_funcs)
                 step_funcs.append(display_progress(t0, t0 + stop_time, self.progress_interval))
+
+                if do_progress:
+                    self.progress = FloatProgress(value=t0, min=t0, max=t0 + stop_time, description="0% done ")
+                    display(self.progress)
             else:
                 assert callable(cond[i]), "Stopping condition {} is not an integer or a function".format(cond[i])
 
@@ -1387,6 +1399,10 @@ class Simulation(object):
 
         for func in step_funcs:
             _eval_step_func(self, func, 'finish')
+
+        if do_progress:
+            self.progress.value = t0 + stop_time
+            self.progress.description = "100% done "
 
         if mp.cvar.verbosity > 0:
             print("run {} finished at t = {} ({} timesteps)".format(self.run_index, self.meep_time(), self.fields.t))
@@ -2597,6 +2613,11 @@ def display_progress(t0, t, dt):
             val2 = val1 / (0.01 * t)
             val3 = t1 - t_0
             val4 = (val3 * (t / val1) - val3) if val1 != 0 else 0
+
+            if do_progress:
+                sim.progress.value = val1
+                sim.progress.description = "{}% done ".format(int(val2))
+
             print(msg_fmt.format(val1, t, val2, val3, val4))
             closure['tlast'] = t1
     return _disp


### PR DESCRIPTION
Unfortunately the idea of using `_repr_markdown_` and `__repr__` to adapt the display to notebooks and the terminal won't work because IPython will always call [`__repr__` in addition to `_repr_markdown_`](https://github.com/ipython/ipython/issues/9771). This PR adds a progress bar for notebooks, but still prints the same text it was printing before. It looks like this:

![Screenshot from 2019-12-16 18-36-29](https://user-images.githubusercontent.com/14114829/70954501-1373d280-2033-11ea-9388-29fd26c0bb43.png)

Including the text kind of defeats the purpose of the progress bar, but I'm not sure we can do much better until there is a reliable way to detect if we're running in a notebook.
@stevengj @oskooi 