### PR TITLE
WIP: near2far for cylindrical coordinates.

### DIFF
--- a/src/meep_internals.hpp
+++ b/src/meep_internals.hpp
@@ -151,4 +151,12 @@ void step_beta_stride1(realnum *f, component c, const realnum *g, const grid_vol
       step_beta(f, c, g, gv, betadt, dsig, siginv, fu, dsigu, siginvu, cndinv, fcnd);              \
   } while (0)
 
+// analytical Green's functions from near2far.cpp, which we might want to expose someday
+void green3d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
+             const vec &x0, component c0, std::complex<double> f0);
+void green2d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
+             const vec &x0, component c0, std::complex<double> f0);
+void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
+              const vec &x0, component c0, std::complex<double> f0, double m, double tol);
+
 } // namespace meep

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -256,14 +256,17 @@ void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, d
   vec x_3d(x.dim == Dcyl ? x.r() : x.x(), x.y(), x.z());
   direction d = component_direction(c0);
   component cx = direction_component(c0, X), cy = direction_component(c0, Y);
+  for (int j = 0; j < 6; ++j) EH[j] = 0;
   const int N0 = 8;
+  double dtheta = 2*TWOPI/N0;
   for (int N = N0; N <= 65536; N *= 2) {
-    std::complex<double> EH_sum[6] = {0,0,0,0,0,0};
-    double dtheta = TWOPI/N;
+    std::complex<double> EH_sum[6];
+    dtheta *= 0.5; /* delta theta is halved on each N loop iteration */
+    for (int j = 0; j < 6; ++j) EH_sum[j] = EH[j] * 0.5; // re-use previous quadrature points
     for (int i = (N>N0); i < N; i += 1 + (N>N0)) {
       double phi = i*dtheta, c = cos(phi), s = sin(phi);
       vec x0_phi(x0.r() * c, x0.r() * s, x0.z());
-      std::complex<double> EH_phi[6], f0_exp_imphi = f0 * std::polar(1.0, m*phi);
+      std::complex<double> EH_phi[6], f0_exp_imphi = f0 * std::polar(1.0, m*phi) * dtheta;
       if (d == Z) {
         green3d(EH_phi, x_3d, freq, eps, mu, x0_phi, c0, f0_exp_imphi);
         for (int j = 0; j < 6; ++j) EH_sum[j] += EH_phi[j];
@@ -283,10 +286,8 @@ void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, d
     }
     double sumdiff = 0, sumabs = 0;
     for (int j = 0; j < 6; ++j) {
-      std::complex<double> old = EH[j];
-      EH[j] = EH_sum[j]*dtheta;
-      sumdiff += abs(EH[j] - old);
-      sumabs += abs(EH[j]);
+      sumdiff += abs(EH[j] - EH_sum[j]);
+      sumabs += abs(EH[j] = EH_sum[j]);
     }
     if (sumdiff <= sumabs * tol) break;
   }

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -260,7 +260,7 @@ void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, d
      should converge exponentially fast with the number N of quadrature points.  We
      repeatedly double N until convergence to tol is achieved, re-using previous points. */
   const int N0 = 4;
-  double dphi = 2 / N0; // factor of 2*pi*r is already included in add_dft weight
+  double dphi = 2.0 / N0; // factor of 2*pi*r is already included in add_dft weight
   for (int N = N0; N <= 65536; N *= 2) {
     std::complex<double> EH_sum[6];
     dphi *= 0.5; // delta phi is halved because N doubles

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -372,6 +372,7 @@ realnum *dft_near2far::get_farfields_array(const volume &where, int &rank, size_
     N *= dims[rank];
     dirs[rank++] = d;
   }
+  if (where.dim == Dcyl) dirs[2] = P; // otherwise Z is listed twice
 
   if (N * Nfreq < 1) return NULL; /* nothing to output */
 

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -256,7 +256,7 @@ void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, d
   for (int j = 0; j < 6; ++j)
     EH[j] = 0;
 
-  /* Perform phi integral.  Since phi integrand is smooth, quadrature qually spaced points
+  /* Perform phi integral.  Since phi integrand is smooth, quadrature with equally spaced points
      should converge exponentially fast with the number N of quadrature points.  We
      repeatedly double N until convergence to tol is achieved, re-using previous points. */
   const int N0 = 4;

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -256,12 +256,12 @@ void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, d
   for (int j = 0; j < 6; ++j)
     EH[j] = 0;
   const int N0 = 8;
-  double dtheta = 4 * pi / N0;
+  double dtheta = 2 / N0; // factor of 2*pi*r is already included in add_dft weight
   for (int N = N0; N <= 65536; N *= 2) {
     std::complex<double> EH_sum[6];
-    dtheta *= 0.5; /* delta theta is halved on each N loop iteration */
+    dtheta *= 0.5; // delta theta is halved because N doubles
     for (int j = 0; j < 6; ++j)
-      EH_sum[j] = EH[j] * 0.5; // re-use previous quadrature points
+      EH_sum[j] = EH[j] * 0.5; // re-use previous quadrature points (with halved dtheta)
     for (int i = (N > N0); i < N; i += 1 + (N > N0)) {
       double phi = i * dtheta, c = cos(phi), s = sin(phi);
       vec x0_phi(x0.r() * c, x0.r() * s, x0.z());

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -250,38 +250,44 @@ void green2d(std::complex<double> *EH, const vec &x, double freq, double eps, do
 // cylindrical Green's function constructed by integrating green3d as the source
 // term rotates around the z axis with exp(im*phi) dependence, integrated to a tolerance tol.
 void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
-             const vec &x0, component c0, std::complex<double> f0,
-             double m, double tol) {
+              const vec &x0, component c0, std::complex<double> f0, double m, double tol) {
   if (x0.dim != Dcyl) abort("wrong dimensionality in greencyl");
   vec x_3d(x.dim == Dcyl ? x.r() : x.x(), x.y(), x.z());
   direction d = component_direction(c0);
   component cx = direction_component(c0, X), cy = direction_component(c0, Y);
-  for (int j = 0; j < 6; ++j) EH[j] = 0;
+  for (int j = 0; j < 6; ++j)
+    EH[j] = 0;
   const int N0 = 8;
-  double dtheta = 2*TWOPI/N0;
+  double dtheta = 2 * TWOPI / N0;
   for (int N = N0; N <= 65536; N *= 2) {
     std::complex<double> EH_sum[6];
     dtheta *= 0.5; /* delta theta is halved on each N loop iteration */
-    for (int j = 0; j < 6; ++j) EH_sum[j] = EH[j] * 0.5; // re-use previous quadrature points
-    for (int i = (N>N0); i < N; i += 1 + (N>N0)) {
-      double phi = i*dtheta, c = cos(phi), s = sin(phi);
+    for (int j = 0; j < 6; ++j)
+      EH_sum[j] = EH[j] * 0.5; // re-use previous quadrature points
+    for (int i = (N > N0); i < N; i += 1 + (N > N0)) {
+      double phi = i * dtheta, c = cos(phi), s = sin(phi);
       vec x0_phi(x0.r() * c, x0.r() * s, x0.z());
-      std::complex<double> EH_phi[6], f0_exp_imphi = f0 * std::polar(1.0, m*phi) * dtheta;
+      std::complex<double> EH_phi[6], f0_exp_imphi = f0 * std::polar(1.0, m * phi) * dtheta;
       if (d == Z) {
         green3d(EH_phi, x_3d, freq, eps, mu, x0_phi, c0, f0_exp_imphi);
-        for (int j = 0; j < 6; ++j) EH_sum[j] += EH_phi[j];
+        for (int j = 0; j < 6; ++j)
+          EH_sum[j] += EH_phi[j];
       }
       else if (d == R) {
-        green3d(EH_phi, x_3d, freq, eps, mu, x0_phi, cx, f0_exp_imphi*c);
-        for (int j = 0; j < 6; ++j) EH_sum[j] += EH_phi[j];
-        green3d(EH_phi, x_3d, freq, eps, mu, x0_phi, cy, f0_exp_imphi*s);
-        for (int j = 0; j < 6; ++j) EH_sum[j] += EH_phi[j];
+        green3d(EH_phi, x_3d, freq, eps, mu, x0_phi, cx, f0_exp_imphi * c);
+        for (int j = 0; j < 6; ++j)
+          EH_sum[j] += EH_phi[j];
+        green3d(EH_phi, x_3d, freq, eps, mu, x0_phi, cy, f0_exp_imphi * s);
+        for (int j = 0; j < 6; ++j)
+          EH_sum[j] += EH_phi[j];
       }
       else { /* (d == P) */
-        green3d(EH_phi, x_3d, freq, eps, mu, x0_phi, cx, f0_exp_imphi*(-s));
-        for (int j = 0; j < 6; ++j) EH_sum[j] += EH_phi[j];
-        green3d(EH_phi, x_3d, freq, eps, mu, x0_phi, cy, f0_exp_imphi*c);
-        for (int j = 0; j < 6; ++j) EH_sum[j] += EH_phi[j];
+        green3d(EH_phi, x_3d, freq, eps, mu, x0_phi, cx, f0_exp_imphi * (-s));
+        for (int j = 0; j < 6; ++j)
+          EH_sum[j] += EH_phi[j];
+        green3d(EH_phi, x_3d, freq, eps, mu, x0_phi, cy, f0_exp_imphi * c);
+        for (int j = 0; j < 6; ++j)
+          EH_sum[j] += EH_phi[j];
       }
     }
     double sumdiff = 0, sumabs = 0;
@@ -294,7 +300,8 @@ void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, d
 }
 
 void dft_near2far::farfield_lowlevel(std::complex<double> *EH, const vec &x) {
-  if (x.dim != D3 && x.dim != D2 && x.dim != Dcyl) abort("only 2d or 3d or cylindrical far-field computation is supported");
+  if (x.dim != D3 && x.dim != D2 && x.dim != Dcyl)
+    abort("only 2d or 3d or cylindrical far-field computation is supported");
   greenfunc green = x.dim == D2 ? green2d : green3d;
 
   for (int i = 0; i < 6 * Nfreq; ++i)

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -361,12 +361,13 @@ realnum *dft_near2far::get_farfields_array(const volume &where, int &rank, size_
   double dx[3] = {0, 0, 0};
   direction dirs[3] = {X, Y, Z};
 
+  rank = 0;
+  N = dims[0] = dims[1] = dims[2] = 1;
+
   LOOP_OVER_DIRECTIONS(where.dim, d) {
     dims[rank] = int(floor(where.in_direction(d) * resolution));
-    if (dims[rank] <= 1) {
+    if (dims[rank] <= 1)
       dims[rank] = 1;
-      dx[rank] = 0;
-    }
     else
       dx[rank] = where.in_direction(d) / (dims[rank] - 1);
     N *= dims[rank];
@@ -384,7 +385,6 @@ realnum *dft_near2far::get_farfields_array(const volume &where, int &rank, size_
   std::complex<double> *EH1 = new std::complex<double>[6 * Nfreq];
 
   double start = wall_time();
-  size_t total_points = dims[0] * dims[1] * dims[2];
   size_t last_point = 0;
 
   vec x(where.dim);
@@ -396,9 +396,9 @@ realnum *dft_near2far::get_farfields_array(const volume &where, int &rank, size_
         x.set_direction(dirs[2], where.in_direction_min(dirs[2]) + i2 * dx[2]);
         double t;
         if (verbosity > 0 && (t = wall_time()) > start + MEEP_MIN_OUTPUT_TIME) {
-          size_t this_point = (dims[1] * dims[2] * i0) + (dims[2] * i1) + i2 + 1;
+          size_t this_point = (dims[1] * i0 + i1) * dims[2] + i2 + 1;
           master_printf("get_farfields_array working on point %zu of %zu (%d%% done), %g s/point\n",
-                        this_point, total_points, (int)((double)this_point / total_points * 100),
+                        this_point, N, (int)((double)this_point / N * 100),
                         (t - start) / (std::max(1, (int)(this_point - last_point))));
           start = t;
           last_point = this_point;

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -247,6 +247,8 @@ void green2d(std::complex<double> *EH, const vec &x, double freq, double eps, do
 
 // cylindrical Green's function constructed by integrating green3d as the source
 // term rotates around the z axis with exp(im*phi) dependence, integrated to a tolerance tol.
+// (note: this is the Green's function divided by 2pi*x0.r(), to compensate for a 2piR factor
+//  in the near2far add_dft weight.)
 void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
               const vec &x0, component c0, std::complex<double> f0, double m, double tol) {
   if (x0.dim != Dcyl) abort("wrong dimensionality in greencyl");

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -264,12 +264,13 @@ void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, d
   for (int N = N0; N <= 65536; N *= 2) {
     std::complex<double> EH_sum[6];
     dphi *= 0.5; // delta phi is halved because N doubles
+    double dphi2pi = dphi * 2*pi;
     for (int j = 0; j < 6; ++j)
       EH_sum[j] = EH[j] * 0.5; // re-use previous quadrature points (with halved dphi)
     /* N-point quadrature points i = 0..N-1.  After the first iteration (N==N0), we
        only need to sum over odd i, since the even i were summed for the previous N. */
     for (int i = (N > N0); i < N; i += 1 + (N > N0)) {
-      double phi = i * dphi, c = cos(phi), s = sin(phi);
+      double phi = i * dphi2pi, c = cos(phi), s = sin(phi);
       vec x0_phi(x0.r() * c, x0.r() * s, x0.z()); // source point rotated by phi
       std::complex<double> EH_phi[6], f0_exp_imphi = f0 * std::polar(1.0, m * phi) * dphi;
       /* if the source direction is in the r or phi directions, then we must rotate

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -255,7 +255,7 @@ void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, d
   component cx = direction_component(c0, X), cy = direction_component(c0, Y);
   for (int j = 0; j < 6; ++j)
     EH[j] = 0;
-  const int N0 = 8;
+  const int N0 = 4;
   double dtheta = 2 / N0; // factor of 2*pi*r is already included in add_dft weight
   for (int N = N0; N <= 65536; N *= 2) {
     std::complex<double> EH_sum[6];

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -245,8 +245,6 @@ void green2d(std::complex<double> *EH, const vec &x, double freq, double eps, do
   }
 }
 
-#define TWOPI 6.2831853071795864769252867665590057683943388
-
 // cylindrical Green's function constructed by integrating green3d as the source
 // term rotates around the z axis with exp(im*phi) dependence, integrated to a tolerance tol.
 void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
@@ -258,7 +256,7 @@ void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, d
   for (int j = 0; j < 6; ++j)
     EH[j] = 0;
   const int N0 = 8;
-  double dtheta = 2 * TWOPI / N0;
+  double dtheta = 4 * pi / N0;
   for (int N = N0; N <= 65536; N *= 2) {
     std::complex<double> EH_sum[6];
     dtheta *= 0.5; /* delta theta is halved on each N loop iteration */

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -20,7 +20,7 @@
    compute the fields on a "far" surface via the homogeneous-medium Green's
    function in 2d or 3d. */
 
-#include <meep.hpp>
+#include "meep_internals.hpp"
 #include <assert.h>
 #include "config.h"
 #include <math.h>


### PR DESCRIPTION
This is a rough draft to fix #1086 using the simplest possible method: integrating `green3d` numerically over φ to get the corresponding cylindrical function.

(Integrates by repeatedly doubling the number of φ points to a tolerance of `1e-3` or 2^16 points, whichever comes first, with a simple Euler/trapezoidal rule — which should be exponentially convergent for smooth cylindrical integrals like this.)

Untested except to check that it compiles, intended as a first draft.