### PR TITLE
fields:time_spent_on returns a list of per process values for all processes

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1025,6 +1025,14 @@ Field time usage:
           everything else: 0.324933 s +/- 0.377573 s
 ```
 
+**`Simulation.time_spent_on(time_sink)`**
+—
+Return a list of times spent by each process for a type of work `time_sink` which can be one of nine integer values: (`0`) connecting chunks, (`1`) time stepping, (`2`) boundaries, (`3`) MPI/synchronization, (`4`) field output, (`5`) Fourier transforming, (`6`) MPB, (`7`) near to far field transformation, and (`8`) other.
+
+**`Simulation.mean_time_spent_on(time_sink)`**
+—
+Return the mean time spent by all processes for a type of work `time_sink` which can be one of nine integer values as shown above.
+
 ### Field Computations
 
 Meep supports a large number of functions to perform computations on the fields. Most of them are accessed via the lower-level C++/SWIG interface. Some of them are based on the following simpler, higher-level versions. They are accessible as methods of a `Simulation` instance.

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2301,6 +2301,9 @@ class Simulation(object):
         if self.fields:
             self.fields.print_times()
 
+    def time_spent_on(self, time_sink):
+        return self.fields.time_spent_on(time_sink)
+
     def get_epsilon(self,frequency=0,omega=0):
         if omega != 0:
             frequency = omega

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1533,7 +1533,7 @@ public:
   void reset();
 
   // time.cpp
-  double time_spent_on(time_sink);
+  std::vector<double> time_spent_on(time_sink);
   double mean_time_spent_on(time_sink);
   void print_times();
   // boundaries.cpp

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -53,15 +53,16 @@ void fields::reset_timers() {
 
 std::vector<double> fields::time_spent_on(time_sink s) {
   int n = count_processors();
-  std::vector<double> time_spent_per_process(n);
-  for (int j =0; j < n; ++j)
-    time_spent_per_process[j] = sum_to_master(j == my_rank() ? times_spent[s] : 0);
+  std::vector<double> time_spent_per_process(n), temp(n);
+  for (int j = 0; j < n; ++j) temp[j] = 0;
+  temp[my_rank()] = times_spent[s];
+  sum_to_all(&temp[0], &time_spent_per_process[0], n);
   return time_spent_per_process;
 }
 
 double fields::mean_time_spent_on(time_sink s) {
   int n = count_processors();
-  double total_time_spent = sum_to_master(times_spent[s]);
+  double total_time_spent = sum_to_all(times_spent[s]);
   return total_time_spent / n;
 }
 

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -51,7 +51,13 @@ void fields::reset_timers() {
   am_now_working_on(Other);
 }
 
-double fields::time_spent_on(time_sink s) { return times_spent[s]; }
+std::vector<double> fields::time_spent_on(time_sink s) {
+  int n = count_processors();
+  std::vector<double> time_spent_per_process(n);
+  for (int j =0; j < n; ++j)
+    time_spent_per_process[j] = sum_to_master(j == my_rank() ? times_spent[s] : 0);
+  return time_spent_per_process;
+}
 
 double fields::mean_time_spent_on(time_sink s) {
   int n = count_processors();


### PR DESCRIPTION
When `verbosity` is greater than `1`, `fields::print_times()` displays the values for each of the nine `time_sink` components of the `fields::times_spent` array for each process separately. Rather than just display these values, it would be useful to be able to access them directly for analysis/debugging purposes, etc. This PR modifies the function `fields::time_spent_on` to return a list containing the per process values for a given `time_sink` for all processes rather than just a single per process value. Documentation is also included.