### PR TITLE
revamp dft_near2far::flux by removing duplicated code for get_fields_array

### DIFF
--- a/doc/docs/Python_Tutorials/Near_to_Far_Field_Spectra.md
+++ b/doc/docs/Python_Tutorials/Near_to_Far_Field_Spectra.md
@@ -31,7 +31,7 @@ resolution = 50  # pixels/um
 
 sxy = 4
 dpml = 1
-cell = mp.Vector3(sxy+2*dpml,sxy+2*dpml,0)
+cell = mp.Vector3(sxy+2*dpml,sxy+2*dpml)
 
 pml_layers = [mp.PML(dpml)]
 

--- a/doc/docs/Python_Tutorials/Near_to_Far_Field_Spectra.md
+++ b/doc/docs/Python_Tutorials/Near_to_Far_Field_Spectra.md
@@ -105,8 +105,8 @@ for n in range(npts):
     E[n,:] = [np.conj(ff[j]) for j in range(3)]
     H[n,:] = [ff[j+3] for j in range(3)]
 
-Px = np.real(np.multiply(E[:,1],H[:,2])-np.multiply(E[:,2],H[:,1]))
-Py = np.real(np.multiply(E[:,2],H[:,0])-np.multiply(E[:,0],H[:,2]))
+Px = np.real(E[:,1]*H[:,2]-E[:,2]*H[:,1])
+Py = np.real(E[:,2]*H[:,0]-E[:,0]*H[:,2])
 Pr = np.sqrt(np.square(Px)+np.square(Py))
 
 far_flux_circle = np.sum(Pr)*2*np.pi*r/len(Pr)

--- a/python/examples/antenna-radiation.ipynb
+++ b/python/examples/antenna-radiation.ipynb
@@ -53,7 +53,7 @@
     "\n",
     "sxy = 4\n",
     "dpml = 1\n",
-    "cell = mp.Vector3(sxy+2*dpml,sxy+2*dpml,0)\n",
+    "cell = mp.Vector3(sxy+2*dpml,sxy+2*dpml)\n",
     "\n",
     "pml_layers = [mp.PML(dpml)]\n",
     "\n",

--- a/python/examples/antenna-radiation.py
+++ b/python/examples/antenna-radiation.py
@@ -9,7 +9,7 @@ resolution = 50  # pixels/um
 
 sxy = 4
 dpml = 1
-cell = mp.Vector3(sxy+2*dpml,sxy+2*dpml,0)
+cell = mp.Vector3(sxy+2*dpml,sxy+2*dpml)
 
 pml_layers = [mp.PML(dpml)]
 
@@ -71,8 +71,8 @@ for n in range(npts):
     E[n,:] = [np.conj(ff[j]) for j in range(3)]
     H[n,:] = [ff[j+3] for j in range(3)]
 
-Px = np.real(np.multiply(E[:,1],H[:,2])-np.multiply(E[:,2],H[:,1]))
-Py = np.real(np.multiply(E[:,2],H[:,0])-np.multiply(E[:,0],H[:,2]))
+Px = np.real(E[:,1]*H[:,2]-E[:,2]*H[:,1])
+Py = np.real(E[:,2]*H[:,0]-E[:,0]*H[:,2])
 Pr = np.sqrt(np.square(Px)+np.square(Py))
 
 far_flux_circle = np.sum(Pr)*2*np.pi*r/len(Pr)

--- a/python/tests/antenna_radiation.py
+++ b/python/tests/antenna_radiation.py
@@ -63,8 +63,8 @@ class TestAntennaRadiation(unittest.TestCase):
             E[n,:] = [np.conj(ff[j]) for j in range(3)]
             H[n,:] = [ff[j+3] for j in range(3)]
 
-        Px = np.real(np.multiply(E[:,1],H[:,2])-np.multiply(E[:,2],H[:,1]))
-        Py = np.real(np.multiply(E[:,2],H[:,0])-np.multiply(E[:,0],H[:,2]))
+        Px = np.real(E[:,1]*H[:,2]-E[:,2]*H[:,1])
+        Py = np.real(E[:,2]*H[:,0]-E[:,0]*H[:,2])
         Pr = np.sqrt(np.square(Px)+np.square(Py))
         far_flux_circle = np.sum(Pr)*2*np.pi*r/len(Pr)
 

--- a/python/tests/antenna_radiation.py
+++ b/python/tests/antenna_radiation.py
@@ -17,7 +17,7 @@ class TestAntennaRadiation(unittest.TestCase):
         resolution = 50
         sxy = 4
         dpml = 1
-        cell = mp.Vector3(sxy+2*dpml,sxy+2*dpml,0)
+        cell = mp.Vector3(sxy+2*dpml,sxy+2*dpml)
 
         pml_layers = mp.PML(dpml)
 
@@ -28,7 +28,8 @@ class TestAntennaRadiation(unittest.TestCase):
                             center=mp.Vector3(),
                             component=mp.Ez)
 
-        symmetries = [mp.Mirror(mp.X), mp.Mirror(mp.Y)]
+        symmetries = [mp.Mirror(mp.X),
+                      mp.Mirror(mp.Y)]
 
         sim = mp.Simulation(cell_size=cell,
                             resolution=resolution,

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -436,7 +436,11 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
     }
   }
 
-  double dV = pow(1/resolution,rank);
+  double dV = 1;
+  LOOP_OVER_DIRECTIONS(where.dim, d) {
+    int dim = int(floor(where.in_direction(d) * resolution));
+    if (dim > 1) dV *= where.in_direction(d) / (dim - 1);
+  }
 
   for (int i = 0; i < Nfreq; ++i)
     F[i] *= dV;

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -406,74 +406,43 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
   if (coordinate_mismatch(where.dim, df) || where.dim == Dcyl)
     abort("cannot get flux for near2far: co-ordinate mismatch");
 
-  /* compute output grid size etc. */
-  int dims[4] = {1, 1, 1, 1};
-  double dx[3] = {0, 0, 0};
-  direction dirs[3] = {X, Y, Z};
-  int rank = 0, N = 1;
-  double vol = 1;
+  size_t dims[4] = {1, 1, 1, 1};
+  int rank = 0;
+  size_t N = 1;
 
-  LOOP_OVER_DIRECTIONS(where.dim, d) {
-    dims[rank] = int(floor(where.in_direction(d) * resolution));
-    if (dims[rank] <= 1) {
-      dims[rank] = 1;
-      dx[rank] = 0;
-    }
-    else {
-      dx[rank] = where.in_direction(d) / (dims[rank] - 1);
-      vol *= dx[rank];
-    }
-    N *= dims[rank];
-    dirs[rank++] = d;
-  }
-
-  /* fields for farfield_lowlevel for a single output point x */
-  std::complex<double> *EH1 = new std::complex<double>[6 * Nfreq];
-  std::complex<double> *EH1_ = new std::complex<double>[6 * Nfreq];
-
-  double *F_ = new double[Nfreq];
-  std::complex<double> ff_EH[6];
-  std::complex<double> cE[2], cH[2];
-
-  for (int i = 0; i < Nfreq; ++i)
-    F_[i] = 0;
-
-  vec x(where.dim);
-  for (int i0 = 0; i0 < dims[0]; ++i0) {
-    x.set_direction(dirs[0], where.in_direction_min(dirs[0]) + i0 * dx[0]);
-    for (int i1 = 0; i1 < dims[1]; ++i1) {
-      x.set_direction(dirs[1], where.in_direction_min(dirs[1]) + i1 * dx[1]);
-      for (int i2 = 0; i2 < dims[2]; ++i2) {
-        x.set_direction(dirs[2], where.in_direction_min(dirs[2]) + i2 * dx[2]);
-        farfield_lowlevel(EH1_, x);
-        sum_to_master(EH1_, EH1, 6 * Nfreq);
-        for (int i = 0; i < Nfreq; ++i) {
-          for (int k = 0; k < 6; ++k)
-            ff_EH[k] = EH1[i * 6 + k];
-          switch (df) {
-            case X: cE[0] = ff_EH[1], cE[1] = ff_EH[2], cH[0] = ff_EH[5], cH[1] = ff_EH[4]; break;
-            case Y: cE[0] = ff_EH[2], cE[1] = ff_EH[0], cH[0] = ff_EH[3], cH[1] = ff_EH[5]; break;
-            case Z: cE[0] = ff_EH[0], cE[1] = ff_EH[1], cH[0] = ff_EH[4], cH[1] = ff_EH[3]; break;
-            case R:
-            case P:
-            case NO_DIRECTION: abort("invalid flux direction");
-          }
-          for (int j = 0; j < 2; ++j)
-            F_[i] += real(cE[j] * conj(cH[j])) * (1 - 2 * j);
-        }
-      }
-    }
-  }
-
-  delete[] EH1_;
-  delete[] EH1;
-
-  for (int i = 0; i < Nfreq; ++i)
-    F_[i] *= vol;
+  realnum *EH = get_farfields_array(where, rank, dims, N, resolution);
 
   double *F = new double[Nfreq];
-  sum_to_all(F_, F, Nfreq);
-  delete[] F_;
+  std::complex<realnum> ff_EH[6];
+  std::complex<realnum> cE[2], cH[2];
+
+  for (int i = 0; i < Nfreq; ++i)
+    F[i] = 0;
+
+  for (int idx = 0; idx < N; ++idx) {
+    for (int i = 0; i < Nfreq; ++i) {
+      for (int k = 0; k < 6; ++k)
+        ff_EH[k] = std::complex<realnum>(*(EH + ((k * 2 + 0) * N + idx) * Nfreq + i), *(EH + ((k * 2 + 1) * N + idx) * Nfreq + i));
+      switch (df) {
+      case X: cE[0] = ff_EH[1], cE[1] = ff_EH[2], cH[0] = ff_EH[5], cH[1] = ff_EH[4]; break;
+      case Y: cE[0] = ff_EH[2], cE[1] = ff_EH[0], cH[0] = ff_EH[3], cH[1] = ff_EH[5]; break;
+      case Z: cE[0] = ff_EH[0], cE[1] = ff_EH[1], cH[0] = ff_EH[4], cH[1] = ff_EH[3]; break;
+      case R:
+      case P:
+      case NO_DIRECTION: abort("invalid flux direction");
+      }
+      for (int j = 0; j < 2; ++j)
+        F[i] += real(cE[j] * conj(cH[j])) * (1 - 2 * j);
+    }
+  }
+
+  double dV = pow(1/resolution,rank);
+
+  for (int i = 0; i < Nfreq; ++i)
+    F[i] *= dV;
+
+  delete[] EH;
+
   return F;
 }
 

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -419,7 +419,7 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
   for (int i = 0; i < Nfreq; ++i)
     F[i] = 0;
 
-  for (int idx = 0; idx < N; ++idx) {
+  for (size_t idx = 0; idx < N; ++idx) {
     for (int i = 0; i < Nfreq; ++i) {
       for (int k = 0; k < 6; ++k)
         ff_EH[k] = std::complex<realnum>(*(EH + ((k * 2 + 0) * N + idx) * Nfreq + i), *(EH + ((k * 2 + 1) * N + idx) * Nfreq + i));


### PR DESCRIPTION
Currently, [`dft_near2far::flux`](https://github.com/NanoComp/meep/blob/master/src/near2far.cpp#L405-L466) contains [duplicated code](https://github.com/NanoComp/meep/blob/master/src/near2far.cpp#L333-L360) from `dft_near2far::get_farfields_array`. This PR removes this duplication by simply calling `get_farfields_array` from within the `flux` routine which has the added benefit that the progress message (which was originally left out) is now included.

One additional minor change is made to the dV term in the integral computation of the Poynting flux.