### PR TITLE
WIP: multithreading support for grid loops

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,16 +7,16 @@ AM_CPPFLAGS = -I$(top_srcdir)/src
 BUILT_SOURCES = sphere-quad.h step_generic_stride1.cpp
 
 HDRS = meep.hpp meep_internals.hpp meep/mympi.hpp meep/vec.hpp	\
-bicgstab.hpp meepgeom.hpp material_data.hpp
+bicgstab.hpp meepgeom.hpp material_data.hpp multithreading.hpp
 
 libmeep_la_SOURCES = array_slice.cpp anisotropic_averaging.cpp 		\
 bands.cpp boundaries.cpp bicgstab.cpp casimir.cpp 	\
 cw_fields.cpp dft.cpp dft_ldos.cpp energy_and_flux.cpp 	\
 fields.cpp loop_in_chunks.cpp h5fields.cpp h5file.cpp 	\
 initialize.cpp integrate.cpp integrate2.cpp monitor.cpp mympi.cpp 	\
-multilevel-atom.cpp near2far.cpp output_directory.cpp random.cpp 	\
-sources.cpp step.cpp step_db.cpp stress.cpp structure.cpp structure_dump.cpp		\
-susceptibility.cpp time.cpp update_eh.cpp mpb.cpp update_pols.cpp 	\
+multilevel-atom.cpp multithreading.cpp near2far.cpp output_directory.cpp random.cpp 	\
+sources.cpp step.cpp step_db.cpp step_multithreaded.cpp step_multithreaded_stride1.cpp  \
+stress.cpp structure.cpp structure_dump.cpp susceptibility.cpp time.cpp update_eh.cpp mpb.cpp update_pols.cpp 	\
 vec.cpp step_generic.cpp meepgeom.cpp GDSIIgeom.cpp $(HDRS) $(BUILT_SOURCES)
 
 SUBDIRS = support
@@ -35,5 +35,8 @@ sphere-quad.h:
 
 step_generic_stride1.cpp: step_generic.cpp
 	(echo $(PRELUDE); echo; sed 's/LOOP_OVER/S1LOOP_OVER/g' $(top_srcdir)/src/step_generic.cpp | sed 's/step_curl/step_curl_stride1/' | sed 's/step_update_EDHB/step_update_EDHB_stride1/' | sed 's/step_beta/step_beta_stride1/') > $@
+
+step_multithreaded_stride1.cpp: step_multithreaded.cpp
+	(echo $(PRELUDE); echo; sed 's/PLOOP_OVER/S1PLOOP_OVER/g' $(top_srcdir)/src/step_multithreaded.cpp | sed 's/step_curl/step_curl_stride1/' | sed 's/step_update_EDHB/step_update_EDHB_stride1/' | sed 's/step_beta/step_beta_stride1/') > $@
 
 MAINTAINERCLEANFILES = $(BUILT_SOURCES)

--- a/src/fields.cpp
+++ b/src/fields.cpp
@@ -81,6 +81,8 @@ fields::fields(structure *s, double m, double beta, bool zero_fields_near_cylori
         s->user_volume.num_direction(d) == 1)
       use_bloch(d, 0.0);
   }
+
+  init_meep_threads();
 }
 
 fields::fields(const fields &thef)

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -191,7 +191,7 @@ component first_field_component(field_type ft);
          loop_ibound++)                                                                            \
   LOOP_OVER_IVECS(gv, loop_notowned_is, loop_notowned_ie, idx)
 
-#define LOOPS_ARE_STRIDE1(gv) ((gv).stride((gv).yucky_direction(2)) == 1)
+#define LOOPS_ARE_STRIDE1(gv) (use_stride1 && ((gv).stride((gv).yucky_direction(2)) == 1))
 
 // The following work identically to the LOOP_* macros above,
 // but assume that the inner loop is stride-1: LOOPS_ARE_STRIDE1(gv) *must*

--- a/src/meep_internals.hpp
+++ b/src/meep_internals.hpp
@@ -17,6 +17,7 @@
 
 #include <string.h>
 #include "meep.hpp"
+#include "multithreading.hpp"
 
 namespace meep {
 

--- a/src/multithreading.cpp
+++ b/src/multithreading.cpp
@@ -1,0 +1,221 @@
+/* Copyright (C) 2005-2020 Massachusetts Institute of Technology
+%
+%  This program is free software; you can redistribute it and/or modify
+%  it under the terms of the GNU General Public License as published by
+%  the Free Software Foundation; either version 2, or (at your option)
+%  any later version.
+%
+%  This program is distributed in the hope that it will be useful,
+%  but WITHOUT ANY WARRANTY; without even the implied warranty of
+%  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%  GNU General Public License for more details.
+%
+%  You should have received a copy of the GNU General Public License
+%  along with this program; if not, write to the Free Software Foundation,
+%  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <complex>
+#include <map>
+#include <limits.h>
+#include <utility>
+#include <vector>
+#include <algorithm>
+
+#include "multithreading.hpp"
+
+using namespace std;
+
+namespace meep {
+
+/***************************************************************/
+/* implementation of ivec_loop_counter                         */
+/***************************************************************/
+ivec_loop_counter::ivec_loop_counter(const grid_volume &gv, const ivec &_is, const ivec &_ie, int nt, int NT) {
+  init(gv, _is, _ie, nt, NT);
+}
+
+void ivec_loop_counter::init(const grid_volume &gv, const ivec &_is, const ivec &_ie, int nt, int NT) {
+  if (is==_is && ie==_ie && gvlc==gv.little_corner() && inva==gv.inva)
+    return; // no need to reinitialize
+
+  is   = _is;
+  gvlc = gv.little_corner();
+  ie   = _ie;
+  inva = gv.inva;
+
+  // tabulate 'active' dimensions, i.e. those in which loop is non-empty
+  idx0 = 0;
+  rank = 0;
+  size_t num_iters = 1;
+  LOOP_OVER_DIRECTIONS(gv.dim, d) {
+    idx0 += gv.stride(d) * ((is - gvlc).in_direction(d)/2);
+    ptrdiff_t count = (ie-is).in_direction(d)/2 + 1;
+    if (count > 1) {
+      idx_stride[rank] =  gv.stride(d);
+      loop_dir[rank]   =  d;
+      N[rank]          =  count;
+      num_iters        *= count;
+      rank++;
+    }
+  }
+  N_inner = N[rank-1];
+  idx_step = idx_stride[rank-1];
+
+  if (NT<1) { nt=0; NT=1; }
+  min_iter = (nt*num_iters) / NT;
+  max_iter = ((nt+1)*num_iters) / NT;
+}
+
+/***************************************************************/
+/* helper function for the 'start' routine that initializes    */
+/* computation of 'k' index into PML sigma arrays for up to    */
+/* two distinct directions                                     */
+/***************************************************************/
+void ivec_loop_counter::init_k(int nd, direction dsig) {
+  if (dsig==NO_DIRECTION) {
+    k0[nd]=INT_MAX;
+    k_step[nd]=0;
+  }
+  else {
+    k0[nd]=(is-gvlc).in_direction(dsig);
+    for(int r=0; r<rank; r++)
+      k_stride[nd][r] = (loop_dir[r]==dsig ? 2 : 0);
+    k_step[nd]=k_stride[nd][rank-1];
+  }
+}
+
+ptrdiff_t ivec_loop_counter::start(direction dsig1, direction dsig2) {
+  complete = false;
+  init_k(0, dsig1);
+  init_k(1, dsig2);
+
+  current_iter=min_iter;
+  N_inner=0;
+  return update_outer();
+}
+
+ptrdiff_t ivec_loop_counter::start(const grid_volume &gv, const ivec &_is, const ivec &_ie, int nt, int NT,
+                                   direction dsig1, direction dsig2) {
+  init(gv, _is, _ie, nt, NT);
+  return start(dsig1, dsig2);
+}
+
+ptrdiff_t ivec_loop_counter::update_outer() {
+  current_iter += N_inner;
+  if (current_iter>=max_iter) {
+    complete=true;
+    return idx0;
+  }
+  ptrdiff_t idx = niter_to_narray(current_iter, n);
+  N_inner = std::min( N[rank-1]-n[rank-1], max_iter-current_iter );
+  idx_max = idx + N_inner*idx_step;
+  return idx;
+}
+
+void ivec_loop_counter::advance() {
+  if (++current_iter < max_iter)
+    for(int r=rank-1; r>=0; n[r--]=0)
+      if ( ++n[r] < N[r] )
+        return;
+  complete=true;
+}
+
+ptrdiff_t ivec_loop_counter::increment(int *k1, int *k2) {
+  advance();
+  get_k(k1,k2);
+  return get_idx();
+}
+
+ptrdiff_t ivec_loop_counter::increment(size_t *k1, size_t *k2) {
+  int ik1, ik2;
+  ptrdiff_t idx=increment( k1 ? &ik1 : 0, k2 ? &ik2 : 0 );
+  if (k1) *k1=ik1;
+  if (k2) *k2=ik2;
+  return idx;
+}
+
+// given the overall index of a loop iteration (between 0 and N[0]*...*N[rank-1]),
+// resolve the loop indices in each dimension
+ptrdiff_t ivec_loop_counter::niter_to_narray(size_t niter, size_t narray[3]) {
+  ptrdiff_t idx=idx0;
+  for(int r=rank-1; r>0; niter/=N[r--]) {
+    narray[r] = niter % N[r];
+    idx+=narray[r]*idx_stride[r];
+  }
+  narray[0]=niter;
+  return idx+narray[0]*idx_stride[0];
+}
+
+ptrdiff_t ivec_loop_counter::get_idx(size_t *narray) {
+  if (narray==0) narray=n;
+  ptrdiff_t idx = idx0;
+  for(int r=0; r<rank; r++)
+    idx += narray[r]*idx_stride[r];
+  return idx;
+}
+
+int ivec_loop_counter::get_k(int nd, size_t *narray) {
+  if (k0[nd]==INT_MAX) return 0;
+  if (narray==0) narray=n;
+  int k=k0[nd];
+  for(int r=0; r<rank; r++)
+    k+=narray[r]*k_stride[nd][r];
+  return k;
+}
+
+void ivec_loop_counter::get_k(int *k1, int *k2, size_t *narray) {
+  if (k1) *k1=get_k(0, narray);
+  if (k2) *k2=get_k(1, narray);
+}
+
+ivec ivec_loop_counter::get_iloc(size_t *narray) {
+  if (narray==0) narray=n;
+  ivec iloc=is;
+  for(int r=0; r<rank; r++)
+    iloc.set_direction(loop_dir[r], is.in_direction(loop_dir[r]) + 2*narray[r]);
+  return iloc;
+}
+
+vec ivec_loop_counter::get_loc(size_t *narray) {
+  ivec iloc=get_iloc(narray);
+  vec loc(iloc.dim);
+  LOOP_OVER_DIRECTIONS(iloc.dim,d)
+    loc.set_direction(d, iloc.in_direction(d) * 0.5 * inva);
+  return loc;
+}
+
+/******************************************************/
+/* global variables related to threads plus a routine */
+/* for setting their values via environment variable  */
+/******************************************************/
+vector<ivec_loop_counter> ilcs;
+int meep_threads=0;
+bool use_stride1=true;
+
+void init_meep_threads() {
+  char *s=getenv("MEEP_NUM_THREADS");
+  if (s)
+    sscanf(s,"%i",&meep_threads);
+  if (verbosity > 0)
+    master_printf("Using %i OpenMP threads.\n",meep_threads);
+
+  s=getenv("MEEP_IGNORE_STRIDE1");
+  use_stride1 = !s || s[0] != '1';
+  if (verbosity > 0)
+    master_printf("%s #pragma ivdep for stride-1 loops.\n",use_stride1 ? "Using" : "Not using");
+}
+
+void update_ilcs(const grid_volume &gv) {
+  if (meep_threads==0 || ((int)ilcs.size())==meep_threads)
+    return;
+  ilcs.clear();
+  ivec is(gv.dim);
+  for(int nt=0; nt<meep_threads; nt++)
+    ilcs.push_back(ivec_loop_counter(gv,is,is,nt,meep_threads));
+}
+
+} // namespace meep

--- a/src/multithreading.hpp
+++ b/src/multithreading.hpp
@@ -1,0 +1,195 @@
+/* Copyright (C) 2005-2020 Massachusetts Institute of Technology
+%
+%  This program is free software; you can redistribute it and/or modify
+%  it under the terms of the GNU General Public License as published by
+%  the Free Software Foundation; either version 2, or (at your option)
+%  any later version.
+%
+%  This program is distributed in the hope that it will be useful,
+%  but WITHOUT ANY WARRANTY; without even the implied warranty of
+%  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%  GNU General Public License for more details.
+%
+%  You should have received a copy of the GNU General Public License
+%  along with this program; if not, write to the Free Software Foundation,
+%  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+*/
+
+#ifndef MULTITHREADING_H
+#define MULTITHREADING_H
+
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#include <complex>
+
+#include "meep.hpp"
+
+using namespace std;
+namespace meep { 
+
+/**************************************************/
+/* ivec_loop_counter is a class that replaces the */
+/* LOOP_OVER_IVECS() macro and its derivatives to */
+/* facilitate shared-memory loop parallelization. */
+/**************************************************/
+class ivec_loop_counter
+ {
+public:
+
+    /***************************************************************/
+    /* initialize to handle loops from _is to _ie in gv.           */
+    /* if NT>1 and nt \in [0,NT), the loop is subdivided into NT   */
+    /* equal chunks and the loop counter handles only chunk #nt.   */
+    /***************************************************************/
+    ivec_loop_counter(const grid_volume &gv, const ivec &_is, const ivec &_ie, int nt=0, int NT=1);
+    void init(const grid_volume &gv, const ivec &_is, const ivec &_ie, int nt=0, int NT=1);
+
+    /*--------------------------------------------------------------*/
+    /* The start() and increment() routines implement a stateful    */
+    /* paradigm in which the current state of the loop is stored in */
+    /* internal class variables. In this case we have separate      */
+    /* ivec_loop_counter structures for each thread, each covering  */
+    /* a fraction of the total loop.                                */
+    /*--------------------------------------------------------------*/
+
+    /***************************************************************/
+    /* Set the loop counter at the beginning of our chunk of the   */
+    /* loop. The return value is 'idx' (index into field arrays) at*/
+    /* the starting grid point. The optional direction arguments   */
+    /* request computation of 'k' indices into PML sigma arrays for*/
+    /* up to two directions. If k1,k2 are non-null they are filled */
+    /* in with the corresponding k values at the starting grid pt. */
+    /***************************************************************/
+    ptrdiff_t start(direction dsig1=NO_DIRECTION, direction dsig2=NO_DIRECTION);
+    ptrdiff_t start(const grid_volume &gv, const ivec &_is, const ivec &_ie, int nt, int NT,
+                    direction dsig1=NO_DIRECTION, direction dsig2=NO_DIRECTION);
+
+    ptrdiff_t update_outer();
+
+    /***************************************************************/
+    /* Advance the loop one iteration. The return value is idx.    */
+    /* The internal class field 'complete' will be set to true if  */
+    /* this was the final loop iteration.                          */
+    /***************************************************************/
+    ptrdiff_t increment(int *k1=0, int *k2=0);
+    ptrdiff_t increment(size_t *k1, size_t *k2=0);
+    ptrdiff_t operator++() { return increment(); }
+
+    /*--------------------------------------------------------------*/
+    /*- The niter_to_narray() routine implements an alternative,    */
+    /*- fully stateless, model. In this case we will have only one  */
+    /*- ivec_loop_counter structure used by *all* threads with no   */
+    /*- thread-specific data stored in the structure. Threads call  */
+    /*- niter_to_narray() with arbitrary values of niter in the     */
+    /*- range [min_iter, max_iter) to compute narray, the loop      */
+    /*- indices for that iteration (the return value is idx). Then  */
+    /*- narray can be passed to routines like get_k, get_iloc, etc. */
+    /*- to compute loop quantities for the given iteration.         */
+    /*--------------------------------------------------------------*/
+    ptrdiff_t niter_to_narray(size_t niter, size_t narray[3]);
+
+    /***************************************************************/
+    /* The following routines are used in both the state-ful model */
+    /* (in which case they should be called with no arguments, to  */
+    /* indicate that internal class variables should be used) and  */
+    /* in the stateless approach, in which case the caller should  */
+    /* supply an narray argument filled in by niter_to_narray.     */
+    /***************************************************************/
+    ptrdiff_t get_idx(size_t *narray=0);
+    int get_k(int nd, size_t *narray=0);
+    void get_k(int *k1, int *k2=0, size_t *narray=0);
+    ivec get_iloc(size_t *narray=0);
+    vec get_loc(size_t *narray=0);
+
+// private
+
+// routines intended for internal use
+    void init_k(int nd, direction dsig);   // helper routine for start()
+    void advance();                        // helper routine for increment()
+
+// class data fields
+
+    // fields used for both state-ful and stateless usage models
+    ivec is, ie, gvlc; 
+    double inva;
+    direction loop_dir[3];
+    ptrdiff_t idx_stride[3];
+    size_t N[3];
+    int rank;
+    ptrdiff_t idx0;
+    size_t min_iter, max_iter;
+    int k0[2], k_stride[2][3]; 
+
+    // fields used only for the state-ful model
+    size_t n[3], N_inner;
+    size_t current_iter;
+    ptrdiff_t idx_max, idx_step;
+    int k_step[2];
+    bool complete;
+
+ }; // class ivec_loop_counter
+
+/**************************************************/
+/* global array of ivec_loop_counters, one per    */
+/* thread, initialized by init_meep_threads()     */
+/**************************************************/
+extern vector<ivec_loop_counter> ilcs;
+extern int meep_threads;
+extern bool use_stride1;
+void init_meep_threads();
+void update_ilcs(const grid_volume &gv);
+
+/************************************************************/
+/* macros for multithreaded grid loops. The basic grid loop */
+/* is PLOOP_OVER_IVECS. Versions with _D or _DD suffixes are*/
+/* for cases requiring one or two 'k' indices into PML sigma*/
+/* arrays in specific directions. S1PLOOP_ versions break   */
+/* out the innermost loop as a separate loop to allow       */
+/* compiler optimization using #pragma ivdep (intel         */
+/* compilers or #pragma gcc ivdep (GNU compilers).          */
+/************************************************************/
+#define _NT meep_threads
+
+#define PLOOP_OVER_IVECS(gv, is, ie, idx)						\
+_Pragma("omp parallel for schedule(guided), num_threads(_NT)")				\
+ for(int nt=0; nt<_NT; nt++)								\
+  for(ptrdiff_t idx=ilcs[nt].start(gv,is,ie,nt,_NT); !(ilcs[nt].complete); idx=ilcs[nt].update_outer()) \
+   for(ptrdiff_t idx_max=ilcs[nt].idx_max, idx_step=ilcs[nt].idx_step; idx<idx_max; idx+=idx_step)
+
+#define PLOOP_OVER_IVECS_D(gv, is, ie, idx, d, k)					\
+_Pragma("omp parallel for schedule(guided), num_threads(_NT)")				\
+ for(int nt=0; nt<_NT; nt++)								\
+  for(ptrdiff_t idx=ilcs[nt].start(gv,is,ie,nt,_NT,d); !(ilcs[nt].complete); idx=ilcs[nt].update_outer()) \
+   for(ptrdiff_t idx_max=ilcs[nt].idx_max, idx_step=ilcs[nt].idx_step, k=ilcs[nt].get_k(0), k_step=ilcs[nt].k_step[0]; idx<idx_max; idx+=idx_step, k+=k_step)
+
+#define PLOOP_OVER_IVECS_DD(gv, is, ie, idx, d1, k1, d2, k2)				\
+_Pragma("omp parallel for schedule(guided), num_threads(_NT)")				\
+ for(int nt=0; nt<_NT; nt++)								\
+  for(ptrdiff_t idx=ilcs[nt].start(gv,is,ie,nt,_NT,d1,d2); !(ilcs[nt].complete); idx=ilcs[nt].update_outer()) \
+   for(ptrdiff_t idx_max=ilcs[nt].idx_max, idx_step=ilcs[nt].idx_step, k1=ilcs[nt].get_k(0), k1_step=ilcs[nt].k_step[0], k2=ilcs[nt].get_k(1), k2_step=ilcs[nt].k_step[1]; idx<idx_max; idx+=idx_step, k1+=k1_step, k2+=k2_step)
+
+#define S1PLOOP_OVER_IVECS(gv, is, ie, idx)						\
+_Pragma("omp parallel for schedule(guided), num_threads(_NT)")				\
+ for(int nt=0; nt<_NT; nt++)								\
+  for(ptrdiff_t idx=ilcs[nt].start(gv,is,ie,nt,_NT); !(ilcs[nt].complete); idx=ilcs[nt].update_outer()) \
+IVDEP										\
+   for(ptrdiff_t idx_max=ilcs[nt].idx_max, idx_step=ilcs[nt].idx_step; idx<idx_max; idx+=idx_step)
+
+#define S1PLOOP_OVER_IVECS_D(gv, is, ie, idx, d, k)					\
+_Pragma("omp parallel for schedule(guided), num_threads(_NT)")				\
+ for(int nt=0; nt<_NT; nt++)								\
+  for(ptrdiff_t idx=ilcs[nt].start(gv,is,ie,nt,_NT,d); !(ilcs[nt].complete); idx=ilcs[nt].update_outer()) \
+IVDEP										\
+   for(ptrdiff_t idx_max=ilcs[nt].idx_max, idx_step=ilcs[nt].idx_step, k=ilcs[nt].get_k(0), k_step=ilcs[nt].k_step[0]; idx<idx_max; idx+=idx_step, k+=k_step)
+
+#define S1PLOOP_OVER_IVECS_DD(gv, is, ie, idx, d1, k1, d2, k2)				\
+_Pragma("omp parallel for schedule(guided), num_threads(_NT)")				\
+ for(int nt=0; nt<_NT; nt++)								\
+  for(ptrdiff_t idx=ilcs[nt].start(gv,is,ie,nt,_NT); !(ilcs[nt].complete); idx=ilcs[nt].update_outer()) \
+IVDEP										\
+   for(ptrdiff_t idx_max=ilcs[nt].idx_max, idx_step=ilcs[nt].idx_step, k1=ilcs[nt].get_k(0), k1_step=ilcs[nt].k_step[0], k2=ilcs[nt].get_k(1), k2_step=ilcs[nt].k_step[1]; idx<idx_max; idx+=idx_step, k1+=k1_step, k2+=k2_step)
+
+} // namespace meep
+
+#endif // MULTITHREADING_H

--- a/src/step.cpp
+++ b/src/step.cpp
@@ -23,6 +23,7 @@
 #include "meep_internals.hpp"
 
 #include "config.h"
+#include "multithreading.hpp"
 
 #define RESTRICT
 

--- a/src/step_multithreaded.cpp
+++ b/src/step_multithreaded.cpp
@@ -1,0 +1,542 @@
+#include "meep.hpp"
+#include "meep_internals.hpp"
+#include "config.h"
+
+#define DPR double * restrict
+#define RPR realnum * restrict
+
+using namespace std;
+
+namespace meep {
+
+/***************************************************************/
+/***************************************************************/
+/***************************************************************/
+#define SWAP(t,a,b) { t xxxx = a; a = b; b = xxxx; }
+
+/* update step for df/dt = curl g,
+   i.e. f += dt curl g = dt/dx (dg1 - dg2)
+   where dgk = gk[i] - gk[i+sk].
+   g = (g1,g2), where g1 or g2 may be NULL.  Note that dt/dx and/or s1
+   and s2 may be negative to flip signs of derivatives.
+   PML: sig[k] = sigma[k]*dt/2, siginv[k] = 1 / (kap[k] + sigma[k]*dt/2).
+   Here, k is the index in the dsig direction.  if dsig ==
+   NO_DIRECTION, then PML is not used.  (dsig is the sigma direction.)
+   if non-NULL, then cnd is an array of conductivity values, changing
+   the underlying PDE to:
+       df/dt = curl g - cnd f
+   which is updated as:
+       f = [ dt * curl g + (1 - dt cnd/2) f ] / (1 + dt cnd/2)
+   cndinv should be an array of 1 / (1 + dt cnd/2).  In the case
+   of PML, cndinv should contain 1 / (1 + dt (cnd + sigma)/2).
+   fcnd is an auxiliary field used ONLY when we simultaneously have
+   PML (dsig != NO_DIR) and conductivity, in which case fcnd solves
+       dfcnd/dt = curl g - cnd*fcnd
+   and f satisfies
+       df/dt = dfcnd/dt - sigma*f.
+   fu is another auxiliary field used only in PML (dsigu != NO_DIR),
+   in which case f solves:
+       df/dt = dfu/dt - sigma_u * f
+   and fu replaces f in the equations above (fu += dt curl g etcetera).
+*/
+void step_curl_multithreaded(RPR f, component c, const RPR g1, const RPR g2,
+                             ptrdiff_t s1, ptrdiff_t s2, // strides for g1/g2 shift
+                             const grid_volume &gv, double dtdx,
+                             direction dsig, const DPR sig, const DPR kap, const DPR siginv,
+                             RPR fu, direction dsigu, const DPR sigu, const DPR kapu, const DPR siginvu,
+                             double dt,
+                             const RPR cnd, const RPR cndinv, RPR fcnd)
+{
+  update_ilcs(gv);
+
+  if (!g1) { // swap g1 and g2
+    SWAP(const RPR, g1, g2);
+    SWAP(ptrdiff_t, s1, s2);
+    dtdx = -dtdx; // need to flip derivative sign
+  }
+
+  /* endpoints of grid loop */
+  ivec is0 = gv.little_owned_corner0(c);
+  ivec ie  = gv.big_corner();
+
+  /* The following are a bunch of special cases of the "MOST GENERAL CASE"
+     loop below.  We make copies of the loop for each special case in
+     order to keep the innermost loop efficient.  This is especially
+     important because the non-PML cases are actually more common.
+     (The "right" way to do this is by partial evaluation of the
+      most general case, but that would require a code generator.) */
+
+  if (dsig == NO_DIRECTION) { // no PML in f update
+    if (dsigu == NO_DIRECTION) { // no fu update
+      if (cnd) {
+    	double dt2 = dt * 0.5;
+    	if (g2) {
+    	  PLOOP_OVER_IVECS(gv, is0, ie, i)
+    	    f[i] = ((1 - dt2 * cnd[i]) * f[i] -
+    		    dtdx * (g1[i+s1] - g1[i] + g2[i] - g2[i+s2])) * cndinv[i];
+    	}
+    	else {
+    	  PLOOP_OVER_IVECS(gv, is0, ie, i)
+    	    f[i] = ((1 - dt2 * cnd[i]) * f[i]
+    		    - dtdx * (g1[i+s1] - g1[i])) * cndinv[i];
+    	}
+      }
+      else { // no conductivity
+    	if (g2) {
+    	  PLOOP_OVER_IVECS(gv, is0, ie, i)
+    	    f[i] -= dtdx * (g1[i+s1] - g1[i] + g2[i] - g2[i+s2]);
+    	}
+    	else {
+    	  PLOOP_OVER_IVECS(gv, is0, ie, i)
+    	    f[i] -= dtdx * (g1[i+s1] - g1[i]);
+    	}
+      }
+    }
+    else { // fu update, no PML in f update
+      if (cnd) {
+    	double dt2 = dt * 0.5;
+    	if (g2) {
+    	  PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsigu, ku) {
+    	            double fprev = fu[i];
+    	    fu[i] = ((1 - dt2 * cnd[i]) * fprev -
+    		    dtdx * (g1[i+s1] - g1[i] + g2[i] - g2[i+s2])) * cndinv[i];
+    	    f[i] = siginvu[ku] * ((kapu[ku] - sigu[ku]) * f[i] + fu[i] - fprev);
+    	  }
+    	}
+    	else {
+    	  PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsigu, ku) {
+    	            double fprev = fu[i];
+    	    fu[i] = ((1 - dt2 * cnd[i]) * fprev
+    		    - dtdx * (g1[i+s1] - g1[i])) * cndinv[i];
+    	    f[i] = siginvu[ku] * ((kapu[ku] - sigu[ku]) * f[i] + fu[i] - fprev);
+    	  }
+    	}
+      }
+      else { // no conductivity
+    	if (g2) {
+    	  PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsigu, ku) {
+    	            double fprev = fu[i];
+    	    fu[i] -= dtdx * (g1[i+s1] - g1[i] + g2[i] - g2[i+s2]);
+    	    f[i] = siginvu[ku] * ((kapu[ku] - sigu[ku]) * f[i] + fu[i] - fprev);
+    	  }
+    	} /*if (g2)*/
+    	else {
+    	  PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsigu, ku) {
+    	            double fprev = fu[i];
+    	    fu[i] -= dtdx * (g1[i+s1] - g1[i]);
+    	    f[i] = siginvu[ku] * ((kapu[ku] - sigu[ku]) * f[i] + fu[i] - fprev);
+    	  }
+    	}
+      }
+    }
+  }
+  else { /* PML in f update */
+    if (dsigu == NO_DIRECTION) { // no fu update
+      if (cnd) {
+	double dt2 = dt * 0.5;
+	if (g2) {
+	  PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsig, k) {
+	    realnum fcnd_prev = fcnd[i];
+	    fcnd[i] = ((1 - dt2 * cnd[i]) * fcnd[i] -
+		       dtdx * (g1[i+s1]-g1[i] + g2[i]-g2[i+s2])) * cndinv[i];
+	    f[i] = ((kap[k] - sig[k]) * f[i] + (fcnd[i] - fcnd_prev)) * siginv[k];
+	  }
+	}
+	else {
+	  PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsig, k) {
+	    realnum fcnd_prev = fcnd[i];
+	    fcnd[i] = ((1 - dt2 * cnd[i]) * fcnd[i] -
+		       dtdx * (g1[i+s1] - g1[i])) * cndinv[i];
+	    f[i] = ((kap[k] - sig[k]) * f[i] + (fcnd[i] - fcnd_prev)) * siginv[k];
+	  }
+	}
+      }
+      else { // no conductivity (other than PML conductivity)
+	if (g2) {
+	  PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsig, k) {
+	    f[i] = ((kap[k] - sig[k]) * f[i] -
+		    dtdx * (g1[i+s1] - g1[i] + g2[i] - g2[i+s2])) * siginv[k];
+	  }
+	}/*if(g2)*/
+	else {
+	  PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsig, k) {
+	    f[i] = ((kap[k] - sig[k]) * f[i] - dtdx * (g1[i+s1]-g1[i])) * siginv[k];
+	  }
+	}
+      }
+    }
+    else { // fu update + PML in f update
+      if (cnd) {
+	double dt2 = dt * 0.5;
+	if (g2) {
+	  //////////////////// MOST GENERAL CASE //////////////////////
+	  PLOOP_OVER_IVECS_DD(gv, is0, ie, i, dsig, k, dsigu, ku) {
+	    double fprev = fu[i];
+	    realnum fcnd_prev = fcnd[i];
+	    fcnd[i] = ((1 - dt2 * cnd[i]) * fcnd[i] -
+		       dtdx * (g1[i+s1]-g1[i] + g2[i]-g2[i+s2])) * cndinv[i];
+	    fu[i] = ((kap[k] - sig[k]) * fu[i] + (fcnd[i] - fcnd_prev)) * siginv[k];
+	    f[i] = siginvu[ku] * ((kapu[ku] - sigu[ku]) * f[i] + fu[i] - fprev);
+	  }
+	  /////////////////////////////////////////////////////////////
+	}
+	else {
+	  PLOOP_OVER_IVECS_DD(gv, is0, ie, i, dsig, k, dsigu, ku) {
+	    double fprev = fu[i];
+	    realnum fcnd_prev = fcnd[i];
+	    fcnd[i] = ((1 - dt2 * cnd[i]) * fcnd[i] -
+		       dtdx * (g1[i+s1] - g1[i])) * cndinv[i];
+	    fu[i] = ((kap[k] - sig[k]) * fu[i] + (fcnd[i] - fcnd_prev)) * siginv[k];
+	    f[i] = siginvu[ku] * ((kapu[ku] - sigu[ku]) * f[i] + fu[i] - fprev);
+	  }
+	}
+      }
+      else { // no conductivity (other than PML conductivity)
+	if (g2) {
+	  PLOOP_OVER_IVECS_DD(gv, is0, ie, i, dsig, k, dsigu, ku) {
+	    double fprev = fu[i];
+	    fu[i] = ((kap[k] - sig[k]) * fu[i] -
+		    dtdx * (g1[i+s1] - g1[i] + g2[i] - g2[i+s2])) * siginv[k];
+	    f[i] = siginvu[ku] * ((kapu[ku] - sigu[ku]) * f[i] + fu[i] - fprev);
+	  }
+	} /*if(g2)*/
+	else {
+	  PLOOP_OVER_IVECS_DD(gv, is0, ie, i, dsig, k, dsigu, ku) {
+	    double fprev = fu[i];
+	    fu[i] = ((kap[k] - sig[k]) * fu[i] - dtdx * (g1[i+s1]-g1[i])) * siginv[k];
+	    f[i] = siginvu[ku] * ((kapu[ku] - sigu[ku]) * f[i] + fu[i] - fprev);
+	  }
+	}
+      }
+    }
+  }
+}
+
+/* field-update equation f += betadt * g (plus variants for conductivity
+   and/or PML).  This is used in 2d calculations to add an exp(i beta z)
+   time dependence, which gives an additional i \beta \hat{z} \times
+   cross-product in the curl equations. */
+void step_beta_multithreaded(RPR f, component c, const RPR g,
+	       const grid_volume &gv, double betadt,
+	       direction dsig, const DPR siginv,
+	       RPR fu, direction dsigu, const DPR siginvu,
+	       const RPR cndinv, RPR fcnd)
+{ 
+  update_ilcs(gv);
+
+  /* endpoints of grid loop */
+  ivec is0 = gv.little_owned_corner0(c);
+  ivec ie  = gv.big_corner();
+
+  if (!g) return;
+  if (dsig != NO_DIRECTION) { // PML in f update
+    if (dsigu != NO_DIRECTION) { // PML in f + fu
+      if (cndinv) { // conductivity + PML
+	//////////////////// MOST GENERAL CASE //////////////////////
+	PLOOP_OVER_IVECS_DD(gv, is0, ie, i, dsig, k, dsigu, ku) {
+	  double df;
+	  double dfcnd = betadt * g[i] * cndinv[i];
+	  fcnd[i] += dfcnd;
+	  fu[i] += (df = dfcnd * siginv[k]);
+	  f[i] += siginvu[ku] * df;
+	}
+	/////////////////////////////////////////////////////////////
+      }
+      else { // PML only
+	PLOOP_OVER_IVECS_DD(gv, is0, ie, i, dsig, k, dsigu, ku) {
+	  double df;
+	  fu[i] += (df = betadt * g[i] * siginv[k]);
+	  f[i] += siginvu[ku] * df;
+	}
+      }
+    }
+    else { // PML in f, no fu
+      if (cndinv) { // conductivity + PML
+	PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsig, k) {
+	  double dfcnd = betadt * g[i] * cndinv[i];
+	  fcnd[i] += dfcnd;
+	  f[i] += dfcnd * siginv[k];
+	}
+      }
+      else { // PML only
+	PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsig, k) {
+	  f[i] += betadt * g[i] * siginv[k];
+	}
+      }
+    }
+  }
+  else { // no PML in f update
+    if (dsigu != NO_DIRECTION) { // fu, no PML in f
+      if (cndinv) { // conductivity, no PML
+	PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsigu, ku) {
+	  double df;
+	  fu[i] += (df = betadt * g[i] * cndinv[i]);
+	  f[i] += siginvu[ku] * df;
+	}
+      }
+      else { // no conductivity or PML
+	PLOOP_OVER_IVECS_D(gv, is0, ie, i, dsigu, ku) {
+	  double df;
+	  fu[i] += (df = betadt * g[i]);
+	  f[i] += siginvu[ku] * df;
+	}
+      }
+    }
+    else { // no PML, no fu
+      if (cndinv) { // conductivity, no PML
+	PLOOP_OVER_IVECS(gv, is0, ie, i)
+	  f[i] += betadt * g[i] * cndinv[i];
+      }
+      else { // no conductivity or PML
+	PLOOP_OVER_IVECS(gv, is0, ie, i)
+	  f[i] += betadt * g[i];
+      }
+    }
+  }
+}
+
+/* Given Dsqr = |D|^2 and Di = component of D, compute the factor f so
+   that Ei = chi1inv * f * Di.   In principle, this would involve solving
+   a cubic equation, but instead we use a Pade approximant that is
+   accurate to several orders.  This is inaccurate if the nonlinear
+   index change is large, of course, but in that case the chi2/chi3
+   power-series expansion isn't accurate anyway, so the cubic isn't
+   physical there either. */
+inline double calc_nonlinear_u(const double Dsqr,
+			       const double Di,
+			       const double chi1inv,
+			       const double chi2, const double chi3) {
+  double c2 = Di*chi2*(chi1inv*chi1inv);
+  double c3 = Dsqr*chi3*(chi1inv*chi1inv*chi1inv);
+  return (1 + c2 + 2*c3)/(1 + 2*c2 + 3*c3);
+}
+
+/* Update E from D using epsilon and PML, *or* update H from B using
+   mu and PML.
+   To be generic, here we set f = u * g, where u may
+   be a tensor, and we also have a nonlinear susceptibility chi.
+   Here, g = (g,g1,g2) where g1 and g2 are the off-diagonal
+   components, if any (g2 may be NULL).
+   In PML (dsigw != NO_DIR), we have an additional auxiliary field fw,
+   which is updated by the equations:
+          fw = u * g
+          df/dt = kappaw dfw/dt - sigmaw * fw
+   That is, fw is updated like the non-PML f, and f is updated from
+   fw by a little ODE.  Here, sigw[k] = sigmaw[k]*dt/2, kappaw[k] = kapw[k]
+*/
+
+/***************************************************************/
+/***************************************************************/
+/***************************************************************/
+void step_update_EDHB_multithreaded(RPR f, component fc, const grid_volume &gv,
+		      const RPR g, const RPR g1, const RPR g2,
+		      const RPR u, const RPR u1, const RPR u2,
+		      ptrdiff_t s, ptrdiff_t s1, ptrdiff_t s2,
+		      const RPR chi2, const RPR chi3,
+		      RPR fw, direction dsigw, const DPR sigw, const DPR kapw)
+{
+  update_ilcs(gv);
+
+  if (!f) return;
+
+  if ((!g1 && g2) || (g1 && g2 && !u1 && u2)) { /* swap g1 and g2 */
+    SWAP(const RPR, g1, g2);
+    SWAP(const RPR, u1, u2);
+    SWAP(ptrdiff_t, s1, s2);
+  }
+
+  // endpoints of grid loop
+  ivec is = gv.little_owned_corner(fc);
+  ivec ie = gv.big_corner();
+
+  // stable averaging of offdiagonal components
+#define OFFDIAG(u,g,sx) (0.25 * ((g[i]+g[i-sx])*u[i] \
+		   	       + (g[i+s]+g[(i+s)-sx])*u[i+s]))
+
+  /* As with step_curl, these loops are all essentially copies
+     of the "MOST GENERAL CASE" loop with various terms thrown out. */
+
+  if (dsigw != NO_DIRECTION) { //////// PML case (with fw) /////////////
+    //KSTRIDE_DEF(dsigw, kw, gv.little_owned_corner0(fc));
+    if (u1 && u2) { // 3x3 off-diagonal u
+      if (chi3) {
+	//////////////////// MOST GENERAL CASE //////////////////////
+	PLOOP_OVER_IVECS_D(gv, is, ie, i, dsigw, kw) {
+	  double g1s = g1[i]+g1[i+s]+g1[i-s1]+g1[i+(s-s1)];
+	  double g2s = g2[i]+g2[i+s]+g2[i-s2]+g2[i+(s-s2)];
+	  double gs = g[i]; double us = u[i];
+	  double fwprev = fw[i], kapwkw = kapw[kw], sigwkw = sigw[kw];
+	  fw[i] = (gs * us + OFFDIAG(u1,g1,s1) + OFFDIAG(u2,g2,s2))
+	    * calc_nonlinear_u(gs * gs + 0.0625 * (g1s*g1s + g2s*g2s),
+			       gs, us, chi2[i], chi3[i]);
+	  f[i] += (kapwkw + sigwkw) * fw[i] - (kapwkw - sigwkw) * fwprev;
+	}
+	/////////////////////////////////////////////////////////////
+      }
+      else {
+	PLOOP_OVER_IVECS_D(gv, is, ie, i, dsigw, kw) {
+	  double gs = g[i]; double us = u[i];
+	  double fwprev = fw[i], kapwkw = kapw[kw], sigwkw = sigw[kw];
+	  fw[i] = (gs * us + OFFDIAG(u1,g1,s1) + OFFDIAG(u2,g2,s2));
+	  f[i] += (kapwkw + sigwkw) * fw[i] - (kapwkw - sigwkw) * fwprev;
+	}
+      }
+    }
+    else if (u1) { // 2x2 off-diagonal u
+      if (chi3) {
+	PLOOP_OVER_IVECS_D(gv, is, ie, i, dsigw, kw) {
+	  double g1s = g1[i]+g1[i+s]+g1[i-s1]+g1[i+(s-s1)];
+	  double gs = g[i]; double us = u[i];
+	  double fwprev = fw[i], kapwkw = kapw[kw], sigwkw = sigw[kw];
+	  fw[i] = (gs * us + OFFDIAG(u1,g1,s1))
+	    * calc_nonlinear_u(gs * gs + 0.0625 * (g1s*g1s),
+			       gs, us, chi2[i], chi3[i]);
+	  f[i] += (kapwkw + sigwkw) * fw[i] - (kapwkw - sigwkw) * fwprev;
+	}
+      }
+      else {
+	PLOOP_OVER_IVECS_D(gv, is, ie, i, dsigw, kw) {
+	  double gs = g[i]; double us = u[i];
+	  double fwprev = fw[i], kapwkw = kapw[kw], sigwkw = sigw[kw];
+	  fw[i] = (gs * us + OFFDIAG(u1,g1,s1));
+	  f[i] += (kapwkw + sigwkw) * fw[i] - (kapwkw - sigwkw) * fwprev;
+	}
+      }
+    }
+    else if (u2) { // 2x2 off-diagonal u
+      abort("bug - didn't swap off-diagonal terms!?");
+    }
+    else { // diagonal u
+      if (chi3) {
+	if (g1 && g2) {
+	  PLOOP_OVER_IVECS_D(gv, is, ie, i, dsigw, kw) {
+	    double g1s = g1[i]+g1[i+s]+g1[i-s1]+g1[i+(s-s1)];
+	    double g2s = g2[i]+g2[i+s]+g2[i-s2]+g2[i+(s-s2)];
+	    double gs = g[i]; double us = u[i];
+	    double fwprev = fw[i], kapwkw = kapw[kw], sigwkw = sigw[kw];
+	    fw[i] = (gs*us)*calc_nonlinear_u(gs*gs+0.0625*(g1s*g1s+g2s*g2s),
+					     gs, us, chi2[i], chi3[i]);
+	    f[i] += (kapwkw + sigwkw) * fw[i] - (kapwkw - sigwkw) * fwprev;
+	  }
+	}
+	else if (g1) {
+	  PLOOP_OVER_IVECS_D(gv, is, ie, i, dsigw, kw) {
+	    double g1s = g1[i]+g1[i+s]+g1[i-s1]+g1[i+(s-s1)];
+	    double gs = g[i]; double us = u[i];
+	    double fwprev = fw[i], kapwkw = kapw[kw], sigwkw = sigw[kw];
+	    fw[i] = (gs*us)*calc_nonlinear_u(gs*gs + 0.0625*(g1s*g1s),
+					     gs, us, chi2[i], chi3[i]);
+	    f[i] += (kapwkw + sigwkw) * fw[i] - (kapwkw - sigwkw) * fwprev;
+	  }
+	}
+	else if (g2) {
+	  abort("bug - didn't swap off-diagonal terms!?");
+	}
+	else {
+	  PLOOP_OVER_IVECS_D(gv, is, ie, i, dsigw, kw) {
+	    double gs = g[i]; double us = u[i];
+	    double fwprev = fw[i], kapwkw = kapw[kw], sigwkw = sigw[kw];
+	    fw[i] = (gs*us)*calc_nonlinear_u(gs*gs, gs,us, chi2[i],chi3[i]);
+	    f[i] += (kapwkw + sigwkw) * fw[i] - (kapwkw - sigwkw) * fwprev;
+	  }
+	}
+      }
+      else if (u) {
+	PLOOP_OVER_IVECS_D(gv, is, ie, i, dsigw, kw) {
+	  double gs = g[i]; double us = u[i];
+	  double fwprev = fw[i], kapwkw = kapw[kw], sigwkw = sigw[kw];
+	  fw[i] = (gs * us);
+	  f[i] += (kapwkw + sigwkw) * fw[i] - (kapwkw - sigwkw) * fwprev;
+	}
+      }
+      else {
+	PLOOP_OVER_IVECS_D(gv, is, ie, i, dsigw, kw) {
+	  double fwprev = fw[i], kapwkw = kapw[kw], sigwkw = sigw[kw];
+	  fw[i] = g[i];
+	  f[i] += (kapwkw + sigwkw) * fw[i] - (kapwkw - sigwkw) * fwprev;
+	}
+      }
+    }
+  }
+  else { /////////////// no PML (no fw) ///////////////////
+    if (u1 && u2) { // 3x3 off-diagonal u
+      if (chi3) {
+	PLOOP_OVER_IVECS(gv, is, ie, i) {
+	  double g1s = g1[i]+g1[i+s]+g1[i-s1]+g1[i+(s-s1)];
+	  double g2s = g2[i]+g2[i+s]+g2[i-s2]+g2[i+(s-s2)];
+	  double gs = g[i]; double us = u[i];
+	  f[i] = (gs * us + OFFDIAG(u1,g1,s1) + OFFDIAG(u2,g2,s2))
+	    * calc_nonlinear_u(gs * gs + 0.0625 * (g1s*g1s + g2s*g2s),
+			       gs, us, chi2[i], chi3[i]);
+	}
+      }
+      else {
+	PLOOP_OVER_IVECS(gv, is, ie, i) {
+	  double gs = g[i]; double us = u[i];
+	  f[i] = (gs * us + OFFDIAG(u1,g1,s1) + OFFDIAG(u2,g2,s2));
+	}
+      }
+    }
+    else if (u1) { // 2x2 off-diagonal u
+      if (chi3) {
+	PLOOP_OVER_IVECS(gv, is, ie, i) {
+	  double g1s = g1[i]+g1[i+s]+g1[i-s1]+g1[i+(s-s1)];
+	  double gs = g[i]; double us = u[i];
+	  f[i] = (gs * us + OFFDIAG(u1,g1,s1))
+	    * calc_nonlinear_u(gs * gs + 0.0625 * (g1s*g1s),
+			       gs, us, chi2[i], chi3[i]);
+	}
+      }
+      else {
+	PLOOP_OVER_IVECS(gv, is, ie, i) {
+	  double gs = g[i]; double us = u[i];
+	  f[i] = (gs * us + OFFDIAG(u1,g1,s1));
+	}
+      }
+    }
+    else if (u2) { // 2x2 off-diagonal u
+      abort("bug - didn't swap off-diagonal terms!?");
+    }
+    else { // diagonal u
+      if (chi3) {
+	if (g1 && g2) {
+	  PLOOP_OVER_IVECS(gv, is, ie, i) {
+	    double g1s = g1[i]+g1[i+s]+g1[i-s1]+g1[i+(s-s1)];
+	    double g2s = g2[i]+g2[i+s]+g2[i-s2]+g2[i+(s-s2)];
+	    double gs = g[i]; double us = u[i];
+	    f[i] = (gs*us)*calc_nonlinear_u(gs*gs+0.0625*(g1s*g1s+g2s*g2s),
+					gs, us, chi2[i], chi3[i]);
+	  }
+	}
+	else if (g1) {
+	  PLOOP_OVER_IVECS(gv, is, ie, i) {
+	    double g1s = g1[i]+g1[i+s]+g1[i-s1]+g1[i+(s-s1)];
+	    double gs = g[i]; double us = u[i];
+	    f[i] = (gs*us)*calc_nonlinear_u(gs*gs + 0.0625*(g1s*g1s),
+						gs, us, chi2[i], chi3[i]);
+	  }
+	}
+	else if (g2) {
+	  abort("bug - didn't swap off-diagonal terms!?");
+	}
+	else {
+	  PLOOP_OVER_IVECS(gv, is, ie, i) {
+	    double gs = g[i]; double us = u[i];
+	    f[i] = (gs*us)*calc_nonlinear_u(gs*gs, gs,us, chi2[i],chi3[i]);
+	  }
+	}
+      }
+      else if (u) {
+	PLOOP_OVER_IVECS(gv, is, ie, i) {
+	  double gs = g[i]; double us = u[i];
+	  f[i] = (gs * us);
+	}
+      }
+      else {
+	PLOOP_OVER_IVECS(gv, is, ie, i) f[i] = g[i];
+    }
+   }
+  }
+}
+
+}// namespace meep


### PR DESCRIPTION
Closes #228.

This is a slightly cleaned up version of @HomerReid's #565. The benchmarking routines (i.e. `checkpoint, print_benchmarks`) have been removed and the formatting has been made consistent with clang.

The good news is that it compiles and all checks pass for `MEEP_NUM_THREADS=0` (the default). The bad news is that some tests are failing (fields are blowing up) whenever `MEEP_NUM_THREADS` is a non-zero value.