### PR TITLE
improve mpi4py error message and update centos7 installer

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1563,8 +1563,8 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
     if with_mpi():
         try:
             from mpi4py import MPI
-        except ImportError:
-            print('\n**\n** failed to load python MPI module (mpi4py)\n**\n')
+        except ImportError as e:
+            print('\n**\n** failed to load python MPI module (mpi4py)\n**', e, '\n**\n')
             pass
         else:
             # this variable reference is needed for lazy initialization of MPI


### PR DESCRIPTION
The change in `python/meep.i` provides a detailed error message that ***allows*** to find out causes of installation issues:
```
**
** failed to load python MPI module (mpi4py)
** /usr/local/lib64/python3.6/site-packages/mpi4py/MPI.cpython-36m-x86_64-linux-gnu.so: undefined symbol: ompi_mpi_logical8 
**
```
as compared to previously:
```
**
** failed to load python MPI module (mpi4py)
**
```

The updated installer builds a working version of meep inside a bare `centos:7` docker image.
The above error is solved by using `LD_PRELOAD` system environment variable.
