### PR TITLE
Fix operator delete[] in typemap for dft_force

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -818,7 +818,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
         PyList_SetItem($result, i, PyFloat_FromDouble($1[i]));
     }
 
-    delete $1;
+    delete[] $1;
 }
 
 // Typemap suite for material_type


### PR DESCRIPTION
The memory in `result` is allocated with `new[]` in `dft_force::force`,
and must therefore be deallocated with `delete[]`.

See eg
https://en.cppreference.com/w/cpp/memory/new/operator_delete

Some compilers/runtimes are more relaxed, but some throw runtime errors on detecting this mismatch.