### PR TITLE
tempdir support

### DIFF
--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1931,7 +1931,7 @@ private:
 // directory, unless the source file hasn't changed.
 
 const char *make_output_directory(const char *exename, const char *jobname = NULL);
-const char *make_output_directory(); // make temporary directory
+char *make_output_directory(); // make temporary directory
 void trash_output_directory(const char *dirname);
 FILE *create_output_file(const char *dirname, const char *fname);
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1931,6 +1931,7 @@ private:
 // directory, unless the source file hasn't changed.
 
 const char *make_output_directory(const char *exename, const char *jobname = NULL);
+const char *make_output_directory(); // make temporary directory
 void trash_output_directory(const char *dirname);
 FILE *create_output_file(const char *dirname, const char *fname);
 

--- a/src/output_directory.cpp
+++ b/src/output_directory.cpp
@@ -150,7 +150,7 @@ got_tmpdir:
   strcat(strcpy(outdirname, tmpdir), meeptemplate);
 
   if (am_master() && !mkdtemp(outdirname)) {
-      abort("failed to create temporary output directory");
+      abort("failed to create temporary output directory \"%s\"", outdirname);
   }
   broadcast(0, outdirname, len);
   return outdirname;

--- a/src/output_directory.cpp
+++ b/src/output_directory.cpp
@@ -137,6 +137,17 @@ const char *make_output_directory(const char *exename, const char *jobname) {
   return outdirname;
 }
 
+/* similar to above, but creates a temporary directory */
+const char *make_output_directory() {
+  static char outdirname[] = "meepXXXXXX";
+  if (am_master()) {
+    if (!mkdtemp(outdirname))
+      abort("failed to create temporary output directory");
+  }
+  broadcast(0, outdirname, strlen(outdirname)+1);
+  return outdirname;
+}
+
 void trash_output_directory(const char *dirname) {
   if (am_master()) mkdir(dirname, 00777);
 }

--- a/src/output_directory.cpp
+++ b/src/output_directory.cpp
@@ -30,18 +30,9 @@ using namespace std;
 
 namespace meep {
 
-const char symlink_name[] = "latest_output";
-
 void structure::set_output_directory(const char *name) {
-  char buf[300];
-  outdir = name;
+  outdir = name; /* fixme: make a copy */
   if (verbosity > 0) master_printf("Using output directory %s/\n", name);
-  if (readlink(symlink_name, buf, 300) > 0) {
-    // Link already exists.
-    unlink(symlink_name);
-  }
-  symlink(name, symlink_name);
-  outdir = name;
 }
 
 void fields::set_output_directory(const char *name) {


### PR DESCRIPTION
`mp.make_output_directory()` now makes a temporary directory with `mkdtemp`.

So, you can do `sim.use_output_directory(mp.make_output_directory())` to work in a temporary directory.

It would be nice to add a parameter to `use_output_directory` that automatically deletes the directory when the simulation destructor is called.