### PR TITLE
write output files from Python tests to temporary system directory rather than source subdirectory

### DIFF
--- a/doc/docs/Build_From_Source.md
+++ b/doc/docs/Build_From_Source.md
@@ -191,7 +191,7 @@ Assuming you've set your `LDFLAGS` etcetera, the configure script should find al
 make check
 ```
 
-Note: several of the unit tests generate output files which are written to disk. The C++ test suite in `meep/tests` outputs its files in the same subdirectory. The Python test suite in `meep/python/tests` outputs its files to a temporary system directory.
+Note: several of the unit tests generate output files which are written to disk. The C++ test suite in `meep/tests` outputs its files in the same subdirectory. The Python test suite in `meep/python/tests` outputs its files to a temporary system directory (i.e., /tmp, etc.).
 
 The configure script accepts several flags to modify its behavior.
 

--- a/doc/docs/Build_From_Source.md
+++ b/doc/docs/Build_From_Source.md
@@ -191,6 +191,8 @@ Assuming you've set your `LDFLAGS` etcetera, the configure script should find al
 make check
 ```
 
+Note: several of the unit tests generate output files which are written to disk. The C++ test suite in `meep/tests` outputs its files in the same subdirectory. The Python test suite in `meep/python/tests` outputs its files to a temporary system directory.
+
 The configure script accepts several flags to modify its behavior.
 
 **`--prefix=dir`**

--- a/python/tests/bend_flux.py
+++ b/python/tests/bend_flux.py
@@ -18,7 +18,7 @@ class TestBendFlux(unittest.TestCase):
         wvg_ycen = -0.5 * (sy - w - (2 * pad))
         wvg_xcen = 0.5 * (sx - w - (2 * pad))
         height = 100
-        data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+        data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
         gdsii_file = os.path.join(data_dir, 'bend-flux.gds')
 
         if no_bend:

--- a/python/tests/bend_flux.py
+++ b/python/tests/bend_flux.py
@@ -18,7 +18,7 @@ class TestBendFlux(unittest.TestCase):
         wvg_ycen = -0.5 * (sy - w - (2 * pad))
         wvg_xcen = 0.5 * (sx - w - (2 * pad))
         height = 100
-        data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
+        data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
         gdsii_file = os.path.join(data_dir, 'bend-flux.gds')
 
         if no_bend:

--- a/python/tests/cavity_arrayslice.py
+++ b/python/tests/cavity_arrayslice.py
@@ -9,7 +9,7 @@ import numpy as np
 
 class TestCavityArraySlice(unittest.TestCase):
 
-    data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+    data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
     expected_1d = np.load(os.path.join(data_dir, 'cavity_arrayslice_1d.npy'))
     expected_2d = np.load(os.path.join(data_dir, 'cavity_arrayslice_2d.npy'))
 

--- a/python/tests/cavity_arrayslice.py
+++ b/python/tests/cavity_arrayslice.py
@@ -9,7 +9,7 @@ import numpy as np
 
 class TestCavityArraySlice(unittest.TestCase):
 
-    data_dir = os.path.abspath(os.path.realpath(os.path.join(__file__, '..', 'data')))
+    data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
     expected_1d = np.load(os.path.join(data_dir, 'cavity_arrayslice_1d.npy'))
     expected_2d = np.load(os.path.join(data_dir, 'cavity_arrayslice_2d.npy'))
 

--- a/python/tests/cavity_farfield.py
+++ b/python/tests/cavity_farfield.py
@@ -7,7 +7,7 @@ import meep as mp
 
 class TestCavityFarfield(unittest.TestCase):
 
-    data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
+    data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 
     def run_test(self, nfreqs):
         eps = 13

--- a/python/tests/cavity_farfield.py
+++ b/python/tests/cavity_farfield.py
@@ -7,7 +7,7 @@ import meep as mp
 
 class TestCavityFarfield(unittest.TestCase):
 
-    data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+    data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
 
     def run_test(self, nfreqs):
         eps = 13

--- a/python/tests/chunks.py
+++ b/python/tests/chunks.py
@@ -64,7 +64,8 @@ if __name__ == '__main__':
         temp_dir = tempfile.mkdtemp()
     else:
         temp_dir = None
-    temp_dir = mp.comm.bcast(temp_dir, root=0)
+    if mp.count_processors() > 1:
+        temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/chunks.py
+++ b/python/tests/chunks.py
@@ -1,6 +1,5 @@
 import unittest
 import meep as mp
-import tempfile
 import os
 
 class TestChunks(unittest.TestCase):
@@ -60,12 +59,7 @@ class TestChunks(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    if mp.am_master():
-        temp_dir = tempfile.mkdtemp()
-    else:
-        temp_dir = None
-    if mp.count_processors() > 1:
-        temp_dir = mp.comm.bcast(temp_dir, root=0)
+    temp_dir = mp.make_output_directory()
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -2,7 +2,6 @@ from __future__ import division
 
 import unittest
 import meep as mp
-import tempfile
 import os
 
 def dummy_eps(vec):
@@ -71,12 +70,7 @@ class TestCylEllipsoid(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    if mp.am_master():
-        temp_dir = tempfile.mkdtemp()
-    else:
-        temp_dir = None
-    if mp.count_processors() > 1:
-        temp_dir = mp.comm.bcast(temp_dir, root=0)
+    temp_dir = mp.make_output_directory()
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -2,11 +2,11 @@ from __future__ import division
 
 import unittest
 import meep as mp
-
+import tempfile
+import os
 
 def dummy_eps(vec):
     return 1.0
-
 
 class TestCylEllipsoid(unittest.TestCase):
 
@@ -34,6 +34,8 @@ class TestCylEllipsoid(unittest.TestCase):
                                  sources=[sources],
                                  symmetries=symmetries,
                                  resolution=100)
+
+        self.sim.use_output_directory(temp_dir)
 
         def print_stuff(sim_obj):
             v = mp.Vector3(4.13, 3.75, 0)
@@ -69,4 +71,11 @@ class TestCylEllipsoid(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    if mp.am_master():
+        temp_dir = tempfile.mkdtemp()
+    else:
+        temp_dir = None
+    temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
+    if mp.am_master():
+        os.removedirs(temp_dir)

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -75,7 +75,8 @@ if __name__ == '__main__':
         temp_dir = tempfile.mkdtemp()
     else:
         temp_dir = None
-    temp_dir = mp.comm.bcast(temp_dir, root=0)
+    if mp.count_processors() > 1:
+        temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/dft_fields.py
+++ b/python/tests/dft_fields.py
@@ -2,7 +2,8 @@ import unittest
 import h5py
 import numpy as np
 import meep as mp
-
+import tempfile
+import os
 
 class TestDFTFields(unittest.TestCase):
 
@@ -62,13 +63,13 @@ class TestDFTFields(unittest.TestCase):
         np.testing.assert_equal(thin_x_array.ndim, 1)
         np.testing.assert_equal(thin_y_array.ndim, 1)
 
-        sim.output_dft(thin_x_flux, 'thin-x-flux')
-        sim.output_dft(thin_y_flux, 'thin-y-flux')
+        sim.output_dft(thin_x_flux, os.path.join(temp_dir, 'thin-x-flux'))
+        sim.output_dft(thin_y_flux, os.path.join(temp_dir, 'thin-y-flux'))
 
-        with h5py.File('thin-x-flux.h5', 'r') as thin_x:
+        with h5py.File(os.path.join(temp_dir, 'thin-x-flux.h5'), 'r') as thin_x:
             thin_x_h5 = mp.complexarray(thin_x['ez_0.r'][()], thin_x['ez_0.i'][()])
 
-        with h5py.File('thin-y-flux.h5', 'r') as thin_y:
+        with h5py.File(os.path.join(temp_dir, 'thin-y-flux.h5'), 'r') as thin_y:
             thin_y_h5 = mp.complexarray(thin_y['ez_0.r'][()], thin_y['ez_0.i'][()])
 
         np.testing.assert_allclose(thin_x_array, thin_x_h5)
@@ -78,10 +79,10 @@ class TestDFTFields(unittest.TestCase):
         fields_arr = sim.get_dft_array(dft_fields, mp.Ez, 0)
         flux_arr = sim.get_dft_array(dft_flux, mp.Ez, 0)
 
-        sim.output_dft(dft_fields, 'dft-fields')
-        sim.output_dft(dft_flux, 'dft-flux')
+        sim.output_dft(dft_fields, os.path.join(temp_dir, 'dft-fields'))
+        sim.output_dft(dft_flux, os.path.join(temp_dir, 'dft-flux'))
 
-        with h5py.File('dft-fields.h5', 'r') as fields, h5py.File('dft-flux.h5', 'r') as flux:
+        with h5py.File(os.path.join(temp_dir, 'dft-fields.h5'), 'r') as fields, h5py.File(os.path.join(temp_dir, 'dft-flux.h5'), 'r') as flux:
             exp_fields = mp.complexarray(fields['ez_0.r'][()], fields['ez_0.i'][()])
             exp_flux = mp.complexarray(flux['ez_0.r'][()], flux['ez_0.i'][()])
 
@@ -89,4 +90,11 @@ class TestDFTFields(unittest.TestCase):
         np.testing.assert_allclose(exp_flux, flux_arr)
 
 if __name__ == '__main__':
+    if mp.am_master():
+        temp_dir = tempfile.mkdtemp()
+    else:
+        temp_dir = None
+    temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
+    if mp.am_master():
+        os.removedirs(temp_dir)

--- a/python/tests/dft_fields.py
+++ b/python/tests/dft_fields.py
@@ -2,7 +2,6 @@ import unittest
 import h5py
 import numpy as np
 import meep as mp
-import tempfile
 import os
 
 class TestDFTFields(unittest.TestCase):
@@ -90,12 +89,7 @@ class TestDFTFields(unittest.TestCase):
         np.testing.assert_allclose(exp_flux, flux_arr)
 
 if __name__ == '__main__':
-    if mp.am_master():
-        temp_dir = tempfile.mkdtemp()
-    else:
-        temp_dir = None
-    if mp.count_processors() > 1:
-        temp_dir = mp.comm.bcast(temp_dir, root=0)
+    temp_dir = mp.make_output_directory()
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/dft_fields.py
+++ b/python/tests/dft_fields.py
@@ -94,7 +94,8 @@ if __name__ == '__main__':
         temp_dir = tempfile.mkdtemp()
     else:
         temp_dir = None
-    temp_dir = mp.comm.bcast(temp_dir, root=0)
+    if mp.count_processors() > 1:
+        temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/dispersive_eigenmode.py
+++ b/python/tests/dispersive_eigenmode.py
@@ -152,7 +152,8 @@ if __name__ == '__main__':
         temp_dir = tempfile.mkdtemp()
     else:
         temp_dir = None
-    temp_dir = mp.comm.bcast(temp_dir, root=0)
+    if mp.count_processors() > 1:
+        temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/dispersive_eigenmode.py
+++ b/python/tests/dispersive_eigenmode.py
@@ -13,7 +13,6 @@ import meep as mp
 import numpy as np
 from meep import mpb
 import h5py
-import tempfile
 import os
 
 class TestDispersiveEigenmode(unittest.TestCase):
@@ -148,12 +147,7 @@ class TestDispersiveEigenmode(unittest.TestCase):
         
 
 if __name__ == '__main__':
-    if mp.am_master():
-        temp_dir = tempfile.mkdtemp()
-    else:
-        temp_dir = None
-    if mp.count_processors() > 1:
-        temp_dir = mp.comm.bcast(temp_dir, root=0)
+    temp_dir = mp.make_output_directory()
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/field_functions.py
+++ b/python/tests/field_functions.py
@@ -104,7 +104,8 @@ if __name__ == '__main__':
         temp_dir = tempfile.mkdtemp()
     else:
         temp_dir = None
-    temp_dir = mp.comm.bcast(temp_dir, root=0)
+    if mp.count_processors() > 1:
+        temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/field_functions.py
+++ b/python/tests/field_functions.py
@@ -1,7 +1,7 @@
 import unittest
-
 import meep as mp
-
+import tempfile
+import os
 
 def f(r, ex, hz, eps):
     return (r.x * r.norm() + ex) - (eps * hz)
@@ -70,6 +70,7 @@ class TestFieldFunctions(unittest.TestCase):
 
     def test_integrate_field_function(self):
         sim = self.init()
+        sim.use_output_directory(temp_dir)
         sim.run(until=200)
 
         res1 = sim.integrate_field_function(self.cs, f)
@@ -99,4 +100,11 @@ class TestFieldFunctions(unittest.TestCase):
         self.assertAlmostEqual(res, 0.27593732304637586)
 
 if __name__ == '__main__':
+    if mp.am_master():
+        temp_dir = tempfile.mkdtemp()
+    else:
+        temp_dir = None
+    temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
+    if mp.am_master():
+        os.removedirs(temp_dir)

--- a/python/tests/field_functions.py
+++ b/python/tests/field_functions.py
@@ -1,6 +1,5 @@
 import unittest
 import meep as mp
-import tempfile
 import os
 
 def f(r, ex, hz, eps):
@@ -100,12 +99,7 @@ class TestFieldFunctions(unittest.TestCase):
         self.assertAlmostEqual(res, 0.27593732304637586)
 
 if __name__ == '__main__':
-    if mp.am_master():
-        temp_dir = tempfile.mkdtemp()
-    else:
-        temp_dir = None
-    if mp.count_processors() > 1:
-        temp_dir = mp.comm.bcast(temp_dir, root=0)
+    temp_dir = mp.make_output_directory()
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -1,7 +1,6 @@
 import unittest
 import meep as mp
 import numpy as np
-import tempfile
 import os
 
 class TestHoleyWvgCavity(unittest.TestCase):
@@ -140,12 +139,7 @@ class TestHoleyWvgCavity(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    if mp.am_master():
-        temp_dir = tempfile.mkdtemp()
-    else:
-        temp_dir = None
-    if mp.count_processors() > 1:
-        temp_dir = mp.comm.bcast(temp_dir, root=0)
+    temp_dir = mp.make_output_directory()
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -144,7 +144,8 @@ if __name__ == '__main__':
         temp_dir = tempfile.mkdtemp()
     else:
         temp_dir = None
-    temp_dir = mp.comm.bcast(temp_dir, root=0)
+    if mp.count_processors() > 1:
+        temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -1,7 +1,8 @@
 import unittest
 import meep as mp
 import numpy as np
-
+import tempfile
+import os
 
 class TestHoleyWvgCavity(unittest.TestCase):
 
@@ -45,6 +46,7 @@ class TestHoleyWvgCavity(unittest.TestCase):
         self.sim.symmetries = [mp.Mirror(mp.Y, phase=-1),
                                mp.Mirror(mp.X, phase=-1)]
 
+        self.sim.use_output_directory(temp_dir)
         h = mp.Harminv(mp.Hz, mp.Vector3(), self.fcen, self.df)
         self.sim.run(mp.at_beginning(mp.output_epsilon),
                      mp.after_sources(h),
@@ -138,4 +140,11 @@ class TestHoleyWvgCavity(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    if mp.am_master():
+        temp_dir = tempfile.mkdtemp()
+    else:
+        temp_dir = None
+    temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
+    if mp.am_master():
+        os.removedirs(temp_dir)

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -15,12 +15,13 @@ from scipy.optimize import ridder
 import meep as mp
 from meep import mpb
 from utils import compare_arrays
-
+import tempfile
+import os
 
 class TestModeSolver(unittest.TestCase):
 
-    data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
-    examples_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), '..', 'examples'))
+    data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+    examples_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'examples')
     sys.path.insert(0, examples_dir)
 
     def setUp(self):

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -15,8 +15,6 @@ from scipy.optimize import ridder
 import meep as mp
 from meep import mpb
 from utils import compare_arrays
-import tempfile
-import os
 
 class TestModeSolver(unittest.TestCase):
 

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -7,7 +7,6 @@ import re
 import sys
 import time
 import unittest
-import tempfile
 import os
 
 import h5py
@@ -1411,12 +1410,7 @@ class TestModeSolver(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    if mp.am_master():
-        temp_dir = tempfile.mkdtemp()
-    else:
-        temp_dir = None
-    if mp.count_processors() > 1:
-        temp_dir = mp.comm.bcast(temp_dir, root=0)
+    temp_dir = mp.make_output_directory()
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -20,8 +20,8 @@ import os
 
 class TestModeSolver(unittest.TestCase):
 
-    data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
-    examples_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'examples')
+    data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
+    examples_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'examples'))
     sys.path.insert(0, examples_dir)
 
     def setUp(self):

--- a/python/tests/pw_source.py
+++ b/python/tests/pw_source.py
@@ -5,7 +5,8 @@ import math
 import unittest
 
 import meep as mp
-
+import tempfile
+import os
 
 class TestPwSource(unittest.TestCase):
 
@@ -52,6 +53,7 @@ class TestPwSource(unittest.TestCase):
             boundary_layers=pml_layers,
             resolution=resolution
         )
+        self.sim.use_output_directory(temp_dir)
         self.s = s
 
     def test_pw_source(self):
@@ -67,4 +69,11 @@ class TestPwSource(unittest.TestCase):
         self.assertAlmostEqual(cmath.exp(1j * self.k.dot(v1 - v2)), 0.7654030066070924 - 0.6435512702783076j)
 
 if __name__ == '__main__':
+    if mp.am_master():
+        temp_dir = tempfile.mkdtemp()
+    else:
+        temp_dir = None
+    temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
+    if mp.am_master():
+        os.removedirs(temp_dir)

--- a/python/tests/pw_source.py
+++ b/python/tests/pw_source.py
@@ -73,7 +73,8 @@ if __name__ == '__main__':
         temp_dir = tempfile.mkdtemp()
     else:
         temp_dir = None
-    temp_dir = mp.comm.bcast(temp_dir, root=0)
+    if mp.count_processors() > 1:
+        temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/pw_source.py
+++ b/python/tests/pw_source.py
@@ -5,7 +5,6 @@ import math
 import unittest
 
 import meep as mp
-import tempfile
 import os
 
 class TestPwSource(unittest.TestCase):
@@ -69,12 +68,7 @@ class TestPwSource(unittest.TestCase):
         self.assertAlmostEqual(cmath.exp(1j * self.k.dot(v1 - v2)), 0.7654030066070924 - 0.6435512702783076j)
 
 if __name__ == '__main__':
-    if mp.am_master():
-        temp_dir = tempfile.mkdtemp()
-    else:
-        temp_dir = None
-    if mp.count_processors() > 1:
-        temp_dir = mp.comm.bcast(temp_dir, root=0)
+    temp_dir = mp.make_output_directory()
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -4,7 +4,8 @@ from __future__ import division
 
 import unittest
 import meep as mp
-
+import tempfile
+import os
 
 class TestRing(unittest.TestCase):
 
@@ -34,6 +35,7 @@ class TestRing(unittest.TestCase):
                                  symmetries=[mp.Mirror(mp.Y)],
                                  boundary_layers=[mp.PML(dpml)])
 
+        self.sim.use_output_directory(temp_dir)
         self.h = mp.Harminv(mp.Ez, mp.Vector3(r + 0.1), fcen, df)
 
     def test_harminv(self):
@@ -61,4 +63,11 @@ class TestRing(unittest.TestCase):
         self.assertAlmostEqual(fp, -0.08185972142450348)
 
 if __name__ == '__main__':
+    if mp.am_master():
+        temp_dir = tempfile.mkdtemp()
+    else:
+        temp_dir = None
+    temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
+    if mp.am_master():
+        os.removedirs(temp_dir)

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -67,7 +67,8 @@ if __name__ == '__main__':
         temp_dir = tempfile.mkdtemp()
     else:
         temp_dir = None
-    temp_dir = mp.comm.bcast(temp_dir, root=0)
+    if mp.count_processors() > 1:
+        temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -4,7 +4,6 @@ from __future__ import division
 
 import unittest
 import meep as mp
-import tempfile
 import os
 
 class TestRing(unittest.TestCase):
@@ -63,12 +62,7 @@ class TestRing(unittest.TestCase):
         self.assertAlmostEqual(fp, -0.08185972142450348)
 
 if __name__ == '__main__':
-    if mp.am_master():
-        temp_dir = tempfile.mkdtemp()
-    else:
-        temp_dir = None
-    if mp.count_processors() > 1:
-        temp_dir = mp.comm.bcast(temp_dir, root=0)
+    temp_dir = mp.make_output_directory()
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -139,10 +139,6 @@ class TestSimulation(unittest.TestCase):
         fname = os.path.join(temp_dir, 'simulation-ez-000100.00.h5')
         self.assertTrue(os.path.exists(fname))
 
-        mp.all_wait()
-        if mp.am_master():
-            os.remove(fname)
-
     def test_after_sources_and_time(self):
         sim = self.init_simple_simulation()
 
@@ -162,10 +158,6 @@ class TestSimulation(unittest.TestCase):
 
         fname = os.path.join(temp_dir, 'test_prefix-simulation-ez-000200.00.h5')
         self.assertTrue(os.path.exists(fname))
-
-        mp.all_wait()
-        if mp.am_master():
-            os.remove(fname)
 
     def test_extra_materials(self):
         sim = self.init_simple_simulation()
@@ -193,18 +185,17 @@ class TestSimulation(unittest.TestCase):
         sim.filename_prefix = 'test_in_volume'
         vol = mp.Volume(mp.Vector3(), size=mp.Vector3(x=2))
         sim.run(mp.at_end(mp.in_volume(vol, mp.output_efield_z)), until=200)
-
-    def test_in_point(self):
-        sim = self.init_simple_simulation(filename_prefix='test_in_point')
-        fn = sim.filename_prefix + '-ez-000200.00.h5'
-        ## sim.use_output_directory(temp_dir)
-        pt = mp.Vector3()
-        sim.run(mp.at_end(mp.in_point(pt, mp.output_efield_z)), until=200)
+        fn = os.path.join(temp_dir, 'test_in_volume-ez-000200.00.h5')
         self.assertTrue(os.path.exists(fn))
 
-        mp.all_wait()
-        if mp.am_master():
-            os.remove(fn)
+    def test_in_point(self):
+        sim = self.init_simple_simulation()
+        sim.use_output_directory(temp_dir)
+        sim.filename_prefix = 'test_in_point'
+        pt = mp.Vector3()
+        sim.run(mp.at_end(mp.in_point(pt, mp.output_efield_z)), until=200)
+        fn = os.path.join(temp_dir, 'test_in_point-ez-000200.00.h5')
+        self.assertTrue(os.path.exists(fn))
 
     def test_epsilon_input_file(self):
         sim = self.init_simple_simulation()
@@ -359,12 +350,6 @@ class TestSimulation(unittest.TestCase):
 
         for ref_pt, pt in zip(ref_field_points, field_points):
             self.assertAlmostEqual(ref_pt, pt)
-
-        mp.all_wait()
-        if mp.am_master():
-            os.remove(dump_fn)
-            if dump_chunk_fname:
-                os.remove(dump_chunk_fname)
 
     def test_load_dump_structure(self):
         self._load_dump_structure()

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -634,7 +634,8 @@ if __name__ == '__main__':
         temp_dir = tempfile.mkdtemp()
     else:
         temp_dir = None
-    temp_dir = mp.comm.bcast(temp_dir, root=0)
+    if mp.count_processors() > 1:
+        temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -378,7 +378,7 @@ class TestSimulation(unittest.TestCase):
         energy_arr = sim.get_tot_pwr()
         efield_arr = sim.get_efield()
 
-        fname_fmt = temp_dir + "/test_get_array_output-{}-000020.00.h5"
+        fname_fmt = os.path.join(temp_dir, 'test_get_array_output-{}-000020.00.h5')
 
         with h5py.File(fname_fmt.format('eps'), 'r') as f:
             eps = f['eps'][()]

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -311,8 +311,6 @@ class TestSimulation(unittest.TestCase):
                              symmetries=symmetries,
                              sources=[sources])
 
-        sim1.use_output_directory(temp_dir)
-
         sample_point = mp.Vector3(0.12, -0.29)
         ref_field_points = []
 
@@ -321,12 +319,12 @@ class TestSimulation(unittest.TestCase):
             ref_field_points.append(p.real)
 
         sim1.run(mp.at_every(5, get_ref_field_point), until=50)
-        dump_fn = 'test_load_dump_structure.h5'
+        dump_fn = os.path.join(temp_dir, 'test_load_dump_structure.h5')
         dump_chunk_fname = None
         chunk_layout = None
         sim1.dump_structure(dump_fn)
         if chunk_file:
-            dump_chunk_fname = 'test_load_dump_structure_chunks.h5'
+            dump_chunk_fname = os.path.join(temp_dir, 'test_load_dump_structure_chunks.h5')
             sim1.dump_chunk_layout(dump_chunk_fname)
             chunk_layout = dump_chunk_fname
         if chunk_sim:

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -6,7 +6,6 @@ import warnings
 import h5py
 import numpy as np
 import meep as mp
-import tempfile
 
 try:
     unicode
@@ -628,12 +627,7 @@ class TestSimulation(unittest.TestCase):
             self.assertAlmostEqual(pt2, expected)
 
 if __name__ == '__main__':
-    if mp.am_master():
-        temp_dir = tempfile.mkdtemp()
-    else:
-        temp_dir = None
-    if mp.count_processors() > 1:
-        temp_dir = mp.comm.bcast(temp_dir, root=0)
+    temp_dir = mp.make_output_directory()
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -200,7 +200,7 @@ class TestSimulation(unittest.TestCase):
     def test_epsilon_input_file(self):
         sim = self.init_simple_simulation()
         eps_input_fname = 'cyl-ellipsoid-eps-ref.h5'
-        eps_input_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'tests')
+        eps_input_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'tests'))
         eps_input_path = os.path.join(eps_input_dir, eps_input_fname)
         sim.epsilon_input_file = eps_input_path
 
@@ -219,7 +219,7 @@ class TestSimulation(unittest.TestCase):
     def test_numpy_epsilon(self):
         sim = self.init_simple_simulation()
         eps_input_fname = 'cyl-ellipsoid-eps-ref.h5'
-        eps_input_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'tests')
+        eps_input_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'tests'))
         eps_input_path = os.path.join(eps_input_dir, eps_input_fname)
 
         with h5py.File(eps_input_path, 'r') as f:
@@ -378,7 +378,7 @@ class TestSimulation(unittest.TestCase):
         energy_arr = sim.get_tot_pwr()
         efield_arr = sim.get_efield()
 
-        fname_fmt = os.path.abspath(temp_dir) + "/test_get_array_output-{}-000020.00.h5"
+        fname_fmt = temp_dir + "/test_get_array_output-{}-000020.00.h5"
 
         with h5py.File(fname_fmt.format('eps'), 'r') as f:
             eps = f['eps'][()]

--- a/python/tests/source.py
+++ b/python/tests/source.py
@@ -10,7 +10,7 @@ from meep.geom import Cylinder, Vector3
 from meep.source import EigenModeSource, ContinuousSource, GaussianSource
 
 
-data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
 
 
 class TestEigenModeSource(unittest.TestCase):

--- a/python/tests/source.py
+++ b/python/tests/source.py
@@ -10,7 +10,7 @@ from meep.geom import Cylinder, Vector3
 from meep.source import EigenModeSource, ContinuousSource, GaussianSource
 
 
-data_dir = os.path.join(os.path.realpath(os.path.dirname(__file__)), 'data')
+data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
 
 
 class TestEigenModeSource(unittest.TestCase):
@@ -149,7 +149,7 @@ class TestAmpFileFunc(unittest.TestCase):
         cen = mp.Vector3(0.1, 0.2)
         sz = mp.Vector3(0.3, 0.2)
 
-        data_dir = os.path.join(os.path.realpath(os.path.dirname(__file__)), 'data')
+        data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
         amp_file = os.path.join(data_dir, 'amp_func_file')
         amp_file += ':amp_data'
 

--- a/python/tests/source.py
+++ b/python/tests/source.py
@@ -149,7 +149,6 @@ class TestAmpFileFunc(unittest.TestCase):
         cen = mp.Vector3(0.1, 0.2)
         sz = mp.Vector3(0.3, 0.2)
 
-        data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
         amp_file = os.path.join(data_dir, 'amp_func_file')
         amp_file += ':amp_data'
 

--- a/python/tests/visualization.py
+++ b/python/tests/visualization.py
@@ -203,7 +203,8 @@ if __name__ == '__main__':
         temp_dir = tempfile.mkdtemp()
     else:
         temp_dir = None
-    temp_dir = mp.comm.bcast(temp_dir, root=0)
+    if mp.count_processors() > 1:
+        temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)

--- a/python/tests/visualization.py
+++ b/python/tests/visualization.py
@@ -12,6 +12,8 @@ from subprocess import call
 
 import meep as mp
 import numpy as np
+import tempfile
+import os
 
 # Make sure we have matplotlib installed
 import matplotlib
@@ -62,7 +64,7 @@ def setup_sim(zDim=0):
                         component=mp.Ez,
                         size=mp.Vector3(0,2,2),
                         center=mp.Vector3(0,1))]
-        
+
     # Add plane sources
     sources += [mp.Source(mp.ContinuousSource(frequency=0.15),
                         component=mp.Ez,
@@ -161,11 +163,11 @@ class TestVisualization(unittest.TestCase):
             until=5)
         
         # Test outputs
-        Animate.to_mp4(5,'test_2D.mp4') # Check mp4 output
-        Animate.to_gif(150,'test_2D.gif') # Check gif output
+        Animate.to_mp4(5,os.path.join(temp_dir, 'test_2D.mp4')) # Check mp4 output
+        Animate.to_gif(150,os.path.join(temp_dir, 'test_2D.gif')) # Check gif output
         Animate.to_jshtml(10) # Check jshtml output
-        Animate_norm.to_mp4(5,'test_2D_norm.mp4') # Check mp4 output
-        Animate_norm.to_gif(150,'test_2D_norm.gif') # Check gif output
+        Animate_norm.to_mp4(5,os.path.join(temp_dir, 'test_2D_norm.mp4')) # Check mp4 output
+        Animate_norm.to_gif(150,os.path.join(temp_dir, 'test_2D_norm.gif')) # Check gif output
         Animate_norm.to_jshtml(10) # Check jshtml output
 
         # ------------------------- #
@@ -183,11 +185,11 @@ class TestVisualization(unittest.TestCase):
             until=5)
         
         # Test outputs
-        Animate_xy.to_mp4(5,'test_3D_xy.mp4') # Check mp4 output
-        Animate_xy.to_gif(150,'test_3D_xy.gif') # Check gif output
+        Animate_xy.to_mp4(5,os.path.join(temp_dir, 'test_3D_xy.mp4')) # Check mp4 output
+        Animate_xy.to_gif(150,os.path.join(temp_dir, 'test_3D_xy.gif')) # Check gif output
         Animate_xy.to_jshtml(10) # Check jshtml output
-        Animate_xz.to_mp4(5,'test_3D_xz.mp4') # Check mp4 output
-        Animate_xz.to_gif(150,'test_3D_xz.gif') # Check gif output
+        Animate_xz.to_mp4(5,os.path.join(temp_dir, 'test_3D_xz.mp4')) # Check mp4 output
+        Animate_xz.to_gif(150,os.path.join(temp_dir, 'test_3D_xz.gif')) # Check gif output
         Animate_xz.to_jshtml(10) # Check jshtml output
     '''
     Travis does not play well with Mayavi
@@ -197,5 +199,12 @@ class TestVisualization(unittest.TestCase):
     '''
 
 if __name__ == '__main__':
+    if mp.am_master():
+        temp_dir = tempfile.mkdtemp()
+    else:
+        temp_dir = None
+    temp_dir = mp.comm.bcast(temp_dir, root=0)
     unittest.main()
+    if mp.am_master():
+        os.removedirs(temp_dir)
     

--- a/python/tests/visualization.py
+++ b/python/tests/visualization.py
@@ -12,7 +12,6 @@ from subprocess import call
 
 import meep as mp
 import numpy as np
-import tempfile
 import os
 
 # Make sure we have matplotlib installed
@@ -199,12 +198,7 @@ class TestVisualization(unittest.TestCase):
     '''
 
 if __name__ == '__main__':
-    if mp.am_master():
-        temp_dir = tempfile.mkdtemp()
-    else:
-        temp_dir = None
-    if mp.count_processors() > 1:
-        temp_dir = mp.comm.bcast(temp_dir, root=0)
+    temp_dir = mp.make_output_directory()
     unittest.main()
     if mp.am_master():
         os.removedirs(temp_dir)


### PR DESCRIPTION
Several of the Python tests create output files due to e.g. `output_epsilon`, `save_flux`, `Animate2D`, etc. which are placed in the `python/tests` subdirectory during `make check`. As a security measure, some operating systems prevent the test suite from writing any kind of file to disk in non-temporary system directories. This PR modifies the output directory of any test which creates a file to a temporary directory determined by the OS at runtime via [`tempfile.mkdtemp`](https://docs.python.org/3.6/library/tempfile.html#tempfile.mkdtemp). 

Additionally, all instances of `os.path.realpath` are replaced with `os.path.abspath` since on certain systems expanding `".."` using `realpath` is *not* allowed.

TODOs: 

1. ~~since [MPB](https://mpb.readthedocs.io/en/latest/Python_User_Interface/#the-modesolver-class) does not contain the equivalent of Meep's `use_output_directory` parameter, the only test that is left out is [python/tests/mpb.cpp](https://github.com/NanoComp/meep/blob/master/python/tests/mpb.py).~~

2. modify the C++ tests in `tests` which also generate output files to write them to a temporary directory.

~~**note**: the tests on Travis are failing due to the following error:~~

```
Traceback (most recent call last):
5280  File "../../../python/tests/holey_wvg_cavity.py", line 147, in <module>
5281    temp_dir = mp.comm.bcast(temp_dir, root=0)
5282AttributeError: module 'meep' has no attribute 'comm'
```