### PR TITLE
eigenmode source runtime warning if component parameter has been specified

### DIFF
--- a/python/source.py
+++ b/python/source.py
@@ -150,7 +150,7 @@ class EigenModeSource(Source):
     @component.setter
     def component(self, val):
         if val != mp.ALL_COMPONENTS:
-            warnings.warn("EigenModeSource component is not ALL_COMPONENTS (default)",RuntimeWarning)
+            warnings.warn("EigenModeSource component is not ALL_COMPONENTS (the default), which makes it non-unidirectional.",RuntimeWarning)
         self._component = val
 
     @property

--- a/python/source.py
+++ b/python/source.py
@@ -1,5 +1,7 @@
 from __future__ import division
 
+import warnings
+
 import meep as mp
 from meep.geom import Vector3, check_nonnegative
 
@@ -140,6 +142,16 @@ class EigenModeSource(Source):
             self._eig_lattice_center = self.center
         else:
             self._eig_lattice_center = val
+
+    @property
+    def component(self):
+        return self._component
+
+    @component.setter
+    def component(self, val):
+        if val != mp.ALL_COMPONENTS:
+            warnings.warn("EigenModeSource component is not ALL_COMPONENTS (default)",RuntimeWarning)
+        self._component = val
 
     @property
     def eig_band(self):


### PR DESCRIPTION
The `component` parameter of the [`EigenModeSource`](https://meep.readthedocs.io/en/latest/Python_User_Interface/#eigenmodesource) should in practically all cases *not* be modified from its default value of `ALL_COMPONENTS`. However, some users accustomed to specifying a `component` parameter for other types of sources may tend to unknowingly set this property which therefore results in a *non*-unidirectional source (which is likely not what is intended). This PR adds a runtime warning to let the user know that the `component` parameter has been modified.