### PR TITLE
support material function for split-by-cost chunk partitioning method

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1024,6 +1024,7 @@ class Simulation(object):
             pml_vols2,
             pml_vols3,
             absorber_vols,
+            self.extra_materials,
             self.subpixel_tol,
             self.subpixel_maxeval,
             self.ensure_periodicity,

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1758,20 +1758,16 @@ void fragment_stats::update_stats_from_material(material_type mat, size_t pixels
       for (int i = 0; i < extra_materials.num_items; ++i) {
         medium_struct *med = &extra_materials.items[i]->medium;
         if (!anisotropic_pixels_already_added && !anisotropic_pixels_extmat_already_added) {
-          count_anisotropic_pixels(med, pixels);
-          anisotropic_pixels_extmat_already_added = true;
+          anisotropic_pixels_extmat_already_added = count_anisotropic_pixels(med, pixels);
         }
         if (!nonlinear_pixels_extmat_already_added) {
-          count_nonlinear_pixels(med, pixels);
-          nonlinear_pixels_extmat_already_added = true;
+          nonlinear_pixels_extmat_already_added = count_nonlinear_pixels(med, pixels);
         }
         if (!susceptibility_pixels_extmat_already_added) {
-          count_susceptibility_pixels(med, pixels);
-          susceptibility_pixels_extmat_already_added = true;
+          susceptibility_pixels_extmat_already_added = count_susceptibility_pixels(med, pixels);
         }
         if (!nonzero_conductivity_pixels_extmat_already_added) {
-          count_nonzero_conductivity_pixels(med, pixels);
-          nonzero_conductivity_pixels_extmat_already_added = true;
+          nonzero_conductivity_pixels_extmat_already_added = count_nonzero_conductivity_pixels(med, pixels);
         }
         break;
       }
@@ -1825,7 +1821,7 @@ void fragment_stats::compute_stats() {
   }
 }
 
-void fragment_stats::count_anisotropic_pixels(medium_struct *med, size_t pixels) {
+bool fragment_stats::count_anisotropic_pixels(medium_struct *med, size_t pixels) {
   size_t eps_offdiag_elements = 0;
   size_t mu_offdiag_elements = 0;
 
@@ -1838,9 +1834,10 @@ void fragment_stats::count_anisotropic_pixels(medium_struct *med, size_t pixels)
 
   num_anisotropic_eps_pixels += eps_offdiag_elements * pixels;
   num_anisotropic_mu_pixels += mu_offdiag_elements * pixels;
+  return (eps_offdiag_elements != 0) || (mu_offdiag_elements != 0);
 }
 
-void fragment_stats::count_nonlinear_pixels(medium_struct *med, size_t pixels) {
+bool fragment_stats::count_nonlinear_pixels(medium_struct *med, size_t pixels) {
   size_t nonzero_chi_elements = 0;
 
   if (med->E_chi2_diag.x != 0) { nonzero_chi_elements++; }
@@ -1857,14 +1854,16 @@ void fragment_stats::count_nonlinear_pixels(medium_struct *med, size_t pixels) {
   if (med->H_chi3_diag.z != 0) { nonzero_chi_elements++; }
 
   num_nonlinear_pixels += nonzero_chi_elements * pixels;
+  return nonzero_chi_elements != 0;
 }
 
-void fragment_stats::count_susceptibility_pixels(medium_struct *med, size_t pixels) {
+bool fragment_stats::count_susceptibility_pixels(medium_struct *med, size_t pixels) {
   num_susceptibility_pixels += med->E_susceptibilities.num_items * pixels;
   num_susceptibility_pixels += med->H_susceptibilities.num_items * pixels;
+  return (med->E_susceptibilities.num_items != 0) || (med->H_susceptibilities.num_items != 0);
 }
 
-void fragment_stats::count_nonzero_conductivity_pixels(medium_struct *med, size_t pixels) {
+bool fragment_stats::count_nonzero_conductivity_pixels(medium_struct *med, size_t pixels) {
   size_t nonzero_conductivity_elements = 0;
 
   if (med->D_conductivity_diag.x != 0) { nonzero_conductivity_elements++; }
@@ -1875,6 +1874,7 @@ void fragment_stats::count_nonzero_conductivity_pixels(medium_struct *med, size_
   if (med->B_conductivity_diag.z != 0) { nonzero_conductivity_elements++; }
 
   num_nonzero_conductivity_pixels += nonzero_conductivity_elements * pixels;
+  return nonzero_conductivity_elements != 0;
 }
 
 void fragment_stats::compute_dft_stats() {

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1751,12 +1751,28 @@ void fragment_stats::update_stats_from_material(material_type mat, size_t pixels
       break;
     }
     case material_data::MATERIAL_USER: {
+      bool anisotropic_pixels_extmat_already_added = false;
+      bool nonlinear_pixels_extmat_already_added = false;
+      bool susceptibility_pixels_extmat_already_added = false;
+      bool nonzero_conductivity_pixels_extmat_already_added = false;
       for (int i = 0; i < extra_materials.num_items; ++i) {
         medium_struct *med = &extra_materials.items[i]->medium;
-        if (!anisotropic_pixels_already_added) { count_anisotropic_pixels(med, pixels); }
-        count_nonlinear_pixels(med, pixels);
-        count_susceptibility_pixels(med, pixels);
-        count_nonzero_conductivity_pixels(med, pixels);
+        if (!anisotropic_pixels_already_added && !anisotropic_pixels_extmat_already_added) {
+          count_anisotropic_pixels(med, pixels);
+          anisotropic_pixels_extmat_already_added = true;
+        }
+        if (!nonlinear_pixels_extmat_already_added) {
+          count_nonlinear_pixels(med, pixels);
+          nonlinear_pixels_extmat_already_added = true;
+        }
+        if (!susceptibility_pixels_extmat_already_added) {
+          count_susceptibility_pixels(med, pixels);
+          susceptibility_pixels_extmat_already_added = true;
+        }
+        if (!nonzero_conductivity_pixels_extmat_already_added) {
+          count_nonzero_conductivity_pixels(med, pixels);
+          nonzero_conductivity_pixels_extmat_already_added = true;
+        }
         break;
       }
     }

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -110,10 +110,10 @@ private:
   void update_stats_from_material(material_type mat, size_t pixels,
                                   bool anisotropic_pixels_already_added = false);
   void compute_stats();
-  void count_anisotropic_pixels(medium_struct *med, size_t pixels);
-  void count_nonlinear_pixels(medium_struct *med, size_t pixels);
-  void count_susceptibility_pixels(medium_struct *med, size_t pixels);
-  void count_nonzero_conductivity_pixels(medium_struct *med, size_t pixels);
+  bool count_anisotropic_pixels(medium_struct *med, size_t pixels);
+  bool count_nonlinear_pixels(medium_struct *med, size_t pixels);
+  bool count_susceptibility_pixels(medium_struct *med, size_t pixels);
+  bool count_nonzero_conductivity_pixels(medium_struct *med, size_t pixels);
   void compute_dft_stats();
   void compute_pml_stats();
   void compute_absorber_stats();

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -72,6 +72,7 @@ struct fragment_stats {
   static std::vector<meep::volume> pml_2d_vols;
   static std::vector<meep::volume> pml_3d_vols;
   static std::vector<meep::volume> absorber_vols;
+  static material_type_list extra_materials;
   static bool split_chunks_evenly;
   static bool eps_averaging;
 
@@ -123,7 +124,8 @@ compute_fragment_stats(geometric_object_list geom, meep::grid_volume *gv, vector
                        vector3 cell_center, material_type default_mat,
                        std::vector<dft_data> dft_data_list, std::vector<meep::volume> pml_1d_vols,
                        std::vector<meep::volume> pml_2d_vols, std::vector<meep::volume> pml_3d_vols,
-                       std::vector<meep::volume> absorber_vols, double tol, int maxeval,
+                       std::vector<meep::volume> absorber_vols, material_type_list extra_materials,
+                       double tol, int maxeval,
                        bool ensure_per, bool eps_averaging);
 
 /***************************************************************/

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -187,7 +187,6 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
 
   bool by_cost = false;
   if (meep_geom::fragment_stats::resolution == 0 ||
-      meep_geom::fragment_stats::has_non_medium_material() ||
       meep_geom::fragment_stats::split_chunks_evenly) {
     if (verbosity > 0 && adjusted_num_chunks > 1)
       master_printf("Splitting into %d chunks evenly\n", adjusted_num_chunks);


### PR DESCRIPTION
Closes #1194.

Adds support for a user-specified material function to the split-by-cost chunk partitioning method (i.e. `split_chunks_evenly=False`). This is verified by the chunk layouts for two different material functions defined for the same `Block` object in a 2d cell: (1) `my_matfunc1` (real, wavelength-independent, scalar permittivity) and (2) `my_matfunc2` (complex, wavelength-dependent permittivity comprised of two Lorentzian susceptibility terms). The user must specify `extra_materials` for `my_matfunc2` otherwise the dispersive material is ignored (see Figs. 2c and 2d below). For `my_matfunc1`, `extra_materials` has no effect since the `Medium` is just a lossless dielectric (see Figs. 1c and 1d).

Note that the user can specify any number of `Medium` objects in `extra_materials` which will all be used in `fragment_stats` to compute the cost of a chunk.

```py
import meep as mp
import numpy as np

import matplotlib
matplotlib.use('agg')
import matplotlib.pyplot as plt

resolution = 25
cell_size = mp.Vector3(10,10)
pml_layers = [mp.PML(thickness=1.0)]

fcen = 1.0
df = 0.2
sources = [mp.Source(src=mp.GaussianSource(fcen,df),
	             component=mp.Ez,
                     center=mp.Vector3(0.12,.36))]

def my_matfunc1(p):
    rr = (p.x**2+p.y**2)**0.5
    return mp.Medium(index=np.cos(2*np.pi*rr)**2+1.0)

def my_matfunc2(p):
    rr = (p.x**2+p.y**2)**0.5
    susc = [mp.LorentzianSusceptibility(frequency=fcen, gamma=0.1*fcen, sigma=np.sin(2*np.pi*rr)**2+1.0),
	    mp.LorentzianSusceptibility(frequency=0.9*fcen, gamma=0.3*fcen, sigma=0.5*np.sin(2*np.pi*rr)**2+1.5)]
    return mp.Medium(epsilon=3.5, E_susceptibilities=susc)

geometry = [mp.Block(center=mp.Vector3(),
                     size=mp.Vector3(5,5),
                     material=my_matfunc1)]

sim = mp.Simulation(cell_size=cell_size,
	            geometry=geometry,
                    sources=sources,
                    eps_averaging=False,
                    split_chunks_evenly=False,
                    resolution=resolution,
                    boundary_layers=pml_layers,
                    extra_materials=[my_matfunc1(mp.Vector3())],                                                                                     
	            collect_stats=True)

nfreq = 25
flux1 = sim.add_flux(fcen, df, nfreq, mp.FluxRegion(center=mp.Vector3(y=3.5),size=mp.Vector3(x=7)))

plt.figure(dpi=200)
sim.plot2D(frequency=fcen)
if mp.am_master():
    plt.savefig('matfunc1_epsilon.png')

plt.figure(dpi=200)
sim.visualize_chunks()
if mp.am_master():
    plt.savefig('matfunc1_chunk_layout.png')

sim.fragment_stats.print_stats()
```

**1a:** `my_matfunc1` simulation layout

![matfunc1_epsilon](https://user-images.githubusercontent.com/7152530/80740747-6a9fae80-8acd-11ea-994d-ed90289ab29c.png)

**1b:** `my_matfunc1`, `split_chunks_evenly=True`, `6` chunks

![matfunc1_chunk_layout_np6_spliteven](https://user-images.githubusercontent.com/7152530/80740825-873be680-8acd-11ea-9e9e-95bf5f206b40.png)

**1c:** `my_matfunc1`, `split_chunks_evenly=False`, `6` chunks, `extra_materials=[my_matfunc1(mp.Vector3())]`

![matfunc1_chunk_layout_np6_splitcost](https://user-images.githubusercontent.com/7152530/80740881-99b62000-8acd-11ea-8a08-5336b57847a4.png)

```
Fragment stats
  num_anisotropic_eps_pixels: 0
  num_anisotropic_mu_pixels: 0
  num_nonlinear_pixels: 0
  num_susceptibility_pixels: 0
  num_nonzero_conductivity_pixels: 0
  num_1d_pml_pixels: 20000
  num_2d_pml_pixels: 2500
  num_3d_pml_pixels: 0
  num_dft_pixels: 70000
  num_pixels_in_box: 62500
```

**1d:**  `my_matfunc1`, `split_chunks_evenly=False`, `6` chunks, `extra_materials=[]`

![matfunc1_chunk_layout_np6_splitcost_noextramaterials](https://user-images.githubusercontent.com/7152530/80741069-ec8fd780-8acd-11ea-9e75-a104c1c75e70.png)

```
Fragment stats
  num_anisotropic_eps_pixels: 0
  num_anisotropic_mu_pixels: 0
  num_nonlinear_pixels: 0
  num_susceptibility_pixels: 0
  num_nonzero_conductivity_pixels: 0
  num_1d_pml_pixels: 20000
  num_2d_pml_pixels: 2500
  num_3d_pml_pixels: 0
  num_dft_pixels: 70000
  num_pixels_in_box: 62500
```

**2a:** `my_matfunc2` simulation layout

![matfunc2_epsilon](https://user-images.githubusercontent.com/7152530/80741235-2a8cfb80-8ace-11ea-9743-9e55dff7713b.png)

**2b:** `my_matfunc1`, `split_chunks_evenly=True`, `6` chunks

![matfunc2_chunk_layout](https://user-images.githubusercontent.com/7152530/80741993-78563380-8acf-11ea-8973-ab9ffb8531d9.png)

**2c:** `my_matfunc2`, `split_chunks_evenly=False`, `6` chunks, `extra_materials=[my_matfunc2(mp.Vector3())]`

![matfunc2_chunk_layout_np6_splitcost](https://user-images.githubusercontent.com/7152530/80740991-c407dd80-8acd-11ea-906e-230b19aad97d.png)

```
Fragment stats
  num_anisotropic_eps_pixels: 0
  num_anisotropic_mu_pixels: 0
  num_nonlinear_pixels: 0
  num_susceptibility_pixels: 31250
  num_nonzero_conductivity_pixels: 0
  num_1d_pml_pixels: 20000
  num_2d_pml_pixels: 2500
  num_3d_pml_pixels: 0
  num_dft_pixels: 70000
  num_pixels_in_box: 62500
```

**2d:** `my_matfunc2`, `split_chunks_evenly=False`, `6` chunks, `extra_materials=[]`

![matfunc2_chunk_layout_np6_splitcost_noextramaterials](https://user-images.githubusercontent.com/7152530/80741022-d4b85380-8acd-11ea-940b-0a454b082eb8.png)

```
Fragment stats
  num_anisotropic_eps_pixels: 0
  num_anisotropic_mu_pixels: 0
  num_nonlinear_pixels: 0
  num_susceptibility_pixels: 0
  num_nonzero_conductivity_pixels: 0
  num_1d_pml_pixels: 20000
  num_2d_pml_pixels: 2500
  num_3d_pml_pixels: 0
  num_dft_pixels: 70000
  num_pixels_in_box: 62500
```
