### PR TITLE
Fix dft fields memory leak

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -418,11 +418,14 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 template<typename dft_type>
 PyObject *_get_dft_array(meep::fields *f, dft_type dft, meep::component c, int num_freq) {
     int rank;
-    size_t dims[3];
+    size_t dims[3] = {1,1,1};
     std::complex<double> *dft_arr = f->get_dft_array(dft, c, num_freq, &rank, dims);
 
-    if (rank==0 || dft_arr==NULL) // this can happen e.g. if component c vanishes by symmetry
-     return PyArray_SimpleNew(0, 0, NPY_CDOUBLE);
+    if (rank==0 || dft_arr==NULL) { // this can happen e.g. if component c vanishes by symmetry
+        npy_intp di[1] = {1};
+        std::complex<double> d[1] = {std::complex<double>(0,0)};
+        return PyArray_SimpleNewFromData(1, di, NPY_CDOUBLE, d);
+    }
 
     size_t length = 1;
     npy_intp *arr_dims = new npy_intp[rank];

--- a/python/meep.i
+++ b/python/meep.i
@@ -422,9 +422,8 @@ PyObject *_get_dft_array(meep::fields *f, dft_type dft, meep::component c, int n
     std::complex<double> *dft_arr = f->get_dft_array(dft, c, num_freq, &rank, dims);
 
     if (rank==0 || dft_arr==NULL) { // this can happen e.g. if component c vanishes by symmetry
-        npy_intp di[1] = {1};
         std::complex<double> d[1] = {std::complex<double>(0,0)};
-        return PyArray_SimpleNewFromData(1, di, NPY_CDOUBLE, d);
+        return PyArray_SimpleNewFromData(0, 0, NPY_CDOUBLE, d);
     }
 
     size_t length = 1;

--- a/python/meep.i
+++ b/python/meep.i
@@ -421,10 +421,8 @@ PyObject *_get_dft_array(meep::fields *f, dft_type dft, meep::component c, int n
     size_t dims[3] = {1,1,1};
     std::complex<double> *dft_arr = f->get_dft_array(dft, c, num_freq, &rank, dims);
 
-    if (rank==0 || dft_arr==NULL) { // this can happen e.g. if component c vanishes by symmetry
-        std::complex<double> d[1] = {std::complex<double>(0,0)};
-        return PyArray_SimpleNewFromData(0, 0, NPY_CDOUBLE, d);
-    }
+    if (rank==0 || dft_arr==NULL) // this can happen e.g. if component c vanishes by symmetry
+        return PyArray_SimpleNewFromData(0, 0, NPY_CDOUBLE, &std::complex<double>(0,0));
 
     size_t length = 1;
     npy_intp *arr_dims = new npy_intp[rank];


### PR DESCRIPTION
Fixes #1262 

Fixes three issues currently found in the `_get_dft_array` routine.
1. Initializes the dimension object `dim`. 2D simulations don't set the third dimension by default, consequently whatever garbage is in memory becomes the third dimension. This is obviously problematic when creating a python array from the dimension object.
2. When a dft array is requested from a component that isn't stored due to symmetry, source specifications, etc, the routine used to return a python array size 0. Python doesn't like this, and produces an array size 1 with whatever garbage is in memory there. Now, the routine returns an array with a size of 1 and with a complex `0`. This is especially important for adjoint calculations, which need to store all field components and don't have knowledge about which components meep is actually calculating. The current adjoint toolbox will already broadcast the `0` accordingly.
3. I am now using `PyArray_SimpleNewFromData` to create and copy the array data.