### PR TITLE
update failing prism tests

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -608,7 +608,7 @@ The vertices that make up the prism. They must lie in a plane that's perpendicul
 
 **`height` [`number`]**
 —
-The prism thickness, extruded in the direction of `axis`. `mp.inf` can be used for infinite height.
+The prism thickness, extruded in the direction of `axis`. `mp.inf` can be used for infinite height. No default value.
 
 **`axis` [`Vector3`]**
 —
@@ -1580,9 +1580,9 @@ mp.GDSII_layers('python/examples/coupler.gds')
 Out[2]: [0, 1, 2, 3, 4, 5, 31, 32]
 ```
 
-**`mp.get_GDSII_prisms(material, gdsii_filename, layer)`**
+**`mp.get_GDSII_prisms(material, gdsii_filename, layer, zmin, zmax)`**
 —
-Returns a list of `GeometricObject`s with `material` (`mp.Medium`) on layer number `layer` of a GDSII file `gdsii_filename`.
+Returns a list of `GeometricObject`s with `material` (`mp.Medium`) on layer number `layer` of a GDSII file `gdsii_filename` with `zmin` and `zmax`.
 
 **`mp.GDSII_vol(fname, layer, zmin, zmax)`**
 —

--- a/python/tests/bend_flux.py
+++ b/python/tests/bend_flux.py
@@ -17,13 +17,13 @@ class TestBendFlux(unittest.TestCase):
         w = 1
         wvg_ycen = -0.5 * (sy - w - (2 * pad))
         wvg_xcen = 0.5 * (sx - w - (2 * pad))
-        height = 100
+        height = mp.inf
         data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
         gdsii_file = os.path.join(data_dir, 'bend-flux.gds')
 
         if no_bend:
             if gdsii:
-                geometry = mp.get_GDSII_prisms(mp.Medium(epsilon=12), gdsii_file, 1)
+                geometry = mp.get_GDSII_prisms(mp.Medium(epsilon=12), gdsii_file, 1, 0, height)
             else:
                 no_bend_vertices = [mp.Vector3(-0.5 * sx - 5, wvg_ycen - 0.5 * w),
                                     mp.Vector3(+0.5 * sx + 5, wvg_ycen - 0.5 * w),
@@ -33,7 +33,7 @@ class TestBendFlux(unittest.TestCase):
                 geometry = [mp.Prism(no_bend_vertices, height, material=mp.Medium(epsilon=12))]
         else:
             if gdsii:
-                geometry = mp.get_GDSII_prisms(mp.Medium(epsilon=12), gdsii_file, 2)
+                geometry = mp.get_GDSII_prisms(mp.Medium(epsilon=12), gdsii_file, 2, 0, height)
             else:
                 bend_vertices = [mp.Vector3(-0.5 * sx, wvg_ycen - 0.5 * w),
                                  mp.Vector3(wvg_xcen + 0.5 * w, wvg_ycen - 0.5 * w),
@@ -148,8 +148,8 @@ class TestBendFlux(unittest.TestCase):
 
     def test_bend_flux(self):
         self.run_bend_flux(False)
-        # if mp.with_libGDSII():
-        #     self.run_bend_flux(True)
+        if mp.with_libGDSII():
+            self.run_bend_flux(True)
 
 
 if __name__ == '__main__':

--- a/python/tests/bend_flux.py
+++ b/python/tests/bend_flux.py
@@ -148,8 +148,8 @@ class TestBendFlux(unittest.TestCase):
 
     def test_bend_flux(self):
         self.run_bend_flux(False)
-        if mp.with_libGDSII():
-            self.run_bend_flux(True)
+        # if mp.with_libGDSII():
+        #     self.run_bend_flux(True)
 
 
 if __name__ == '__main__':

--- a/python/tests/mode_coeffs.py
+++ b/python/tests/mode_coeffs.py
@@ -81,7 +81,7 @@ class TestModeCoeffs(unittest.TestCase):
         self.assertTrue(res.kdom[0].close(mp.Vector3(0.604301, 0, 0)))
         self.assertTrue(res.kdom[1].close(mp.Vector3(0.494353, 0, 0), tol=1e-2))
         self.assertAlmostEqual(res.cscale[0],0.50000977,places=5)
-        self.assertAlmostEqual(res.cscale[1],0.50181621,places=5)
+        self.assertAlmostEqual(res.cscale[1],0.50096888,places=5)
         mode_power = mp.get_fluxes(mode_flux)[0]
 
         TestPassed = True
@@ -117,8 +117,8 @@ class TestModeCoeffs(unittest.TestCase):
         eval_point = mp.Vector3(0.7, -0.2, 0.3)
         ex_at_eval_point = emdata.amplitude(eval_point, mp.Ex)
         hz_at_eval_point = emdata.amplitude(eval_point, mp.Hz)
-        self.assertAlmostEqual(ex_at_eval_point, 0.45358518109307083+0.5335421986481814j)
-        self.assertAlmostEqual(hz_at_eval_point, 3.717865162096829-3.1592989829386298j)
+        self.assertAlmostEqual(ex_at_eval_point, 0.4887779638178009+0.48424014532428294j)
+        self.assertAlmostEqual(hz_at_eval_point, 3.4249236584603495-3.455974863884166j)
 
     def test_kpoint_func(self):
 


### PR DESCRIPTION
This PR updates the two failing Python tests due to NanoComp/libctl#53 in order to restore Travis CI. One of the tests (`mode_coeffs.py`) requires just a minor update to three of its hard-coded values. ~~The other test (`bend_flux.py`) is failing due to something more significant that is broken in `libGDSII`; this is commented out until a fix can be found.~~