### PR TITLE
use Ubuntu python-h5py package for parallel-HDF5 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,9 +95,9 @@ matrix:
         packages:
           - *common_deps
           - libhdf5-openmpi-dev
+          - python-h5py
     install:
       - pip install numpy mpi4py scipy matplotlib
-      - pip install --no-binary=h5py h5py
   - python: "3.7"
     env:
       - MPICONF="--without-mpi"
@@ -141,9 +141,9 @@ matrix:
         packages:
           - *common_deps
           - libhdf5-openmpi-dev
+          - python-h5py
     install:
       - pip install numpy mpi4py scipy matplotlib ipython
-      - pip install --no-binary=h5py h5py
 
 
 ##################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,7 @@ matrix:
           - libhdf5-serial-dev
     install:
       - pip install numpy mpi4py scipy h5py matplotlib
-  - python: "3.7"
+  - python: "3.5"
     env:
       - MPICONF="--with-mpi"
       - MKCHECKFLAGS=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,8 @@ matrix:
       - CXX=mpic++
       - CPPFLAGS="${HDF5_PARALLEL_CPPFLAGS} ${CPPFLAGS}"
       - LDFLAGS="${HDF5_PARALLEL_LDFLAGS} ${LDFLAGS}"
+    virtualenv:
+      system_site_packages: true
     addons:
       apt:
         packages:
@@ -136,6 +138,8 @@ matrix:
       - CXX=mpic++
       - CPPFLAGS="${HDF5_PARALLEL_CPPFLAGS} ${CPPFLAGS}"
       - LDFLAGS="${HDF5_PARALLEL_LDFLAGS} ${LDFLAGS}"
+    virtualenv:
+      system_site_packages: true
     addons:
       apt:
         packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ matrix:
         packages:
           - *common_deps
           - libhdf5-openmpi-dev
-          - python-h5py
+          - python3-h5py
     install:
       - pip install numpy mpi4py scipy matplotlib ipython
 


### PR DESCRIPTION
Instead of pip, which seems to be running into some trouble compiling h5py with the latest versions.