### PR TITLE
enable support for SWIG 4.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -520,11 +520,6 @@ AC_CHECK_PROG(SWIG, swig, swig, echo)
 if test "$USE_MAINTAINER_MODE" = yes && (test "x$with_python" = "xyes" || test "x$with_scheme" = "xyes") && test "x$SWIG" = xecho; then
   AC_MSG_ERROR([SWIG not found; configure --without-python --without-scheme or use a release tarball])
 fi
-if test "$USE_MAINTAINER_MODE" = yes && test "x$with_python" = "xyes"; then
-  if ($SWIG -version | grep "SWIG Version 4" > /dev/null 2>&1); then
-    AC_MSG_ERROR([SWIG version 4 is not supported for Python; configure --without-python or use a release tarball])
-  fi
-fi
 
 if test "x$with_python" = xno; then
   have_python=no

--- a/python/tests/simulation.py
+++ b/python/tests/simulation.py
@@ -487,7 +487,7 @@ class TestSimulation(unittest.TestCase):
             assert_two(v2)
             v3 = mp.vec(three)
             assert_three(v3)
-            assert_raises(four, NotImplementedError)
+            assert_raises(four, (NotImplementedError,TypeError))
 
         check_iterable([1], [1, 2], [1, 2, 3], [1, 2, 3, 4])
         check_iterable((1,), (1, 2), (1, 2, 3), (1, 2, 3, 4))


### PR DESCRIPTION
Closes #965.

swig/swig@fd651ff changed the exception raised from [`NotImplementedError`](https://docs.python.org/3/library/exceptions.html#NotImplementedError) to [`TypeError`](https://docs.python.org/3/library/exceptions.html#TypeError) when incorrect types are passed to a function. As reported in #965:[comment](https://github.com/NanoComp/meep/issues/965#issuecomment-603999839), this change was causing a build error using SWIG 4.0.1 (built from source) on Ubuntu.

This PR fixes that error by supporting both types of exceptions (as a tuple in [assertRaises](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertRaises)) in that single failing test in `python/tests/simulation.py`.