### PR TITLE
WIP: filtered source

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1555,6 +1555,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
     from .source import (
         ContinuousSource,
         CustomSource,
+        FilteredSource,
         EigenModeSource,
         GaussianSource,
         Source,

--- a/python/source.py
+++ b/python/source.py
@@ -4,7 +4,7 @@ import meep as mp
 from meep.geom import Vector3, check_nonnegative
 from scipy import signal
 import numpy as np
-from scipy.interpolate import interp1d
+from scipy.interpolate import Rbf, PchipInterpolator
 
 def check_positive(prop, val):
     if val > 0:
@@ -83,110 +83,38 @@ class CustomSource(SourceTime):
         self.swigobj.is_integrated = self.is_integrated
 
 class FilteredSource(CustomSource):
-    def __init__(self,center_frequency,frequencies,frequency_response,time_src,min_err=1e-6):
+    def __init__(self,center_frequency,frequencies,frequency_response,dt,T,time_src,min_err=1e-6):
         self.center_frequency=center_frequency
         self.frequencies=frequencies
-
-        signal_fourier_transform = np.array([time_src.fourier_transform(f) for f in self.frequencies])
-        self.frequency_response= signal_fourier_transform * frequency_response
         self.time_src=time_src
-        self.current_time = None
         self.min_err = min_err
 
-        f = self.func()
+        # calculate dtft of input signal
+        signal_t = np.array([time_src.swigobj.current(t,dt) for t in np.arange(0,T,dt)])
+        signal_dtft = np.zeros((frequencies.shape),dtype=np.complex128)
+        for n, st in enumerate(signal_t):
+            for fi, f in enumerate(frequencies):
+                signal_dtft[fi] += np.exp(1j*2*np.pi*f*n*dt)*st
 
+        # multiply sampled dft of input signal with filter transfer function
+        H = signal_dtft #* frequency_response
+
+        # fit final frequency response to rbf
+        H_rbf = Rbf(frequencies, H, function='gaussian')
+        f_rbf = np.arange(0,1/dt,1/T)
+
+        # estimate impulse response of final frequency response using ifft
+        h = np.flipud(np.fft.ifft(H_rbf(f_rbf))) # flip signal becuase fft convention is backwards of meeps
+        t_h = np.arange(0,T,dt)
+
+        # fit impulse response to function to make implementation easy
+        h_rbf = PchipInterpolator(t_h, h)  # we don't need a ton of extra accuracy at this point -- just speed
+
+        def f_temp(t):
+            return np.asscalar(h_rbf(t))
+        
         # initialize super
-        super(FilteredSource, self).__init__(src_func=f,center_frequency=self.center_frequency,is_integrated=time_src.is_integrated)
-
-        # estimate impulse response from frequency response
-        self.estimate_impulse_response()
-        
-
-    def __call__(self,t):
-        # simple RBF with gaussian kernel reduces to inner product at time step
-        return np.dot(self.gauss_t(t,self.frequencies,self.gaus_widths),self.nodes)
-    
-    def func(self):
-        def _f(t): 
-            return self(t)
-        return _f
-    
-    def estimate_impulse_response(self):
-        '''
-        find gaussian weighting coefficients.
-
-        TODO use optimizer to find optimal gaussian widths
-        '''
-        # Use vandermonde matrix to calculate weights of each gaussian.
-        # Each gaussian is centered at each frequency point
-        h = self.frequency_response
-        def rbf_l2(fwidth):
-            vandermonde = np.zeros((self.frequencies.size,self.frequencies.size),dtype=np.complex128)
-            for ri, rf in enumerate(self.frequencies):
-                for ci, cf in enumerate(self.frequencies):
-                    vandermonde[ri,ci] = self.gauss_f(rf,cf,fwidth)
-            
-            nodes = np.matmul(np.linalg.pinv(vandermonde),h)
-            h_hat = np.matmul(vandermonde,nodes)
-            l2_err = np.sum(np.abs(h-h_hat)**2)
-            return nodes, l2_err
-        
-        df = self.frequencies[2] - self.frequencies[1]
-        err_high = True
-        fwidth = 1/self.time_src.width
-        
-        # Iterate through smaller and smaller widths until error is small enough or width is distance between frequency points
-        while err_high:
-            nodes, l2_err = rbf_l2(fwidth)
-            if l2_err < self.min_err or fwidth < df:
-                err_high = False
-            else:
-                fwidth = 0.5 * fwidth
-        self.gaus_widths = fwidth
-        self.nodes = nodes
-
-        from matplotlib import pyplot as plt
-
-        temp = self.gauss_f(self.frequencies[:,np.newaxis],self.frequencies,fwidth)
-        i_hat = np.inner(self.nodes,temp)
-
-        '''plt.figure()
-        plt.subplot(2,1,1)
-        plt.title('')
-        plt.semilogy(self.frequencies,np.abs(h),label='Desired response')
-        plt.semilogy(self.frequencies,np.abs(i_hat),'--',label='Fit response')
-        plt.legend()
-        plt.ylabel('Magnitude')
-        plt.grid(True)
-
-        plt.subplot(2,1,2)
-        plt.plot(self.frequencies,np.unwrap(np.angle(self.frequency_response)),label='Desired response')
-        plt.plot(self.frequencies,np.unwrap(np.angle(i_hat)),'--',label='Fit response')
-        plt.legend()
-        plt.ylabel('Phase')
-        plt.xlabel('Frequency')
-        plt.grid(True)
-
-        plt.savefig('fit_results.png')
-        plt.show()'''
-    
-    def gauss_t(self,t,f0,fwidth):
-        s = 5
-        w = 1.0 / fwidth
-        t0 = w * s
-        tt = (t - t0)
-        amp = 1.0 / (-1j*2*np.pi*f0)
-        return amp * np.exp(-tt * tt / (2 * w * w))*np.exp(-1j*2 * np.pi * f0 * tt) #/ np.sqrt(2*np.pi)
-    
-    def gauss_f(self,f,f0,fwidth):
-        s = 5
-        w = 1.0 / fwidth
-        t0 = w * s
-        omega = 2.0 * np.pi * f
-        omega0 = 2.0 * np.pi * f0
-        delta = (omega - omega0) * w
-        amp = self.center_frequency/f0#/np.sqrt(omega0)#1j / (omega0)
-        return amp * w * np.exp(1j*omega*t0) * np.exp(-0.5 * delta * delta)
+        super(FilteredSource, self).__init__(src_func=f_temp,center_frequency=self.center_frequency,is_integrated=time_src.is_integrated)
 
 class EigenModeSource(Source):
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -928,12 +928,6 @@ public:
       : func(func), data(data), freq(f), start_time(float(st)), end_time(float(et)) {}
   virtual ~custom_src_time() {}
 
-  virtual std::complex<double> current(double time, double dt) const {
-    if (is_integrated)
-      return src_time::current(time, dt);
-    else
-      return dipole(time);
-  }
   virtual std::complex<double> dipole(double time) const {
     float rtime = float(time);
     if (rtime >= start_time && rtime <= end_time)

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -928,6 +928,12 @@ public:
       : func(func), data(data), freq(f), start_time(float(st)), end_time(float(et)) {}
   virtual ~custom_src_time() {}
 
+  virtual std::complex<double> current(double time, double dt) const {
+    if (is_integrated)
+      return src_time::current(time, dt);
+    else
+      return dipole(time);
+  }
   virtual std::complex<double> dipole(double time) const {
     float rtime = float(time);
     if (rtime >= start_time && rtime <= end_time)

--- a/tests/temp.py
+++ b/tests/temp.py
@@ -1,0 +1,116 @@
+import meep as mp
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy import signal
+import meep_adjoint as mpa
+
+# --------------------------- #
+# Design filter
+# --------------------------- #
+
+freq_min = 1/1.7
+freq_max = 1/1.4
+nfreq = 200
+freqs = np.linspace(freq_min,freq_max,nfreq)
+resolution = 10
+run_time = 4000
+
+# --------------------------- #
+# Run normal simulation
+# --------------------------- #
+
+cell = [16,8,0]
+geometry = [mp.Block(mp.Vector3(mp.inf,1,mp.inf),
+                     center=mp.Vector3(),
+                     material=mp.Medium(epsilon=12))]
+fcen = 1/1.55
+gauss_src = mp.GaussianSource(frequency=fcen,fwidth=0.1/1.55,is_integrated=False)
+sources = [mp.EigenModeSource(gauss_src,
+                     eig_band=1,
+                     size=[0,8],
+                     center=[-6,0])]
+pml_layers = [mp.PML(1.0)]
+
+sim = mp.Simulation(cell_size=cell,
+                    boundary_layers=pml_layers,
+                    geometry=geometry,
+                    sources=sources,
+                    resolution=resolution)
+mon = sim.add_dft_fields([mp.Ez],freq_min,freq_max,nfreq,center=[0,0],size=[0,1])
+
+sim.run(until=run_time)
+
+fields = np.zeros((nfreq,),dtype=np.complex128)
+# just store one spatial point for each freq
+for f in range(nfreq):
+    fields[f] = sim.get_dft_array(mon,mp.Ez,f)[10]
+
+# build simple bandpass filter
+dt = sim.fields.dt
+fs = 1/dt
+freqs_scipy = freqs * np.pi / (fs/2)
+num_taps = 321
+taps = signal.firwin(num_taps,[freq_min/(fs/2), freq_max/(fs/2)], pass_zero='bandstop',window='boxcar')
+
+w,h = signal.freqz(taps,worN=freqs_scipy)
+
+'''plt.figure()
+plt.plot(w,np.abs(h))
+plt.show()
+quit()'''
+
+# frequency domain calculation
+desired_fields = h * fields
+
+# --------------------------- #
+# Run filtered simulation
+# --------------------------- #
+
+filtered_src = mp.FilteredSource(fcen,freqs,h,gauss_src)
+
+sources = [mp.EigenModeSource(filtered_src,
+                     eig_band=1,
+                     size=[0,8],
+                     center=[-6,0])]
+
+sim.reset_meep()
+sim.change_sources(sources)
+
+mon = sim.add_dft_fields([mp.Ez],freq_min,freq_max,nfreq,center=[0,0],size=[0,1])
+sim.run(until=run_time)
+
+fields_filtered = np.zeros((nfreq,),dtype=np.complex128)
+# just store one spatial point for each freq
+for f in range(nfreq):
+    fields_filtered[f] = sim.get_dft_array(mon,mp.Ez,f)[10]
+
+# --------------------------- #
+# Compare results
+# --------------------------- #
+print(np.abs(fields_filtered/desired_fields), np.angle(fields_filtered/desired_fields))
+
+plt.figure()
+plt.subplot(2,1,1)
+plt.semilogy(freqs,np.abs(desired_fields),label='Frequency Domain')
+plt.semilogy(freqs,np.abs(fields_filtered),'-.',label='Time Domain')
+#plt.plot(freqs,np.abs(fields),'--',label='Gaussian Src')
+#plt.plot(freqs,np.abs(h),'--',label='Window')
+plt.grid()
+plt.xlabel('Frequency')
+plt.ylabel('Magnitude')
+plt.legend()
+
+plt.subplot(2,1,2)
+plt.plot(freqs,np.unwrap(np.angle(desired_fields)),label='Frequency Domain')
+plt.plot(freqs,np.unwrap(np.angle(fields_filtered)),'-.',label='Time Domain')
+#plt.plot(freqs,np.unwrap(np.angle(fields)),'--',label='Gaussian Src')
+#plt.plot(freqs,np.unwrap(np.angle(h)),'--',label='Window')
+plt.grid()
+plt.xlabel('Frequency')
+plt.ylabel('Angle')
+plt.legend()
+
+plt.tight_layout()
+plt.savefig('filtered.png')
+
+plt.show()


### PR DESCRIPTION
Filtered time source object used to "convolve" an impulse response with a user-provided source time profile (i.e. a conventional gaussian). Useful for adjoint calculations.

Estimates the time domain frequency response using a simple, brute force least squares from the frequency response.

Ran a simple test that computes the filtered response in the frequency domain and the time domain (using the `FilteredSource`). The test is over simple waveguide structure. The current test is failing.

![filter_ob](https://user-images.githubusercontent.com/24902086/75209673-e0de0880-574c-11ea-9f7e-d34271f5cefd.png)

![filtered](https://user-images.githubusercontent.com/24902086/75209466-51385a00-574c-11ea-83dc-33b9911a4aaf.png)

```python
import meep as mp
import numpy as np
import matplotlib.pyplot as plt
from scipy import signal

# --------------------------- #
# Design filter
# --------------------------- #

freq_min = 1/1.6
freq_max = 1/1.5
nfreq = 100
freqs = np.linspace(freq_min,freq_max,nfreq)

run_time = 1000

# --------------------------- #
# Run normal simulation
# --------------------------- #

cell = [16,8,0]
geometry = [mp.Block(mp.Vector3(mp.inf,1,mp.inf),
                     center=mp.Vector3(),
                     material=mp.Medium(epsilon=12))]
fcen = 1/1.55
gauss_src = mp.GaussianSource(frequency=fcen,fwidth=0.1/1.55)
sources = [mp.EigenModeSource(gauss_src,
                     eig_band=1,
                     size=[0,8],
                     center=[-6,0])]
pml_layers = [mp.PML(1.0)]
resolution = 10
sim = mp.Simulation(cell_size=cell,
                    boundary_layers=pml_layers,
                    geometry=geometry,
                    sources=sources,
                    resolution=resolution)
mon = sim.add_dft_fields([mp.Ez],freq_min,freq_max,nfreq,center=[0,0],size=[0,1])

sim.run(until=run_time)

fields = np.zeros((nfreq,),dtype=np.complex128)
# just store one spatial point for each freq
for f in range(nfreq):
    print(sim.get_dft_array(mon,mp.Ez,f)[0])
    fields[f] = sim.get_dft_array(mon,mp.Ez,f)[0]

# build simple bandpass filter
dt = sim.fields.dt
fs = 1/dt
freqs_scipy = freqs * np.pi / (fs/2)
num_taps = 320
taps = signal.firwin(num_taps,[0.8*freq_min/(fs/2), freq_max/(fs/2)], pass_zero=False,window='boxcar')
w,h = signal.freqz(taps,worN=freqs_scipy)

# frequency domain calculation
desired_fields = h * fields

# --------------------------- #
# Run filtered simulation
# --------------------------- #

filtered_src = mp.FilteredSource(fcen,freqs,h,num_taps,fs,gauss_src)

sources = [mp.EigenModeSource(filtered_src,
                     eig_band=1,
                     size=[0,8],
                     center=[-6,0])]

sim.reset_meep()
sim.change_sources(sources)

mon = sim.add_dft_fields([mp.Ez],freq_min,freq_max,nfreq,center=[0,0],size=[0,1])

sim.run(until=run_time)

fields_filtered = np.zeros((nfreq,),dtype=np.complex128)
# just store one spatial point for each freq
for f in range(nfreq):
    fields_filtered[f] = sim.get_dft_array(mon,mp.Ez,f)[0]

# --------------------------- #
# Compare results
# --------------------------- #

plt.figure()
plt.subplot(2,1,1)
plt.semilogy(freqs,np.abs(desired_fields)**2,'o',label='Frequency Domain')
plt.semilogy(freqs,np.abs(fields_filtered)**2,'--',label='Time Domain')
plt.grid()
plt.xlabel('Frequency')
plt.ylabel('Power')
plt.legend()

plt.subplot(2,1,2)
plt.plot(freqs,np.unwrap(np.angle(desired_fields)),'o',label='Frequency Domain')
plt.plot(freqs,np.unwrap(np.angle(fields_filtered)),'--',label='Time Domain')
plt.grid()
plt.xlabel('Frequency')
plt.ylabel('Angle')
plt.legend()

plt.tight_layout()
plt.savefig('filtered.png')

plt.show()
```


