### PR TITLE
check for valid swig in configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -511,9 +511,20 @@ AC_TRY_COMPILE([], [_Pragma("ivdep")], [], [AC_DEFINE([_Pragma],[],[define to no
 
 # checks for python
 ##############################################################################
+
 AC_ARG_WITH(python,
 	[AC_HELP_STRING([--without-python], [compile without Python interface])],
         with_python=$withval,with_python=yes)
+
+AC_CHECK_PROG(SWIG, swig, swig, echo)
+if test "$USE_MAINTAINER_MODE" = yes && test "x$SWIG" = xecho; then
+  AC_MSG_ERROR([SWIG not found; configure --without-python --without-scheme or use a release tarball])
+fi
+if test "$USE_MAINTAINER_MODE" = yes && test "x$with_python" = "xyes"; then
+  if ($SWIG -version | grep "SWIG Version 4" > /dev/null 2>&1); then
+    AC_MSG_ERROR([SWIG version 4 is not supported for Python; configure --without-python or use a release tarball])
+  fi
+fi
 
 if test "x$with_python" = xno; then
   have_python=no

--- a/configure.ac
+++ b/configure.ac
@@ -517,7 +517,7 @@ AC_ARG_WITH(python,
         with_python=$withval,with_python=yes)
 
 AC_CHECK_PROG(SWIG, swig, swig, echo)
-if test "$USE_MAINTAINER_MODE" = yes && test "x$SWIG" = xecho; then
+if test "$USE_MAINTAINER_MODE" = yes && (test "x$with_python" = "xyes" || test "x$with_scheme" = "xyes") && test "x$SWIG" = xecho; then
   AC_MSG_ERROR([SWIG not found; configure --without-python --without-scheme or use a release tarball])
 fi
 if test "$USE_MAINTAINER_MODE" = yes && test "x$with_python" = "xyes"; then

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -137,7 +137,6 @@ endif
 ##################################################
 if MAINTAINER_MODE
 
-SWIG ?= swig
 SWIG_VERSION = $(shell $(SWIG) -version | grep Version | awk '{print $$3}')
 MEEP_SWIG_SRC = meep.i numpy.i vec.i
 

--- a/scheme/Makefile.am
+++ b/scheme/Makefile.am
@@ -23,7 +23,6 @@ meep_wrap.o: meep_wrap.cxx $(srcdir)/meep-ctl-swig.hpp $(CTLHDRS)
 
 if WITH_LIBCTL
 if MAINTAINER_MODE
-SWIG ?= swig
 meep_wrap.cxx: meep.i meep_op_renames.i meep_enum_renames.i meep_renames.i ctl-io.i meep-ctl-swig.hpp meep_swig_bug_workaround.i $(LIBHDRS)
 	$(SWIG) -I$(top_srcdir)/src -c++ -guile -o $@ $(srcdir)/meep.i
 	patch -p0 $@ < $(srcdir)/meep_wrap.patch


### PR DESCRIPTION
This now checks for `swig` in the `configure` script (and lets you pass the `SWIG=...` variable to `configure`).     In `--enable-maintainer-mode`, it gives an error if `swig` is not found.

Until #965 is fixed, it also gives an error if SWIG 4 is found in `--enable-maintainer-mode`.