### PR TITLE
Python interface for slanted prisms

### DIFF
--- a/python/geom.py
+++ b/python/geom.py
@@ -493,7 +493,7 @@ class Ellipsoid(Block):
 
 class Prism(GeometricObject):
 
-    def __init__(self, vertices, height, axis=Vector3(z=1), center=None, **kwargs):
+    def __init__(self, vertices, height, axis=Vector3(z=1), center=None, sidewall_angle=0, **kwargs):
         centroid = sum(vertices, Vector3(0)) * (1.0 / len(vertices)) # centroid of floor polygon
         original_center = centroid + (0.5*height)*axis               # center as computed from vertices, height, axis
         if center is not None and len(vertices):
@@ -506,6 +506,7 @@ class Prism(GeometricObject):
         self.vertices = vertices
         self.height = height
         self.axis = axis
+        self.sidewall_angle = sidewall_angle
 
         super(Prism, self).__init__(center=center, **kwargs)
 

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -764,10 +764,11 @@ static int pyellipsoid_to_ellipsoid(PyObject *py_ell, geometric_object *e) {
 
 static int pyprism_to_prism(PyObject *py_prism, geometric_object *p) {
   material_type material;
-  double height;
+  double height, sidewall_angle;
   vector3 axis, center;
 
   if (!get_attr_material(py_prism, &material) || !get_attr_dbl(py_prism, &height, "height") ||
+      !get_attr_dbl(py_prism, &sidewall_angle, "sidewall_angle") ||
       !get_attr_v3(py_prism, &center, "center") || !get_attr_v3(py_prism, &axis, "axis")) {
 
     return 0;
@@ -788,7 +789,12 @@ static int pyprism_to_prism(PyObject *py_prism, geometric_object *p) {
     vertices[i] = v3;
   }
 
+#if defined(LIBCTL_MAJOR_VERSION) && (LIBCTL_MAJOR_VERSION > 4 || (LIBCTL_MAJOR_VERSION == 4 && LIBCTL_MINOR_VERSION >= 5))
+  *p = make_slanted_prism(material, vertices, num_vertices, height, axis, sidewall_angle);
+#else
+  if (sidewall_angle != 0) { meep::abort("slanted prisms require libctl 4.5 or later\n"); }
   *p = make_prism(material, vertices, num_vertices, height, axis);
+#endif
   p->center = center;
 
   delete[] vertices;


### PR DESCRIPTION
Adds `sidewall_angle` parameter to Python prism objects (defaults to zero), allowing them to interface the new slanted-prism feature in libctl 4.5 (NanoComp/libctl#53).