### PR TITLE
create and delete temporary directory using unittest methods

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1582,11 +1582,11 @@ Out[2]: [0, 1, 2, 3, 4, 5, 31, 32]
 
 **`mp.get_GDSII_prisms(material, gdsii_filename, layer, zmin, zmax)`**
 —
-Returns a list of `GeometricObject`s with `material` (`mp.Medium`) on layer number `layer` of a GDSII file `gdsii_filename` with `zmin` and `zmax`.
+Returns a list of `GeometricObject`s with `material` (`mp.Medium`) on layer number `layer` of a GDSII file `gdsii_filename` with `zmin` and `zmax` (default 0).
 
 **`mp.GDSII_vol(fname, layer, zmin, zmax)`**
 —
-Returns a `mp.Volume` read from a GDSII file `fname` on layer number `layer` with `zmin` and `zmax`. This function is useful for creating a `FluxRegion` from a GDSII file as follows
+Returns a `mp.Volume` read from a GDSII file `fname` on layer number `layer` with `zmin` and `zmax` (default 0). This function is useful for creating a `FluxRegion` from a GDSII file as follows
 
 ```python
 fr = mp.FluxRegion(volume=mp.GDSII_vol(fname, layer, zmin, zmax))

--- a/python/tests/chunks.py
+++ b/python/tests/chunks.py
@@ -3,11 +3,13 @@ import meep as mp
 
 class TestChunks(unittest.TestCase):
 
-    def setUpClass(self):
-        self.temp_dir = mp.make_output_directory()
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = mp.make_output_directory()
 
-    def tearDownClass(self):
-        mp.delete_directory(self.temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        mp.delete_directory(cls.temp_dir)
 
     def test_chunks(self):
         sxy = 10

--- a/python/tests/chunks.py
+++ b/python/tests/chunks.py
@@ -1,8 +1,15 @@
 import unittest
 import meep as mp
-import os
+import shutil
 
 class TestChunks(unittest.TestCase):
+
+    def setUp(self):
+      self.temp_dir = mp.make_output_directory()
+
+    def tearDown(self):
+        if mp.am_master():
+            shutil.rmtree(self.temp_dir,ignore_errors=True)
 
     def test_chunks(self):
         sxy = 10
@@ -23,7 +30,7 @@ class TestChunks(unittest.TestCase):
                             resolution=resolution,
                             split_chunks_evenly=False)
 
-        sim.use_output_directory(temp_dir)
+        sim.use_output_directory(self.temp_dir)
 
         top = mp.FluxRegion(center=mp.Vector3(0,+0.5*sxy-dpml), size=mp.Vector3(sxy-2*dpml,0), weight=+1.0)
         bot = mp.FluxRegion(center=mp.Vector3(0,-0.5*sxy+dpml), size=mp.Vector3(sxy-2*dpml,0), weight=-1.0)
@@ -47,7 +54,7 @@ class TestChunks(unittest.TestCase):
                             resolution=resolution,
                             chunk_layout=sim1)
 
-        sim.use_output_directory(temp_dir)
+        sim.use_output_directory(self.temp_dir)
 
         tot_flux = sim.add_flux(fcen, 0, 1, top, bot, rgt, lft)
 
@@ -59,7 +66,4 @@ class TestChunks(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    temp_dir = mp.make_output_directory()
     unittest.main()
-    if mp.am_master():
-        os.removedirs(temp_dir)

--- a/python/tests/chunks.py
+++ b/python/tests/chunks.py
@@ -1,16 +1,13 @@
 import unittest
 import meep as mp
-import shutil
 
 class TestChunks(unittest.TestCase):
 
     def setUp(self):
-      self.temp_dir = mp.make_output_directory()
+        self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(self.temp_dir,ignore_errors=True)
+        mp.delete_directory(self.temp_dir)
 
     def test_chunks(self):
         sxy = 10

--- a/python/tests/chunks.py
+++ b/python/tests/chunks.py
@@ -3,10 +3,10 @@ import meep as mp
 
 class TestChunks(unittest.TestCase):
 
-    def setUp(self):
+    def setUpClass(self):
         self.temp_dir = mp.make_output_directory()
 
-    def tearDown(self):
+    def tearDownClass(self):
         mp.delete_directory(self.temp_dir)
 
     def test_chunks(self):

--- a/python/tests/chunks.py
+++ b/python/tests/chunks.py
@@ -8,6 +8,7 @@ class TestChunks(unittest.TestCase):
       self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
+        mp.all_wait()
         if mp.am_master():
             shutil.rmtree(self.temp_dir,ignore_errors=True)
 

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -2,7 +2,6 @@ from __future__ import division
 
 import unittest
 import meep as mp
-import shutil
 
 def dummy_eps(vec):
     return 1.0
@@ -13,12 +12,10 @@ class TestCylEllipsoid(unittest.TestCase):
     ref_Hz = -4.5623185899766e-5
 
     def setUp(self):
-      self.temp_dir = mp.make_output_directory()
+        self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(self.temp_dir,ignore_errors=True)
+        mp.delete_directory(self.temp_dir)
 
     def init(self):
 

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -16,6 +16,7 @@ class TestCylEllipsoid(unittest.TestCase):
       self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
+        mp.all_wait()
         if mp.am_master():
             shutil.rmtree(self.temp_dir,ignore_errors=True)
 

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 import unittest
 import meep as mp
-import os
+import shutil
 
 def dummy_eps(vec):
     return 1.0
@@ -11,6 +11,13 @@ class TestCylEllipsoid(unittest.TestCase):
 
     ref_Ez = -8.29555720049629e-5
     ref_Hz = -4.5623185899766e-5
+
+    def setUp(self):
+      self.temp_dir = mp.make_output_directory()
+
+    def tearDown(self):
+        if mp.am_master():
+            shutil.rmtree(self.temp_dir,ignore_errors=True)
 
     def init(self):
 
@@ -34,7 +41,7 @@ class TestCylEllipsoid(unittest.TestCase):
                                  symmetries=symmetries,
                                  resolution=100)
 
-        self.sim.use_output_directory(temp_dir)
+        self.sim.use_output_directory(self.temp_dir)
 
         def print_stuff(sim_obj):
             v = mp.Vector3(4.13, 3.75, 0)
@@ -70,7 +77,4 @@ class TestCylEllipsoid(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    temp_dir = mp.make_output_directory()
     unittest.main()
-    if mp.am_master():
-        os.removedirs(temp_dir)

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -11,10 +11,10 @@ class TestCylEllipsoid(unittest.TestCase):
     ref_Ez = -8.29555720049629e-5
     ref_Hz = -4.5623185899766e-5
 
-    def setUp(self):
+    def setUpClass(self):
         self.temp_dir = mp.make_output_directory()
 
-    def tearDown(self):
+    def tearDownClass(self):
         mp.delete_directory(self.temp_dir)
 
     def init(self):

--- a/python/tests/cyl_ellipsoid.py
+++ b/python/tests/cyl_ellipsoid.py
@@ -11,11 +11,13 @@ class TestCylEllipsoid(unittest.TestCase):
     ref_Ez = -8.29555720049629e-5
     ref_Hz = -4.5623185899766e-5
 
-    def setUpClass(self):
-        self.temp_dir = mp.make_output_directory()
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = mp.make_output_directory()
 
-    def tearDownClass(self):
-        mp.delete_directory(self.temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        mp.delete_directory(cls.temp_dir)
 
     def init(self):
 

--- a/python/tests/dft_fields.py
+++ b/python/tests/dft_fields.py
@@ -6,10 +6,10 @@ import os
 
 class TestDFTFields(unittest.TestCase):
 
-    def setUp(self):
+    def setUpClass(self):
         self.temp_dir = mp.make_output_directory()
 
-    def tearDown(self):
+    def tearDownClass(self):
         mp.delete_directory(self.temp_dir)
 
     def init(self):

--- a/python/tests/dft_fields.py
+++ b/python/tests/dft_fields.py
@@ -3,17 +3,14 @@ import h5py
 import numpy as np
 import meep as mp
 import os
-import shutil
 
 class TestDFTFields(unittest.TestCase):
 
     def setUp(self):
-      self.temp_dir = mp.make_output_directory()
+        self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(self.temp_dir,ignore_errors=True)
+        mp.delete_directory(self.temp_dir)
 
     def init(self):
         resolution = 10

--- a/python/tests/dft_fields.py
+++ b/python/tests/dft_fields.py
@@ -3,8 +3,16 @@ import h5py
 import numpy as np
 import meep as mp
 import os
+import shutil
 
 class TestDFTFields(unittest.TestCase):
+
+    def setUp(self):
+      self.temp_dir = mp.make_output_directory()
+
+    def tearDown(self):
+        if mp.am_master():
+            shutil.rmtree(self.temp_dir,ignore_errors=True)
 
     def init(self):
         resolution = 10
@@ -62,13 +70,13 @@ class TestDFTFields(unittest.TestCase):
         np.testing.assert_equal(thin_x_array.ndim, 1)
         np.testing.assert_equal(thin_y_array.ndim, 1)
 
-        sim.output_dft(thin_x_flux, os.path.join(temp_dir, 'thin-x-flux'))
-        sim.output_dft(thin_y_flux, os.path.join(temp_dir, 'thin-y-flux'))
+        sim.output_dft(thin_x_flux, os.path.join(self.temp_dir, 'thin-x-flux'))
+        sim.output_dft(thin_y_flux, os.path.join(self.temp_dir, 'thin-y-flux'))
 
-        with h5py.File(os.path.join(temp_dir, 'thin-x-flux.h5'), 'r') as thin_x:
+        with h5py.File(os.path.join(self.temp_dir, 'thin-x-flux.h5'), 'r') as thin_x:
             thin_x_h5 = mp.complexarray(thin_x['ez_0.r'][()], thin_x['ez_0.i'][()])
 
-        with h5py.File(os.path.join(temp_dir, 'thin-y-flux.h5'), 'r') as thin_y:
+        with h5py.File(os.path.join(self.temp_dir, 'thin-y-flux.h5'), 'r') as thin_y:
             thin_y_h5 = mp.complexarray(thin_y['ez_0.r'][()], thin_y['ez_0.i'][()])
 
         np.testing.assert_allclose(thin_x_array, thin_x_h5)
@@ -78,10 +86,10 @@ class TestDFTFields(unittest.TestCase):
         fields_arr = sim.get_dft_array(dft_fields, mp.Ez, 0)
         flux_arr = sim.get_dft_array(dft_flux, mp.Ez, 0)
 
-        sim.output_dft(dft_fields, os.path.join(temp_dir, 'dft-fields'))
-        sim.output_dft(dft_flux, os.path.join(temp_dir, 'dft-flux'))
+        sim.output_dft(dft_fields, os.path.join(self.temp_dir, 'dft-fields'))
+        sim.output_dft(dft_flux, os.path.join(self.temp_dir, 'dft-flux'))
 
-        with h5py.File(os.path.join(temp_dir, 'dft-fields.h5'), 'r') as fields, h5py.File(os.path.join(temp_dir, 'dft-flux.h5'), 'r') as flux:
+        with h5py.File(os.path.join(self.temp_dir, 'dft-fields.h5'), 'r') as fields, h5py.File(os.path.join(self.temp_dir, 'dft-flux.h5'), 'r') as flux:
             exp_fields = mp.complexarray(fields['ez_0.r'][()], fields['ez_0.i'][()])
             exp_flux = mp.complexarray(flux['ez_0.r'][()], flux['ez_0.i'][()])
 
@@ -89,7 +97,4 @@ class TestDFTFields(unittest.TestCase):
         np.testing.assert_allclose(exp_flux, flux_arr)
 
 if __name__ == '__main__':
-    temp_dir = mp.make_output_directory()
     unittest.main()
-    if mp.am_master():
-        os.removedirs(temp_dir)

--- a/python/tests/dft_fields.py
+++ b/python/tests/dft_fields.py
@@ -6,11 +6,13 @@ import os
 
 class TestDFTFields(unittest.TestCase):
 
-    def setUpClass(self):
-        self.temp_dir = mp.make_output_directory()
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = mp.make_output_directory()
 
-    def tearDownClass(self):
-        mp.delete_directory(self.temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        mp.delete_directory(cls.temp_dir)
 
     def init(self):
         resolution = 10

--- a/python/tests/dft_fields.py
+++ b/python/tests/dft_fields.py
@@ -11,6 +11,7 @@ class TestDFTFields(unittest.TestCase):
       self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
+        mp.all_wait()
         if mp.am_master():
             shutil.rmtree(self.temp_dir,ignore_errors=True)
 

--- a/python/tests/dispersive_eigenmode.py
+++ b/python/tests/dispersive_eigenmode.py
@@ -43,6 +43,7 @@ class TestDispersiveEigenmode(unittest.TestCase):
       self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
+        mp.all_wait()
         if mp.am_master():
             shutil.rmtree(self.temp_dir,ignore_errors=True)
 

--- a/python/tests/dispersive_eigenmode.py
+++ b/python/tests/dispersive_eigenmode.py
@@ -14,7 +14,6 @@ import numpy as np
 from meep import mpb
 import h5py
 import os
-import shutil
 
 class TestDispersiveEigenmode(unittest.TestCase):
     # ----------------------------------------- #
@@ -40,12 +39,10 @@ class TestDispersiveEigenmode(unittest.TestCase):
         np.testing.assert_allclose(n,n_actual)
 
     def setUp(self):
-      self.temp_dir = mp.make_output_directory()
+        self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(self.temp_dir,ignore_errors=True)
+        mp.delete_directory(self.temp_dir)
 
     def verify_output_and_slice(self,material,omega):
         # Since the slice routines average the diagonals, we need to do that too:

--- a/python/tests/dispersive_eigenmode.py
+++ b/python/tests/dispersive_eigenmode.py
@@ -38,10 +38,10 @@ class TestDispersiveEigenmode(unittest.TestCase):
         
         np.testing.assert_allclose(n,n_actual)
 
-    def setUp(self):
+    def setUpClass(self):
         self.temp_dir = mp.make_output_directory()
 
-    def tearDown(self):
+    def tearDownClass(self):
         mp.delete_directory(self.temp_dir)
 
     def verify_output_and_slice(self,material,omega):

--- a/python/tests/dispersive_eigenmode.py
+++ b/python/tests/dispersive_eigenmode.py
@@ -38,11 +38,13 @@ class TestDispersiveEigenmode(unittest.TestCase):
         
         np.testing.assert_allclose(n,n_actual)
 
-    def setUpClass(self):
-        self.temp_dir = mp.make_output_directory()
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = mp.make_output_directory()
 
-    def tearDownClass(self):
-        mp.delete_directory(self.temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        mp.delete_directory(cls.temp_dir)
 
     def verify_output_and_slice(self,material,omega):
         # Since the slice routines average the diagonals, we need to do that too:

--- a/python/tests/field_functions.py
+++ b/python/tests/field_functions.py
@@ -19,6 +19,7 @@ class TestFieldFunctions(unittest.TestCase):
       self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
+        mp.all_wait()
         if mp.am_master():
             shutil.rmtree(self.temp_dir,ignore_errors=True)
 

--- a/python/tests/field_functions.py
+++ b/python/tests/field_functions.py
@@ -14,10 +14,10 @@ class TestFieldFunctions(unittest.TestCase):
     cs = [mp.Ex, mp.Hz, mp.Dielectric]
     vol = mp.Volume(size=mp.Vector3(1), center=mp.Vector3())
 
-    def setUp(self):
+    def setUpClass(self):
         self.temp_dir = mp.make_output_directory()
 
-    def tearDown(self):
+    def tearDownClass(self):
         mp.delete_directory(self.temp_dir)
 
     def init(self):

--- a/python/tests/field_functions.py
+++ b/python/tests/field_functions.py
@@ -14,11 +14,13 @@ class TestFieldFunctions(unittest.TestCase):
     cs = [mp.Ex, mp.Hz, mp.Dielectric]
     vol = mp.Volume(size=mp.Vector3(1), center=mp.Vector3())
 
-    def setUpClass(self):
-        self.temp_dir = mp.make_output_directory()
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = mp.make_output_directory()
 
-    def tearDownClass(self):
-        mp.delete_directory(self.temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        mp.delete_directory(cls.temp_dir)
 
     def init(self):
         resolution = 20

--- a/python/tests/field_functions.py
+++ b/python/tests/field_functions.py
@@ -1,6 +1,6 @@
 import unittest
 import meep as mp
-import os
+import shutil
 
 def f(r, ex, hz, eps):
     return (r.x * r.norm() + ex) - (eps * hz)
@@ -14,6 +14,13 @@ class TestFieldFunctions(unittest.TestCase):
 
     cs = [mp.Ex, mp.Hz, mp.Dielectric]
     vol = mp.Volume(size=mp.Vector3(1), center=mp.Vector3())
+
+    def setUp(self):
+      self.temp_dir = mp.make_output_directory()
+
+    def tearDown(self):
+        if mp.am_master():
+            shutil.rmtree(self.temp_dir,ignore_errors=True)
 
     def init(self):
         resolution = 20
@@ -69,7 +76,7 @@ class TestFieldFunctions(unittest.TestCase):
 
     def test_integrate_field_function(self):
         sim = self.init()
-        sim.use_output_directory(temp_dir)
+        sim.use_output_directory(self.temp_dir)
         sim.run(until=200)
 
         res1 = sim.integrate_field_function(self.cs, f)
@@ -99,7 +106,4 @@ class TestFieldFunctions(unittest.TestCase):
         self.assertAlmostEqual(res, 0.27593732304637586)
 
 if __name__ == '__main__':
-    temp_dir = mp.make_output_directory()
     unittest.main()
-    if mp.am_master():
-        os.removedirs(temp_dir)

--- a/python/tests/field_functions.py
+++ b/python/tests/field_functions.py
@@ -1,6 +1,5 @@
 import unittest
 import meep as mp
-import shutil
 
 def f(r, ex, hz, eps):
     return (r.x * r.norm() + ex) - (eps * hz)
@@ -16,12 +15,10 @@ class TestFieldFunctions(unittest.TestCase):
     vol = mp.Volume(size=mp.Vector3(1), center=mp.Vector3())
 
     def setUp(self):
-      self.temp_dir = mp.make_output_directory()
+        self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(self.temp_dir,ignore_errors=True)
+        mp.delete_directory(self.temp_dir)
 
     def init(self):
         resolution = 20

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -37,9 +37,10 @@ class TestHoleyWvgCavity(unittest.TestCase):
                                  boundary_layers=[mp.PML(self.dpml)],
                                  resolution=20)
 
+    def setUpClass(self):
         self.temp_dir = mp.make_output_directory()
 
-    def tearDown(self):
+    def tearDownClass(self):
         mp.delete_directory(self.temp_dir)
 
     def test_resonant_modes(self):

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -41,6 +41,7 @@ class TestHoleyWvgCavity(unittest.TestCase):
         self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
+        mp.all_wait()
         if mp.am_master():
             shutil.rmtree(self.temp_dir,ignore_errors=True)
 

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -1,7 +1,7 @@
 import unittest
 import meep as mp
 import numpy as np
-import os
+import shutil
 
 class TestHoleyWvgCavity(unittest.TestCase):
 
@@ -38,6 +38,12 @@ class TestHoleyWvgCavity(unittest.TestCase):
                                  boundary_layers=[mp.PML(self.dpml)],
                                  resolution=20)
 
+        self.temp_dir = mp.make_output_directory()
+
+    def tearDown(self):
+        if mp.am_master():
+            shutil.rmtree(self.temp_dir,ignore_errors=True)
+
     def test_resonant_modes(self):
         self.sim.sources = [mp.Source(mp.GaussianSource(self.fcen, fwidth=self.df),
                                       mp.Hz, mp.Vector3())]
@@ -45,7 +51,7 @@ class TestHoleyWvgCavity(unittest.TestCase):
         self.sim.symmetries = [mp.Mirror(mp.Y, phase=-1),
                                mp.Mirror(mp.X, phase=-1)]
 
-        self.sim.use_output_directory(temp_dir)
+        self.sim.use_output_directory(self.temp_dir)
         h = mp.Harminv(mp.Hz, mp.Vector3(), self.fcen, self.df)
         self.sim.run(mp.at_beginning(mp.output_epsilon),
                      mp.after_sources(h),
@@ -139,7 +145,4 @@ class TestHoleyWvgCavity(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    temp_dir = mp.make_output_directory()
     unittest.main()
-    if mp.am_master():
-        os.removedirs(temp_dir)

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -1,7 +1,6 @@
 import unittest
 import meep as mp
 import numpy as np
-import shutil
 
 class TestHoleyWvgCavity(unittest.TestCase):
 
@@ -41,9 +40,7 @@ class TestHoleyWvgCavity(unittest.TestCase):
         self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(self.temp_dir,ignore_errors=True)
+        mp.delete_directory(self.temp_dir)
 
     def test_resonant_modes(self):
         self.sim.sources = [mp.Source(mp.GaussianSource(self.fcen, fwidth=self.df),

--- a/python/tests/holey_wvg_cavity.py
+++ b/python/tests/holey_wvg_cavity.py
@@ -37,11 +37,13 @@ class TestHoleyWvgCavity(unittest.TestCase):
                                  boundary_layers=[mp.PML(self.dpml)],
                                  resolution=20)
 
-    def setUpClass(self):
-        self.temp_dir = mp.make_output_directory()
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = mp.make_output_directory()
 
-    def tearDownClass(self):
-        mp.delete_directory(self.temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        mp.delete_directory(cls.temp_dir)
 
     def test_resonant_modes(self):
         self.sim.sources = [mp.Source(mp.GaussianSource(self.fcen, fwidth=self.df),

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -25,15 +25,19 @@ class TestModeSolver(unittest.TestCase):
     def setUp(self):
         self.start = time.time()
 
-        self.temp_dir = mp.make_output_directory()
         self.filename_prefix = os.path.join(self.temp_dir, self.id().split('.')[-1])
         print()
         print(self.filename_prefix)
         print('=' * 24)
 
+    def setUpClass(self):
+        self.temp_dir = mp.make_output_directory()
+
     def tearDown(self):
         end = time.time() - self.start
         print("{}: {:.2f}s".format(self.filename_prefix, end))
+
+    def tearDownClass(self):
         mp.delete_directory(self.temp_dir)
 
     def init_solver(self, geom=True):

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -30,15 +30,17 @@ class TestModeSolver(unittest.TestCase):
         print(self.filename_prefix)
         print('=' * 24)
 
-    def setUpClass(self):
-        self.temp_dir = mp.make_output_directory()
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
         end = time.time() - self.start
         print("{}: {:.2f}s".format(self.filename_prefix, end))
 
-    def tearDownClass(self):
-        mp.delete_directory(self.temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        mp.delete_directory(cls.temp_dir)
 
     def init_solver(self, geom=True):
         num_bands = 8

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -36,6 +36,7 @@ class TestModeSolver(unittest.TestCase):
         end = time.time() - self.start
         print("{}: {:.2f}s".format(self.filename_prefix, end))
 
+        mp.all_wait()
         if mp.am_master():
             shutil.rmtree(self.temp_dir,ignore_errors=True)
 

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -7,7 +7,6 @@ import re
 import sys
 import time
 import unittest
-import shutil
 
 import h5py
 import numpy as np
@@ -35,10 +34,7 @@ class TestModeSolver(unittest.TestCase):
     def tearDown(self):
         end = time.time() - self.start
         print("{}: {:.2f}s".format(self.filename_prefix, end))
-
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(self.temp_dir,ignore_errors=True)
+        mp.delete_directory(self.temp_dir)
 
     def init_solver(self, geom=True):
         num_bands = 8

--- a/python/tests/mpb.py
+++ b/python/tests/mpb.py
@@ -7,7 +7,7 @@ import re
 import sys
 import time
 import unittest
-import os
+import shutil
 
 import h5py
 import numpy as np
@@ -26,7 +26,8 @@ class TestModeSolver(unittest.TestCase):
     def setUp(self):
         self.start = time.time()
 
-        self.filename_prefix = os.path.join(temp_dir, self.id().split('.')[-1])
+        self.temp_dir = mp.make_output_directory()
+        self.filename_prefix = os.path.join(self.temp_dir, self.id().split('.')[-1])
         print()
         print(self.filename_prefix)
         print('=' * 24)
@@ -34,6 +35,9 @@ class TestModeSolver(unittest.TestCase):
     def tearDown(self):
         end = time.time() - self.start
         print("{}: {:.2f}s".format(self.filename_prefix, end))
+
+        if mp.am_master():
+            shutil.rmtree(self.temp_dir,ignore_errors=True)
 
     def init_solver(self, geom=True):
         num_bands = 8
@@ -1410,7 +1414,4 @@ class TestModeSolver(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    temp_dir = mp.make_output_directory()
     unittest.main()
-    if mp.am_master():
-        os.removedirs(temp_dir)

--- a/python/tests/pw_source.py
+++ b/python/tests/pw_source.py
@@ -54,11 +54,13 @@ class TestPwSource(unittest.TestCase):
         self.sim.use_output_directory(self.temp_dir)
         self.s = s
 
-    def setUpClass(self):
-        self.temp_dir = mp.make_output_directory()
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = mp.make_output_directory()
 
-    def tearDownClass(self):
-        mp.delete_directory(self.temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        mp.delete_directory(cls.temp_dir)
 
     def test_pw_source(self):
         self.sim.run(mp.at_end(mp.output_efield_z), until=400)

--- a/python/tests/pw_source.py
+++ b/python/tests/pw_source.py
@@ -5,7 +5,6 @@ import math
 import unittest
 
 import meep as mp
-import shutil
 
 class TestPwSource(unittest.TestCase):
 
@@ -57,9 +56,7 @@ class TestPwSource(unittest.TestCase):
         self.s = s
 
     def tearDown(self):
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(self.temp_dir,ignore_errors=True)
+        mp.delete_directory(self.temp_dir)
 
     def test_pw_source(self):
         self.sim.run(mp.at_end(mp.output_efield_z), until=400)

--- a/python/tests/pw_source.py
+++ b/python/tests/pw_source.py
@@ -51,11 +51,13 @@ class TestPwSource(unittest.TestCase):
             boundary_layers=pml_layers,
             resolution=resolution
         )
-        self.temp_dir = mp.make_output_directory()
         self.sim.use_output_directory(self.temp_dir)
         self.s = s
 
-    def tearDown(self):
+    def setUpClass(self):
+        self.temp_dir = mp.make_output_directory()
+
+    def tearDownClass(self):
         mp.delete_directory(self.temp_dir)
 
     def test_pw_source(self):

--- a/python/tests/pw_source.py
+++ b/python/tests/pw_source.py
@@ -5,7 +5,7 @@ import math
 import unittest
 
 import meep as mp
-import os
+import shutil
 
 class TestPwSource(unittest.TestCase):
 
@@ -52,8 +52,13 @@ class TestPwSource(unittest.TestCase):
             boundary_layers=pml_layers,
             resolution=resolution
         )
-        self.sim.use_output_directory(temp_dir)
+        self.temp_dir = mp.make_output_directory()
+        self.sim.use_output_directory(self.temp_dir)
         self.s = s
+
+    def tearDown(self):
+        if mp.am_master():
+            shutil.rmtree(self.temp_dir,ignore_errors=True)
 
     def test_pw_source(self):
         self.sim.run(mp.at_end(mp.output_efield_z), until=400)
@@ -68,7 +73,4 @@ class TestPwSource(unittest.TestCase):
         self.assertAlmostEqual(cmath.exp(1j * self.k.dot(v1 - v2)), 0.7654030066070924 - 0.6435512702783076j)
 
 if __name__ == '__main__':
-    temp_dir = mp.make_output_directory()
     unittest.main()
-    if mp.am_master():
-        os.removedirs(temp_dir)

--- a/python/tests/pw_source.py
+++ b/python/tests/pw_source.py
@@ -57,6 +57,7 @@ class TestPwSource(unittest.TestCase):
         self.s = s
 
     def tearDown(self):
+        mp.all_wait()
         if mp.am_master():
             shutil.rmtree(self.temp_dir,ignore_errors=True)
 

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -12,6 +12,7 @@ class TestRing(unittest.TestCase):
       self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
+        mp.all_wait()
         if mp.am_master():
             shutil.rmtree(self.temp_dir,ignore_errors=True)
 

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -7,10 +7,10 @@ import meep as mp
 
 class TestRing(unittest.TestCase):
 
-    def setUp(self):
+    def setUpClass(self):
         self.temp_dir = mp.make_output_directory()
 
-    def tearDown(self):
+    def tearDownClass(self):
         mp.delete_directory(self.temp_dir)
 
     def init(self):

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -7,11 +7,13 @@ import meep as mp
 
 class TestRing(unittest.TestCase):
 
-    def setUpClass(self):
-        self.temp_dir = mp.make_output_directory()
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = mp.make_output_directory()
 
-    def tearDownClass(self):
-        mp.delete_directory(self.temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        mp.delete_directory(cls.temp_dir)
 
     def init(self):
         n = 3.4

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -4,9 +4,16 @@ from __future__ import division
 
 import unittest
 import meep as mp
-import os
+import shutil
 
 class TestRing(unittest.TestCase):
+
+    def setUp(self):
+      self.temp_dir = mp.make_output_directory()
+
+    def tearDown(self):
+        if mp.am_master():
+            shutil.rmtree(self.temp_dir,ignore_errors=True)
 
     def init(self):
         n = 3.4
@@ -34,7 +41,7 @@ class TestRing(unittest.TestCase):
                                  symmetries=[mp.Mirror(mp.Y)],
                                  boundary_layers=[mp.PML(dpml)])
 
-        self.sim.use_output_directory(temp_dir)
+        self.sim.use_output_directory(self.temp_dir)
         self.h = mp.Harminv(mp.Ez, mp.Vector3(r + 0.1), fcen, df)
 
     def test_harminv(self):
@@ -62,7 +69,4 @@ class TestRing(unittest.TestCase):
         self.assertAlmostEqual(fp, -0.08185972142450348)
 
 if __name__ == '__main__':
-    temp_dir = mp.make_output_directory()
     unittest.main()
-    if mp.am_master():
-        os.removedirs(temp_dir)

--- a/python/tests/ring.py
+++ b/python/tests/ring.py
@@ -4,17 +4,14 @@ from __future__ import division
 
 import unittest
 import meep as mp
-import shutil
 
 class TestRing(unittest.TestCase):
 
     def setUp(self):
-      self.temp_dir = mp.make_output_directory()
+        self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(self.temp_dir,ignore_errors=True)
+        mp.delete_directory(self.temp_dir)
 
     def init(self):
         n = 3.4

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -19,6 +19,11 @@ class TestSimulation(unittest.TestCase):
 
     def setUp(self):
         print("Running {}".format(self._testMethodName))
+        self.temp_dir = mp.make_output_directory()
+
+    def tearDown(self):
+        if mp.am_master():
+            shutil.rmtree(self.temp_dir,ignore_errors=True)
 
     def test_interpolate_numbers(self):
 
@@ -120,22 +125,18 @@ class TestSimulation(unittest.TestCase):
 
     def test_use_output_directory_default(self):
         sim = self.init_simple_simulation()
-        output_dir = os.path.join(temp_dir, 'simulation-out')
+        output_dir = os.path.join(self.temp_dir, 'simulation-out')
         sim.use_output_directory(output_dir)
         sim.run(mp.at_end(mp.output_efield_z), until=200)
 
         self.assertTrue(os.path.exists(os.path.join(output_dir, self.fname)))
 
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(output_dir)
-
     def test_at_time(self):
         sim = self.init_simple_simulation()
-        sim.use_output_directory(temp_dir)
+        sim.use_output_directory(self.temp_dir)
         sim.run(mp.at_time(100, mp.output_efield_z), until=200)
 
-        fname = os.path.join(temp_dir, 'simulation-ez-000100.00.h5')
+        fname = os.path.join(self.temp_dir, 'simulation-ez-000100.00.h5')
         self.assertTrue(os.path.exists(fname))
 
     def test_after_sources_and_time(self):
@@ -152,10 +153,10 @@ class TestSimulation(unittest.TestCase):
 
     def test_with_prefix(self):
         sim = self.init_simple_simulation()
-        sim.use_output_directory(temp_dir)
+        sim.use_output_directory(self.temp_dir)
         sim.run(mp.with_prefix('test_prefix-', mp.at_end(mp.output_efield_z)), until=200)
 
-        fname = os.path.join(temp_dir, 'test_prefix-simulation-ez-000200.00.h5')
+        fname = os.path.join(self.temp_dir, 'test_prefix-simulation-ez-000200.00.h5')
         self.assertTrue(os.path.exists(fname))
 
     def test_extra_materials(self):
@@ -180,20 +181,20 @@ class TestSimulation(unittest.TestCase):
 
     def test_in_volume(self):
         sim = self.init_simple_simulation()
-        sim.use_output_directory(temp_dir)
+        sim.use_output_directory(self.temp_dir)
         sim.filename_prefix = 'test_in_volume'
         vol = mp.Volume(mp.Vector3(), size=mp.Vector3(x=2))
         sim.run(mp.at_end(mp.in_volume(vol, mp.output_efield_z)), until=200)
-        fn = os.path.join(temp_dir, 'test_in_volume-ez-000200.00.h5')
+        fn = os.path.join(self.temp_dir, 'test_in_volume-ez-000200.00.h5')
         self.assertTrue(os.path.exists(fn))
 
     def test_in_point(self):
         sim = self.init_simple_simulation()
-        sim.use_output_directory(temp_dir)
+        sim.use_output_directory(self.temp_dir)
         sim.filename_prefix = 'test_in_point'
         pt = mp.Vector3()
         sim.run(mp.at_end(mp.in_point(pt, mp.output_efield_z)), until=200)
-        fn = os.path.join(temp_dir, 'test_in_point-ez-000200.00.h5')
+        fn = os.path.join(self.temp_dir, 'test_in_point-ez-000200.00.h5')
         self.assertTrue(os.path.exists(fn))
 
     def test_epsilon_input_file(self):
@@ -318,12 +319,12 @@ class TestSimulation(unittest.TestCase):
             ref_field_points.append(p.real)
 
         sim1.run(mp.at_every(5, get_ref_field_point), until=50)
-        dump_fn = os.path.join(temp_dir, 'test_load_dump_structure.h5')
+        dump_fn = os.path.join(self.temp_dir, 'test_load_dump_structure.h5')
         dump_chunk_fname = None
         chunk_layout = None
         sim1.dump_structure(dump_fn)
         if chunk_file:
-            dump_chunk_fname = os.path.join(temp_dir, 'test_load_dump_structure_chunks.h5')
+            dump_chunk_fname = os.path.join(self.temp_dir, 'test_load_dump_structure_chunks.h5')
             sim1.dump_chunk_layout(dump_chunk_fname)
             chunk_layout = dump_chunk_fname
         if chunk_sim:
@@ -359,7 +360,7 @@ class TestSimulation(unittest.TestCase):
 
     def test_get_array_output(self):
         sim = self.init_simple_simulation()
-        sim.use_output_directory(temp_dir)
+        sim.use_output_directory(self.temp_dir)
         sim.symmetries = []
         sim.geometry = [mp.Cylinder(0.2, material=mp.Medium(index=3))]
         sim.filename_prefix = 'test_get_array_output'
@@ -375,7 +376,7 @@ class TestSimulation(unittest.TestCase):
         energy_arr = sim.get_tot_pwr()
         efield_arr = sim.get_efield()
 
-        fname_fmt = os.path.join(temp_dir, 'test_get_array_output-{}-000020.00.h5')
+        fname_fmt = os.path.join(self.temp_dir, 'test_get_array_output-{}-000020.00.h5')
 
         with h5py.File(fname_fmt.format('eps'), 'r') as f:
             eps = f['eps'][()]
@@ -420,7 +421,7 @@ class TestSimulation(unittest.TestCase):
             resolution=resolution
         )
 
-        sim.use_output_directory(temp_dir)
+        sim.use_output_directory(self.temp_dir)
         sim.run(mp.synchronized_magnetic(mp.output_bfield_y), until=10)
 
     def test_harminv_warnings(self):
@@ -627,7 +628,4 @@ class TestSimulation(unittest.TestCase):
             self.assertAlmostEqual(pt2, expected)
 
 if __name__ == '__main__':
-    temp_dir = mp.make_output_directory()
     unittest.main()
-    if mp.am_master():
-        os.removedirs(temp_dir)

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -18,9 +18,11 @@ class TestSimulation(unittest.TestCase):
 
     def setUp(self):
         print("Running {}".format(self._testMethodName))
+
+    def setUpClass(self):
         self.temp_dir = mp.make_output_directory()
 
-    def tearDown(self):
+    def tearDownClass(self):
         mp.delete_directory(self.temp_dir)
 
     def test_interpolate_numbers(self):

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -19,11 +19,13 @@ class TestSimulation(unittest.TestCase):
     def setUp(self):
         print("Running {}".format(self._testMethodName))
 
-    def setUpClass(self):
-        self.temp_dir = mp.make_output_directory()
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = mp.make_output_directory()
 
-    def tearDownClass(self):
-        mp.delete_directory(self.temp_dir)
+    @classmethod
+    def tearDownClass(cls):
+        mp.delete_directory(cls.temp_dir)
 
     def test_interpolate_numbers(self):
 

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import sys
 import unittest
 import warnings
@@ -22,9 +21,7 @@ class TestSimulation(unittest.TestCase):
         self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(self.temp_dir,ignore_errors=True)
+        mp.delete_directory(self.temp_dir)
 
     def test_interpolate_numbers(self):
 

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -22,6 +22,7 @@ class TestSimulation(unittest.TestCase):
         self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
+        mp.all_wait()
         if mp.am_master():
             shutil.rmtree(self.temp_dir,ignore_errors=True)
 

--- a/python/tests/visualization.py
+++ b/python/tests/visualization.py
@@ -13,7 +13,6 @@ from subprocess import call
 import meep as mp
 import numpy as np
 import os
-import shutil
 
 # Make sure we have matplotlib installed
 import matplotlib
@@ -117,12 +116,10 @@ def view_sim():
     plt.show()
 class TestVisualization(unittest.TestCase):
     def setUp(self):
-      self.temp_dir = mp.make_output_directory()
+        self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
-        mp.all_wait()
-        if mp.am_master():
-            shutil.rmtree(self.temp_dir,ignore_errors=True)
+        mp.delete_directory(self.temp_dir)
 
     def test_plot2D(self):
         # Check plotting of geometry with several sources, monitors, and PMLs

--- a/python/tests/visualization.py
+++ b/python/tests/visualization.py
@@ -13,6 +13,7 @@ from subprocess import call
 import meep as mp
 import numpy as np
 import os
+import shutil
 
 # Make sure we have matplotlib installed
 import matplotlib
@@ -115,7 +116,13 @@ def view_sim():
     plt.tight_layout()
     plt.show()
 class TestVisualization(unittest.TestCase):
-    
+    def setUp(self):
+      self.temp_dir = mp.make_output_directory()
+
+    def tearDown(self):
+        if mp.am_master():
+            shutil.rmtree(self.temp_dir,ignore_errors=True)
+
     def test_plot2D(self):
         # Check plotting of geometry with several sources, monitors, and PMLs
         f = plt.figure()
@@ -143,7 +150,7 @@ class TestVisualization(unittest.TestCase):
         if mp.am_master():
             hash_figure(f)
             #self.assertAlmostEqual(hash_figure(f),68926258)
-    
+
     @unittest.skipIf(call(['which', 'ffmpeg']) != 0, "ffmpeg is not installed")
     def test_animation_output(self):
         # ------------------------- #
@@ -151,7 +158,7 @@ class TestVisualization(unittest.TestCase):
         # ------------------------- #
 
         sim = setup_sim() # generate 2D simulation
-        
+
         Animate = mp.Animate2D(sim,fields=mp.Ez, realtime=False, normalize=False) # Check without normalization
         Animate_norm = mp.Animate2D(sim,mp.Ez,realtime=False,normalize=True) # Check with normalization
 
@@ -160,20 +167,20 @@ class TestVisualization(unittest.TestCase):
             mp.at_every(1,Animate),
             mp.at_every(1,Animate_norm),
             until=5)
-        
+
         # Test outputs
-        Animate.to_mp4(5,os.path.join(temp_dir, 'test_2D.mp4')) # Check mp4 output
-        Animate.to_gif(150,os.path.join(temp_dir, 'test_2D.gif')) # Check gif output
+        Animate.to_mp4(5,os.path.join(self.temp_dir, 'test_2D.mp4')) # Check mp4 output
+        Animate.to_gif(150,os.path.join(self.temp_dir, 'test_2D.gif')) # Check gif output
         Animate.to_jshtml(10) # Check jshtml output
-        Animate_norm.to_mp4(5,os.path.join(temp_dir, 'test_2D_norm.mp4')) # Check mp4 output
-        Animate_norm.to_gif(150,os.path.join(temp_dir, 'test_2D_norm.gif')) # Check gif output
+        Animate_norm.to_mp4(5,os.path.join(self.temp_dir, 'test_2D_norm.mp4')) # Check mp4 output
+        Animate_norm.to_gif(150,os.path.join(self.temp_dir, 'test_2D_norm.gif')) # Check gif output
         Animate_norm.to_jshtml(10) # Check jshtml output
 
         # ------------------------- #
         # Check over 3D domain
         # ------------------------- #
         sim = setup_sim(5) # generate 2D simulation
-        
+
         Animate_xy = mp.Animate2D(sim,fields=mp.Ey, realtime=False, normalize=True) # Check without normalization
         Animate_xz = mp.Animate2D(sim,mp.Ey,realtime=False,normalize=True) # Check with normalization
 
@@ -182,13 +189,13 @@ class TestVisualization(unittest.TestCase):
             mp.at_every(1,mp.in_volume(mp.Volume(center=mp.Vector3(),size=mp.Vector3(sim.cell_size.x,sim.cell_size.y)),Animate_xy)),
             mp.at_every(1,mp.in_volume(mp.Volume(center=mp.Vector3(),size=mp.Vector3(sim.cell_size.x,0,sim.cell_size.z)),Animate_xz)),
             until=5)
-        
+
         # Test outputs
-        Animate_xy.to_mp4(5,os.path.join(temp_dir, 'test_3D_xy.mp4')) # Check mp4 output
-        Animate_xy.to_gif(150,os.path.join(temp_dir, 'test_3D_xy.gif')) # Check gif output
+        Animate_xy.to_mp4(5,os.path.join(self.temp_dir, 'test_3D_xy.mp4')) # Check mp4 output
+        Animate_xy.to_gif(150,os.path.join(self.temp_dir, 'test_3D_xy.gif')) # Check gif output
         Animate_xy.to_jshtml(10) # Check jshtml output
-        Animate_xz.to_mp4(5,os.path.join(temp_dir, 'test_3D_xz.mp4')) # Check mp4 output
-        Animate_xz.to_gif(150,os.path.join(temp_dir, 'test_3D_xz.gif')) # Check gif output
+        Animate_xz.to_mp4(5,os.path.join(self.temp_dir, 'test_3D_xz.mp4')) # Check mp4 output
+        Animate_xz.to_gif(150,os.path.join(self.temp_dir, 'test_3D_xz.gif')) # Check gif output
         Animate_xz.to_jshtml(10) # Check jshtml output
     '''
     Travis does not play well with Mayavi
@@ -198,8 +205,5 @@ class TestVisualization(unittest.TestCase):
     '''
 
 if __name__ == '__main__':
-    temp_dir = mp.make_output_directory()
     unittest.main()
-    if mp.am_master():
-        os.removedirs(temp_dir)
     

--- a/python/tests/visualization.py
+++ b/python/tests/visualization.py
@@ -120,6 +120,7 @@ class TestVisualization(unittest.TestCase):
       self.temp_dir = mp.make_output_directory()
 
     def tearDown(self):
+        mp.all_wait()
         if mp.am_master():
             shutil.rmtree(self.temp_dir,ignore_errors=True)
 

--- a/python/tests/visualization.py
+++ b/python/tests/visualization.py
@@ -115,10 +115,10 @@ def view_sim():
     plt.tight_layout()
     plt.show()
 class TestVisualization(unittest.TestCase):
-    def setUp(self):
+    def setUpClass(self):
         self.temp_dir = mp.make_output_directory()
 
-    def tearDown(self):
+    def tearDownClass(self):
         mp.delete_directory(self.temp_dir)
 
     def test_plot2D(self):

--- a/python/tests/visualization.py
+++ b/python/tests/visualization.py
@@ -115,11 +115,14 @@ def view_sim():
     plt.tight_layout()
     plt.show()
 class TestVisualization(unittest.TestCase):
-    def setUpClass(self):
-        self.temp_dir = mp.make_output_directory()
 
-    def tearDownClass(self):
-        mp.delete_directory(self.temp_dir)
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = mp.make_output_directory()
+
+    @classmethod
+    def tearDownClass(cls):
+        mp.delete_directory(cls.temp_dir)
 
     def test_plot2D(self):
         # Check plotting of geometry with several sources, monitors, and PMLs

--- a/tests/h5test.cpp
+++ b/tests/h5test.cpp
@@ -451,6 +451,8 @@ int main(int argc, char **argv) {
       }
 #endif /* HAVE_HDF5 */
 
+  all_wait();
+  sync();
   delete_directory(temp_dir);
 
   return 0;

--- a/tests/h5test.cpp
+++ b/tests/h5test.cpp
@@ -451,8 +451,6 @@ int main(int argc, char **argv) {
       }
 #endif /* HAVE_HDF5 */
 
-  all_wait();
-  sync();
   delete_directory(temp_dir);
 
   return 0;


### PR DESCRIPTION
#1121 involved creating and deleting a temporary directory directly within the `__main__` function. However, certain interpreters have script scope enforcement and do not allow the `temp_dir` directory name to be used outside of the `__main__` function leading to an error. Also, on certain systems, [`os.removedirs`](https://docs.python.org/3/library/os.html#os.removedirs) cannot delete non-empty directories and aborts with an error.

This PR moves the creation of the temporary directory to within the [`setUpClass`](https://docs.python.org/3.6/library/unittest.html#unittest.TestCase.setUpClass) method of the `unittest` mechanism and stores the directory name as a member of the `cls` object. The directory deletion is moved to the [`tearDownClass`](https://docs.python.org/3.6/library/unittest.html#unittest.TestCase.tearDownClass) method and `os.removedirs` is replaced with `meep.delete_output_directory` which can force the deletion of a non-empty directory and has a built-in `all_wait()` to prevent race conditions.

All the tests from #1121 have been updated with these changes.