### PR TITLE
get_ldos_freqs method for Python LDOS objects

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1417,9 +1417,9 @@ Meep can also calculate the LDOS (local density of states) spectrum, as describe
 —
 Create an LDOS object with frequency bandwidth `df` centered at `fcen`, at `nfreq` frequency points. This can be passed to the `dft_ldos` step function below, and has the properties `freq_min`, `nfreq` and `dfreq`.
 
-**`freqs()`**
+**`get_ldos_freqs(ldos)`**
 —
-Method of `Ldos` that returns a list of the frequencies that this `Ldos` instance is computing the spectrum for.
+Given an LDOS object, returns a list of the frequencies that it is computing the spectrum for.
 
 **`dft_ldos(fcen=None, df=None, nfreq=None, ldos=None)`**
 —

--- a/python/meep.i
+++ b/python/meep.i
@@ -1458,6 +1458,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         get_fluxes,
         get_force_freqs,
         get_forces,
+        get_ldos_freqs,
         get_magnetic_energy,
         get_near2far_freqs,
         get_total_energy,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2961,12 +2961,16 @@ def dft_ldos(fcen=None, df=None, nfreq=None, ldos=None):
             sim.ldos_data = mp._dft_ldos_ldos(ldos)
             sim.ldos_Fdata = mp._dft_ldos_F(ldos)
             sim.ldos_Jdata = mp._dft_ldos_J(ldos)
-            display_csv(sim, 'ldos', zip(ldos.freq, sim.ldos_data))
+            display_csv(sim, 'ldos', zip(mp.get_ldos_freqs(ldos), sim.ldos_data))
     return _ldos
 
 
 def scale_flux_fields(s, flux):
     flux.scale_dfts(s)
+
+
+def get_ldos_freqs(l):
+    return [l.freq[i] for i in range(l.freq.size())]
 
 
 def get_flux_freqs(f):

--- a/python/tests/ldos.py
+++ b/python/tests/ldos.py
@@ -1,4 +1,3 @@
-import math
 import unittest
 
 import meep as mp
@@ -43,7 +42,7 @@ class TestLDOS(unittest.TestCase):
         )
 
         self.assertAlmostEqual(self.sim.ldos_data[0], 1.011459560620368)
-        self.assertEqual(ldos.freq.size(), 1)
+        self.assertEqual(len(mp.get_ldos_freqs(ldos)), 1)
 
     def test_invalid_dft_ldos(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
#581 introduced a `freqs()` method for Python LDOS objects that was removed by #1154 in order to enable support for SWIG 4.0. This PR restores that functionality with a new `get_ldos_freqs` method which is similar to `get_flux_freqs`, `get_eigenmode_freqs`, `get_near2far_freqs`, etc.