### PR TITLE
WIP: x parity constraints for eigenmodes

### DIFF
--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -75,11 +75,10 @@ static void meep_mpb_eps_coordcycle(symmetric_matrix *eps, symmetric_matrix *eps
       o[1] = o_copy[2];
       o[2] = o_copy[0];
       p = vec(p.y(), p.z(), p.x());
-      //operation on f ?
+      //TODO: operation on f ?
     }
   }
 
-  // need to find out what eps_inv is doing exactly, but I believe all the necessary changes are made above this
   eps_inv->m00 = real(f->get_chi1inv(Ex, X, p, omega));
   eps_inv->m11 = real(f->get_chi1inv(Ey, Y, p, omega));
   eps_inv->m22 = real(f->get_chi1inv(Ez, Z, p, omega));
@@ -281,7 +280,7 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
                             int band_num, const vec &_kpoint, bool match_frequency, int parity,
                             double resolution, double eigensolver_tol, double *kdom,
                             void **user_mdata) {
-  return get_eigenmode_coordcycle(omega_src, d, where, eig_vol, band_num, &_kpoint, match_frequency, parity, resolution,
+  return get_eigenmode_coordcycle(omega_src, d, where, eig_vol, band_num, _kpoint, match_frequency, parity, resolution,
                                   eigensolver_tol, kdom, user_mdata, 0);
 }
 
@@ -453,6 +452,7 @@ void *fields::get_eigenmode_coordcycle(double omega_src, direction d, const volu
       kmatch = kcart_len;
   }
   else {
+    // TODO: rotate
     kmatch = G[d - X][d - X] * k[d - X]; // k[d] in cartesian
     kdir[d - X] = 1;                     // kdir = unit vector in d direction
   }
@@ -468,14 +468,17 @@ void *fields::get_eigenmode_coordcycle(double omega_src, direction d, const volu
       if (gv.dim == D2) k[2] = beta;
     }
     else {
+      // TODO: rotate
       k[d - X] = kmatch * R[d - X][d - X]; // convert to reciprocal basis
       if (eig_vol.in_direction(d) > 0 &&
           fabs(k[d - X]) > 0.4) // ensure k is well inside the Brillouin zone
         k[d - X] = k[d - X] > 0 ? 0.4 : -0.4;
+      // end rotate to do
     }
     if (verbosity > 1) master_printf("NEW KPOINT: %g, %g, %g\n", k[0], k[1], k[2]);
   }
 
+  // TODO: rotate
   set_maxwell_data_parity(mdata, parity);
   update_maxwell_data_k(mdata, k, G[0], G[1], G[2]);
 
@@ -562,6 +565,7 @@ void *fields::get_eigenmode_coordcycle(double omega_src, direction d, const volu
           if (gv.dim == D2) k[2] = beta;
         }
         else {
+          // TODO: rotate
           k[d - X] = kmatch * R[d - X][d - X];
         }
         update_maxwell_data_k(mdata, k, G[0], G[1], G[2]);
@@ -703,6 +707,7 @@ double get_group_velocity(void *vedata) {
 
 vec get_k(void *vedata) {
   eigenmode_data *edata = (eigenmode_data *)vedata;
+  // TODO: rotate
   return vec(edata->Gk[0], edata->Gk[1], edata->Gk[2]);
 }
 

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -51,6 +51,9 @@ static void meep_mpb_eps(symmetric_matrix *eps, symmetric_matrix *eps_inv, const
 
 static void meep_mpb_eps_coordcycle(symmetric_matrix *eps, symmetric_matrix *eps_inv, const mpb_real r[3],
                          void *eps_data_, int coordcycle = 0) {
+  if (coordcycle != 0 && coordcycle != 1 && coordcycle != 2) {
+    abort("unsupported coordcycle value");
+  }
   meep_mpb_eps_data *eps_data = (meep_mpb_eps_data *)eps_data_;
   double *s_temp = eps_data->s;
   double *o_temp = eps_data->o;
@@ -282,6 +285,14 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
                             int band_num, const vec &_kpoint, bool match_frequency, int parity,
                             double resolution, double eigensolver_tol, double *kdom,
                             void **user_mdata) {
+  return get_eigenmode_coordcycle(omega_src, d, where, eig_vol, band_num, &_kpoint, match_frequency, parity, resolution,
+                                  eigensolver_tol, kdom, user_mdata, 0);
+}
+
+void *fields::get_eigenmode_coordcycle(double omega_src, direction d, const volume where, const volume eig_vol,
+                            int band_num, const vec &_kpoint, bool match_frequency, int parity,
+                            double resolution, double eigensolver_tol, double *kdom,
+                            void **user_mdata, int coordcycle) {
   /*--------------------------------------------------------------*/
   /*- part 1: preliminary setup for calling MPB  -----------------*/
   /*--------------------------------------------------------------*/
@@ -325,15 +336,42 @@ void *fields::get_eigenmode(double omega_src, direction d, const volume where, c
 
   switch (gv.dim) {
     case D3:
-      o[0] = eig_vol.in_direction_min(X);
-      o[1] = eig_vol.in_direction_min(Y);
-      o[2] = eig_vol.in_direction_min(Z);
-      s[0] = eig_vol.in_direction(X);
-      s[1] = eig_vol.in_direction(Y);
-      s[2] = eig_vol.in_direction(Z);
-      kcart[0] = kpoint.in_direction(X);
-      kcart[1] = kpoint.in_direction(Y);
-      kcart[2] = kpoint.in_direction(Z);
+      switch (coordcycle) {
+        case 0:
+          o[0] = eig_vol.in_direction_min(X);
+          o[1] = eig_vol.in_direction_min(Y);
+          o[2] = eig_vol.in_direction_min(Z);
+          s[0] = eig_vol.in_direction(X);
+          s[1] = eig_vol.in_direction(Y);
+          s[2] = eig_vol.in_direction(Z);
+          kcart[0] = kpoint.in_direction(X);
+          kcart[1] = kpoint.in_direction(Y);
+          kcart[2] = kpoint.in_direction(Z);
+          break;
+        case 1:
+          o[0] = eig_vol.in_direction_min(Y);
+          o[1] = eig_vol.in_direction_min(Z);
+          o[2] = eig_vol.in_direction_min(X);
+          s[0] = eig_vol.in_direction(Y);
+          s[1] = eig_vol.in_direction(Z);
+          s[2] = eig_vol.in_direction(X);
+          kcart[0] = kpoint.in_direction(Y);
+          kcart[1] = kpoint.in_direction(Z);
+          kcart[2] = kpoint.in_direction(X);
+          break;
+        case 2:
+          o[0] = eig_vol.in_direction_min(Z);
+          o[1] = eig_vol.in_direction_min(X);
+          o[2] = eig_vol.in_direction_min(Y);
+          s[0] = eig_vol.in_direction(Z);
+          s[1] = eig_vol.in_direction(X);
+          s[2] = eig_vol.in_direction(Y);
+          kcart[0] = kpoint.in_direction(Z);
+          kcart[1] = kpoint.in_direction(X);
+          kcart[2] = kpoint.in_direction(Y);
+          break;
+        default: abort("unsupported coordcycle value");
+      }
       break;
     case D2:
       o[0] = eig_vol.in_direction_min(X);

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -55,33 +55,29 @@ static void meep_mpb_eps_coordcycle(symmetric_matrix *eps, symmetric_matrix *eps
     abort("unsupported coordcycle value");
   }
   meep_mpb_eps_data *eps_data = (meep_mpb_eps_data *)eps_data_;
-  double *s_temp = eps_data->s;
-  double *o_temp = eps_data->o;
+  double *s = eps_data->s;
+  double *o = eps_data->o;
   double omega = eps_data->omega;
   vec p(eps_data->dim == D3 ? vec(o[0] + r[0] * s[0], o[1] + r[1] * s[1], o[2] + r[2] * s[2])
                             : (eps_data->dim == D2 ? vec(o[0] + r[0] * s[0], o[1] + r[1] * s[1]) :
                                                    /* D1 */ vec(o[2] + r[2] * s[2])));
-  fields *f_temp = eps_data->f;
+  fields *f = eps_data->f;
 
   if (eps_date->dim == D3 && coordcycle) {
     int i;
     for (i = 0; i < coordcycle; i++) {
-      double s_copy[3] = *s_temp;
-      double o_copy[3] = *o_temp;
-      s_temp[0] = s_copy[1];
-      s_temp[1] = s_copy[2];
-      s_temp[2] = s_copy[0];
-      o_temp[0] = o_copy[1];
-      o_temp[1] = o_copy[2];
-      o_temp[2] = o_copy[0];
+      double s_copy[3] = *s;
+      double o_copy[3] = *s;
+      s[0] = s_copy[1];
+      s[1] = s_copy[2];
+      s[2] = s_copy[0];
+      o[0] = o_copy[1];
+      o[1] = o_copy[2];
+      o[2] = o_copy[0];
       p = vec(p.y(), p.z(), p.x());
       //operation on f ?
     }
   }
-
-  const double *s = s_temp;
-  const double *o = o_temp;
-  const fields *f = f_temp;
 
   // need to find out what eps_inv is doing exactly, but I believe all the necessary changes are made above this
   eps_inv->m00 = real(f->get_chi1inv(Ex, X, p, omega));


### PR DESCRIPTION
Closes #1109. 

In process of making changes to cyclically rotate Meep's coordinate systems when passed into MPB so that wave propagation is always in the x direction. So of the math involved and its implementation (notation) is a bit opaque, so at the moment the largest part of the problem is understanding what exactly is happening in the `src/mpb.cpp` so I don't miss any necessary transformations, either from Meep to MPB or from MPB to Meep.