### PR TITLE
Get chunk communciation areas

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1354,6 +1354,12 @@ void _get_eigenmode(meep::fields *f, double omega_src, meep::direction d, const 
     %}
 }
 
+%extend meep::fields {
+  bool is_periodic(boundary_side side, direction dir) {
+    return $self->boundaries[side][dir] == meep::Periodic;
+  }
+}
+
 extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
 extern boolean point_in_periodic_objectp(vector3 p, GEOMETRIC_OBJECT o);
 void display_geometric_object_info(int indentby, GEOMETRIC_OBJECT o);


### PR DESCRIPTION
Closes #1069. Adds `get_max_chunk_communication_area` and `get_avg_chunk_communication_area`. Unions all chunks on the same processor to a single volume. Counts all inner boundaries, but only counts outer boundaries that are periodic.

Usage:

```py
sim = mp.Simulation(...)
max_comm = sim.get_max_chunk_communication_area()
avg_comm = sim.get_avg_chunk_communication_area()
```
@stevengj @oskooi 