### PR TITLE
Python doc tool updates

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -2,13 +2,12 @@ This is the documentation tree for MEEP.
 
 markdown (.md) files are in the `doc/docs` folder.
 
-To build and visualize the HTML documentation locally using the
-mkdocs package (useful for verifying changes on your local machine
-before committing), first install `mkdocs` (version 0.17.5) as
-well as two auxiliary packages via e.g.:
+To build and visualize the HTML documentation locally using the mkdocs package
+(useful for verifying changes on your local machine before committing), first
+install `mkdocs` as well as two auxiliary packages via e.g.:
 
 ```
-% pip3 install --user mkdocs==0.17.5 python-markdown-math mkdocs-material
+% pip3 install --user mkdocs python-markdown-math mkdocs-material
 ```
 
 To (re)generate the Python API documentation (extracted from the docstrings)

--- a/doc/_api_snippets/class_template.md
+++ b/doc/_api_snippets/class_template.md
@@ -13,8 +13,3 @@ class {class_name}({base_classes}):
 
 </div>
 
-<div class="class_members" markdown="1">
-
-{method_docs}
-
-</div>

--- a/doc/_api_snippets/function_template.md
+++ b/doc/_api_snippets/function_template.md
@@ -1,8 +1,6 @@
 
 <a id="{function_name}"></a>
 
-**meep.{function_name_escaped} function**
-
 ```python
 def {function_name}{parameters}:
 ```

--- a/doc/_api_snippets/method_template.md
+++ b/doc/_api_snippets/method_template.md
@@ -1,6 +1,8 @@
 
 <a id="{class_name}.{method_name}"></a>
 
+<div class="class_members" markdown="1">
+
 ```python
 def {method_name}{parameters}:
 ```
@@ -8,5 +10,7 @@ def {method_name}{parameters}:
 <div class="method_docstring" markdown="1">
 
 {docstring}
+
+</div>
 
 </div>

--- a/doc/_api_snippets/method_template.md
+++ b/doc/_api_snippets/method_template.md
@@ -1,8 +1,6 @@
 
 <a id="{class_name}.{method_name}"></a>
 
-**{class_name}.{method_name_escaped}**
-
 ```python
 def {method_name}{parameters}:
 ```

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1374,7 +1374,7 @@ def add_energy(self, *args):
 
 <div class="method_docstring" markdown="1">
 
-add_energy(fcen, df, nfreq, freq, EnergyRegions...)
+`add_energy(fcen, df, nfreq, freq, EnergyRegions...)`
 
 Add a bunch of `EnergyRegion`s to the current simulation (initializing the fields
 if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -1600,7 +1600,7 @@ def add_force(self, *args):
 
 <div class="method_docstring" markdown="1">
 
-add_force(fcen, df, nfreq, freq, ForceRegions...)
+`add_force(fcen, df, nfreq, freq, ForceRegions...)`
 
 Add a bunch of `ForceRegion`s to the current simulation (initializing the fields
 if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -1807,7 +1807,7 @@ def Ldos(*args):
 
 <div class="function_docstring" markdown="1">
 
-Ldos(fcen, df, nfreq, freq)
+`Ldos(fcen, df, nfreq, freq)`
 
 Create an LDOS object with either frequency bandwidth `df` centered at `fcen` and
 `nfreq` equally spaced frequency points or an array/list `freq` for arbitrarily spaced
@@ -1837,7 +1837,7 @@ def dft_ldos(*args, **kwargs):
 
 <div class="function_docstring" markdown="1">
 
-dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)
+`dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)`
 
 Compute the power spectrum of the sources (usually a single point dipole source),
 normalized to correspond to the LDOS, in either a frequency bandwidth `df` centered at
@@ -2577,10 +2577,53 @@ follows the `run` function (e.g., outputting fields).
 </div>
 
 
-Finally, another run function, useful for computing ω(**k**) band diagrams, is available via these top-level functions:
+Finally, another run function, useful for computing ω(**k**) band diagrams, is available via these `Simulation` methods:
 
-@@ meep.run_k_points @@
-@@ meep.run_k_point @@
+
+<a id="Simulation.run_k_points"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def run_k_points(self, t, k_points):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a list of `Vector3`, `k_points` of *k* vectors, runs a simulation for each
+*k* point (i.e. specifying Bloch-periodic boundary conditions) and extracts the
+eigen-frequencies, and returns a list of the complex frequencies. In particular,
+you should have specified one or more Gaussian sources. It will run the simulation
+until the sources are turned off plus an additional $t$ time units. It will run
+[Harminv](#harminv) at the same point/component as the first Gaussian source and
+look for modes in the union of the frequency ranges for all sources. Returns a
+list of lists of frequencies (one list of frequencies for each *k*). Also prints
+out a comma-delimited list of frequencies, prefixed by `freqs:`, and their
+imaginary parts, prefixed by `freqs-im:`. See [Tutorial/Resonant Modes and
+Transmission in a Waveguide
+Cavity](Python_Tutorials/Resonant_Modes_and_Transmission_in_a_Waveguide_Cavity.md).
+
+</div>
+
+</div>
+
+<a id="Simulation.run_k_point"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def run_k_point(self, t, k):
+```
+
+<div class="method_docstring" markdown="1">
+
+Lower level function called by `run_k_points` that runs a simulation for a single
+*k* point `k_point` and returns a `Harminv` instance. Useful when you need to
+access more `Harminv` data than just the frequencies.
+
+</div>
+
+</div>
 
 
 ### Predefined Step Functions
@@ -5497,7 +5540,7 @@ def __init__(self,
              side=-1,
              R_asymptotic=1e-15,
              mean_stretch=1.0,
-             pml_profile=<function PML.<lambda> at 0x7f9aa8547dd0>):
+             pml_profile=<function PML.<lambda> at 0x7ff729b8fdd0>):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -7057,7 +7100,7 @@ def Ldos(*args):
 
 <div class="function_docstring" markdown="1">
 
-Ldos(fcen, df, nfreq, freq)
+`Ldos(fcen, df, nfreq, freq)`
 
 Create an LDOS object with either frequency bandwidth `df` centered at `fcen` and
 `nfreq` equally spaced frequency points or an array/list `freq` for arbitrarily spaced
@@ -7087,7 +7130,7 @@ def dft_ldos(*args, **kwargs):
 
 <div class="function_docstring" markdown="1">
 
-dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)
+`dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)`
 
 Compute the power spectrum of the sources (usually a single point dipole source),
 normalized to correspond to the LDOS, in either a frequency bandwidth `df` centered at

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -43,8 +43,6 @@ get this prefix by calling `get_filename_prefix`.
 
 <a id="Simulation.__init__"></a>
 
-**Simulation.\_\_init\_\_**
-
 ```python
 def __init__(self,
              cell_size,
@@ -315,8 +313,6 @@ use. See also [SWIG Wrappers](#swig-wrappers).
 
 <a id="Simulation.add_dft_fields"></a>
 
-**Simulation.add\_dft\_fields**
-
 ```python
 def add_dft_fields(self, *args, **kwargs):
 ```
@@ -337,8 +333,6 @@ fields evaluated at each corresponding Yee grid point is available by setting
 
 <a id="Simulation.add_eigenmode"></a>
 
-**Simulation.add\_eigenmode**
-
 ```python
 def add_eigenmode(self, *args):
 ```
@@ -350,8 +344,6 @@ def add_eigenmode(self, *args):
 </div>
 
 <a id="Simulation.add_energy"></a>
-
-**Simulation.add\_energy**
 
 ```python
 def add_energy(self, *args):
@@ -370,8 +362,6 @@ below to get the energy spectrum, etcetera.
 
 <a id="Simulation.add_flux"></a>
 
-**Simulation.add\_flux**
-
 ```python
 def add_flux(self, *args):
 ```
@@ -388,8 +378,6 @@ below to get the flux spectrum, etcetera.
 </div>
 
 <a id="Simulation.add_force"></a>
-
-**Simulation.add\_force**
 
 ```python
 def add_force(self, *args):
@@ -408,8 +396,6 @@ below to get the force spectrum, etcetera.
 
 <a id="Simulation.add_mode_monitor"></a>
 
-**Simulation.add\_mode\_monitor**
-
 ```python
 def add_mode_monitor(self, *args):
 ```
@@ -421,8 +407,6 @@ Similar to `add_flux`, but for use with `get_eigenmode_coefficients`.
 </div>
 
 <a id="Simulation.add_near2far"></a>
-
-**Simulation.add\_near2far**
 
 ```python
 def add_near2far(self, *args, **kwargs):
@@ -443,8 +427,6 @@ to the functions below to get the far fields.
 
 <a id="Simulation.add_source"></a>
 
-**Simulation.add\_source**
-
 ```python
 def add_source(self, src):
 ```
@@ -457,8 +439,6 @@ def add_source(self, src):
 
 <a id="Simulation.change_k_point"></a>
 
-**Simulation.change\_k\_point**
-
 ```python
 def change_k_point(self, k):
 ```
@@ -470,8 +450,6 @@ Change the `k_point` (the Bloch periodicity).
 </div>
 
 <a id="Simulation.change_sources"></a>
-
-**Simulation.change\_sources**
 
 ```python
 def change_sources(self, new_sources):
@@ -486,8 +464,6 @@ the sources used for the current simulation. `new_sources` must be a list of
 </div>
 
 <a id="Simulation.display_electric_energy"></a>
-
-**Simulation.display\_electric\_energy**
 
 ```python
 def display_electric_energy(self, *energys):
@@ -505,8 +481,6 @@ column are the frequencies, and subsequent columns are the energy density spectr
 
 <a id="Simulation.display_fluxes"></a>
 
-**Simulation.display\_fluxes**
-
 ```python
 def display_fluxes(self, *fluxes):
 ```
@@ -522,8 +496,6 @@ subsequent columns are the flux spectra.
 </div>
 
 <a id="Simulation.display_forces"></a>
-
-**Simulation.display\_forces**
 
 ```python
 def display_forces(self, *forces):
@@ -541,8 +513,6 @@ subsequent columns are the force spectra.
 
 <a id="Simulation.display_magnetic_energy"></a>
 
-**Simulation.display\_magnetic\_energy**
-
 ```python
 def display_magnetic_energy(self, *energys):
 ```
@@ -558,8 +528,6 @@ column are the frequencies, and subsequent columns are the energy density spectr
 </div>
 
 <a id="Simulation.display_total_energy"></a>
-
-**Simulation.display\_total\_energy**
 
 ```python
 def display_total_energy(self, *energys):
@@ -577,8 +545,6 @@ frequencies, and subsequent columns are the energy density spectra.
 
 <a id="Simulation.dump_chunk_layout"></a>
 
-**Simulation.dump\_chunk\_layout**
-
 ```python
 def dump_chunk_layout(self, fname):
 ```
@@ -591,8 +557,6 @@ Dumps the chunk layout to file `fname`.
 
 <a id="Simulation.dump_structure"></a>
 
-**Simulation.dump\_structure**
-
 ```python
 def dump_structure(self, fname):
 ```
@@ -604,8 +568,6 @@ Dumps the structure to the file `fname`.
 </div>
 
 <a id="Simulation.electric_energy_in_box"></a>
-
-**Simulation.electric\_energy\_in\_box**
 
 ```python
 def electric_energy_in_box(self, box=None, center=None, size=None):
@@ -627,8 +589,6 @@ volume.
 
 <a id="Simulation.field_energy_in_box"></a>
 
-**Simulation.field\_energy\_in\_box**
-
 ```python
 def field_energy_in_box(self, box=None, center=None, size=None):
 ```
@@ -649,8 +609,6 @@ volume.
 
 <a id="Simulation.flux_in_box"></a>
 
-**Simulation.flux\_in\_box**
-
 ```python
 def flux_in_box(self, d, box=None, center=None, size=None):
 ```
@@ -667,8 +625,6 @@ construct the appropriate volume for you.
 </div>
 
 <a id="Simulation.get_array"></a>
-
-**Simulation.get\_array**
 
 ```python
 def get_array(self,
@@ -737,8 +693,6 @@ arrays; rather, you should simply rely on Meep's output.
 
 <a id="Simulation.get_array_metadata"></a>
 
-**Simulation.get\_array\_metadata**
-
 ```python
 def get_array_metadata(self,
                        vol=None,
@@ -782,8 +736,6 @@ then the entire cell is used.
 
 <a id="Simulation.get_avg_chunk_communication_area"></a>
 
-**Simulation.get\_avg\_chunk\_communication\_area**
-
 ```python
 def get_avg_chunk_communication_area(self):
 ```
@@ -795,8 +747,6 @@ def get_avg_chunk_communication_area(self):
 </div>
 
 <a id="Simulation.get_bfield"></a>
-
-**Simulation.get\_bfield**
 
 ```python
 def get_bfield(self):
@@ -810,8 +760,6 @@ def get_bfield(self):
 
 <a id="Simulation.get_bfield_p"></a>
 
-**Simulation.get\_bfield\_p**
-
 ```python
 def get_bfield_p(self):
 ```
@@ -823,8 +771,6 @@ def get_bfield_p(self):
 </div>
 
 <a id="Simulation.get_bfield_r"></a>
-
-**Simulation.get\_bfield\_r**
 
 ```python
 def get_bfield_r(self):
@@ -838,8 +784,6 @@ def get_bfield_r(self):
 
 <a id="Simulation.get_bfield_x"></a>
 
-**Simulation.get\_bfield\_x**
-
 ```python
 def get_bfield_x(self):
 ```
@@ -851,8 +795,6 @@ def get_bfield_x(self):
 </div>
 
 <a id="Simulation.get_bfield_y"></a>
-
-**Simulation.get\_bfield\_y**
 
 ```python
 def get_bfield_y(self):
@@ -866,8 +808,6 @@ def get_bfield_y(self):
 
 <a id="Simulation.get_bfield_z"></a>
 
-**Simulation.get\_bfield\_z**
-
 ```python
 def get_bfield_z(self):
 ```
@@ -879,8 +819,6 @@ def get_bfield_z(self):
 </div>
 
 <a id="Simulation.get_dfield"></a>
-
-**Simulation.get\_dfield**
 
 ```python
 def get_dfield(self):
@@ -894,8 +832,6 @@ def get_dfield(self):
 
 <a id="Simulation.get_dfield_p"></a>
 
-**Simulation.get\_dfield\_p**
-
 ```python
 def get_dfield_p(self):
 ```
@@ -907,8 +843,6 @@ def get_dfield_p(self):
 </div>
 
 <a id="Simulation.get_dfield_r"></a>
-
-**Simulation.get\_dfield\_r**
 
 ```python
 def get_dfield_r(self):
@@ -922,8 +856,6 @@ def get_dfield_r(self):
 
 <a id="Simulation.get_dfield_x"></a>
 
-**Simulation.get\_dfield\_x**
-
 ```python
 def get_dfield_x(self):
 ```
@@ -935,8 +867,6 @@ def get_dfield_x(self):
 </div>
 
 <a id="Simulation.get_dfield_y"></a>
-
-**Simulation.get\_dfield\_y**
 
 ```python
 def get_dfield_y(self):
@@ -950,8 +880,6 @@ def get_dfield_y(self):
 
 <a id="Simulation.get_dfield_z"></a>
 
-**Simulation.get\_dfield\_z**
-
 ```python
 def get_dfield_z(self):
 ```
@@ -963,8 +891,6 @@ def get_dfield_z(self):
 </div>
 
 <a id="Simulation.get_dft_array"></a>
-
-**Simulation.get\_dft\_array**
 
 ```python
 def get_dft_array(self, dft_obj, component, num_freq):
@@ -989,8 +915,6 @@ Returns the Fourier-transformed fields as a NumPy array.
 
 <a id="Simulation.get_dft_array_metadata"></a>
 
-**Simulation.get\_dft\_array\_metadata**
-
 ```python
 def get_dft_array_metadata(self,
                            dft_cell=None,
@@ -1007,8 +931,6 @@ def get_dft_array_metadata(self,
 
 <a id="Simulation.get_dft_data"></a>
 
-**Simulation.get\_dft\_data**
-
 ```python
 def get_dft_data(self, dft_chunk):
 ```
@@ -1020,8 +942,6 @@ def get_dft_data(self, dft_chunk):
 </div>
 
 <a id="Simulation.get_dpwr"></a>
-
-**Simulation.get\_dpwr**
 
 ```python
 def get_dpwr(self):
@@ -1035,8 +955,6 @@ def get_dpwr(self):
 
 <a id="Simulation.get_efield"></a>
 
-**Simulation.get\_efield**
-
 ```python
 def get_efield(self):
 ```
@@ -1048,8 +966,6 @@ def get_efield(self):
 </div>
 
 <a id="Simulation.get_efield_p"></a>
-
-**Simulation.get\_efield\_p**
 
 ```python
 def get_efield_p(self):
@@ -1063,8 +979,6 @@ def get_efield_p(self):
 
 <a id="Simulation.get_efield_r"></a>
 
-**Simulation.get\_efield\_r**
-
 ```python
 def get_efield_r(self):
 ```
@@ -1076,8 +990,6 @@ def get_efield_r(self):
 </div>
 
 <a id="Simulation.get_efield_x"></a>
-
-**Simulation.get\_efield\_x**
 
 ```python
 def get_efield_x(self):
@@ -1091,8 +1003,6 @@ def get_efield_x(self):
 
 <a id="Simulation.get_efield_y"></a>
 
-**Simulation.get\_efield\_y**
-
 ```python
 def get_efield_y(self):
 ```
@@ -1105,8 +1015,6 @@ def get_efield_y(self):
 
 <a id="Simulation.get_efield_z"></a>
 
-**Simulation.get\_efield\_z**
-
 ```python
 def get_efield_z(self):
 ```
@@ -1118,8 +1026,6 @@ def get_efield_z(self):
 </div>
 
 <a id="Simulation.get_eigenmode"></a>
-
-**Simulation.get\_eigenmode**
 
 ```python
 def get_eigenmode(self,
@@ -1160,8 +1066,6 @@ If `match_frequency=False` or `kpoint` is not zero in the given `direction`, the
 
 <a id="Simulation.get_eigenmode_coefficients"></a>
 
-**Simulation.get\_eigenmode\_coefficients**
-
 ```python
 def get_eigenmode_coefficients(self,
                                flux,
@@ -1194,8 +1098,6 @@ See [Mode Decomposition](#mode-decomposition)
 
 <a id="Simulation.get_epsilon"></a>
 
-**Simulation.get\_epsilon**
-
 ```python
 def get_epsilon(self, frequency=0, omega=0):
 ```
@@ -1207,8 +1109,6 @@ def get_epsilon(self, frequency=0, omega=0):
 </div>
 
 <a id="Simulation.get_epsilon_point"></a>
-
-**Simulation.get\_epsilon\_point**
 
 ```python
 def get_epsilon_point(self, pt, frequency=0, omega=0):
@@ -1225,8 +1125,6 @@ frequency-independent part of ε (the $\omega    o\infty$ limit).
 
 <a id="Simulation.get_estimated_costs"></a>
 
-**Simulation.get\_estimated\_costs**
-
 ```python
 def get_estimated_costs(self):
 ```
@@ -1239,8 +1137,6 @@ def get_estimated_costs(self):
 
 <a id="Simulation.get_estimated_memory_usage"></a>
 
-**Simulation.get\_estimated\_memory\_usage**
-
 ```python
 def get_estimated_memory_usage(self):
 ```
@@ -1252,8 +1148,6 @@ def get_estimated_memory_usage(self):
 </div>
 
 <a id="Simulation.get_farfield"></a>
-
-**Simulation.get\_farfield**
 
 ```python
 def get_farfield(self, near2far, x):
@@ -1271,8 +1165,6 @@ for the frequencies 1,2,…,`nfreq`.
 </div>
 
 <a id="Simulation.get_farfields"></a>
-
-**Simulation.get\_farfields**
 
 ```python
 def get_farfields(self,
@@ -1299,8 +1191,6 @@ far fields in one region vs. another region.
 
 <a id="Simulation.get_field_point"></a>
 
-**Simulation.get\_field\_point**
-
 ```python
 def get_field_point(self, c, pt):
 ```
@@ -1313,8 +1203,6 @@ returns the value of that component at that point.
 </div>
 
 <a id="Simulation.get_filename_prefix"></a>
-
-**Simulation.get\_filename\_prefix**
 
 ```python
 def get_filename_prefix(self):
@@ -1335,8 +1223,6 @@ by calling `Simulation.use_output_directory([dirname])`
 
 <a id="Simulation.get_flux_data"></a>
 
-**Simulation.get\_flux\_data**
-
 ```python
 def get_flux_data(self, flux):
 ```
@@ -1350,8 +1236,6 @@ only useful for passing to `load_flux_data` below and should be considered opaqu
 </div>
 
 <a id="Simulation.get_force_data"></a>
-
-**Simulation.get\_force\_data**
 
 ```python
 def get_force_data(self, force):
@@ -1368,8 +1252,6 @@ opaque.
 
 <a id="Simulation.get_hfield"></a>
 
-**Simulation.get\_hfield**
-
 ```python
 def get_hfield(self):
 ```
@@ -1381,8 +1263,6 @@ def get_hfield(self):
 </div>
 
 <a id="Simulation.get_hfield_p"></a>
-
-**Simulation.get\_hfield\_p**
 
 ```python
 def get_hfield_p(self):
@@ -1396,8 +1276,6 @@ def get_hfield_p(self):
 
 <a id="Simulation.get_hfield_r"></a>
 
-**Simulation.get\_hfield\_r**
-
 ```python
 def get_hfield_r(self):
 ```
@@ -1409,8 +1287,6 @@ def get_hfield_r(self):
 </div>
 
 <a id="Simulation.get_hfield_x"></a>
-
-**Simulation.get\_hfield\_x**
 
 ```python
 def get_hfield_x(self):
@@ -1424,8 +1300,6 @@ def get_hfield_x(self):
 
 <a id="Simulation.get_hfield_y"></a>
 
-**Simulation.get\_hfield\_y**
-
 ```python
 def get_hfield_y(self):
 ```
@@ -1437,8 +1311,6 @@ def get_hfield_y(self):
 </div>
 
 <a id="Simulation.get_hfield_z"></a>
-
-**Simulation.get\_hfield\_z**
 
 ```python
 def get_hfield_z(self):
@@ -1452,8 +1324,6 @@ def get_hfield_z(self):
 
 <a id="Simulation.get_hpwr"></a>
 
-**Simulation.get\_hpwr**
-
 ```python
 def get_hpwr(self):
 ```
@@ -1466,8 +1336,6 @@ def get_hpwr(self):
 
 <a id="Simulation.get_max_chunk_communication_area"></a>
 
-**Simulation.get\_max\_chunk\_communication\_area**
-
 ```python
 def get_max_chunk_communication_area(self):
 ```
@@ -1479,8 +1347,6 @@ def get_max_chunk_communication_area(self):
 </div>
 
 <a id="Simulation.get_mode_data"></a>
-
-**Simulation.get\_mode\_data**
 
 ```python
 def get_mode_data(self, flux):
@@ -1496,8 +1362,6 @@ only useful for passing to `load_flux_data` below and should be considered opaqu
 
 <a id="Simulation.get_mu"></a>
 
-**Simulation.get\_mu**
-
 ```python
 def get_mu(self):
 ```
@@ -1509,8 +1373,6 @@ def get_mu(self):
 </div>
 
 <a id="Simulation.get_near2far_data"></a>
-
-**Simulation.get\_near2far\_data**
 
 ```python
 def get_near2far_data(self, near2far):
@@ -1527,8 +1389,6 @@ considered opaque.
 
 <a id="Simulation.get_sfield"></a>
 
-**Simulation.get\_sfield**
-
 ```python
 def get_sfield(self):
 ```
@@ -1540,8 +1400,6 @@ def get_sfield(self):
 </div>
 
 <a id="Simulation.get_sfield_p"></a>
-
-**Simulation.get\_sfield\_p**
 
 ```python
 def get_sfield_p(self):
@@ -1555,8 +1413,6 @@ def get_sfield_p(self):
 
 <a id="Simulation.get_sfield_r"></a>
 
-**Simulation.get\_sfield\_r**
-
 ```python
 def get_sfield_r(self):
 ```
@@ -1568,8 +1424,6 @@ def get_sfield_r(self):
 </div>
 
 <a id="Simulation.get_sfield_x"></a>
-
-**Simulation.get\_sfield\_x**
 
 ```python
 def get_sfield_x(self):
@@ -1583,8 +1437,6 @@ def get_sfield_x(self):
 
 <a id="Simulation.get_sfield_y"></a>
 
-**Simulation.get\_sfield\_y**
-
 ```python
 def get_sfield_y(self):
 ```
@@ -1597,8 +1449,6 @@ def get_sfield_y(self):
 
 <a id="Simulation.get_sfield_z"></a>
 
-**Simulation.get\_sfield\_z**
-
 ```python
 def get_sfield_z(self):
 ```
@@ -1610,8 +1460,6 @@ def get_sfield_z(self):
 </div>
 
 <a id="Simulation.get_source"></a>
-
-**Simulation.get\_source**
 
 ```python
 def get_source(self,
@@ -1631,8 +1479,6 @@ dimensions as that returned by [`get_array`](#array-slices).
 
 <a id="Simulation.get_tot_pwr"></a>
 
-**Simulation.get\_tot\_pwr**
-
 ```python
 def get_tot_pwr(self):
 ```
@@ -1644,8 +1490,6 @@ def get_tot_pwr(self):
 </div>
 
 <a id="Simulation.h5topng"></a>
-
-**Simulation.h5topng**
 
 ```python
 def h5topng(self, rm_h5, option, *step_funcs):
@@ -1659,8 +1503,6 @@ def h5topng(self, rm_h5, option, *step_funcs):
 
 <a id="Simulation.has_mu"></a>
 
-**Simulation.has\_mu**
-
 ```python
 def has_mu(self):
 ```
@@ -1672,8 +1514,6 @@ def has_mu(self):
 </div>
 
 <a id="Simulation.init_fields"></a>
-
-**Simulation.init\_fields**
 
 ```python
 def init_fields(self):
@@ -1687,8 +1527,6 @@ def init_fields(self):
 
 <a id="Simulation.init_sim"></a>
 
-**Simulation.init\_sim**
-
 ```python
 def init_sim(self):
 ```
@@ -1700,8 +1538,6 @@ def init_sim(self):
 </div>
 
 <a id="Simulation.initialize_field"></a>
-
-**Simulation.initialize\_field**
 
 ```python
 def initialize_field(self, cmpnt, amp_func):
@@ -1716,8 +1552,6 @@ of the field at that point.
 </div>
 
 <a id="Simulation.integrate2_field_function"></a>
-
-**Simulation.integrate2\_field\_function**
 
 ```python
 def integrate2_field_function(self,
@@ -1764,8 +1598,6 @@ this requires you to call much lower-level functions like `fields_step()`.
 
 <a id="Simulation.integrate_field_function"></a>
 
-**Simulation.integrate\_field\_function**
-
 ```python
 def integrate_field_function(self,
                              cs,
@@ -1796,8 +1628,6 @@ volume.
 
 <a id="Simulation.load_chunk_layout"></a>
 
-**Simulation.load\_chunk\_layout**
-
 ```python
 def load_chunk_layout(self, br, source):
 ```
@@ -1809,8 +1639,6 @@ def load_chunk_layout(self, br, source):
 </div>
 
 <a id="Simulation.load_energy"></a>
-
-**Simulation.load\_energy**
 
 ```python
 def load_energy(self, fname, energy):
@@ -1829,8 +1657,6 @@ processors.
 
 <a id="Simulation.load_flux"></a>
 
-**Simulation.load\_flux**
-
 ```python
 def load_flux(self, fname, flux):
 ```
@@ -1848,8 +1674,6 @@ processors.
 
 <a id="Simulation.load_flux_data"></a>
 
-**Simulation.load\_flux\_data**
-
 ```python
 def load_flux_data(self, flux, fdata):
 ```
@@ -1864,8 +1688,6 @@ object that was created by `get_flux_data` in a simulation of the same dimension
 </div>
 
 <a id="Simulation.load_force"></a>
-
-**Simulation.load\_force**
 
 ```python
 def load_force(self, fname, force):
@@ -1884,8 +1706,6 @@ processors.
 
 <a id="Simulation.load_force_data"></a>
 
-**Simulation.load\_force\_data**
-
 ```python
 def load_force_data(self, force, fdata):
 ```
@@ -1901,8 +1721,6 @@ object that was created by `get_force_data` in a simulation of the same dimensio
 
 <a id="Simulation.load_minus_energy"></a>
 
-**Simulation.load\_minus\_energy**
-
 ```python
 def load_minus_energy(self, fname, energy):
 ```
@@ -1916,8 +1734,6 @@ transforms that are accumulated.
 </div>
 
 <a id="Simulation.load_minus_flux"></a>
-
-**Simulation.load\_minus\_flux**
 
 ```python
 def load_minus_flux(self, fname, flux):
@@ -1933,8 +1749,6 @@ that are accumulated.
 
 <a id="Simulation.load_minus_flux_data"></a>
 
-**Simulation.load\_minus\_flux\_data**
-
 ```python
 def load_minus_flux_data(self, flux, fdata):
 ```
@@ -1948,8 +1762,6 @@ transforms that are accumulated.
 </div>
 
 <a id="Simulation.load_minus_force"></a>
-
-**Simulation.load\_minus\_force**
 
 ```python
 def load_minus_force(self, fname, force):
@@ -1965,8 +1777,6 @@ that are accumulated.
 
 <a id="Simulation.load_minus_force_data"></a>
 
-**Simulation.load\_minus\_force\_data**
-
 ```python
 def load_minus_force_data(self, force, fdata):
 ```
@@ -1980,8 +1790,6 @@ transforms that are accumulated.
 </div>
 
 <a id="Simulation.load_minus_mode"></a>
-
-**Simulation.load\_minus\_mode**
 
 ```python
 def load_minus_mode(self, fname, flux):
@@ -1997,8 +1805,6 @@ that are accumulated.
 
 <a id="Simulation.load_minus_mode_data"></a>
 
-**Simulation.load\_minus\_mode\_data**
-
 ```python
 def load_minus_mode_data(self, flux, fdata):
 ```
@@ -2012,8 +1818,6 @@ transforms that are accumulated.
 </div>
 
 <a id="Simulation.load_minus_near2far"></a>
-
-**Simulation.load\_minus\_near2far**
 
 ```python
 def load_minus_near2far(self, fname, near2far):
@@ -2029,8 +1833,6 @@ transforms that are accumulated.
 
 <a id="Simulation.load_minus_near2far_data"></a>
 
-**Simulation.load\_minus\_near2far\_data**
-
 ```python
 def load_minus_near2far_data(self, near2far, n2fdata):
 ```
@@ -2044,8 +1846,6 @@ transforms that are accumulated.
 </div>
 
 <a id="Simulation.load_mode"></a>
-
-**Simulation.load\_mode**
 
 ```python
 def load_mode(self, fname, flux):
@@ -2064,8 +1864,6 @@ processors.
 
 <a id="Simulation.load_mode_data"></a>
 
-**Simulation.load\_mode\_data**
-
 ```python
 def load_mode_data(self, flux, fdata):
 ```
@@ -2080,8 +1878,6 @@ object that was created by `get_flux_data` in a simulation of the same dimension
 </div>
 
 <a id="Simulation.load_near2far"></a>
-
-**Simulation.load\_near2far**
 
 ```python
 def load_near2far(self, fname, near2far):
@@ -2100,8 +1896,6 @@ processors.
 
 <a id="Simulation.load_near2far_data"></a>
 
-**Simulation.load\_near2far\_data**
-
 ```python
 def load_near2far_data(self, near2far, n2fdata):
 ```
@@ -2118,8 +1912,6 @@ processors.
 
 <a id="Simulation.load_structure"></a>
 
-**Simulation.load\_structure**
-
 ```python
 def load_structure(self, fname):
 ```
@@ -2132,8 +1924,6 @@ the `Simulation` constructor via the `load_structure` keyword argument.
 </div>
 
 <a id="Simulation.magnetic_energy_in_box"></a>
-
-**Simulation.magnetic\_energy\_in\_box**
 
 ```python
 def magnetic_energy_in_box(self, box=None, center=None, size=None):
@@ -2154,8 +1944,6 @@ volume.
 </div>
 
 <a id="Simulation.max_abs_field_function"></a>
-
-**Simulation.max\_abs\_field\_function**
 
 ```python
 def max_abs_field_function(self,
@@ -2189,8 +1977,6 @@ and the same PML layers (if any).
 
 <a id="Simulation.mean_time_spent_on"></a>
 
-**Simulation.mean\_time\_spent\_on**
-
 ```python
 def mean_time_spent_on(self, time_sink):
 ```
@@ -2206,8 +1992,6 @@ other.
 </div>
 
 <a id="Simulation.meep_time"></a>
-
-**Simulation.meep\_time**
 
 ```python
 def meep_time(self):
@@ -2228,8 +2012,6 @@ rounded to single precision.
 </div>
 
 <a id="Simulation.modal_volume_in_box"></a>
-
-**Simulation.modal\_volume\_in\_box**
 
 ```python
 def modal_volume_in_box(self, box=None, center=None, size=None):
@@ -2262,8 +2044,6 @@ via the functions:
 
 <a id="Simulation.output_component"></a>
 
-**Simulation.output\_component**
-
 ```python
 def output_component(self, c, h5file=None, frequency=0, omega=0):
 ```
@@ -2276,8 +2056,6 @@ def output_component(self, c, h5file=None, frequency=0, omega=0):
 
 <a id="Simulation.output_components"></a>
 
-**Simulation.output\_components**
-
 ```python
 def output_components(self, fname, *components):
 ```
@@ -2289,8 +2067,6 @@ def output_components(self, fname, *components):
 </div>
 
 <a id="Simulation.output_dft"></a>
-
-**Simulation.output\_dft**
 
 ```python
 def output_dft(self, dft_fields, fname):
@@ -2305,8 +2081,6 @@ suffix).
 </div>
 
 <a id="Simulation.output_farfields"></a>
-
-**Simulation.output\_farfields**
 
 ```python
 def output_farfields(self,
@@ -2335,8 +2109,6 @@ that =1 are omitted. The volume can optionally be specified via `center` and
 
 <a id="Simulation.output_field_function"></a>
 
-**Simulation.output\_field\_function**
-
 ```python
 def output_field_function(self,
                           name,
@@ -2357,8 +2129,6 @@ field components corresponding to `cs`: a list of `component` constants. If
 </div>
 
 <a id="Simulation.phase_in_material"></a>
-
-**Simulation.phase\_in\_material**
 
 ```python
 def phase_in_material(self, structure, time):
@@ -2383,8 +2153,6 @@ simulation script is in
 </div>
 
 <a id="Simulation.plot2D"></a>
-
-**Simulation.plot2D**
 
 ```python
 def plot2D(self,
@@ -2487,8 +2255,6 @@ plt.savefig('sim_domain.png')
 
 <a id="Simulation.plot3D"></a>
 
-**Simulation.plot3D**
-
 ```python
 def plot3D(self):
 ```
@@ -2502,8 +2268,6 @@ Can also be embedded in Jupyter notebooks.
 
 <a id="Simulation.plot_fields"></a>
 
-**Simulation.plot\_fields**
-
 ```python
 def plot_fields(self, **kwargs):
 ```
@@ -2515,8 +2279,6 @@ def plot_fields(self, **kwargs):
 </div>
 
 <a id="Simulation.print_times"></a>
-
-**Simulation.print\_times**
 
 ```python
 def print_times(self):
@@ -2541,8 +2303,6 @@ Field time usage:
 
 <a id="Simulation.require_dimensions"></a>
 
-**Simulation.require\_dimensions**
-
 ```python
 def require_dimensions(self):
 ```
@@ -2554,8 +2314,6 @@ def require_dimensions(self):
 </div>
 
 <a id="Simulation.reset_meep"></a>
-
-**Simulation.reset\_meep**
 
 ```python
 def reset_meep(self):
@@ -2570,8 +2328,6 @@ memory as if you had not run any computations.
 
 <a id="Simulation.restart_fields"></a>
 
-**Simulation.restart\_fields**
-
 ```python
 def restart_fields(self):
 ```
@@ -2585,8 +2341,6 @@ transforms of the flux planes, which continue to be accumulated.
 
 <a id="Simulation.round_time"></a>
 
-**Simulation.round\_time**
-
 ```python
 def round_time(self):
 ```
@@ -2598,8 +2352,6 @@ def round_time(self):
 </div>
 
 <a id="Simulation.run"></a>
-
-**Simulation.run**
 
 ```python
 def run(self, *step_funcs, **kwargs):
@@ -2613,8 +2365,6 @@ def run(self, *step_funcs, **kwargs):
 
 <a id="Simulation.run_k_point"></a>
 
-**Simulation.run\_k\_point**
-
 ```python
 def run_k_point(self, t, k):
 ```
@@ -2626,8 +2376,6 @@ def run_k_point(self, t, k):
 </div>
 
 <a id="Simulation.run_k_points"></a>
-
-**Simulation.run\_k\_points**
 
 ```python
 def run_k_points(self, t, k_points):
@@ -2652,8 +2400,6 @@ Cavity](Python_Tutorials/Resonant_Modes_and_Transmission_in_a_Waveguide_Cavity.m
 
 <a id="Simulation.save_energy"></a>
 
-**Simulation.save\_energy**
-
 ```python
 def save_energy(self, fname, energy):
 ```
@@ -2667,8 +2413,6 @@ filename-prefix is prepended automatically).
 </div>
 
 <a id="Simulation.save_flux"></a>
-
-**Simulation.save\_flux**
 
 ```python
 def save_flux(self, fname, flux):
@@ -2684,8 +2428,6 @@ filename-prefix is prepended automatically).
 
 <a id="Simulation.save_force"></a>
 
-**Simulation.save\_force**
-
 ```python
 def save_force(self, fname, force):
 ```
@@ -2699,8 +2441,6 @@ filename-prefix is prepended automatically).
 </div>
 
 <a id="Simulation.save_mode"></a>
-
-**Simulation.save\_mode**
 
 ```python
 def save_mode(self, fname, flux):
@@ -2716,8 +2456,6 @@ filename-prefix is prepended automatically).
 
 <a id="Simulation.save_near2far"></a>
 
-**Simulation.save\_near2far**
-
 ```python
 def save_near2far(self, fname, near2far):
 ```
@@ -2731,8 +2469,6 @@ filename-prefix is prepended automatically.
 </div>
 
 <a id="Simulation.set_boundary"></a>
-
-**Simulation.set\_boundary**
 
 ```python
 def set_boundary(self, side, direction, condition):
@@ -2748,8 +2484,6 @@ section for valid `side`, `direction`, and `boundary_condition` values.
 
 <a id="Simulation.set_epsilon"></a>
 
-**Simulation.set\_epsilon**
-
 ```python
 def set_epsilon(self, eps):
 ```
@@ -2761,8 +2495,6 @@ def set_epsilon(self, eps):
 </div>
 
 <a id="Simulation.set_materials"></a>
-
-**Simulation.set\_materials**
 
 ```python
 def set_materials(self, geometry=None, default_material=None):
@@ -2776,8 +2508,6 @@ This can be called in a step function, and is useful for changing the geometry o
 
 <a id="Simulation.solve_cw"></a>
 
-**Simulation.solve\_cw**
-
 ```python
 def solve_cw(self, tol=1e-08, maxiters=10000, L=2):
 ```
@@ -2789,8 +2519,6 @@ def solve_cw(self, tol=1e-08, maxiters=10000, L=2):
 </div>
 
 <a id="Simulation.solve_eigfreq"></a>
-
-**Simulation.solve\_eigfreq**
 
 ```python
 def solve_eigfreq(self,
@@ -2810,8 +2538,6 @@ def solve_eigfreq(self,
 
 <a id="Simulation.time_spent_on"></a>
 
-**Simulation.time\_spent\_on**
-
 ```python
 def time_spent_on(self, time_sink):
 ```
@@ -2828,8 +2554,6 @@ other.
 
 <a id="Simulation.use_output_directory"></a>
 
-**Simulation.use\_output\_directory**
-
 ```python
 def use_output_directory(self, dname=''):
 ```
@@ -2844,8 +2568,6 @@ e.g. `test.py` implies a directory of `"test-out"`.
 </div>
 
 <a id="Simulation.visualize_chunks"></a>
-
-**Simulation.visualize\_chunks**
 
 ```python
 def visualize_chunks(self):
@@ -2945,7 +2667,7 @@ class Medium(object):
 
 This class is used to specify the materials that geometric objects are made of. It
 represents an electromagnetic medium which is possibly nonlinear and/or dispersive.
-See also [Materials](Materials.md). To model a perfectly conducting metal, use the
+See also [Materials](Materials.md). To model a perfectly-conducting metal, use the
 predefined `metal` object, above. To model imperfect conductors, use a dispersive
 dielectric material. See also the [Predefined Variables](#predefined-variables):
 `metal`, `perfect_electric_conductor`, and `perfect_magnetic_conductor`.
@@ -2995,8 +2717,6 @@ objects that are subclasses of type `Susceptibility`.
 
 
 <a id="Medium.__init__"></a>
-
-**Medium.\_\_init\_\_**
 
 ```python
 def __init__(self,
@@ -3087,8 +2807,6 @@ Creates a `Medium` object.
 
 <a id="Medium.__repr__"></a>
 
-**Medium.\_\_repr\_\_**
-
 ```python
 def __repr__(self):
 ```
@@ -3100,8 +2818,6 @@ Return repr(self).
 </div>
 
 <a id="Medium.epsilon"></a>
-
-**Medium.epsilon**
 
 ```python
 def epsilon(self, freq):
@@ -3117,8 +2833,6 @@ of a list/array of N frequency points, a Numpy array of size Nx3x3 is returned.
 
 <a id="Medium.mu"></a>
 
-**Medium.mu**
-
 ```python
 def mu(self, freq):
 ```
@@ -3133,8 +2847,6 @@ of a list/array of N frequency points, a Numpy array of size Nx3x3 is returned.
 
 <a id="Medium.rotate"></a>
 
-**Medium.rotate**
-
 ```python
 def rotate(self, axis, theta):
 ```
@@ -3146,8 +2858,6 @@ def rotate(self, axis, theta):
 </div>
 
 <a id="Medium.transform"></a>
-
-**Medium.transform**
 
 ```python
 def transform(self, m):
@@ -3191,8 +2901,6 @@ anisotropic amplitude σ. See [Material Dispersion](Materials.md#material-disper
 
 <a id="Susceptibility.__init__"></a>
 
-**Susceptibility.\_\_init\_\_**
-
 ```python
 def __init__(self,
              sigma_diag=Vector3<0.0, 0.0, 0.0>,
@@ -3215,8 +2923,6 @@ corresponds to a σ tensor
 </div>
 
 <a id="Susceptibility.transform"></a>
-
-**Susceptibility.transform**
 
 ```python
 def transform(self, m):
@@ -3252,8 +2958,6 @@ the parameters (in addition to σ):
 
 <a id="LorentzianSusceptibility.__init__"></a>
 
-**LorentzianSusceptibility.\_\_init\_\_**
-
 ```python
 def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
 ```
@@ -3271,8 +2975,6 @@ preliminary simulation info output.
 </div>
 
 <a id="LorentzianSusceptibility.eval_susceptibility"></a>
-
-**LorentzianSusceptibility.eval\_susceptibility**
 
 ```python
 def eval_susceptibility(self, freq):
@@ -3307,8 +3009,6 @@ Dispersion](Materials.md#material-dispersion), with the parameters (in addition 
 
 <a id="DrudeSusceptibility.__init__"></a>
 
-**DrudeSusceptibility.\_\_init\_\_**
-
 ```python
 def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
 ```
@@ -3323,8 +3023,6 @@ def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
 </div>
 
 <a id="DrudeSusceptibility.eval_susceptibility"></a>
-
-**DrudeSusceptibility.eval\_susceptibility**
 
 ```python
 def eval_susceptibility(self, freq):
@@ -3362,8 +3060,6 @@ Absorption](Materials.md#saturable-gain-and-absorption).
 
 
 <a id="MultilevelAtom.__init__"></a>
-
-**MultilevelAtom.\_\_init\_\_**
 
 ```python
 def __init__(self,
@@ -3407,8 +3103,6 @@ A `Transition` is... (TODO)
 
 
 <a id="Transition.__init__"></a>
-
-**Transition.\_\_init\_\_**
 
 ```python
 def __init__(self,
@@ -3468,8 +3162,6 @@ space and time, zero mean) added to the **P** damped-oscillator equation.
 
 <a id="NoisyLorentzianSusceptibility.__init__"></a>
 
-**NoisyLorentzianSusceptibility.\_\_init\_\_**
-
 ```python
 def __init__(self, noise_amp=0.0, **kwargs):
 ```
@@ -3519,8 +3211,6 @@ space and time, zero mean) added to the **P** damped-oscillator equation.
 
 
 <a id="NoisyDrudeSusceptibility.__init__"></a>
-
-**NoisyDrudeSusceptibility.\_\_init\_\_**
 
 ```python
 def __init__(self, noise_amp=0.0, **kwargs):
@@ -3572,8 +3262,6 @@ meanings](#susceptibility), and an additional 3-vector `bias`:
 
 <a id="GyrotropicLorentzianSusceptibility.__init__"></a>
 
-**GyrotropicLorentzianSusceptibility.\_\_init\_\_**
-
 ```python
 def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs):
 ```
@@ -3611,8 +3299,6 @@ meanings](#susceptibility), and an additional 3-vector `bias`:
 
 
 <a id="GyrotropicDrudeSusceptibility.__init__"></a>
-
-**GyrotropicDrudeSusceptibility.\_\_init\_\_**
 
 ```python
 def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs):
@@ -3653,8 +3339,6 @@ parameter and an `alpha` parameter:
 
 
 <a id="GyrotropicSaturatedSusceptibility.__init__"></a>
-
-**GyrotropicSaturatedSusceptibility.\_\_init\_\_**
 
 ```python
 def __init__(self,
@@ -3717,8 +3401,6 @@ iterable (e.g., a tuple or list) and automatically convert to a `Vector3`.
 
 <a id="Vector3.__init__"></a>
 
-**Vector3.\_\_init\_\_**
-
 ```python
 def __init__(self, x=0.0, y=0.0, z=0.0):
 ```
@@ -3731,8 +3413,6 @@ zero. This can also be represented simply as `(x,y,z)` or `[x,y,z]`.
 </div>
 
 <a id="Vector3.__add__"></a>
-
-**Vector3.\_\_add\_\_**
 
 ```python
 def __add__(self, other):
@@ -3750,8 +3430,6 @@ v3 = v1 + v2
 
 <a id="Vector3.__array__"></a>
 
-**Vector3.\_\_array\_\_**
-
 ```python
 def __array__(self):
 ```
@@ -3763,8 +3441,6 @@ def __array__(self):
 </div>
 
 <a id="Vector3.__eq__"></a>
-
-**Vector3.\_\_eq\_\_**
 
 ```python
 def __eq__(self, other):
@@ -3784,8 +3460,6 @@ v1 == v2
 
 <a id="Vector3.__getitem__"></a>
 
-**Vector3.\_\_getitem\_\_**
-
 ```python
 def __getitem__(self, i):
 ```
@@ -3797,8 +3471,6 @@ def __getitem__(self, i):
 </div>
 
 <a id="Vector3.__mul__"></a>
-
-**Vector3.\_\_mul\_\_**
 
 ```python
 def __mul__(self, other):
@@ -3816,8 +3488,6 @@ c = v1 * other
 </div>
 
 <a id="Vector3.__ne__"></a>
-
-**Vector3.\_\_ne\_\_**
 
 ```python
 def __ne__(self, other):
@@ -3837,8 +3507,6 @@ v1 != v2
 
 <a id="Vector3.__repr__"></a>
 
-**Vector3.\_\_repr\_\_**
-
 ```python
 def __repr__(self):
 ```
@@ -3850,8 +3518,6 @@ Return repr(self).
 </div>
 
 <a id="Vector3.__rmul__"></a>
-
-**Vector3.\_\_rmul\_\_**
 
 ```python
 def __rmul__(self, other):
@@ -3870,8 +3536,6 @@ c = other * v1
 
 <a id="Vector3.__sub__"></a>
 
-**Vector3.\_\_sub\_\_**
-
 ```python
 def __sub__(self, other):
 ```
@@ -3888,8 +3552,6 @@ v3 = v1 - v2
 
 <a id="Vector3.__truediv__"></a>
 
-**Vector3.\_\_truediv\_\_**
-
 ```python
 def __truediv__(self, other):
 ```
@@ -3902,8 +3564,6 @@ def __truediv__(self, other):
 
 <a id="Vector3.cdot"></a>
 
-**Vector3.cdot**
-
 ```python
 def cdot(self, v):
 ```
@@ -3915,8 +3575,6 @@ Returns the conjugated dot product: *self*\* dot *v*.
 </div>
 
 <a id="Vector3.close"></a>
-
-**Vector3.close**
 
 ```python
 def close(self, v, tol=1e-07):
@@ -3935,8 +3593,6 @@ v1.close(v2, [tol])
 
 <a id="Vector3.conj"></a>
 
-**Vector3.conj**
-
 ```python
 def conj(self):
 ```
@@ -3948,8 +3604,6 @@ def conj(self):
 </div>
 
 <a id="Vector3.cross"></a>
-
-**Vector3.cross**
 
 ```python
 def cross(self, v):
@@ -3967,8 +3621,6 @@ v3 = v1.cross(v2)
 
 <a id="Vector3.dot"></a>
 
-**Vector3.dot**
-
 ```python
 def dot(self, v):
 ```
@@ -3985,8 +3637,6 @@ v3 = v1.dot(v2)
 
 <a id="Vector3.norm"></a>
 
-**Vector3.norm**
-
 ```python
 def norm(self):
 ```
@@ -4002,8 +3652,6 @@ v2 = v1.norm()
 </div>
 
 <a id="Vector3.rotate"></a>
-
-**Vector3.rotate**
 
 ```python
 def rotate(self, axis, theta):
@@ -4024,8 +3672,6 @@ v2 = v1.rotate(axis, theta)
 
 <a id="Vector3.rotate_lattice"></a>
 
-**Vector3.rotate\_lattice**
-
 ```python
 def rotate_lattice(self, axis, theta, lat):
 ```
@@ -4037,8 +3683,6 @@ def rotate_lattice(self, axis, theta, lat):
 </div>
 
 <a id="Vector3.rotate_reciprocal"></a>
-
-**Vector3.rotate\_reciprocal**
 
 ```python
 def rotate_reciprocal(self, axis, theta, lat):
@@ -4052,8 +3696,6 @@ def rotate_reciprocal(self, axis, theta, lat):
 
 <a id="Vector3.scale"></a>
 
-**Vector3.scale**
-
 ```python
 def scale(self, s):
 ```
@@ -4065,8 +3707,6 @@ def scale(self, s):
 </div>
 
 <a id="Vector3.unit"></a>
-
-**Vector3.unit**
 
 ```python
 def unit(self):
@@ -4153,8 +3793,6 @@ geometry = [mp.Prism(vertices, height=1.5, center=mp.Vector3(), material=cSi)]
 
 <a id="GeometricObject.__init__"></a>
 
-**GeometricObject.\_\_init\_\_**
-
 ```python
 def __init__(self,
              material=Medium(),
@@ -4186,8 +3824,6 @@ constructor via keyword arguments.
 
 <a id="GeometricObject.__add__"></a>
 
-**GeometricObject.\_\_add\_\_**
-
 ```python
 def __add__(self, vec):
 ```
@@ -4199,8 +3835,6 @@ def __add__(self, vec):
 </div>
 
 <a id="GeometricObject.__contains__"></a>
-
-**GeometricObject.\_\_contains\_\_**
 
 ```python
 def __contains__(self, point):
@@ -4214,8 +3848,6 @@ def __contains__(self, point):
 
 <a id="GeometricObject.__iadd__"></a>
 
-**GeometricObject.\_\_iadd\_\_**
-
 ```python
 def __iadd__(self, vec):
 ```
@@ -4227,8 +3859,6 @@ def __iadd__(self, vec):
 </div>
 
 <a id="GeometricObject.__radd__"></a>
-
-**GeometricObject.\_\_radd\_\_**
 
 ```python
 def __radd__(self, vec):
@@ -4242,8 +3872,6 @@ def __radd__(self, vec):
 
 <a id="GeometricObject.info"></a>
 
-**GeometricObject.info**
-
 ```python
 def info(self, indent_by=0):
 ```
@@ -4256,8 +3884,6 @@ Displays all properties and current values of a `GeometricObject`, indented by
 </div>
 
 <a id="GeometricObject.shift"></a>
-
-**GeometricObject.shift**
 
 ```python
 def shift(self, vec):
@@ -4302,8 +3928,6 @@ Represents a sphere.
 
 <a id="Sphere.__init__"></a>
 
-**Sphere.\_\_init\_\_**
-
 ```python
 def __init__(self, radius, **kwargs):
 ```
@@ -4345,8 +3969,6 @@ A cylinder, with circular cross-section and finite height.
 
 <a id="Cylinder.__init__"></a>
 
-**Cylinder.\_\_init\_\_**
-
 ```python
 def __init__(self,
              radius,
@@ -4382,8 +4004,6 @@ Represents a cylindrical wedge.
 
 
 <a id="Wedge.__init__"></a>
-
-**Wedge.\_\_init\_\_**
 
 ```python
 def __init__(self,
@@ -4425,8 +4045,6 @@ is halfway between the two circular ends.
 
 <a id="Cone.__init__"></a>
 
-**Cone.\_\_init\_\_**
-
 ```python
 def __init__(self, radius, radius2=0, **kwargs):
 ```
@@ -4462,8 +4080,6 @@ A parallelepiped (i.e., a brick, possibly with non-orthogonal axes).
 
 
 <a id="Block.__init__"></a>
-
-**Block.\_\_init\_\_**
 
 ```python
 def __init__(self,
@@ -4511,8 +4127,6 @@ properties, but defines an ellipsoid inscribed inside the block.
 
 <a id="Ellipsoid.__init__"></a>
 
-**Ellipsoid.\_\_init\_\_**
-
 ```python
 def __init__(self, **kwargs):
 ```
@@ -4544,8 +4158,6 @@ Polygonal prism type.
 
 
 <a id="Prism.__init__"></a>
-
-**Prism.\_\_init\_\_**
 
 ```python
 def __init__(self,
@@ -4637,8 +4249,6 @@ Scales the matrix `m` by the number `s`.
 
 <a id="Matrix.__init__"></a>
 
-**Matrix.\_\_init\_\_**
-
 ```python
 def __init__(self,
              c1=Vector3<0.0, 0.0, 0.0>,
@@ -4656,8 +4266,6 @@ Constructs a `Matrix`.
 
 <a id="Matrix.__add__"></a>
 
-**Matrix.\_\_add\_\_**
-
 ```python
 def __add__(self, m):
 ```
@@ -4669,8 +4277,6 @@ def __add__(self, m):
 </div>
 
 <a id="Matrix.__array__"></a>
-
-**Matrix.\_\_array\_\_**
 
 ```python
 def __array__(self):
@@ -4684,8 +4290,6 @@ def __array__(self):
 
 <a id="Matrix.__getitem__"></a>
 
-**Matrix.\_\_getitem\_\_**
-
 ```python
 def __getitem__(self, i):
 ```
@@ -4697,8 +4301,6 @@ def __getitem__(self, i):
 </div>
 
 <a id="Matrix.__mul__"></a>
-
-**Matrix.\_\_mul\_\_**
 
 ```python
 def __mul__(self, m):
@@ -4712,8 +4314,6 @@ def __mul__(self, m):
 
 <a id="Matrix.__repr__"></a>
 
-**Matrix.\_\_repr\_\_**
-
 ```python
 def __repr__(self):
 ```
@@ -4725,8 +4325,6 @@ Return repr(self).
 </div>
 
 <a id="Matrix.__rmul__"></a>
-
-**Matrix.\_\_rmul\_\_**
 
 ```python
 def __rmul__(self, left_arg):
@@ -4740,8 +4338,6 @@ def __rmul__(self, left_arg):
 
 <a id="Matrix.__sub__"></a>
 
-**Matrix.\_\_sub\_\_**
-
 ```python
 def __sub__(self, m):
 ```
@@ -4753,8 +4349,6 @@ def __sub__(self, m):
 </div>
 
 <a id="Matrix.__truediv__"></a>
-
-**Matrix.\_\_truediv\_\_**
 
 ```python
 def __truediv__(self, scalar):
@@ -4768,8 +4362,6 @@ def __truediv__(self, scalar):
 
 <a id="Matrix.conj"></a>
 
-**Matrix.conj**
-
 ```python
 def conj(self):
 ```
@@ -4781,8 +4373,6 @@ def conj(self):
 </div>
 
 <a id="Matrix.determinant"></a>
-
-**Matrix.determinant**
 
 ```python
 def determinant(self):
@@ -4796,8 +4386,6 @@ def determinant(self):
 
 <a id="Matrix.getH"></a>
 
-**Matrix.getH**
-
 ```python
 def getH(self):
 ```
@@ -4809,8 +4397,6 @@ def getH(self):
 </div>
 
 <a id="Matrix.inverse"></a>
-
-**Matrix.inverse**
 
 ```python
 def inverse(self):
@@ -4824,8 +4410,6 @@ def inverse(self):
 
 <a id="Matrix.mm_mult"></a>
 
-**Matrix.mm\_mult**
-
 ```python
 def mm_mult(self, m):
 ```
@@ -4837,8 +4421,6 @@ def mm_mult(self, m):
 </div>
 
 <a id="Matrix.mv_mult"></a>
-
-**Matrix.mv\_mult**
 
 ```python
 def mv_mult(self, v):
@@ -4852,8 +4434,6 @@ def mv_mult(self, v):
 
 <a id="Matrix.row"></a>
 
-**Matrix.row**
-
 ```python
 def row(self, i):
 ```
@@ -4866,8 +4446,6 @@ def row(self, i):
 
 <a id="Matrix.scale"></a>
 
-**Matrix.scale**
-
 ```python
 def scale(self, s):
 ```
@@ -4879,8 +4457,6 @@ def scale(self, s):
 </div>
 
 <a id="Matrix.transpose"></a>
-
-**Matrix.transpose**
 
 ```python
 def transpose(self):
@@ -4897,8 +4473,6 @@ def transpose(self):
 **Related function:**
 
 <a id="get_rotation_matrix"></a>
-
-**meep.get\_rotation\_matrix function**
 
 ```python
 def get_rotation_matrix(axis, theta):
@@ -4953,8 +4527,6 @@ the axis of the rotation.
 
 
 <a id="Symmetry.__init__"></a>
-
-**Symmetry.\_\_init\_\_**
 
 ```python
 def __init__(self, direction, phase=1):
@@ -5090,8 +4662,6 @@ properties.
 
 <a id="PML.__init__"></a>
 
-**PML.\_\_init\_\_**
-
 ```python
 def __init__(self,
              thickness,
@@ -5099,7 +4669,7 @@ def __init__(self,
              side=-1,
              R_asymptotic=1e-15,
              mean_stretch=1.0,
-             pml_profile=<function PML.<lambda> at 0x7f9960b058c0>):
+             pml_profile=<function PML.<lambda> at 0x7fe669109b00>):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5227,8 +4797,6 @@ Nanotechnology](https://www.amazon.com/Advances-FDTD-Computational-Electrodynami
 
 <a id="Source.__init__"></a>
 
-**Source.\_\_init\_\_**
-
 ```python
 def __init__(self,
              src,
@@ -5326,8 +4894,6 @@ TODO:
 
 <a id="SourceTime.__init__"></a>
 
-**SourceTime.\_\_init\_\_**
-
 ```python
 def __init__(self, is_integrated=False):
 ```
@@ -5407,8 +4973,6 @@ source, can be one of `ContinuousSource`, `GaussianSource` or `CustomSource`.
 
 
 <a id="EigenModeSource.__init__"></a>
-
-**EigenModeSource.\_\_init\_\_**
 
 ```python
 def __init__(self,
@@ -5512,8 +5076,6 @@ Construct an `EigenModeSource`.
 
 <a id="EigenModeSource.eig_power"></a>
 
-**EigenModeSource.eig\_power**
-
 ```python
 def eig_power(self, freq):
 ```
@@ -5548,8 +5110,6 @@ response](FAQ.md#why-doesnt-the-continuous-wave-cw-source-produce-an-exact-singl
 
 
 <a id="ContinuousSource.__init__"></a>
-
-**ContinuousSource.\_\_init\_\_**
 
 ```python
 def __init__(self,
@@ -5626,8 +5186,6 @@ irrelevant.
 
 <a id="GaussianSource.__init__"></a>
 
-**GaussianSource.\_\_init\_\_**
-
 ```python
 def __init__(self,
              frequency=None,
@@ -5687,8 +5245,6 @@ Construct a `GaussianSource`.
 
 <a id="GaussianSource.fourier_transform"></a>
 
-**GaussianSource.fourier\_transform**
-
 ```python
 def fourier_transform(self, freq):
 ```
@@ -5728,8 +5284,6 @@ demonstration of a [linear-chirped pulse](FAQ.md#how-do-i-create-a-chirped-pulse
 
 
 <a id="CustomSource.__init__"></a>
-
-**CustomSource.\_\_init\_\_**
 
 ```python
 def __init__(self,
@@ -5801,8 +5355,6 @@ the box add instead of subtract.
 
 
 <a id="FluxRegion.__init__"></a>
-
-**FluxRegion.\_\_init\_\_**
 
 ```python
 def __init__(self,
@@ -5939,8 +5491,6 @@ specify a list of `Vector3` vertices using the `vertices` parameter. The `center
 
 <a id="Volume.__init__"></a>
 
-**Volume.\_\_init\_\_**
-
 ```python
 def __init__(self,
              center=Vector3<0.0, 0.0, 0.0>,
@@ -5958,8 +5508,6 @@ Construct a Volume.
 
 <a id="Volume.get_edges"></a>
 
-**Volume.get\_edges**
-
 ```python
 def get_edges(self):
 ```
@@ -5972,8 +5520,6 @@ def get_edges(self):
 
 <a id="Volume.get_vertices"></a>
 
-**Volume.get\_vertices**
-
 ```python
 def get_vertices(self):
 ```
@@ -5985,8 +5531,6 @@ def get_vertices(self):
 </div>
 
 <a id="Volume.pt_in_volume"></a>
-
-**Volume.pt\_in\_volume**
 
 ```python
 def pt_in_volume(self, pt):
@@ -6003,8 +5547,6 @@ def pt_in_volume(self, pt):
 ** Related function:**
 
 <a id="get_center_and_size"></a>
-
-**meep.get\_center\_and\_size function**
 
 ```python
 def get_center_and_size(vol):
@@ -6057,8 +5599,6 @@ swigobj_attr and return the property they requested.
 
 <a id="DftObj.__init__"></a>
 
-**DftObj.\_\_init\_\_**
-
 ```python
 def __init__(self, func, args):
 ```
@@ -6070,8 +5610,6 @@ Initialize self.  See help(type(self)) for accurate signature.
 </div>
 
 <a id="DftObj.swigobj_attr"></a>
-
-**DftObj.swigobj\_attr**
 
 ```python
 def swigobj_attr(self, attr):
@@ -6104,8 +5642,6 @@ class DftFlux(DftObj):
 
 <a id="DftFlux.__init__"></a>
 
-**DftFlux.\_\_init\_\_**
-
 ```python
 def __init__(self, func, args):
 ```
@@ -6136,8 +5672,6 @@ class DftForce(DftObj):
 
 
 <a id="DftForce.__init__"></a>
-
-**DftForce.\_\_init\_\_**
 
 ```python
 def __init__(self, func, args):
@@ -6170,8 +5704,6 @@ class DftNear2Far(DftObj):
 
 <a id="DftNear2Far.__init__"></a>
 
-**DftNear2Far.\_\_init\_\_**
-
 ```python
 def __init__(self, func, args):
 ```
@@ -6183,8 +5715,6 @@ Initialize self.  See help(type(self)) for accurate signature.
 </div>
 
 <a id="DftNear2Far.flux"></a>
-
-**DftNear2Far.flux**
 
 ```python
 def flux(self, direction, where, resolution):
@@ -6221,8 +5751,6 @@ class DftEnergy(DftObj):
 
 <a id="DftEnergy.__init__"></a>
 
-**DftEnergy.\_\_init\_\_**
-
 ```python
 def __init__(self, func, args):
 ```
@@ -6253,8 +5781,6 @@ class DftFields(DftObj):
 
 
 <a id="DftFields.__init__"></a>
-
-**DftFields.\_\_init\_\_**
 
 ```python
 def __init__(self, func, args):
@@ -6315,8 +5841,6 @@ track different volume locations (using `mp.in_volume`) or field components.
 
 <a id="Animate2D.__init__"></a>
 
-**Animate2D.\_\_init\_\_**
-
 ```python
 def __init__(self,
              sim,
@@ -6368,8 +5892,6 @@ Construct an `Animate2D` object.
 
 <a id="Animate2D.__call__"></a>
 
-**Animate2D.\_\_call\_\_**
-
 ```python
 def __call__(self, sim, todo):
 ```
@@ -6381,8 +5903,6 @@ Call self as a function.
 </div>
 
 <a id="Animate2D.grab_frame"></a>
-
-**Animate2D.grab\_frame**
 
 ```python
 def grab_frame(self):
@@ -6396,8 +5916,6 @@ def grab_frame(self):
 
 <a id="Animate2D.reset"></a>
 
-**Animate2D.reset**
-
 ```python
 def reset(self):
 ```
@@ -6410,8 +5928,6 @@ def reset(self):
 
 <a id="Animate2D.set_figure"></a>
 
-**Animate2D.set\_figure**
-
 ```python
 def set_figure(self, f):
 ```
@@ -6423,8 +5939,6 @@ def set_figure(self, f):
 </div>
 
 <a id="Animate2D.to_gif"></a>
-
-**Animate2D.to\_gif**
 
 ```python
 def to_gif(self, fps, filename):
@@ -6442,8 +5956,6 @@ format only supports 256 colors from a _predefined_ color palette. Requires
 
 <a id="Animate2D.to_jshtml"></a>
 
-**Animate2D.to\_jshtml**
-
 ```python
 def to_jshtml(self, fps):
 ```
@@ -6457,8 +5969,6 @@ playback. User must specify a frame rate `fps` in frames per second.
 </div>
 
 <a id="Animate2D.to_mp4"></a>
-
-**Animate2D.to\_mp4**
 
 ```python
 def to_mp4(self, fps, filename):
@@ -6537,8 +6047,6 @@ sim.run(mp.after_sources(h))
 
 <a id="Harminv.__init__"></a>
 
-**Harminv.\_\_init\_\_**
-
 ```python
 def __init__(self, c, pt, fcen, df, mxbands=None):
 ```
@@ -6559,8 +6067,6 @@ search for. Defaults to 100.
 
 <a id="Harminv.__call__"></a>
 
-**Harminv.\_\_call\_\_**
-
 ```python
 def __call__(self, sim, todo):
 ```
@@ -6580,8 +6086,6 @@ Miscellaneous Functions
 
 <a id="quiet"></a>
 
-**meep.quiet function**
-
 ```python
 def quiet(quietval=True):
 ```
@@ -6598,8 +6102,6 @@ value will persist across runs within the same script.
 
 <a id="verbosity"></a>
 
-**meep.verbosity function**
-
 ```python
 def verbosity(v=1):
 ```
@@ -6614,8 +6116,6 @@ output.
 
 
 <a id="interpolate"></a>
-
-**meep.interpolate function**
 
 ```python
 def interpolate(n, nums):
@@ -6634,8 +6134,6 @@ original list.
 
 <a id="get_flux_freqs"></a>
 
-**meep.get\_flux\_freqs function**
-
 ```python
 def get_flux_freqs(f):
 ```
@@ -6649,8 +6147,6 @@ spectrum for.
 
 
 <a id="get_fluxes"></a>
-
-**meep.get\_fluxes function**
 
 ```python
 def get_fluxes(f):
@@ -6666,8 +6162,6 @@ accumulated.
 
 <a id="scale_flux_fields"></a>
 
-**meep.scale\_flux\_fields function**
-
 ```python
 def scale_flux_fields(s, flux):
 ```
@@ -6682,8 +6176,6 @@ Scale the Fourier-transformed fields in `flux` by the complex number `s`. e.g.
 
 
 <a id="get_eigenmode_freqs"></a>
-
-**meep.get\_eigenmode\_freqs function**
 
 ```python
 def get_eigenmode_freqs(f):
@@ -6702,8 +6194,6 @@ spectrum for.
 
 <a id="get_energy_freqs"></a>
 
-**meep.get\_energy\_freqs function**
-
 ```python
 def get_energy_freqs(f):
 ```
@@ -6716,8 +6206,6 @@ spectrum for.
 </div>
 
 <a id="get_electric_energy"></a>
-
-**meep.get\_electric\_energy function**
 
 ```python
 def get_electric_energy(f):
@@ -6732,8 +6220,6 @@ electric fields that it has accumulated.
 
 <a id="get_magnetic_energy"></a>
 
-**meep.get\_magnetic\_energy function**
-
 ```python
 def get_magnetic_energy(f):
 ```
@@ -6746,8 +6232,6 @@ magnetic fields that it has accumulated.
 </div>
 
 <a id="get_total_energy"></a>
-
-**meep.get\_total\_energy function**
 
 ```python
 def get_total_energy(f):
@@ -6766,8 +6250,6 @@ total fields that it has accumulated.
 
 <a id="get_force_freqs"></a>
 
-**meep.get\_force\_freqs function**
-
 ```python
 def get_force_freqs(f):
 ```
@@ -6780,8 +6262,6 @@ spectrum for.
 </div>
 
 <a id="get_forces"></a>
-
-**meep.get\_forces function**
 
 ```python
 def get_forces(f):
@@ -6800,8 +6280,6 @@ accumulated.
 
 <a id="Ldos"></a>
 
-**meep.Ldos function**
-
 ```python
 def Ldos(*args):
 ```
@@ -6819,8 +6297,6 @@ argument.
 
 <a id="get_ldos_freqs"></a>
 
-**meep.get\_ldos\_freqs function**
-
 ```python
 def get_ldos_freqs(l):
 ```
@@ -6833,8 +6309,6 @@ spectrum for.
 </div>
 
 <a id="dft_ldos"></a>
-
-**meep.dft\_ldos function**
 
 ```python
 def dft_ldos(*args, **kwargs):
@@ -6862,8 +6336,6 @@ is complete.
 
 <a id="get_near2far_freqs"></a>
 
-**meep.get\_near2far\_freqs function**
-
 ```python
 def get_near2far_freqs(f):
 ```
@@ -6876,8 +6348,6 @@ spectrum for.
 </div>
 
 <a id="scale_near2far_fields"></a>
-
-**meep.scale\_near2far\_fields function**
 
 ```python
 def scale_near2far_fields(s, near2far):
@@ -6897,8 +6367,6 @@ Scale the Fourier-transformed fields in `near2far` by the complex number `s`. e.
 
 <a id="GDSII_layers"></a>
 
-**meep.GDSII\_layers function**
-
 ```python
 def GDSII_layers(fname):
 ```
@@ -6917,8 +6385,6 @@ Out[2]: [0, 1, 2, 3, 4, 5, 31, 32]
 
 <a id="GDSII_prisms"></a>
 
-**meep.GDSII\_prisms function**
-
 ```python
 def GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0):
 ```
@@ -6931,8 +6397,6 @@ Returns a list of `GeometricObject`s with `material` (`mp.Medium`) on layer numb
 </div>
 
 <a id="GDSII_vol"></a>
-
-**meep.GDSII\_vol function**
 
 ```python
 def GDSII_vol(fname, layer, zmin, zmax):
@@ -6955,8 +6419,6 @@ fr = mp.FluxRegion(volume=mp.GDSII_vol(fname, layer, zmin, zmax))
 
 
 <a id="stop_when_fields_decayed"></a>
-
-**meep.stop\_when\_fields\_decayed function**
 
 ```python
 def stop_when_fields_decayed(dt, c, pt, decay_by):
@@ -6982,8 +6444,6 @@ slow group velocities and are absorbed poorly by [PML](Perfectly_Matched_Layer.m
 
 <a id="stop_after_walltime"></a>
 
-**meep.stop\_after\_walltime function**
-
 ```python
 def stop_after_walltime(t):
 ```
@@ -6996,8 +6456,6 @@ parameter. Stops the simulation after `t` seconds of wall time have passed.
 </div>
 
 <a id="stop_on_interrupt"></a>
-
-**meep.stop\_on\_interrupt function**
 
 ```python
 def stop_on_interrupt():
@@ -7018,8 +6476,6 @@ follows the `run` function (e.g., outputting fields).
 
 <a id="output_epsilon"></a>
 
-**meep.output\_epsilon function**
-
 ```python
 def output_epsilon(sim, *step_func_args, **kwargs):
 ```
@@ -7035,8 +6491,6 @@ frequency-independent part of ε (the $\omega        o\infty$ limit).
 </div>
 
 <a id="output_mu"></a>
-
-**meep.output\_mu function**
 
 ```python
 def output_mu(sim, *step_func_args, **kwargs):
@@ -7054,8 +6508,6 @@ frequency-independent part of μ (the $\omega        o\infty$ limit).
 
 <a id="output_poynting"></a>
 
-**meep.output\_poynting function**
-
 ```python
 def output_poynting(sim):
 ```
@@ -7071,8 +6523,6 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 
 <a id="output_hpwr"></a>
 
-**meep.output\_hpwr function**
-
 ```python
 def output_hpwr(sim):
 ```
@@ -7085,8 +6535,6 @@ Output the magnetic-field energy density $\mathbf{H}^* \cdot \mathbf{B} / 2$
 
 <a id="output_dpwr"></a>
 
-**meep.output\_dpwr function**
-
 ```python
 def output_dpwr(sim):
 ```
@@ -7098,8 +6546,6 @@ Output the electric-field energy density $\mathbf{E}^* \cdot \mathbf{D} / 2$
 </div>
 
 <a id="output_tot_pwr"></a>
-
-**meep.output\_tot\_pwr function**
 
 ```python
 def output_tot_pwr(sim):
@@ -7115,8 +6561,6 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 </div>
 
 <a id="output_png"></a>
-
-**meep.output\_png function**
 
 ```python
 def output_png(compnt, options, rm_h5=True):
@@ -7148,8 +6592,6 @@ file requires `output_png(component, h5topng_options, rm_h5=False)`.
 
 <a id="output_hfield"></a>
 
-**meep.output\_hfield function**
-
 ```python
 def output_hfield(sim):
 ```
@@ -7162,8 +6604,6 @@ the different components are stored as different datasets within the *same* file
 </div>
 
 <a id="output_hfield_x"></a>
-
-**meep.output\_hfield\_x function**
 
 ```python
 def output_hfield_x(sim):
@@ -7179,8 +6619,6 @@ imaginary parts, respectively.
 
 <a id="output_hfield_y"></a>
 
-**meep.output\_hfield\_y function**
-
 ```python
 def output_hfield_y(sim):
 ```
@@ -7194,8 +6632,6 @@ imaginary parts, respectively.
 </div>
 
 <a id="output_hfield_z"></a>
-
-**meep.output\_hfield\_z function**
 
 ```python
 def output_hfield_z(sim):
@@ -7211,8 +6647,6 @@ imaginary parts, respectively.
 
 <a id="output_hfield_r"></a>
 
-**meep.output\_hfield\_r function**
-
 ```python
 def output_hfield_r(sim):
 ```
@@ -7226,8 +6660,6 @@ imaginary parts, respectively.
 </div>
 
 <a id="output_hfield_p"></a>
-
-**meep.output\_hfield\_p function**
 
 ```python
 def output_hfield_p(sim):
@@ -7244,8 +6676,6 @@ and imaginary parts, respectively.
 
 <a id="output_bfield"></a>
 
-**meep.output\_bfield function**
-
 ```python
 def output_bfield(sim):
 ```
@@ -7258,8 +6688,6 @@ the different components are stored as different datasets within the *same* file
 </div>
 
 <a id="output_bfield_x"></a>
-
-**meep.output\_bfield\_x function**
 
 ```python
 def output_bfield_x(sim):
@@ -7275,8 +6703,6 @@ imaginary parts, respectively.
 
 <a id="output_bfield_y"></a>
 
-**meep.output\_bfield\_y function**
-
 ```python
 def output_bfield_y(sim):
 ```
@@ -7290,8 +6716,6 @@ imaginary parts, respectively.
 </div>
 
 <a id="output_bfield_z"></a>
-
-**meep.output\_bfield\_z function**
 
 ```python
 def output_bfield_z(sim):
@@ -7307,8 +6731,6 @@ imaginary parts, respectively.
 
 <a id="output_bfield_r"></a>
 
-**meep.output\_bfield\_r function**
-
 ```python
 def output_bfield_r(sim):
 ```
@@ -7322,8 +6744,6 @@ imaginary parts, respectively.
 </div>
 
 <a id="output_bfield_p"></a>
-
-**meep.output\_bfield\_p function**
 
 ```python
 def output_bfield_p(sim):
@@ -7343,8 +6763,6 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 
 <a id="output_efield"></a>
 
-**meep.output\_efield function**
-
 ```python
 def output_efield(sim):
 ```
@@ -7357,8 +6775,6 @@ the different components are stored as different datasets within the *same* file
 </div>
 
 <a id="output_efield_x"></a>
-
-**meep.output\_efield\_x function**
 
 ```python
 def output_efield_x(sim):
@@ -7374,8 +6790,6 @@ imaginary parts, respectively.
 
 <a id="output_efield_y"></a>
 
-**meep.output\_efield\_y function**
-
 ```python
 def output_efield_y(sim):
 ```
@@ -7389,8 +6803,6 @@ imaginary parts, respectively.
 </div>
 
 <a id="output_efield_z"></a>
-
-**meep.output\_efield\_z function**
 
 ```python
 def output_efield_z(sim):
@@ -7406,8 +6818,6 @@ imaginary parts, respectively.
 
 <a id="output_efield_r"></a>
 
-**meep.output\_efield\_r function**
-
 ```python
 def output_efield_r(sim):
 ```
@@ -7421,8 +6831,6 @@ imaginary parts, respectively.
 </div>
 
 <a id="output_efield_p"></a>
-
-**meep.output\_efield\_p function**
 
 ```python
 def output_efield_p(sim):
@@ -7442,8 +6850,6 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 
 <a id="output_dfield"></a>
 
-**meep.output\_dfield function**
-
 ```python
 def output_dfield(sim):
 ```
@@ -7456,8 +6862,6 @@ is, the different components are stored as different datasets within the *same* 
 </div>
 
 <a id="output_dfield_x"></a>
-
-**meep.output\_dfield\_x function**
 
 ```python
 def output_dfield_x(sim):
@@ -7473,8 +6877,6 @@ and imaginary parts, respectively.
 
 <a id="output_dfield_y"></a>
 
-**meep.output\_dfield\_y function**
-
 ```python
 def output_dfield_y(sim):
 ```
@@ -7488,8 +6890,6 @@ and imaginary parts, respectively.
 </div>
 
 <a id="output_dfield_z"></a>
-
-**meep.output\_dfield\_z function**
 
 ```python
 def output_dfield_z(sim):
@@ -7505,8 +6905,6 @@ and imaginary parts, respectively.
 
 <a id="output_dfield_r"></a>
 
-**meep.output\_dfield\_r function**
-
 ```python
 def output_dfield_r(sim):
 ```
@@ -7520,8 +6918,6 @@ and imaginary parts, respectively.
 </div>
 
 <a id="output_dfield_p"></a>
-
-**meep.output\_dfield\_p function**
 
 ```python
 def output_dfield_p(sim):
@@ -7541,8 +6937,6 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 
 <a id="output_sfield"></a>
 
-**meep.output\_sfield function**
-
 ```python
 def output_sfield(sim):
 ```
@@ -7559,8 +6953,6 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 
 <a id="output_sfield_x"></a>
 
-**meep.output\_sfield\_x function**
-
 ```python
 def output_sfield_x(sim):
 ```
@@ -7574,8 +6966,6 @@ and imaginary parts, respectively.
 </div>
 
 <a id="output_sfield_y"></a>
-
-**meep.output\_sfield\_y function**
 
 ```python
 def output_sfield_y(sim):
@@ -7591,8 +6981,6 @@ and imaginary parts, respectively.
 
 <a id="output_sfield_z"></a>
 
-**meep.output\_sfield\_z function**
-
 ```python
 def output_sfield_z(sim):
 ```
@@ -7607,8 +6995,6 @@ and imaginary parts, respectively.
 
 <a id="output_sfield_r"></a>
 
-**meep.output\_sfield\_r function**
-
 ```python
 def output_sfield_r(sim):
 ```
@@ -7622,8 +7008,6 @@ and imaginary parts, respectively.
 </div>
 
 <a id="output_sfield_p"></a>
-
-**meep.output\_sfield\_p function**
 
 ```python
 def output_sfield_p(sim):
@@ -8153,6 +7537,7 @@ plt.show()
 
 #### Source Slices
 
+* *get_source_slice(component, vol=None, center=None, size=None)* — Deprecated. Use `get_source` below.
 * [Simulation.get_source(component, vol=None, center=None, size=None)](#Simulation.get_source)
 
 
@@ -8174,8 +7559,6 @@ See also [Tutorial/Basics](Python_Tutorials/Basics.md) for examples.
 
 <a id="combine_step_funcs"></a>
 
-**meep.combine\_step\_funcs function**
-
 ```python
 def combine_step_funcs(*step_funcs):
 ```
@@ -8188,8 +7571,6 @@ all of the passed step functions.
 </div>
 
 <a id="synchronized_magnetic"></a>
-
-**meep.synchronized\_magnetic function**
 
 ```python
 def synchronized_magnetic(*step_funcs):
@@ -8210,8 +7591,6 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 
 <a id="when_true"></a>
 
-**meep.when\_true function**
-
 ```python
 def when_true(cond, *step_funcs):
 ```
@@ -8224,8 +7603,6 @@ no arguments), evaluate the step functions whenever `condition` returns `True`.
 </div>
 
 <a id="when_false"></a>
-
-**meep.when\_false function**
 
 ```python
 def when_false(cond, *step_funcs):
@@ -8240,8 +7617,6 @@ no arguments), evaluate the step functions whenever `condition` returns `False`.
 
 <a id="at_every"></a>
 
-**meep.at\_every function**
-
 ```python
 def at_every(dt, *step_funcs):
 ```
@@ -8254,8 +7629,6 @@ Given zero or more step functions, evaluates them at every time interval of $dT$
 </div>
 
 <a id="after_time"></a>
-
-**meep.after\_time function**
 
 ```python
 def after_time(t, *step_funcs):
@@ -8270,8 +7643,6 @@ units have elapsed from the start of the run.
 
 <a id="before_time"></a>
 
-**meep.before\_time function**
-
 ```python
 def before_time(t, *step_funcs):
 ```
@@ -8284,8 +7655,6 @@ units have elapsed from the start of the run.
 </div>
 
 <a id="at_time"></a>
-
-**meep.at\_time function**
 
 ```python
 def at_time(t, *step_funcs):
@@ -8300,8 +7669,6 @@ have elapsed from the start of the run.
 
 <a id="after_sources"></a>
 
-**meep.after\_sources function**
-
 ```python
 def after_sources(*step_funcs):
 ```
@@ -8314,8 +7681,6 @@ sources have turned off.
 </div>
 
 <a id="after_sources_and_time"></a>
-
-**meep.after\_sources\_and\_time function**
 
 ```python
 def after_sources_and_time(t, *step_funcs):
@@ -8330,8 +7695,6 @@ sources have turned off, plus an additional $T$ time units have elapsed.
 
 <a id="during_sources"></a>
 
-**meep.during\_sources function**
-
 ```python
 def during_sources(*step_funcs):
 ```
@@ -8345,8 +7708,6 @@ sources have turned off.
 
 <a id="at_beginning"></a>
 
-**meep.at\_beginning function**
-
 ```python
 def at_beginning(*step_funcs):
 ```
@@ -8359,8 +7720,6 @@ run.
 </div>
 
 <a id="at_end"></a>
-
-**meep.at\_end function**
 
 ```python
 def at_end(*step_funcs):
@@ -8378,8 +7737,6 @@ Given zero or more step functions, evaluates them only once, at the end of the r
 
 <a id="in_volume"></a>
 
-**meep.in\_volume function**
-
 ```python
 def in_volume(v, *step_funcs):
 ```
@@ -8394,8 +7751,6 @@ output a subset (or a superset) of the cell, corresponding to the `meep::volume*
 
 <a id="in_point"></a>
 
-**meep.in\_point function**
-
 ```python
 def in_point(pt, *step_funcs):
 ```
@@ -8408,8 +7763,6 @@ output a single *point* of data, at `pt` (a `Vector3`).
 </div>
 
 <a id="to_appended"></a>
-
-**meep.to\_appended function**
 
 ```python
 def to_appended(fname, *step_funcs):
@@ -8425,8 +7778,6 @@ dimension* to their datasets, corresponding to time.
 </div>
 
 <a id="with_prefix"></a>
-
-**meep.with\_prefix function**
 
 ```python
 def with_prefix(pre, *step_funcs):

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -8,6 +8,55 @@ The Python API functions and classes can be found in the `meep` module, which sh
 
 [TOC]
 
+
+Predefined Variables
+--------------------
+
+These are available directly via the `meep` package.
+
+**`air`, `vacuum` [`Medium` class ]**
+—
+Two aliases for a predefined material type with a dielectric constant of 1.
+
+**`perfect_electric_conductor` or `metal` [`Medium` class ]**
+—
+A predefined material type corresponding to a perfect electric conductor at the boundary of which the parallel electric field is zero. Technically, $\varepsilon = -\infty$.
+
+**`perfect_magnetic_conductor` [`Medium` class ]**
+—
+A predefined material type corresponding to a perfect magnetic conductor at the boundary of which the parallel magnetic field is zero. Technically, $\mu = -\infty$.
+
+**`inf` [`number`]**
+—
+A big number (10<sup>20</sup>) to use for "infinite" dimensions of objects.
+
+Constants (Enumerated Types)
+----------------------------
+
+Several of the functions/classes in Meep ask you to specify e.g. a field component or a direction in the grid. These should be one of the following constants (which are available directly via the `meep` package):
+
+**`direction` constants**
+—
+Specify a direction in the grid. One of `X`, `Y`, `Z`, `R`, `P` for $x$, $y$, $z$, $r$, $\phi$, respectively.
+
+**`side` constants**
+—
+Specify particular boundary in the positive `High` (e.g., +`X`) or negative `Low` (e.g., -`X`) direction.
+
+**`boundary_condition` constants**
+—
+`Metallic` (i.e., zero electric field) or `Magnetic` (i.e., zero magnetic field).
+
+**`component` constants**
+—
+Specify a particular field or other component. One of `Ex`, `Ey`, `Ez`, `Er`, `Ep`, `Hx`, `Hy`, `Hz`, `Hy`, `Hp`, `Hz`, `Bx`, `By`, `Bz`, `By`, `Bp`, `Bz`, `Dx`, `Dy`, `Dz`, `Dr`, `Dp`, `Dielectric`, `Permeability`, for $E_x$, $E_y$, $E_z$, $E_r$, $E_\phi$, $H_x$, $H_y$, $H_z$, $H_r$, $H_\phi$, $B_x$, $B_y$, $B_z$, $B_r$, $B_\phi$, $D_x$, $D_y$, $D_z$, $D_r$, $D_\phi$, ε, μ, respectively.
+
+**`derived_component` constants**
+—
+These are additional components which are not actually stored by Meep but are computed as needed, mainly for use in output functions. One of `Sx`, `Sy`, `Sz`, `Sr`, `Sp`, `EnergyDensity`, `D_EnergyDensity`, `H_EnergyDensity` for $S_x$, $S_y$, $S_z$, $S_r$, $S_\phi$ (components of the Poynting vector $\mathrm{Re}\,\mathbf{E}^* \times \mathbf{H}$), $(\mathbf{E}^* \cdot \mathbf{D} + \mathbf{H}^* \cdot \mathbf{B})/2$, $\mathbf{E}^* \cdot \mathbf{D}/2$, $\mathbf{H}^* \cdot \mathbf{B}/2$, respectively.
+
+
+
 The Simulation Class
 ---------------------
 
@@ -38,10 +87,11 @@ get this prefix by calling `get_filename_prefix`.
 
 </div>
 
-<div class="class_members" markdown="1">
 
-
+   
 <a id="Simulation.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -311,7 +361,264 @@ use. See also [SWIG Wrappers](#swig-wrappers).
 
 </div>
 
+</div>
+
+
+### Output File Names
+
+The output filenames used by Meep, e.g. for HDF5 files, are automatically prefixed by the
+input variable `filename_prefix`. If `filename_prefix` is `None` (the default), however,
+then Meep constructs a default prefix based on the current Python filename with `".py"`
+replaced by `"-"`: e.g. `test.py` implies a prefix of `"test-"`. You can get this prefix,
+or set the output folder, with these methods of the `Simulation` class:
+
+
+<a id="Simulation.get_filename_prefix"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_filename_prefix(self):
+```
+
+<div class="method_docstring" markdown="1">
+
+Return the current prefix string that is prepended, by default, to all file names.
+
+If you don't want to use any prefix, then you should set `filename_prefix` to the
+empty string `''`.
+
+In addition to the filename prefix, you can also specify that all the output files
+be written into a newly-created directory (if it does not yet exist). This is done
+by calling `Simulation.use_output_directory([dirname])`
+
+</div>
+
+</div>
+
+<a id="Simulation.use_output_directory"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def use_output_directory(self, dname=''):
+```
+
+<div class="method_docstring" markdown="1">
+
+Put output in a subdirectory, which is created if necessary. If the optional
+argument dirname is specified, that is the name of the directory. Otherwise, the
+directory name is the current Python file name with `".py"` replaced by `"-out"`:
+e.g. `test.py` implies a directory of `"test-out"`.
+
+</div>
+
+</div>
+
+
+### Simulation Time
+
+The `Simulation` class provides the following time-related methods:
+
+
+<a id="Simulation.meep_time"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def meep_time(self):
+```
+
+<div class="method_docstring" markdown="1">
+
+Return the current simulation time in simulation time units (e.g. during a run
+function). This is not the wall-clock time.
+
+Occasionally, e.g. for termination conditions of the form $time < T?$, it is
+desirable to round the time to single precision in order to avoid small
+differences in roundoff error from making your results different by one timestep
+from machine to machine (a difference much bigger than roundoff error); in this
+case you can call `Simulation.round_time()` instead, which returns the time
+rounded to single precision.
+
+</div>
+
+</div>
+
+<a id="Simulation.print_times"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def print_times(self):
+```
+
+<div class="method_docstring" markdown="1">
+
+Call after running a simulation to print the times spent on various types of work.
+Example output:
+
+```
+Field time usage:
+        connecting chunks: 0.0819176 s +/- 0.000428381 s
+            time stepping: 0.198949 s +/- 0.0225551 s
+            communicating: 0.410577 s +/- 0.278853 s
+        outputting fields: 0.512352 s +/- 0.0238399 s
+     Fourier transforming: 0.0738274 s +/- 0.0967926 s
+          everything else: 0.324933 s +/- 0.377573 s
+```
+
+</div>
+
+</div>
+
+<a id="Simulation.time_spent_on"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def time_spent_on(self, time_sink):
+```
+
+<div class="method_docstring" markdown="1">
+
+Return a list of times spent by each process for a type of work `time_sink` which
+can be one of nine integer values `0`-`8`: (`0`) connecting chunks, (`1`) time
+stepping, (`2`) boundaries, (`3`) MPI/synchronization, (`4`) field output, (`5`)
+Fourier transforming, (`6`) MPB, (`7`) near to far field transformation, and (`8`)
+other.
+
+</div>
+
+</div>
+
+<a id="Simulation.mean_time_spent_on"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def mean_time_spent_on(self, time_sink):
+```
+
+<div class="method_docstring" markdown="1">
+
+Return the mean time spent by all processes for a type of work `time_sink` which
+can be one of nine integer values `0`-`8`: (`0`) connecting chunks, (`1`) time
+stepping, (`2`) boundaries, (`3`) MPI/synchronization, (`4`) field output, (`5`)
+Fourier transforming, (`6`) MPB, (`7`) near to far field transformation, and (`8`)
+other.
+
+</div>
+
+</div>
+
+
+### Field Computations
+
+Meep supports a large number of functions to perform computations on the fields. Most of them are accessed via the lower-level C++/SWIG interface. Some of them are based on the following simpler, higher-level versions. They are accessible as methods of a `Simulation` instance.
+
+
+<a id="Simulation.set_boundary"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def set_boundary(self, side, direction, condition):
+```
+
+<div class="method_docstring" markdown="1">
+
+Sets the condition of the boundary on the specified side in the specified
+direction. See the [Constants (Enumerated Types)](#constants-enumerated-types)
+section for valid `side`, `direction`, and `boundary_condition` values.
+
+</div>
+
+</div>
+
+<a id="Simulation.phase_in_material"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def phase_in_material(self, structure, time):
+```
+
+<div class="method_docstring" markdown="1">
+
+`newstructure` should be the `structure` field of another `Simulation` object with
+the same cell size and resolution.   Over the next time period `phasetime` (in the
+current simulation's time units), the current structure (ε, μ, and conductivity)
+will be gradually changed to `newstructure`. In particular, at each timestep it
+linearly interpolates between the old structure and the new structure. After
+`phasetime` has elapsed, the structure will remain equal to `newstructure`. This
+is demonstrated in the following image for two [Cylinder](#cylinder) objects (the
+simulation script is in
+[examples/phase_in_material.py](https://github.com/NanoComp/meep/blob/master/python/examples/phase_in_material.py)).
+
+![](images/phase-in-material.png)
+
+</div>
+
+</div>
+
+<a id="Simulation.get_field_point"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_field_point(self, c, pt):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a `component` or `derived_component` constant `c` and a `Vector3` `pt`,
+returns the value of that component at that point.
+
+</div>
+
+</div>
+
+<a id="Simulation.get_epsilon_point"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_epsilon_point(self, pt, frequency=0, omega=0):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a frequency `frequency` and a `Vector3` `pt`, returns the average eigenvalue
+of the permittivity tensor at that location and frequency. If `frequency` is
+non-zero, the result is complex valued; otherwise it is the real,
+frequency-independent part of ε (the $\omega    o\infty$ limit).
+
+</div>
+
+</div>
+
+<a id="Simulation.initialize_field"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def initialize_field(self, cmpnt, amp_func):
+```
+
+<div class="method_docstring" markdown="1">
+
+Initialize the component `c` fields using the function `func` which has a single
+argument, a `Vector3` giving a position and returns a complex number for the value
+of the field at that point.
+
+</div>
+
+</div>
+
 <a id="Simulation.add_dft_fields"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def add_dft_fields(self, *args, **kwargs):
@@ -331,243 +638,32 @@ fields evaluated at each corresponding Yee grid point is available by setting
 
 </div>
 
-<a id="Simulation.add_eigenmode"></a>
-
-```python
-def add_eigenmode(self, *args):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
 </div>
 
-<a id="Simulation.add_energy"></a>
+<a id="Simulation.flux_in_box"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
-def add_energy(self, *args):
+def flux_in_box(self, d, box=None, center=None, size=None):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Add a bunch of `EnergyRegion`s to the current simulation (initializing the fields
-if they have not yet been initialized), telling Meep to accumulate the appropriate
-field Fourier transforms for `nfreq` equally spaced frequencies covering the
-frequency range `fcen-df/2` to `fcen+df/2` or an array/list `freq` for arbitrarily
-spaced frequencies. Return an *energy object*, which you can pass to the functions
-below to get the energy spectrum, etcetera.
+Given a `direction` constant, and a `mp.Volume`, returns the flux (the integral of
+$\Re [\mathbf{E}^*      imes \mathbf{H}]$) in that volume. Most commonly, you specify
+a volume that is a plane or a line, and a direction perpendicular to it, e.g.
+`flux_in_box(d=mp.X,mp.Volume(center=mp.Vector3(0,0,0),size=mp.Vector3(0,1,1)))`.
+If the `center` and `size` arguments are provided instead of `box`, Meep will
+construct the appropriate volume for you.
 
 </div>
-
-<a id="Simulation.add_flux"></a>
-
-```python
-def add_flux(self, *args):
-```
-
-<div class="method_docstring" markdown="1">
-
-Add a bunch of `FluxRegion`s to the current simulation (initializing the fields if
-they have not yet been initialized), telling Meep to accumulate the appropriate
-field Fourier transforms for `nfreq` equally spaced frequencies covering the
-frequency range `fcen-df/2` to `fcen+df/2` or an array/list `freq` for arbitrarily
-spaced frequencies. Return a *flux object*, which you can pass to the functions
-below to get the flux spectrum, etcetera.
-
-</div>
-
-<a id="Simulation.add_force"></a>
-
-```python
-def add_force(self, *args):
-```
-
-<div class="method_docstring" markdown="1">
-
-Add a bunch of `ForceRegion`s to the current simulation (initializing the fields
-if they have not yet been initialized), telling Meep to accumulate the appropriate
-field Fourier transforms for `nfreq` equally spaced frequencies covering the
-frequency range `fcen-df/2` to `fcen+df/2` or an array/list `freq` for arbitrarily
-spaced frequencies. Return a `force`object, which you can pass to the functions
-below to get the force spectrum, etcetera.
-
-</div>
-
-<a id="Simulation.add_mode_monitor"></a>
-
-```python
-def add_mode_monitor(self, *args):
-```
-
-<div class="method_docstring" markdown="1">
-
-Similar to `add_flux`, but for use with `get_eigenmode_coefficients`.
-
-</div>
-
-<a id="Simulation.add_near2far"></a>
-
-```python
-def add_near2far(self, *args, **kwargs):
-```
-
-<div class="method_docstring" markdown="1">
-
-add_near2far(fcen, df, nfreq, freq, Near2FarRegions..., nperiods=1)
-
-Add a bunch of `Near2FarRegion`s to the current simulation (initializing the
-fields if they have not yet been initialized), telling Meep to accumulate the
-appropriate field Fourier transforms for `nfreq` equally spaced frequencies
-covering the frequency range `fcen-df/2` to `fcen+df/2` or an array/list `freq`
-for arbitrarily spaced frequencies. Return a `near2far` object, which you can pass
-to the functions below to get the far fields.
-
-</div>
-
-<a id="Simulation.add_source"></a>
-
-```python
-def add_source(self, src):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.change_k_point"></a>
-
-```python
-def change_k_point(self, k):
-```
-
-<div class="method_docstring" markdown="1">
-
-Change the `k_point` (the Bloch periodicity).
-
-</div>
-
-<a id="Simulation.change_sources"></a>
-
-```python
-def change_sources(self, new_sources):
-```
-
-<div class="method_docstring" markdown="1">
-
-Change the list of sources in `Simulation.sources` to `new_sources`, and changes
-the sources used for the current simulation. `new_sources` must be a list of
-`Source` objects.
-
-</div>
-
-<a id="Simulation.display_electric_energy"></a>
-
-```python
-def display_electric_energy(self, *energys):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a number of energy objects, this displays a comma-separated table of
-frequencies and energy density spectra for the electric fields prefixed by
-"electric_energy1:" or similar (where the number is incremented after each run).
-All of the energy should be for the same `fcen`/`df`/`nfreq` or `freq`. The first
-column are the frequencies, and subsequent columns are the energy density spectra.
-
-</div>
-
-<a id="Simulation.display_fluxes"></a>
-
-```python
-def display_fluxes(self, *fluxes):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a number of flux objects, this displays a comma-separated table of
-frequencies and flux spectra, prefixed by "flux1:" or similar (where the number is
-incremented after each run). All of the fluxes should be for the same
-`fcen`/`df`/`nfreq` or `freq`. The first column are the frequencies, and
-subsequent columns are the flux spectra.
-
-</div>
-
-<a id="Simulation.display_forces"></a>
-
-```python
-def display_forces(self, *forces):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a number of force objects, this displays a comma-separated table of
-frequencies and force spectra, prefixed by "force1:" or similar (where the number
-is incremented after each run). All of the forces should be for the same
-`fcen`/`df`/`nfreq` or `freq`. The first column are the frequencies, and
-subsequent columns are the force spectra.
-
-</div>
-
-<a id="Simulation.display_magnetic_energy"></a>
-
-```python
-def display_magnetic_energy(self, *energys):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a number of energy objects, this displays a comma-separated table of
-frequencies and energy density spectra for the magnetic fields prefixed by
-"magnetic_energy1:" or similar (where the number is incremented after each run).
-All of the energy should be for the same `fcen`/`df`/`nfreq` or `freq`. The first
-column are the frequencies, and subsequent columns are the energy density spectra.
-
-</div>
-
-<a id="Simulation.display_total_energy"></a>
-
-```python
-def display_total_energy(self, *energys):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a number of energy objects, this displays a comma-separated table of
-frequencies and energy density spectra for the total fields "total_energy1:" or
-similar (where the number is incremented after each run). All of the energy should
-be for the same `fcen`/`df`/`nfreq` or `freq`. The first column are the
-frequencies, and subsequent columns are the energy density spectra.
-
-</div>
-
-<a id="Simulation.dump_chunk_layout"></a>
-
-```python
-def dump_chunk_layout(self, fname):
-```
-
-<div class="method_docstring" markdown="1">
-
-Dumps the chunk layout to file `fname`.
-
-</div>
-
-<a id="Simulation.dump_structure"></a>
-
-```python
-def dump_structure(self, fname):
-```
-
-<div class="method_docstring" markdown="1">
-
-Dumps the structure to the file `fname`.
 
 </div>
 
 <a id="Simulation.electric_energy_in_box"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def electric_energy_in_box(self, box=None, center=None, size=None):
@@ -587,7 +683,35 @@ volume.
 
 </div>
 
+</div>
+
+<a id="Simulation.magnetic_energy_in_box"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def magnetic_energy_in_box(self, box=None, center=None, size=None):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a `mp.Volume`, returns the integral of the magnetic-field energy
+$\mathbf{H}^* \cdot \mathbf{B}/2$ in the given volume. If the volume has zero size
+along a dimension, a lower-dimensional integral is used. If the `center` and
+`size` arguments are provided instead of `box`, Meep will construct the
+appropriate volume for you. Note: in cylindrical coordinates $(r,\phi,z)$, the
+integrand is
+[multiplied](https://en.wikipedia.org/wiki/Cylindrical_coordinate_system#Line_and_volume_elements)
+by the circumference $2\pi r$, or equivalently the integral is over an annular
+volume.
+
+</div>
+
+</div>
+
 <a id="Simulation.field_energy_in_box"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def field_energy_in_box(self, box=None, center=None, size=None):
@@ -607,951 +731,116 @@ volume.
 
 </div>
 
-<a id="Simulation.flux_in_box"></a>
+</div>
+
+<a id="Simulation.modal_volume_in_box"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
-def flux_in_box(self, d, box=None, center=None, size=None):
+def modal_volume_in_box(self, box=None, center=None, size=None):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Given a `direction` constant, and a `mp.Volume`, returns the flux (the integral of
-$\Re [\mathbf{E}^*      imes \mathbf{H}]$) in that volume. Most commonly, you specify
-a volume that is a plane or a line, and a direction perpendicular to it, e.g.
-`flux_in_box(d=mp.X,mp.Volume(center=mp.Vector3(0,0,0),size=mp.Vector3(0,1,1)))`.
-If the `center` and `size` arguments are provided instead of `box`, Meep will
-construct the appropriate volume for you.
+Given a `mp.Volume`, returns the instantaneous modal volume according to the
+Purcell-effect definition: integral (ε|E|<sup>2</sup>) / maximum
+(ε|E|<sup>2</sup>). If no volume argument is provided, the entire cell is used by
+default. If the `center` and `size` arguments are provided instead of `box`, Meep
+will construct the appropriate volume for you.
+
+Note that if you are at a fixed frequency and you use complex fields (via
+Bloch-periodic boundary conditions or `fields_complex=True`), then one half of the
+flux or energy integrals above corresponds to the time average of the flux or
+energy for a simulation with real fields.
+
+Often, you want the integration box to be the entire cell. A useful function to
+return this box, which you can then use for the `box` arguments above, is
+`Simulation.total_volume()`.
+
+One versatile feature is that you can supply an arbitrary function
+$f(\mathbf{x},c_1,c_2,\ldots)$ of position $\mathbf{x}$ and various field
+components $c_1,\ldots$ and ask Meep to integrate it over a given volume, find its
+maximum, or output it (via `output_field_function`, described later). This is done
+via the functions:
 
 </div>
 
-<a id="Simulation.get_array"></a>
+</div>
+
+<a id="Simulation.integrate_field_function"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
-def get_array(self,
-              component=None,
-              vol=None,
-              center=None,
-              size=None,
-              cmplx=None,
-              arr=None,
-              frequency=0,
-              omega=0):
+def integrate_field_function(self,
+                             cs,
+                             func,
+                             where=None,
+                             center=None,
+                             size=None):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Takes as input a subregion of the cell and the field/material component. The
-method returns a NumPy array containing values of the field/material at the
-current simulation time.
+Returns the integral of the complex-valued function `func` over the `Volume`
+specified by `where` (defaults to entire cell) for the `meep::fields` contained in
+the `Simulation` instance that calls this method. `func` is a function of position
+(a `Vector3`, its first argument) and zero or more field components specified by
+`cs`: a list of `component` constants. `func` can be real- or complex-valued. The
+volume can optionally be specified via the `center` and `size` arguments.
 
-**Parameters:**
+If any dimension of `where` is zero, that dimension is not integrated over. In
+this way you can specify 1d, 2d, or 3d integrals.
 
-+ `vol`: `Volume`; the orthogonal subregion/slice of the computational volume. The
-  return value of `get_array` has the same dimensions as the `Volume`'s `size`
-  attribute. If `None` (default), then a `size` and `center` must be specified.
-
-+ `center`, `size` : `Vector3`; if both are specified, the library will construct
-  an appropriate `Volume`. This is a convenience feature and alternative to
-  supplying a `Volume`.
-
-+ `component`: field/material component (i.e., `mp.Ex`, `mp.Hy`, `mp.Sz`,
-  `mp.Dielectric`, etc). Defaults to `mp.Ez`.
-
-+ `cmplx`: `boolean`; if `True`, return complex-valued data otherwise return
-  real-valued data (default).
-
-+ `arr`: optional field to pass a pre-allocated NumPy array of the correct size,
-  which will be overwritten with the field/material data instead of allocating a
-  new array.  Normally, this will be the array returned from a previous call to
-  `get_array` for a similar slice, allowing one to re-use `arr` (e.g., when
-  fetching the same slice repeatedly at different times).
-
-+ `frequency`: optional frequency point over which the average eigenvalue of the
-  dielectric and permeability tensors are evaluated (defaults to 0).
-
-For convenience, the following wrappers for `get_array` over the entire cell are
-available: `get_epsilon()`, `get_mu()`, `get_hpwr()`, `get_dpwr()`,
-`get_tot_pwr()`, `get_Xfield()`, `get_Xfield_x()`, `get_Xfield_y()`,
-`get_Xfield_z()`, `get_Xfield_r()`, `get_Xfield_p()` where `X` is one of `h`, `b`,
-`e`, `d`, or `s`. The routines `get_Xfield_*` all return an array type consistent
-with the fields (real or complex). The routines `get_epsilon()` and `get_mu()`
-accept the optional `frequency` parameter (defaults to 0).
-
-**Note on array-slice dimensions:** The routines `get_epsilon`, `get_Xfield_z`,
-etc. use as default `size=meep.Simulation.fields.total_volume()` which for
-simulations involving Bloch-periodic boundaries (via `k_point`) will result in
-arrays that have slightly *different* dimensions than e.g.
-`get_array(center=meep.Vector3(), size=cell_size, component=meep.Dielectric`, etc.
-(i.e., the slice spans the entire cell volume `cell_size`). Neither of these
-approaches is "wrong", they are just slightly different methods of fetching the
-boundaries. The key point is that if you pass the same value for the `size`
-parameter, or use the default, the slicing routines always give you the same-size
-array for all components. You should *not* try to predict the exact size of these
-arrays; rather, you should simply rely on Meep's output.
+Note: in cylindrical coordinates $(r,\phi,z)$, the integrand is
+[multiplied](https://en.wikipedia.org/wiki/Cylindrical_coordinate_system#Line_and_volume_elements)
+by the circumference $2\pi r$, or equivalently the integral is over an annular
+volume.
 
 </div>
 
-<a id="Simulation.get_array_metadata"></a>
-
-```python
-def get_array_metadata(self,
-                       vol=None,
-                       center=None,
-                       size=None,
-                       dft_cell=None,
-                       collapse=False,
-                       snap=False,
-                       return_pw=False):
-```
-
-<div class="method_docstring" markdown="1">
-
-This routine provides geometric information useful for interpreting the arrays
-returned by `get_array` or `get_dft_array` for the spatial region defined by `vol`
-or `center/size`. In both cases, the return value is a tuple `(x,y,z,w)`, where:
-
-+ `x,y,z` are 1d NumPy arrays storing the $x,y,z$ coordinates of the points in the
-  grid slice
-+ `w` is an array of the same dimensions as the array returned by
-  `get_array`/`get_dft_array`, whose entries are the weights in a cubature rule
-  for integrating over the spatial region (with the points in the cubature rule
-  being just the grid points contained in the region). Thus, if $Q(\mathbf{x})$ is
-  some spatially-varying quantity whose value at the $n$th grid point is $Q_n$,
-  the integral of $Q$ over the region may be approximated by the sum:
-
-$$ \int_{\mathcal V} Q(\mathbf{x})d\mathbf{x} pprox \sum_{n} w_n Q_n.$$
-
-This is a 1-, 2-, or 3-dimensional integral depending on the number of dimensions
-in which $\mathcal{V}$ has zero extent. If the $\{Q_n\}$ samples are stored in an
-array `Q` of the same dimensions as `w`, then evaluating the sum on the RHS is
-just one line: `np.sum(w*Q).`
-
-A convenience parameter `dft_cell` is provided as an alternative to `vol` or
-`center/size`; set `dft_cell` to a `dft_flux` or `dft_fields` object to define the
-region covered by the array. If the `dft` argument is provided then all other
-arguments (`vol`, `center`, and `size`) are ignored. If no arguments are provided,
-then the entire cell is used.
-
 </div>
 
-<a id="Simulation.get_avg_chunk_communication_area"></a>
+<a id="Simulation.max_abs_field_function"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
-def get_avg_chunk_communication_area(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_bfield"></a>
-
-```python
-def get_bfield(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_bfield_p"></a>
-
-```python
-def get_bfield_p(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_bfield_r"></a>
-
-```python
-def get_bfield_r(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_bfield_x"></a>
-
-```python
-def get_bfield_x(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_bfield_y"></a>
-
-```python
-def get_bfield_y(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_bfield_z"></a>
-
-```python
-def get_bfield_z(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_dfield"></a>
-
-```python
-def get_dfield(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_dfield_p"></a>
-
-```python
-def get_dfield_p(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_dfield_r"></a>
-
-```python
-def get_dfield_r(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_dfield_x"></a>
-
-```python
-def get_dfield_x(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_dfield_y"></a>
-
-```python
-def get_dfield_y(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_dfield_z"></a>
-
-```python
-def get_dfield_z(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_dft_array"></a>
-
-```python
-def get_dft_array(self, dft_obj, component, num_freq):
-```
-
-<div class="method_docstring" markdown="1">
-
-Returns the Fourier-transformed fields as a NumPy array.
-
-**Parameters:**
-
-+ `dft_obj`: a `dft_flux`, `dft_force`, `dft_fields`, or `dft_near2far` object
-  obtained from calling the appropriate `add` function (e.g., `mp.add_flux`).
-
-+ `component`: a field component (e.g., `mp.Ez`)
-
-+ `num_freq`: the index of the frequency: an integer in the range `0...nfreq-1`,
-  where `nfreq` is the number of frequencies stored in `dft_obj` as set by the
-  `nfreq` parameter to `add_dft_fields`, `add_dft_flux`, etc.
-
-</div>
-
-<a id="Simulation.get_dft_array_metadata"></a>
-
-```python
-def get_dft_array_metadata(self,
-                           dft_cell=None,
-                           vol=None,
+def max_abs_field_function(self,
+                           cs,
+                           func,
+                           where=None,
                            center=None,
                            size=None):
 ```
 
 <div class="method_docstring" markdown="1">
 
+As `integrate_field_function`, but returns the maximum absolute value of `func` in
+the volume `where` instead of its integral.
 
+The integration is performed by summing over the grid points with a simple
+trapezoidal rule, and the maximum is similarly over the grid points. See [Field
+Functions](Field_Functions.md) for examples of how to call
+`integrate_field_function` and `max_abs_field_function`. See [Synchronizing the
+Magnetic and Electric Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md)
+if you want to do computations combining the electric and magnetic fields. The
+volume can optionally be specified via the `center` and `size` arguments.
 
-</div>
-
-<a id="Simulation.get_dft_data"></a>
-
-```python
-def get_dft_data(self, dft_chunk):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_dpwr"></a>
-
-```python
-def get_dpwr(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
+Occasionally, one wants to compute an integral that combines fields from two
+separate simulations (e.g. for nonlinear coupled-mode calculations). This
+functionality is supported in Meep, as long as the two simulations have the *same*
+cell, the same resolution, the same boundary conditions and symmetries (if any),
+and the same PML layers (if any).
 
 </div>
-
-<a id="Simulation.get_efield"></a>
-
-```python
-def get_efield(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_efield_p"></a>
-
-```python
-def get_efield_p(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_efield_r"></a>
-
-```python
-def get_efield_r(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_efield_x"></a>
-
-```python
-def get_efield_x(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_efield_y"></a>
-
-```python
-def get_efield_y(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_efield_z"></a>
-
-```python
-def get_efield_z(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_eigenmode"></a>
-
-```python
-def get_eigenmode(self,
-                  frequency,
-                  direction,
-                  where,
-                  band_num,
-                  kpoint,
-                  eig_vol=None,
-                  match_frequency=True,
-                  parity=0,
-                  resolution=0,
-                  eigensolver_tol=1e-12):
-```
-
-<div class="method_docstring" markdown="1">
-
-The parameters of this routine are the same as that of
-`get_eigenmode_coefficients` or `EigenModeSource`, but this function returns an
-object that can be used to inspect the computed mode.  In particular, it returns
-an `EigenmodeData` instance with the following fields:
-
-+ `band_num`: same as the `band_num` parameter
-+ `freq`: the computed frequency, same as the `frequency` input parameter if
-  `match_frequency=True`
-+ `group_velocity`: the group velocity of the mode in `direction`
-+ `k`: the Bloch wavevector of the mode in `direction`
-+ `kdom`: the dominant planewave of mode `band_num`
-+ `amplitude(point, component)`: the (complex) value of the given E or H field
-  `component` (`Ex`, `Hy`, etcetera) at a particular `point` (a `Vector3`) in
-  space (interpreted with Bloch-periodic boundary conditions if you give a point
-  outside the original `eig_vol`).
-
-If `match_frequency=False` or `kpoint` is not zero in the given `direction`, the
-`frequency` input parameter is ignored.
-
-</div>
-
-<a id="Simulation.get_eigenmode_coefficients"></a>
-
-```python
-def get_eigenmode_coefficients(self,
-                               flux,
-                               bands,
-                               eig_parity=0,
-                               eig_vol=None,
-                               eig_resolution=0,
-                               eig_tolerance=1e-12,
-                               kpoint_func=None,
-                               direction=-1):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a flux object and list of band indices, return a `namedtuple` with the
-following fields:
-
-+ `alpha`: the complex eigenmode coefficients as a 3d NumPy array of size
-  (`len(bands)`, `flux.nfreqs`, `2`). The last/third dimension refers to modes
-  propagating in the forward (+) or backward (-) directions.
-+ `vgrp`: the group velocity as a NumPy array.
-+ `kpoints`: a list of `mp.Vector3`s of the `kpoint` used in the mode calculation.
-+ `kdom`: a list of `mp.Vector3`s of the mode's dominant wavevector.
-+ `cscale`: a NumPy array of each mode's scaling coefficient. Useful for adjoint
-  calculations.
-
-See [Mode Decomposition](#mode-decomposition)
-
-</div>
-
-<a id="Simulation.get_epsilon"></a>
-
-```python
-def get_epsilon(self, frequency=0, omega=0):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_epsilon_point"></a>
-
-```python
-def get_epsilon_point(self, pt, frequency=0, omega=0):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a frequency `frequency` and a `Vector3` `pt`, returns the average eigenvalue
-of the permittivity tensor at that location and frequency. If `frequency` is
-non-zero, the result is complex valued; otherwise it is the real,
-frequency-independent part of ε (the $\omega    o\infty$ limit).
-
-</div>
-
-<a id="Simulation.get_estimated_costs"></a>
-
-```python
-def get_estimated_costs(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_estimated_memory_usage"></a>
-
-```python
-def get_estimated_memory_usage(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_farfield"></a>
-
-```python
-def get_farfield(self, near2far, x):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a `Vector3` point `x` which can lie anywhere outside the near-field surface,
-including outside the cell and a `near2far` object, returns the computed
-(Fourier-transformed) "far" fields at `x` as list of length 6`nfreq`, consisting
-of fields
-(E<sub>x</sub><sup>1</sup>,E<sub>y</sub><sup>1</sup>,E<sub>z</sub><sup>1</sup>,H<sub>x</sub><sup>1</sup>,H<sub>y</sub><sup>1</sup>,H<sub>z</sub><sup>1</sup>,E<sub>x</sub><sup>2</sup>,E<sub>y</sub><sup>2</sup>,E<sub>z</sub><sup>2</sup>,H<sub>x</sub><sup>2</sup>,H<sub>y</sub><sup>2</sup>,H<sub>z</sub><sup>2</sup>,...)
-for the frequencies 1,2,…,`nfreq`.
-
-</div>
-
-<a id="Simulation.get_farfields"></a>
-
-```python
-def get_farfields(self,
-                  near2far,
-                  resolution,
-                  where=None,
-                  center=None,
-                  size=None):
-```
-
-<div class="method_docstring" markdown="1">
-
-Like `output_farfields` but returns a dictionary of NumPy arrays instead of
-writing to a file. The dictionary keys are `Ex`, `Ey`, `Ez`, `Hx`, `Hy`, `Hz`.
-Each array has the same shape as described in `output_farfields`.
-
-Note that far fields have the same units and scaling as the *Fourier transforms*
-of the fields, and hence cannot be directly compared to time-domain fields. In
-practice, it is easiest to use the far fields in computations where overall
-scaling (units) cancel out or are irrelevant, e.g. to compute the fraction of the
-far fields in one region vs. another region.
-
-</div>
-
-<a id="Simulation.get_field_point"></a>
-
-```python
-def get_field_point(self, c, pt):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a `component` or `derived_component` constant `c` and a `Vector3` `pt`,
-returns the value of that component at that point.
-
-</div>
-
-<a id="Simulation.get_filename_prefix"></a>
-
-```python
-def get_filename_prefix(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-Return the current prefix string that is prepended, by default, to all file names.
-
-If you don't want to use any prefix, then you should set `filename_prefix` to the
-empty string `''`.
-
-In addition to the filename prefix, you can also specify that all the output files
-be written into a newly-created directory (if it does not yet exist). This is done
-by calling `Simulation.use_output_directory([dirname])`
-
-</div>
-
-<a id="Simulation.get_flux_data"></a>
-
-```python
-def get_flux_data(self, flux):
-```
-
-<div class="method_docstring" markdown="1">
-
-Get the Fourier-transformed fields corresponding to the given flux object as a
-`FluxData`, which is just a named tuple of NumPy arrays. Note that this object is
-only useful for passing to `load_flux_data` below and should be considered opaque.
-
-</div>
-
-<a id="Simulation.get_force_data"></a>
-
-```python
-def get_force_data(self, force):
-```
-
-<div class="method_docstring" markdown="1">
-
-Get the Fourier-transformed fields corresponding to the given force object as a
-`ForceData`, which is just a named tuple of NumPy arrays. Note that this object is
-only useful for passing to `load_force_data` below and should be considered
-opaque.
-
-</div>
-
-<a id="Simulation.get_hfield"></a>
-
-```python
-def get_hfield(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_hfield_p"></a>
-
-```python
-def get_hfield_p(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_hfield_r"></a>
-
-```python
-def get_hfield_r(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_hfield_x"></a>
-
-```python
-def get_hfield_x(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_hfield_y"></a>
-
-```python
-def get_hfield_y(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_hfield_z"></a>
-
-```python
-def get_hfield_z(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_hpwr"></a>
-
-```python
-def get_hpwr(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_max_chunk_communication_area"></a>
-
-```python
-def get_max_chunk_communication_area(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_mode_data"></a>
-
-```python
-def get_mode_data(self, flux):
-```
-
-<div class="method_docstring" markdown="1">
-
-Get the Fourier-transformed fields corresponding to the given flux object as a
-`FluxData`, which is just a named tuple of NumPy arrays. Note that this object is
-only useful for passing to `load_flux_data` below and should be considered opaque.
-
-</div>
-
-<a id="Simulation.get_mu"></a>
-
-```python
-def get_mu(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_near2far_data"></a>
-
-```python
-def get_near2far_data(self, near2far):
-```
-
-<div class="method_docstring" markdown="1">
-
-Get the Fourier-transformed fields corresponding to the given `near2far` object as
-a `NearToFarData`, which is just a named tuple of NumPy arrays. Note that this
-object is only useful for passing to `load_near2far_data` below and should be
-considered opaque.
-
-</div>
-
-<a id="Simulation.get_sfield"></a>
-
-```python
-def get_sfield(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_sfield_p"></a>
-
-```python
-def get_sfield_p(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_sfield_r"></a>
-
-```python
-def get_sfield_r(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_sfield_x"></a>
-
-```python
-def get_sfield_x(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_sfield_y"></a>
-
-```python
-def get_sfield_y(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_sfield_z"></a>
-
-```python
-def get_sfield_z(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.get_source"></a>
-
-```python
-def get_source(self,
-               component,
-               vol=None,
-               center=None,
-               size=None):
-```
-
-<div class="method_docstring" markdown="1">
-
-Return an array of complex values of the [source](#source) amplitude for
-`component` over the given `vol` or `center`/`size`. The array has the same
-dimensions as that returned by [`get_array`](#array-slices).
-
-</div>
-
-<a id="Simulation.get_tot_pwr"></a>
-
-```python
-def get_tot_pwr(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.h5topng"></a>
-
-```python
-def h5topng(self, rm_h5, option, *step_funcs):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.has_mu"></a>
-
-```python
-def has_mu(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.init_fields"></a>
-
-```python
-def init_fields(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.init_sim"></a>
-
-```python
-def init_sim(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.initialize_field"></a>
-
-```python
-def initialize_field(self, cmpnt, amp_func):
-```
-
-<div class="method_docstring" markdown="1">
-
-Initialize the component `c` fields using the function `func` which has a single
-argument, a `Vector3` giving a position and returns a complex number for the value
-of the field at that point.
 
 </div>
 
 <a id="Simulation.integrate2_field_function"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def integrate2_field_function(self,
@@ -1596,66 +885,210 @@ this requires you to call much lower-level functions like `fields_step()`.
 
 </div>
 
-<a id="Simulation.integrate_field_function"></a>
+</div>
+
+
+### Reloading Parameters
+
+Once the fields/simulation have been initialized, you can change the values of various parameters by using the following functions (which are members of the `Simulation` class):
+
+
+<a id="Simulation.reset_meep"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
-def integrate_field_function(self,
-                             cs,
-                             func,
-                             where=None,
-                             center=None,
-                             size=None):
+def reset_meep(self):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Returns the integral of the complex-valued function `func` over the `Volume`
-specified by `where` (defaults to entire cell) for the `meep::fields` contained in
-the `Simulation` instance that calls this method. `func` is a function of position
-(a `Vector3`, its first argument) and zero or more field components specified by
-`cs`: a list of `component` constants. `func` can be real- or complex-valued. The
-volume can optionally be specified via the `center` and `size` arguments.
-
-If any dimension of `where` is zero, that dimension is not integrated over. In
-this way you can specify 1d, 2d, or 3d integrals.
-
-Note: in cylindrical coordinates $(r,\phi,z)$, the integrand is
-[multiplied](https://en.wikipedia.org/wiki/Cylindrical_coordinate_system#Line_and_volume_elements)
-by the circumference $2\pi r$, or equivalently the integral is over an annular
-volume.
+Reset all of Meep's parameters, deleting the fields, structures, etcetera, from
+memory as if you had not run any computations.
 
 </div>
 
-<a id="Simulation.load_chunk_layout"></a>
+</div>
+
+<a id="Simulation.restart_fields"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
-def load_chunk_layout(self, br, source):
+def restart_fields(self):
 ```
 
 <div class="method_docstring" markdown="1">
 
-
+Restart the fields at time zero, with zero fields. Does *not* reset the Fourier
+transforms of the flux planes, which continue to be accumulated.
 
 </div>
 
-<a id="Simulation.load_energy"></a>
+</div>
+
+<a id="Simulation.change_k_point"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
-def load_energy(self, fname, energy):
+def change_k_point(self, k):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Load the Fourier-transformed fields into the given energy object (replacing any
-values currently there) from an HDF5 file of the given `filename` without the
-".h5" suffix (the current filename-prefix is prepended automatically). You must
-load from a file that was saved by `save_energy` in a simulation of the same
-dimensions for both the cell and the energy regions with the same number of
-processors.
+Change the `k_point` (the Bloch periodicity).
+
+</div>
+
+</div>
+
+<a id="Simulation.change_sources"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def change_sources(self, new_sources):
+```
+
+<div class="method_docstring" markdown="1">
+
+Change the list of sources in `Simulation.sources` to `new_sources`, and changes
+the sources used for the current simulation. `new_sources` must be a list of
+`Source` objects.
+
+</div>
+
+</div>
+
+<a id="Simulation.set_materials"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def set_materials(self, geometry=None, default_material=None):
+```
+
+<div class="method_docstring" markdown="1">
+
+This can be called in a step function, and is useful for changing the geometry or
+default material as a function of time.
+
+</div>
+
+</div>
+
+
+### Flux Spectra
+
+Given a bunch of [`FluxRegion`](#fluxregion) objects, you can tell Meep to accumulate the Fourier transforms of the fields in those regions in order to compute the Poynting flux spectra. (Note: as a matter of convention, the "intensity" of the electromagnetic fields refers to the Poynting flux, *not* to the [energy density](#energy-density-spectra).) See also [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend). These are attributes of the `Simulation` class. The most important function is:
+
+
+<a id="Simulation.add_flux"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def add_flux(self, *args):
+```
+
+<div class="method_docstring" markdown="1">
+
+Add a bunch of `FluxRegion`s to the current simulation (initializing the fields if
+they have not yet been initialized), telling Meep to accumulate the appropriate
+field Fourier transforms for `nfreq` equally spaced frequencies covering the
+frequency range `fcen-df/2` to `fcen+df/2` or an array/list `freq` for arbitrarily
+spaced frequencies. Return a *flux object*, which you can pass to the functions
+below to get the flux spectrum, etcetera.
+
+</div>
+
+</div>
+
+As described in the tutorial, you normally use `add_flux` via statements like:
+
+```python
+transmission = sim.add_flux(...)
+```
+
+to store the flux object in a variable.  You can create as many flux objects as you want, e.g. to look at powers flowing in different regions or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the flux region multiplied by the number of electric and magnetic field components required to get the Poynting vector multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
+
+Once you have called `add_flux`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the [run functions](#run-functions). At any time, you can ask for Meep to print out the current flux spectrum via the `display_fluxes` method.
+
+
+<a id="Simulation.display_fluxes"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def display_fluxes(self, *fluxes):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a number of flux objects, this displays a comma-separated table of
+frequencies and flux spectra, prefixed by "flux1:" or similar (where the number is
+incremented after each run). All of the fluxes should be for the same
+`fcen`/`df`/`nfreq` or `freq`. The first column are the frequencies, and
+subsequent columns are the flux spectra.
+
+</div>
+
+</div>
+
+You might have to do something lower-level if you have multiple flux regions corresponding to *different* frequency ranges, or have other special needs. `display_fluxes(f1, f2, f3)` is actually equivalent to `meep.display_csv("flux", meep.get_flux_freqs(f1), meep.get_fluxes(f1), meep.get_fluxes(f2), meep.get_fluxes(f3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling two lower-level functions:
+
+
+<a id="get_flux_freqs"></a>
+
+```python
+def get_flux_freqs(f):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given a flux object, returns a list of the frequencies that it is computing the
+spectrum for.
+
+</div>
+
+<a id="get_fluxes"></a>
+
+```python
+def get_fluxes(f):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given a flux object, returns a list of the current flux spectrum that it has
+accumulated.
+
+</div>
+
+As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend), for a reflection spectrum you often want to save the Fourier-transformed fields from a "normalization" run and then load them into another run to be subtracted. This can be done via:
+
+
+<a id="Simulation.save_flux"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def save_flux(self, fname, flux):
+```
+
+<div class="method_docstring" markdown="1">
+
+Save the Fourier-transformed fields corresponding to the given flux object in an
+HDF5 file of the given `filename` without the ".h5" suffix (the current
+filename-prefix is prepended automatically).
+
+</div>
 
 </div>
 
 <a id="Simulation.load_flux"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def load_flux(self, fname, flux):
@@ -1672,7 +1105,50 @@ processors.
 
 </div>
 
+</div>
+
+<a id="Simulation.load_minus_flux"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def load_minus_flux(self, fname, flux):
+```
+
+<div class="method_docstring" markdown="1">
+
+As `load_flux`, but negates the Fourier-transformed fields after they are loaded.
+This means that they will be *subtracted* from any future field Fourier transforms
+that are accumulated.
+
+</div>
+
+</div>
+
+Sometimes it is more convenient to keep the Fourier-transformed fields in memory rather than writing them to a file and immediately loading them back again. To that end, the `Simulation` class exposes the following three methods:
+
+
+<a id="Simulation.get_flux_data"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_flux_data(self, flux):
+```
+
+<div class="method_docstring" markdown="1">
+
+Get the Fourier-transformed fields corresponding to the given flux object as a
+`FluxData`, which is just a named tuple of NumPy arrays. Note that this object is
+only useful for passing to `load_flux_data` below and should be considered opaque.
+
+</div>
+
+</div>
+
 <a id="Simulation.load_flux_data"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def load_flux_data(self, flux, fdata):
@@ -1687,7 +1163,509 @@ object that was created by `get_flux_data` in a simulation of the same dimension
 
 </div>
 
+</div>
+
+<a id="Simulation.load_minus_flux_data"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def load_minus_flux_data(self, flux, fdata):
+```
+
+<div class="method_docstring" markdown="1">
+
+As `load_flux_data`, but negates the Fourier-transformed fields after they are
+loaded. This means that they will be *subtracted* from any future field Fourier
+transforms that are accumulated.
+
+</div>
+
+</div>
+
+
+The `Simulation` class also provides some aliases for the corresponding "flux" methods.
+
+* **`save_mode`**
+* **`load_mode`**
+* **`load_minus_mode`**
+* **`get_mode_data`**
+* **`load_mode_data`**
+* **`load_minus_mode_data`**
+
+
+### Mode Decomposition
+
+Given a structure, Meep can decompose the Fourier-transformed fields into a superposition of its harmonic modes. For a theoretical background, see [Mode Decomposition](Mode_Decomposition.md).
+
+
+<a id="Simulation.get_eigenmode_coefficients"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_eigenmode_coefficients(self,
+                               flux,
+                               bands,
+                               eig_parity=0,
+                               eig_vol=None,
+                               eig_resolution=0,
+                               eig_tolerance=1e-12,
+                               kpoint_func=None,
+                               direction=-1):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a flux object and list of band indices, return a `namedtuple` with the
+following fields:
+
++ `alpha`: the complex eigenmode coefficients as a 3d NumPy array of size
+  (`len(bands)`, `flux.nfreqs`, `2`). The last/third dimension refers to modes
+  propagating in the forward (+) or backward (-) directions.
++ `vgrp`: the group velocity as a NumPy array.
++ `kpoints`: a list of `mp.Vector3`s of the `kpoint` used in the mode calculation.
++ `kdom`: a list of `mp.Vector3`s of the mode's dominant wavevector.
++ `cscale`: a NumPy array of each mode's scaling coefficient. Useful for adjoint
+  calculations.
+
+See [Mode Decomposition](#mode-decomposition)
+
+</div>
+
+</div>
+
+The flux object should be created using `add_mode_monitor`.  (You could also use `add_flux`, but with `add_flux` you need to be more careful about symmetries that bisect the flux plane: the `add_flux` object should only be used with `get_eigenmode_coefficients` for modes of the same symmetry, e.g. constrained via `eig_parity`.  On the other hand, the performance of `add_flux` planes benefits more from symmetry.) `eig_vol` is the volume passed to [MPB](https://mpb.readthedocs.io) for the eigenmode calculation (based on interpolating the discretized materials from the Yee grid); in most cases this will simply be the volume over which the frequency-domain fields are tabulated, which is the default (i.e. `flux.where`). `eig_parity` should be one of [`mp.NO_PARITY` (default), `mp.EVEN_Z`, `mp.ODD_Z`, `mp.EVEN_Y`, `mp.ODD_Y`]. It is the parity (= polarization in 2d) of the mode to calculate, assuming the structure has $z$ and/or $y$ mirror symmetry *in the source region*, just as for `EigenModeSource` above. If the structure has both $y$ and $z$ mirror symmetry, you can combine more than one of these, e.g. `EVEN_Z+ODD_Y`. Default is `NO_PARITY`, in which case MPB computes all of the bands which will still be even or odd if the structure has mirror symmetry, of course. This is especially useful in 2d simulations to restrict yourself to a desired polarization. `eig_resolution` is the spatial resolution to use in MPB for the eigenmode calculations. This defaults to twice the Meep `resolution` in which case the structure is linearly interpolated from the Meep pixels. `eig_tolerance` is the tolerance to use in the MPB eigensolver. MPB terminates when the eigenvalues stop changing to less than this fractional tolerance. Defaults to `1e-12`.  (Note that this is the tolerance for the frequency eigenvalue ω; the tolerance for the mode profile is effectively the square root of this.) For examples, see [Tutorial/Mode Decomposition](Python_Tutorials/Mode_Decomposition.md).
+
+Technically, MPB computes `ωₙ(k)` and then inverts it with Newton's method to find the wavevector `k` normal to `eig_vol` and mode for a given frequency; in rare cases (primarily waveguides with *nonmonotonic* dispersion relations, which doesn't usually happen in simple dielectric waveguides), MPB may need you to supply an initial "guess" for `k` in order for this Newton iteration to converge.  You can supply this initial guess with `kpoint_func`, which is a function `kpoint_func(f, n)` that supplies a rough initial guess for the `k` of band number `n` at frequency `f = ω/2π`. (By default, the **k** components in the plane of the `eig_vol` region are zero.  However, if this region spans the *entire* cell in some directions, and the cell has Bloch-periodic boundary conditions via the `k_point` parameter, then the mode's **k** components in those directions will match `k_point` so that the mode satisfies the Meep boundary conditions, regardless of `kpoint_func`.) If `direction` is set to `mp.NO_DIRECTION`, then `kpoint_func` is not only the initial guess and the search direction of the **k** vectors, but is also taken to be the direction of the waveguide, allowing you to [detect modes in oblique waveguides](Python_Tutorials/Eigenmode_Source.md#oblique-waveguides) (not perpendicular to the flux plane).
+
+**Note:** for planewaves in homogeneous media, the `kpoints` may *not* necessarily be equivalent to the actual wavevector of the mode. This quantity is given by `kdom`.
+
+
+<a id="Simulation.add_mode_monitor"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def add_mode_monitor(self, *args):
+```
+
+<div class="method_docstring" markdown="1">
+
+Similar to `add_flux`, but for use with `get_eigenmode_coefficients`.
+
+</div>
+
+</div>
+
+`add_mode_monitor` works properly with arbitrary symmetries, but may be suboptimal because the Fourier-transformed region does not exploit the symmetry.  As an optimization, if you have a mirror plane that bisects the mode monitor, you can instead use `add_flux` to gain a factor of two, but in that case you *must* also pass the corresponding `eig_parity` to `get_eigenmode_coefficients` in order to only compute eigenmodes with the corresponding mirror symmetry.
+
+
+<a id="Simulation.get_eigenmode"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_eigenmode(self,
+                  frequency,
+                  direction,
+                  where,
+                  band_num,
+                  kpoint,
+                  eig_vol=None,
+                  match_frequency=True,
+                  parity=0,
+                  resolution=0,
+                  eigensolver_tol=1e-12):
+```
+
+<div class="method_docstring" markdown="1">
+
+The parameters of this routine are the same as that of
+`get_eigenmode_coefficients` or `EigenModeSource`, but this function returns an
+object that can be used to inspect the computed mode.  In particular, it returns
+an `EigenmodeData` instance with the following fields:
+
++ `band_num`: same as the `band_num` parameter
++ `freq`: the computed frequency, same as the `frequency` input parameter if
+  `match_frequency=True`
++ `group_velocity`: the group velocity of the mode in `direction`
++ `k`: the Bloch wavevector of the mode in `direction`
++ `kdom`: the dominant planewave of mode `band_num`
++ `amplitude(point, component)`: the (complex) value of the given E or H field
+  `component` (`Ex`, `Hy`, etcetera) at a particular `point` (a `Vector3`) in
+  space (interpreted with Bloch-periodic boundary conditions if you give a point
+  outside the original `eig_vol`).
+
+If `match_frequency=False` or `kpoint` is not zero in the given `direction`, the
+`frequency` input parameter is ignored.
+
+</div>
+
+</div>
+
+The following top-level function is also available:
+
+
+<a id="get_eigenmode_freqs"></a>
+
+```python
+def get_eigenmode_freqs(f):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given a flux object, returns a list of the frequencies that it is computing the
+spectrum for.
+
+</div>
+
+
+
+### Energy Density Spectra
+
+Very similar to flux spectra, you can also compute **energy density spectra**: the energy density of the electromagnetic fields as a function of frequency, computed by Fourier transforming the fields and integrating the energy density:
+
+$$ \frac{1}{2}ε|\mathbf{E}|^2 + \frac{1}{2}μ|\mathbf{H}|^2 $$
+
+The usage is similar to the flux spectra: you define a set of [`EnergyRegion`](#EnergyRegion) objects telling Meep where it should compute the Fourier-transformed fields and energy densities, and call `add_energy` to add these regions to the current simulation over a specified frequency bandwidth, and then use `display_electric_energy`, `display_magnetic_energy`, or `display_total_energy` to display the energy density spectra at the end. There are also `save_energy`, `load_energy`, and `load_minus_energy` functions that you can use to subtract the fields from two simulation, e.g. in order to compute just the energy from scattered fields, similar to the flux spectra. The function used to add an [`EnergyRegion`](#EnergyRegion) is as follows:
+
+
+<a id="Simulation.add_energy"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def add_energy(self, *args):
+```
+
+<div class="method_docstring" markdown="1">
+
+add_energy(fcen, df, nfreq, freq, EnergyRegions...)
+
+Add a bunch of `EnergyRegion`s to the current simulation (initializing the fields
+if they have not yet been initialized), telling Meep to accumulate the appropriate
+field Fourier transforms for `nfreq` equally spaced frequencies covering the
+frequency range `fcen-df/2` to `fcen+df/2` or an array/list `freq` for arbitrarily
+spaced frequencies. Return an *energy object*, which you can pass to the functions
+below to get the energy spectrum, etcetera.
+
+</div>
+
+</div>
+
+As for flux regions, you normally use `add_energy` via statements like:
+
+```py
+En = sim.add_energy(...)
+```
+
+to store the energy object in a variable.  You can create as many energy objects as you want, e.g. to look at the energy densities in different objects or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the energy region multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
+
+Once you have called `add_energy`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the `run` functions. At any time, you can ask for Meep to print out the current energy density spectrum via:
+
+
+<a id="Simulation.display_electric_energy"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def display_electric_energy(self, *energys):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a number of energy objects, this displays a comma-separated table of
+frequencies and energy density spectra for the electric fields prefixed by
+"electric_energy1:" or similar (where the number is incremented after each run).
+All of the energy should be for the same `fcen`/`df`/`nfreq` or `freq`. The first
+column are the frequencies, and subsequent columns are the energy density spectra.
+
+</div>
+
+</div>
+
+<a id="Simulation.display_magnetic_energy"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def display_magnetic_energy(self, *energys):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a number of energy objects, this displays a comma-separated table of
+frequencies and energy density spectra for the magnetic fields prefixed by
+"magnetic_energy1:" or similar (where the number is incremented after each run).
+All of the energy should be for the same `fcen`/`df`/`nfreq` or `freq`. The first
+column are the frequencies, and subsequent columns are the energy density spectra.
+
+</div>
+
+</div>
+
+<a id="Simulation.display_total_energy"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def display_total_energy(self, *energys):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a number of energy objects, this displays a comma-separated table of
+frequencies and energy density spectra for the total fields "total_energy1:" or
+similar (where the number is incremented after each run). All of the energy should
+be for the same `fcen`/`df`/`nfreq` or `freq`. The first column are the
+frequencies, and subsequent columns are the energy density spectra.
+
+</div>
+
+</div>
+
+
+You might have to do something lower-level if you have multiple energy regions corresponding to *different* frequency ranges, or have other special needs. `display_electric_energy(e1, e2, e3)` is actually equivalent to `meep.display_csv("electric_energy", meep.get_energy_freqs(e1), meep.get_electric_energy(e1), meep.get_electric_energy(e2), meep.get_electric_energy(e3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling lower-level functions:
+
+
+<a id="get_energy_freqs"></a>
+
+```python
+def get_energy_freqs(f):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given an energy object, returns a list of the frequencies that it is computing the
+spectrum for.
+
+</div>
+
+<a id="get_electric_energy"></a>
+
+```python
+def get_electric_energy(f):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given an energy object, returns a list of the current energy density spectrum for the
+electric fields that it has accumulated.
+
+</div>
+
+<a id="get_magnetic_energy"></a>
+
+```python
+def get_magnetic_energy(f):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given an energy object, returns a list of the current energy density spectrum for the
+magnetic fields that it has accumulated.
+
+</div>
+
+<a id="get_total_energy"></a>
+
+```python
+def get_total_energy(f):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given an energy object, returns a list of the current energy density spectrum for the
+total fields that it has accumulated.
+
+</div>
+
+As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, to compute the energy density from the scattered fields you often want to save the Fourier-transformed fields from a "normalization" run and then load them into another run to be subtracted. This can be done via:
+
+
+<a id="Simulation.save_energy"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def save_energy(self, fname, energy):
+```
+
+<div class="method_docstring" markdown="1">
+
+Save the Fourier-transformed fields corresponding to the given energy object in an
+HDF5 file of the given `filename` without the ".h5" suffix (the current
+filename-prefix is prepended automatically).
+
+</div>
+
+</div>
+
+<a id="Simulation.load_energy"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def load_energy(self, fname, energy):
+```
+
+<div class="method_docstring" markdown="1">
+
+Load the Fourier-transformed fields into the given energy object (replacing any
+values currently there) from an HDF5 file of the given `filename` without the
+".h5" suffix (the current filename-prefix is prepended automatically). You must
+load from a file that was saved by `save_energy` in a simulation of the same
+dimensions for both the cell and the energy regions with the same number of
+processors.
+
+</div>
+
+</div>
+
+<a id="Simulation.load_minus_energy"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def load_minus_energy(self, fname, energy):
+```
+
+<div class="method_docstring" markdown="1">
+
+As `load_energy`, but negates the Fourier-transformed fields after they are
+loaded. This means that they will be *subtracted* from any future field Fourier
+transforms that are accumulated.
+
+</div>
+
+</div>
+
+
+### Force Spectra
+
+Very similar to flux spectra, you can also compute **force spectra**: forces on an object as a function of frequency, computed by Fourier transforming the fields and integrating the vacuum [Maxwell stress tensor](https://en.wikipedia.org/wiki/Maxwell_stress_tensor):
+
+$$\sigma_{ij} = E_i^*E_j + H_i^*H_j - \frac{1}{2} δ_{ij} \left( |\mathbf{E}|^2 + |\mathbf{H}|^2 \right)$$
+
+over a surface $S$ via $\mathbf{F} = \int_S \sigma d\mathbf{A}$. You should normally **only evaluate the stress tensor over a surface lying in vacuum**, as the interpretation and definition of the stress tensor in arbitrary media is often problematic (the subject of extensive and controversial literature). It is fine if the surface *encloses* an object made of arbitrary materials, as long as the surface itself is in vacuum.
+
+See also [Tutorial/Optical Forces](Python_Tutorials/Optical_Forces.md).
+
+Most commonly, you will want to **normalize** the force spectrum in some way, just as for flux spectra. Most simply, you could divide two different force spectra to compute the ratio of forces on two objects. Often, you will divide a force spectrum by a flux spectrum, to divide the force $F$ by the incident power $P$ on an object, in order to compute the useful dimensionless ratio $Fc$/$P$ where $c=1$ in Meep units. For example, it is a simple exercise to show that the force $F$ on a perfectly reflecting mirror with normal-incident power $P$ satisfies $Fc$/$P=2$, and for a perfectly absorbing (black) surface $Fc$/$P=1$.
+
+The usage is similar to the [flux spectra](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend): you define a set of [`ForceRegion`](#ForceRegion) objects telling Meep where it should compute the Fourier-transformed fields and stress tensors, and call `add_force` to add these regions to the current simulation over a specified frequency bandwidth, and then use `display_forces` to display the force spectra at the end. There are also `save_force`, `load_force`, and `load_minus_force` functions that you can use to subtract the fields from two simulation, e.g. in order to compute just the force from scattered fields, similar to the flux spectra. The function used to add a [`ForceRegion`](#ForceRegion) object is defined as follows:
+
+
+<a id="Simulation.add_force"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def add_force(self, *args):
+```
+
+<div class="method_docstring" markdown="1">
+
+add_force(fcen, df, nfreq, freq, ForceRegions...)
+
+Add a bunch of `ForceRegion`s to the current simulation (initializing the fields
+if they have not yet been initialized), telling Meep to accumulate the appropriate
+field Fourier transforms for `nfreq` equally spaced frequencies covering the
+frequency range `fcen-df/2` to `fcen+df/2` or an array/list `freq` for arbitrarily
+spaced frequencies. Return a `force`object, which you can pass to the functions
+below to get the force spectrum, etcetera.
+
+</div>
+
+</div>
+
+As for flux regions, you normally use `add_force` via statements like:
+
+```py
+Fx = sim.add_force(...)
+```
+
+to store the force object in a variable.  You can create as many force objects as you want, e.g. to look at forces on different objects, in different directions, or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the force region, multiplied by the number of electric and magnetic field components required to get the stress vector, multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
+
+Once you have called `add_force`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the `run` functions. At any time, you can ask for Meep to print out the current force spectrum via:
+
+
+<a id="Simulation.display_forces"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def display_forces(self, *forces):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a number of force objects, this displays a comma-separated table of
+frequencies and force spectra, prefixed by "force1:" or similar (where the number
+is incremented after each run). All of the forces should be for the same
+`fcen`/`df`/`nfreq` or `freq`. The first column are the frequencies, and
+subsequent columns are the force spectra.
+
+</div>
+
+</div>
+
+You might have to do something lower-level if you have multiple force regions corresponding to *different* frequency ranges, or have other special needs. `display_forces(f1, f2, f3)` is actually equivalent to `meep.display_csv("force", meep.get_force_freqs(f1), meep.get_forces(f1), meep.get_forces(f2), meep.get_forces(f3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling two lower-level functions:
+
+
+
+<a id="get_force_freqs"></a>
+
+```python
+def get_force_freqs(f):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given a force object, returns a list of the frequencies that it is computing the
+spectrum for.
+
+</div>
+
+<a id="get_forces"></a>
+
+```python
+def get_forces(f):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given a force object, returns a list of the current force spectrum that it has
+accumulated.
+
+</div>
+
+
+As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, to compute the force from the scattered fields often requires saving the Fourier-transformed fields from a "normalization" run and then loading them into another run to be subtracted. This can be done via these `Simulation` methods:
+
+
+<a id="Simulation.save_force"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def save_force(self, fname, force):
+```
+
+<div class="method_docstring" markdown="1">
+
+Save the Fourier-transformed fields corresponding to the given force object in an
+HDF5 file of the given `filename` without the ".h5" suffix (the current
+filename-prefix is prepended automatically).
+
+</div>
+
+</div>
+
 <a id="Simulation.load_force"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def load_force(self, fname, force):
@@ -1704,7 +1682,51 @@ processors.
 
 </div>
 
+</div>
+
+<a id="Simulation.load_minus_force"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def load_minus_force(self, fname, force):
+```
+
+<div class="method_docstring" markdown="1">
+
+As `load_force`, but negates the Fourier-transformed fields after they are loaded.
+This means that they will be *subtracted* from any future field Fourier transforms
+that are accumulated.
+
+</div>
+
+</div>
+
+To keep the fields in memory and avoid writing to and reading from a file, use the following three `Simulation` methods:
+
+
+<a id="Simulation.get_force_data"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_force_data(self, force):
+```
+
+<div class="method_docstring" markdown="1">
+
+Get the Fourier-transformed fields corresponding to the given force object as a
+`ForceData`, which is just a named tuple of NumPy arrays. Note that this object is
+only useful for passing to `load_force_data` below and should be considered
+opaque.
+
+</div>
+
+</div>
+
 <a id="Simulation.load_force_data"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def load_force_data(self, force, fdata):
@@ -1719,63 +1741,11 @@ object that was created by `get_force_data` in a simulation of the same dimensio
 
 </div>
 
-<a id="Simulation.load_minus_energy"></a>
-
-```python
-def load_minus_energy(self, fname, energy):
-```
-
-<div class="method_docstring" markdown="1">
-
-As `load_energy`, but negates the Fourier-transformed fields after they are
-loaded. This means that they will be *subtracted* from any future field Fourier
-transforms that are accumulated.
-
-</div>
-
-<a id="Simulation.load_minus_flux"></a>
-
-```python
-def load_minus_flux(self, fname, flux):
-```
-
-<div class="method_docstring" markdown="1">
-
-As `load_flux`, but negates the Fourier-transformed fields after they are loaded.
-This means that they will be *subtracted* from any future field Fourier transforms
-that are accumulated.
-
-</div>
-
-<a id="Simulation.load_minus_flux_data"></a>
-
-```python
-def load_minus_flux_data(self, flux, fdata):
-```
-
-<div class="method_docstring" markdown="1">
-
-As `load_flux_data`, but negates the Fourier-transformed fields after they are
-loaded. This means that they will be *subtracted* from any future field Fourier
-transforms that are accumulated.
-
-</div>
-
-<a id="Simulation.load_minus_force"></a>
-
-```python
-def load_minus_force(self, fname, force):
-```
-
-<div class="method_docstring" markdown="1">
-
-As `load_force`, but negates the Fourier-transformed fields after they are loaded.
-This means that they will be *subtracted* from any future field Fourier transforms
-that are accumulated.
-
 </div>
 
 <a id="Simulation.load_minus_force_data"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def load_minus_force_data(self, force, fdata):
@@ -1789,298 +1759,137 @@ transforms that are accumulated.
 
 </div>
 
-<a id="Simulation.load_minus_mode"></a>
+</div>
+
+### LDOS spectra
+
+Meep can also calculate the LDOS (local density of states) spectrum, as described in [Tutorial/Local Density of States](Python_Tutorials/Local_Density_of_States.md). To do this, you simply pass the following step function to your `run` command:
+
+
+<a id="Ldos"></a>
 
 ```python
-def load_minus_mode(self, fname, flux):
+def Ldos(*args):
 ```
 
-<div class="method_docstring" markdown="1">
+<div class="function_docstring" markdown="1">
 
-As `load_flux`, but negates the Fourier-transformed fields after they are loaded.
-This means that they will be *subtracted* from any future field Fourier transforms
-that are accumulated.
+Ldos(fcen, df, nfreq, freq)
+
+Create an LDOS object with either frequency bandwidth `df` centered at `fcen` and
+`nfreq` equally spaced frequency points or an array/list `freq` for arbitrarily spaced
+frequencies. This can be passed to the `dft_ldos` step function below as a keyword
+argument.
 
 </div>
 
-<a id="Simulation.load_minus_mode_data"></a>
+<a id="get_ldos_freqs"></a>
 
 ```python
-def load_minus_mode_data(self, flux, fdata):
+def get_ldos_freqs(l):
 ```
 
-<div class="method_docstring" markdown="1">
+<div class="function_docstring" markdown="1">
 
-As `load_flux_data`, but negates the Fourier-transformed fields after they are
-loaded. This means that they will be *subtracted* from any future field Fourier
-transforms that are accumulated.
+Given an LDOS object, returns a list of the frequencies that it is computing the
+spectrum for.
 
 </div>
 
-<a id="Simulation.load_minus_near2far"></a>
+<a id="dft_ldos"></a>
 
 ```python
-def load_minus_near2far(self, fname, near2far):
+def dft_ldos(*args, **kwargs):
 ```
 
-<div class="method_docstring" markdown="1">
+<div class="function_docstring" markdown="1">
 
-As `load_near2far`, but negates the Fourier-transformed fields after they are
-loaded. This means that they will be *subtracted* from any future field Fourier
-transforms that are accumulated.
+dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)
+
+Compute the power spectrum of the sources (usually a single point dipole source),
+normalized to correspond to the LDOS, in either a frequency bandwidth `df` centered at
+`fcen` and `nfreq` equally spaced frequency points or an array/list `freq` for
+arbitrarily spaced frequencies. One can also pass in an `Ldos` object as
+`dft_ldos(ldos=my_Ldos)`.
+
+The resulting spectrum is outputted as comma-delimited text, prefixed by `ldos:,`, and
+is also stored in the `ldos_data` variable of the `Simulation` object after the `run`
+is complete.
 
 </div>
 
-<a id="Simulation.load_minus_near2far_data"></a>
+
+Analytically, the per-polarization LDOS is exactly proportional to the power radiated by an $\ell$-oriented point-dipole current, $p(t)$, at a given position in space. For a more mathematical treatment of the theory behind the LDOS, refer to the relevant discussion in Section 4.4 ("Currents and Fields: The Local Density of States") in [Chapter 4](http://arxiv.org/abs/arXiv:1301.5366) ("Electromagnetic Wave Source Conditions") of the book [Advances in FDTD Computational Electrodynamics: Photonics and Nanotechnology](https://www.amazon.com/Advances-FDTD-Computational-Electrodynamics-Nanotechnology/dp/1608071707), but for now it is defined as:
+
+$$\operatorname{LDOS}_{\ell}(\vec{x}_0,\omega)=-\frac{2}{\pi}\varepsilon(\vec{x}_0)\frac{\operatorname{Re}[\hat{E}_{\ell}(\vec{x}_0,\omega)\hat{p}(\omega)^*]}{|\hat{p}(\omega)|^2}$$
+
+where the $|\hat{p}(\omega)|^2$ normalization is necessary for obtaining the power exerted by a unit-amplitude dipole (assuming linear materials), and hats denote Fourier transforms. It is this quantity that is computed by the `dft_ldos` command for a single dipole source. For a volumetric source, the numerator and denominator are both integrated over the current volume, but "LDOS" computation is less meaningful in this case.
+
+### Near-to-Far-Field Spectra
+
+Meep can compute a near-to-far-field transformation in the frequency domain as described in [Tutorial/Near-to-Far Field Spectra](Python_Tutorials/Near_to_Far_Field_Spectra.md): given the fields on a "near" bounding surface inside the cell, it can compute the fields arbitrarily far away using an analytical transformation, assuming that the "near" surface and the "far" region lie in a single homogeneous non-periodic 2d, 3d, or cylindrical region. That is, in a simulation *surrounded by PML* that absorbs outgoing waves, the near-to-far-field feature can compute the fields outside the cell as if the outgoing waves had not been absorbed (i.e. in the fictitious infinite open volume). Moreover, this operation is performed on the Fourier-transformed fields: like the flux and force spectra above, you specify a set of desired frequencies, Meep accumulates the Fourier transforms, and then Meep computes the fields at *each frequency* for the desired far-field points.
+
+This is based on the principle of equivalence: given the Fourier-transformed tangential fields on the "near" surface, Meep computes equivalent currents and convolves them with the analytical Green's functions in order to compute the fields at any desired point in the "far" region. For details, see Section 4.2.1 ("The Principle of Equivalence") in [Chapter 4](http://arxiv.org/abs/arXiv:1301.5366) ("Electromagnetic Wave Source Conditions") of the book [Advances in FDTD Computational Electrodynamics: Photonics and Nanotechnology](https://www.amazon.com/Advances-FDTD-Computational-Electrodynamics-Nanotechnology/dp/1608071707).
+
+Note: in order for the far-field results to be accurate, the [far region must be separated from the near region](https://en.wikipedia.org/wiki/Near_and_far_field) by *at least* 2D<sup>2</sup>/λ, the Fraunhofer distance, where D is the largest dimension of the radiator and λ is the vacuum wavelength.
+
+There are three steps to using the near-to-far-field feature: first, define the "near" surface(s) as a set of surfaces capturing *all* outgoing radiation in the desired direction(s); second, run the simulation, typically with a pulsed source, to allow Meep to accumulate the Fourier transforms on the near surface(s); third, tell Meep to compute the far fields at any desired points (optionally saving the far fields from a grid of points to an HDF5 file). To define the near surfaces, use this `Simulation` method:
+
+
+<a id="Simulation.add_near2far"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
-def load_minus_near2far_data(self, near2far, n2fdata):
+def add_near2far(self, *args, **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
 
-As `load_near2far_data`, but negates the Fourier-transformed fields after they are
-loaded. This means that they will be *subtracted* from any future field Fourier
-transforms that are accumulated.
+add_near2far(fcen, df, nfreq, freq, Near2FarRegions..., nperiods=1)
+
+Add a bunch of `Near2FarRegion`s to the current simulation (initializing the
+fields if they have not yet been initialized), telling Meep to accumulate the
+appropriate field Fourier transforms for `nfreq` equally spaced frequencies
+covering the frequency range `fcen-df/2` to `fcen+df/2` or an array/list `freq`
+for arbitrarily spaced frequencies. Return a `near2far` object, which you can pass
+to the functions below to get the far fields.
 
 </div>
 
-<a id="Simulation.load_mode"></a>
-
-```python
-def load_mode(self, fname, flux):
-```
-
-<div class="method_docstring" markdown="1">
-
-Load the Fourier-transformed fields into the given flux object (replacing any
-values currently there) from an HDF5 file of the given `filename` without the
-".h5" suffix (the current filename-prefix is prepended automatically). You must
-load from a file that was saved by `save_flux` in a simulation of the same
-dimensions (for both the cell and the flux regions) with the same number of
-processors.
-
 </div>
 
-<a id="Simulation.load_mode_data"></a>
+Each `Near2FarRegion` is identical to `FluxRegion` except for the name: in 3d, these give a set of planes (**important:** all these "near surfaces" must lie in a single *homogeneous* material with *isotropic* ε and μ &mdash; and they should *not* lie in the PML regions) surrounding the source(s) of outgoing radiation that you want to capture and convert to a far field. Ideally, these should form a closed surface, but in practice it is sufficient for the `Near2FarRegion`s to capture all of the radiation in the direction of the far-field points. **Important:** as for flux computations, each `Near2FarRegion` should be assigned a `weight` of &#177;1 indicating the direction of the outward normal relative to the +coordinate direction. So, for example, if you have six regions defining the six faces of a cube, i.e. the faces in the +x, -x, +y, -y, +z, and -z directions, then they should have weights +1, -1, +1, -1, +1, and -1 respectively. Note that, neglecting discretization errors, all near-field surfaces that enclose the same outgoing fields are equivalent and will yield the same far fields with a discretization-induced difference that vanishes with increasing resolution etc.
+
+After the simulation run is complete, you can compute the far fields. This is usually for a pulsed source so that the fields have decayed away and the Fourier transforms have finished accumulating.
+
+If you have Bloch-periodic boundary conditions, then the corresponding near-to-far transformation actually needs to perform a "lattice sum" of infinitely many periodic copies of the near fields.  This doesn't happen by default, which means the default `near2far` calculation may not be what you want for periodic boundary conditions.  However, if the `Near2FarRegion` spans the entire cell along the periodic directions, you can turn on an approximate lattice sum by passing `nperiods > 1`.  In particular, it then sums `2*nperiods+1` Bloch-periodic copies of the near fields whenever a far field is requested.  You can repeatedly double `nperiods` until the answer converges to your satisfaction; in general, if the far field is at a distance d, and the period is a, then you want `nperiods` to be much larger than d/a.  (Future versions of Meep may use fancier techniques like [Ewald summation](https://en.wikipedia.org/wiki/Ewald_summation) to compute the lattice sum more rapidly at large distances.)
+
+
+<a id="Simulation.get_farfield"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
-def load_mode_data(self, flux, fdata):
+def get_farfield(self, near2far, x):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Load the Fourier-transformed fields into the given flux object (replacing any
-values currently there) from the `FluxData` object `fdata`. You must load from an
-object that was created by `get_flux_data` in a simulation of the same dimensions
-(for both the cell and the flux regions) with the same number of processors.
+Given a `Vector3` point `x` which can lie anywhere outside the near-field surface,
+including outside the cell and a `near2far` object, returns the computed
+(Fourier-transformed) "far" fields at `x` as list of length 6`nfreq`, consisting
+of fields
+(E<sub>x</sub><sup>1</sup>,E<sub>y</sub><sup>1</sup>,E<sub>z</sub><sup>1</sup>,H<sub>x</sub><sup>1</sup>,H<sub>y</sub><sup>1</sup>,H<sub>z</sub><sup>1</sup>,E<sub>x</sub><sup>2</sup>,E<sub>y</sub><sup>2</sup>,E<sub>z</sub><sup>2</sup>,H<sub>x</sub><sup>2</sup>,H<sub>y</sub><sup>2</sup>,H<sub>z</sub><sup>2</sup>,...)
+for the frequencies 1,2,…,`nfreq`.
 
 </div>
-
-<a id="Simulation.load_near2far"></a>
-
-```python
-def load_near2far(self, fname, near2far):
-```
-
-<div class="method_docstring" markdown="1">
-
-Load the Fourier-transformed fields into the given `near2far` object (replacing
-any values currently there) from an HDF5 file of the given `filename` without the
-".h5" suffix (the current filename-prefix is prepended automatically). You must
-load from a file that was saved by `save_near2far` in a simulation of *the same
-dimensions* for both the cell and the near2far regions with the same number of
-processors.
-
-</div>
-
-<a id="Simulation.load_near2far_data"></a>
-
-```python
-def load_near2far_data(self, near2far, n2fdata):
-```
-
-<div class="method_docstring" markdown="1">
-
-Load the Fourier-transformed fields into the `near2far` object (replacing any
-values currently there) from the `NearToFarData` object `n2fdata`. You must load
-from an object that was created by `get_near2far_data` in a simulation of the same
-dimensions (for both the cell and the flux regions) with the same number of
-processors.
-
-</div>
-
-<a id="Simulation.load_structure"></a>
-
-```python
-def load_structure(self, fname):
-```
-
-<div class="method_docstring" markdown="1">
-
-Loads a structure from the file `fname`. A file name to load can also be passed to
-the `Simulation` constructor via the `load_structure` keyword argument.
-
-</div>
-
-<a id="Simulation.magnetic_energy_in_box"></a>
-
-```python
-def magnetic_energy_in_box(self, box=None, center=None, size=None):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a `mp.Volume`, returns the integral of the magnetic-field energy
-$\mathbf{H}^* \cdot \mathbf{B}/2$ in the given volume. If the volume has zero size
-along a dimension, a lower-dimensional integral is used. If the `center` and
-`size` arguments are provided instead of `box`, Meep will construct the
-appropriate volume for you. Note: in cylindrical coordinates $(r,\phi,z)$, the
-integrand is
-[multiplied](https://en.wikipedia.org/wiki/Cylindrical_coordinate_system#Line_and_volume_elements)
-by the circumference $2\pi r$, or equivalently the integral is over an annular
-volume.
-
-</div>
-
-<a id="Simulation.max_abs_field_function"></a>
-
-```python
-def max_abs_field_function(self,
-                           cs,
-                           func,
-                           where=None,
-                           center=None,
-                           size=None):
-```
-
-<div class="method_docstring" markdown="1">
-
-As `integrate_field_function`, but returns the maximum absolute value of `func` in
-the volume `where` instead of its integral.
-
-The integration is performed by summing over the grid points with a simple
-trapezoidal rule, and the maximum is similarly over the grid points. See [Field
-Functions](Field_Functions.md) for examples of how to call
-`integrate_field_function` and `max_abs_field_function`. See [Synchronizing the
-Magnetic and Electric Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md)
-if you want to do computations combining the electric and magnetic fields. The
-volume can optionally be specified via the `center` and `size` arguments.
-
-Occasionally, one wants to compute an integral that combines fields from two
-separate simulations (e.g. for nonlinear coupled-mode calculations). This
-functionality is supported in Meep, as long as the two simulations have the *same*
-cell, the same resolution, the same boundary conditions and symmetries (if any),
-and the same PML layers (if any).
-
-</div>
-
-<a id="Simulation.mean_time_spent_on"></a>
-
-```python
-def mean_time_spent_on(self, time_sink):
-```
-
-<div class="method_docstring" markdown="1">
-
-Return the mean time spent by all processes for a type of work `time_sink` which
-can be one of nine integer values `0`-`8`: (`0`) connecting chunks, (`1`) time
-stepping, (`2`) boundaries, (`3`) MPI/synchronization, (`4`) field output, (`5`)
-Fourier transforming, (`6`) MPB, (`7`) near to far field transformation, and (`8`)
-other.
-
-</div>
-
-<a id="Simulation.meep_time"></a>
-
-```python
-def meep_time(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-Return the current simulation time in simulation time units (e.g. during a run
-function). This is not the wall-clock time.
-
-Occasionally, e.g. for termination conditions of the form $time < T?$, it is
-desirable to round the time to single precision in order to avoid small
-differences in roundoff error from making your results different by one timestep
-from machine to machine (a difference much bigger than roundoff error); in this
-case you can call `Simulation.round_time()` instead, which returns the time
-rounded to single precision.
-
-</div>
-
-<a id="Simulation.modal_volume_in_box"></a>
-
-```python
-def modal_volume_in_box(self, box=None, center=None, size=None):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a `mp.Volume`, returns the instantaneous modal volume according to the
-Purcell-effect definition: integral (ε|E|<sup>2</sup>) / maximum
-(ε|E|<sup>2</sup>). If no volume argument is provided, the entire cell is used by
-default. If the `center` and `size` arguments are provided instead of `box`, Meep
-will construct the appropriate volume for you.
-
-Note that if you are at a fixed frequency and you use complex fields (via
-Bloch-periodic boundary conditions or `fields_complex=True`), then one half of the
-flux or energy integrals above corresponds to the time average of the flux or
-energy for a simulation with real fields.
-
-Often, you want the integration box to be the entire cell. A useful function to
-return this box, which you can then use for the `box` arguments above, is
-`Simulation.total_volume()`.
-
-One versatile feature is that you can supply an arbitrary function
-$f(\mathbf{x},c_1,c_2,\ldots)$ of position $\mathbf{x}$ and various field
-components $c_1,\ldots$ and ask Meep to integrate it over a given volume, find its
-maximum, or output it (via `output_field_function`, described later). This is done
-via the functions:
-
-</div>
-
-<a id="Simulation.output_component"></a>
-
-```python
-def output_component(self, c, h5file=None, frequency=0, omega=0):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.output_components"></a>
-
-```python
-def output_components(self, fname, *components):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.output_dft"></a>
-
-```python
-def output_dft(self, dft_fields, fname):
-```
-
-<div class="method_docstring" markdown="1">
-
-Output the Fourier-transformed fields in `dft_fields` (created by
-`add_dft_fields`) to an HDF5 file with name `fname` (does *not* include the `.h5`
-suffix).
 
 </div>
 
 <a id="Simulation.output_farfields"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def output_farfields(self,
@@ -2107,52 +1916,396 @@ that =1 are omitted. The volume can optionally be specified via `center` and
 
 </div>
 
-<a id="Simulation.output_field_function"></a>
+</div>
+
+<a id="Simulation.get_farfields"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
-def output_field_function(self,
-                          name,
-                          cs,
-                          func,
-                          real_only=False,
-                          h5file=None):
+def get_farfields(self,
+                  near2far,
+                  resolution,
+                  where=None,
+                  center=None,
+                  size=None):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Output the field function `func` to an HDF5 file in the datasets named `name*.r`
-and `name*.i` for the real and imaginary parts. Similar to
-`integrate_field_function`, `func` is a function of position (a `Vector3`) and the
-field components corresponding to `cs`: a list of `component` constants. If
-`real_only` is True, only outputs the real part of `func`.
+Like `output_farfields` but returns a dictionary of NumPy arrays instead of
+writing to a file. The dictionary keys are `Ex`, `Ey`, `Ez`, `Hx`, `Hy`, `Hz`.
+Each array has the same shape as described in `output_farfields`.
+
+Note that far fields have the same units and scaling as the *Fourier transforms*
+of the fields, and hence cannot be directly compared to time-domain fields. In
+practice, it is easiest to use the far fields in computations where overall
+scaling (units) cancel out or are irrelevant, e.g. to compute the fraction of the
+far fields in one region vs. another region.
 
 </div>
 
-<a id="Simulation.phase_in_material"></a>
+</div>
+
+This lower-level function is also available:
+
+
+<a id="get_near2far_freqs"></a>
 
 ```python
-def phase_in_material(self, structure, time):
+def get_near2far_freqs(f):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given a `near2far` object, returns a list of the frequencies that it is computing the
+spectrum for.
+
+</div>
+
+
+(Multi-frequency `get_farfields` and `output_farfields` can be accelerated by
+[compiling Meep](Build_From_Source.md#meep) with `--with-openmp` and using the
+`OMP_NUM_THREADS` environment variable to specify multiple threads.)
+
+For a scattered-field computation, you often want to separate the scattered and incident fields. As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Scheme_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, you can do this by saving the Fourier-transformed incident from a "normalization" run and then load them into another run to be subtracted. This can be done via these `Simulation` methods:
+
+
+<a id="Simulation.save_near2far"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def save_near2far(self, fname, near2far):
 ```
 
 <div class="method_docstring" markdown="1">
 
-`newstructure` should be the `structure` field of another `Simulation` object with
-the same cell size and resolution.   Over the next time period `phasetime` (in the
-current simulation's time units), the current structure (ε, μ, and conductivity)
-will be gradually changed to `newstructure`. In particular, at each timestep it
-linearly interpolates between the old structure and the new structure. After
-`phasetime` has elapsed, the structure will remain equal to `newstructure`. This
-is demonstrated in the following image for two [Cylinder](#cylinder) objects (the
-simulation script is in
-[examples/phase_in_material.py](https://github.com/NanoComp/meep/blob/master/python/examples/phase_in_material.py)).
-
-<center>
-![](images/phase-in-material.png)
-</center>
+Save the Fourier-transformed fields corresponding to the given `near2far` object
+in an HDF5 file of the given `filename` (without the ".h5" suffix). The current
+filename-prefix is prepended automatically.
 
 </div>
+
+</div>
+
+<a id="Simulation.load_near2far"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def load_near2far(self, fname, near2far):
+```
+
+<div class="method_docstring" markdown="1">
+
+Load the Fourier-transformed fields into the given `near2far` object (replacing
+any values currently there) from an HDF5 file of the given `filename` without the
+".h5" suffix (the current filename-prefix is prepended automatically). You must
+load from a file that was saved by `save_near2far` in a simulation of *the same
+dimensions* for both the cell and the near2far regions with the same number of
+processors.
+
+</div>
+
+</div>
+
+<a id="Simulation.load_minus_near2far"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def load_minus_near2far(self, fname, near2far):
+```
+
+<div class="method_docstring" markdown="1">
+
+As `load_near2far`, but negates the Fourier-transformed fields after they are
+loaded. This means that they will be *subtracted* from any future field Fourier
+transforms that are accumulated.
+
+</div>
+
+</div>
+
+
+To keep the fields in memory and avoid writing to and reading from a file, use the following three methods:
+
+
+<a id="Simulation.get_near2far_data"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_near2far_data(self, near2far):
+```
+
+<div class="method_docstring" markdown="1">
+
+Get the Fourier-transformed fields corresponding to the given `near2far` object as
+a `NearToFarData`, which is just a named tuple of NumPy arrays. Note that this
+object is only useful for passing to `load_near2far_data` below and should be
+considered opaque.
+
+</div>
+
+</div>
+
+<a id="Simulation.load_near2far_data"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def load_near2far_data(self, near2far, n2fdata):
+```
+
+<div class="method_docstring" markdown="1">
+
+Load the Fourier-transformed fields into the `near2far` object (replacing any
+values currently there) from the `NearToFarData` object `n2fdata`. You must load
+from an object that was created by `get_near2far_data` in a simulation of the same
+dimensions (for both the cell and the flux regions) with the same number of
+processors.
+
+</div>
+
+</div>
+
+<a id="Simulation.load_minus_near2far_data"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def load_minus_near2far_data(self, near2far, n2fdata):
+```
+
+<div class="method_docstring" markdown="1">
+
+As `load_near2far_data`, but negates the Fourier-transformed fields after they are
+loaded. This means that they will be *subtracted* from any future field Fourier
+transforms that are accumulated.
+
+</div>
+
+</div>
+
+See also this lower-level function:
+
+
+<a id="scale_near2far_fields"></a>
+
+```python
+def scale_near2far_fields(s, near2far):
+```
+
+<div class="function_docstring" markdown="1">
+
+Scale the Fourier-transformed fields in `near2far` by the complex number `s`. e.g.
+`load_minus_near2far` is equivalent to `load_near2far` followed by
+`scale_near2far_fields` with `s=-1`.
+
+</div>
+
+And this [`DftNear2Far`](#DftNear2Far) method:
+
+
+<a id="DftNear2Far.flux"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def flux(self, direction, where, resolution):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a `Volume` `where` (may be 0d, 1d, 2d, or 3d) and a `resolution` (in grid
+points / distance unit), compute the far fields in `where` (which may lie
+*outside* the cell) in a grid with the given resolution (which may differ from the
+FDTD solution) and return its Poynting flux in `direction` as a list. The dataset
+is a 1d array of `nfreq` dimensions.
+
+</div>
+
+</div>
+
+
+### Load and Dump Structure
+
+These functions dump the raw ε and μ data to disk and load it back for doing multiple simulations with the same materials but different sources etc. The only prerequisite is that the dump/load simulations have the same [chunks](Chunks_and_Symmetry.md) (i.e. the same grid, number of processors, symmetries, and PML). When using `split_chunks_evenly=False`, you must also dump the original chunk layout using `dump_chunk_layout` and load it into the new `Simulation` using the `chunk_layout` parameter. Currently only stores dispersive and non-dispersive ε and μ but not nonlinearities. Note that loading data from a file in this way overwrites any `geometry` data passed to the `Simulation` constructor.
+
+
+<a id="Simulation.dump_structure"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def dump_structure(self, fname):
+```
+
+<div class="method_docstring" markdown="1">
+
+Dumps the structure to the file `fname`.
+
+</div>
+
+</div>
+
+<a id="Simulation.load_structure"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def load_structure(self, fname):
+```
+
+<div class="method_docstring" markdown="1">
+
+Loads a structure from the file `fname`. A file name to load can also be passed to
+the `Simulation` constructor via the `load_structure` keyword argument.
+
+</div>
+
+</div>
+
+<a id="Simulation.dump_chunk_layout"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def dump_chunk_layout(self, fname):
+```
+
+<div class="method_docstring" markdown="1">
+
+Dumps the chunk layout to file `fname`.
+
+</div>
+
+</div>
+
+
+To load a chunk layout into a `Simulation`, use the `chunk_layout` argument to the constructor, passing either a file obtained from `dump_chunk_layout` or another `Simulation` instance. Note that when using `split_chunks_evenly=False` this parameter is required when saving and loading flux spectra, force spectra, or near-to-far spectra so that the two runs have the same chunk layout. Just pass the `Simulation` object from the first run to the second run:
+
+```python
+# Split chunks based on amount of work instead of size
+sim1 = mp.Simulation(..., split_chunks_evenly=False)
+norm_flux = sim1.add_flux(...)
+sim1.run(...)
+sim1.save_flux(...)
+
+# Make sure the second run uses the same chunk layout as the first
+sim2 = mp.Simulation(..., chunk_layout=sim1)
+flux = sim2.add_flux(...)
+sim2.load_minus_flux(...)
+sim2.run(...)
+```
+
+### Frequency-Domain Solver
+
+Meep contains a frequency-domain solver that computes the fields produced in a geometry in response to a [continuous-wave (CW) source](https://en.wikipedia.org/wiki/Continuous_wave). This is based on an [iterative linear solver](https://en.wikipedia.org/wiki/Iterative_method) instead of time-stepping. For details, see Section 5.3 ("Frequency-domain solver") of [Computer Physics Communications, Vol. 181, pp. 687-702, 2010](http://ab-initio.mit.edu/~oskooi/papers/Oskooi10.pdf). Benchmarking results have shown that in many instances, such as cavities (e.g., [ring resonators](Python_Tutorials/Frequency_Domain_Solver.md)) with long-lived resonant modes, this solver converges much faster than simply running an equivalent time-domain simulation with a CW source (using the default `width` of zero for no transient turn-on), time-stepping until all transient effects from the source turn-on have disappeared, especially if the fields are desired to a very high accuracy.
+
+To use the frequency-domain solver, simply define a `ContinuousSource` with the desired frequency and [initialize the fields and geometry](#initializing-the-structure-and-fields) via `init_sim()`:
+
+```py
+sim = mp.Simulation(...)
+sim.init_sim()
+sim.solve_cw(tol, maxiters, L)
+```
+
+The first two parameters to the frequency-domain solver are the tolerance `tol` for the iterative solver (10<sup>−8</sup>, by default) and a maximum number of iterations `maxiters` (10<sup>4</sup>, by default). Finally, there is a parameter $L$ that determines a tradeoff between memory and work per step and convergence rate of the iterative algorithm, biconjugate gradient stabilized ([BiCGSTAB-L](https://en.wikipedia.org/wiki/Biconjugate_gradient_stabilized_method)), that is used; larger values of $L$ will often lead to faster convergence at the expense of more memory and more work per iteration. Default is $L=2$, and normally a value ≥ 2 should be used.
+
+The frequency-domain solver supports arbitrary geometries, PML, boundary conditions, symmetries, parallelism, conductors, and arbitrary nondispersive materials. Lorentz-Drude dispersive materials are not currently supported in the frequency-domain solver, but since you are solving at a known fixed frequency rather than timestepping, you should be able to pick conductivities etcetera in order to obtain any desired complex ε and μ at that frequency.
+
+The frequency-domain solver requires you to use complex-valued fields, via `force_complex_fields=True`.
+
+After `solve_cw` completes, it should be as if you had just run the simulation for an infinite time with the source at that frequency. You can call the various field-output functions and so on as usual at this point. For examples, see [Tutorial/Frequency Domain Solver](Python_Tutorials/Frequency_Domain_Solver.md) and [Tutorial/Mode Decomposition/Reflectance and Transmittance Spectra for Planewave at Oblique Incidence](Python_Tutorials/Mode_Decomposition.md#reflectance-and-transmittance-spectra-for-planewave-at-oblique-incidence).
+
+**Note:** The convergence of the iterative solver can sometimes encounter difficulties. For example, increasing the diameter of a ring resonator relative to the wavelength increases the [condition number](https://en.wikipedia.org/wiki/Condition_number), which worsens the convergence of iterative solvers. The general way to improve this is to implement a more sophisticated iterative solver that employs [preconditioners](https://en.wikipedia.org/wiki/Preconditioner). Preconditioning wave equations (Helmholtz-like equations) is notoriously difficult to do well, but some possible strategies are discussed in [Issue #548](https://github.com/NanoComp/meep/issues/548). In the meantime, a simpler way improving convergence (at the expense of computational cost) is to increase the $L$ parameter and the number of iterations.
+
+### Frequency-Domain Eigensolver
+
+Building on the frequency-domain solver above, Meep also includes a frequency-domain eigensolver that computes resonant frequencies and modes in the frequency domain.  The usage is very similar to `solve_cw`:
+
+```py
+sim = mp.Simulation(...)
+sim.init_sim()
+eigfreq = sim.solve_eigfreq(tol, maxiters, guessfreq, cwtol, cwmaxiters, L)
+```
+
+The `solve_eig` routine performs repeated calls to `solve_cw` in a way that converges to the resonant mode whose frequency is *closest* to the source frequency.  The complex resonant-mode frequency is returned, and the mode Q can be computed from `eigfreq.real / (-2*eigfreq.imag)`.  Upon return, the fields should be the corresponding resonant mode (with an arbitrary scaling).
+
+The resonant mode is converged to a relative error of roughly `tol`, which defaults to `1e-7`. A maximum of `maxiters` (defaults to `100`) calls to `solve_cw` are performed.  The tolerance for each `solve_cw` call is `cwtol` (defaults to `tol*1e-3`) and the maximum iterations is `cwmaxiters` (10<sup>4</sup>, by default); the `L` parameter (defaults to `10`) is also passed through to `solve_cw`.
+
+The closer the input frequency is to the resonant-mode frequency, the faster `solve_eig` should converge. Instead of using the source frequency, you can instead pass a `guessfreq` argument to `solve_eigfreq` specifying an input frequency (which may even be complex).
+
+Technically, `solve_eig` is using a [shift-and-invert power iteration](https://en.wikipedia.org/wiki/Inverse_iteration) to compute the resonant mode, as reviewed in [Frequency-Domain Eigensolver](Eigensolver_Math.md).
+
+As for `solve_cw` above, you are required to set `force_complex_fields=True` to use `solve_eigfreq`.
+
+### GDSII Support
+
+This feature is only available if Meep is built with [libGDSII](Build_From_Source.md#libgdsii). It so, then the following functions are available:
+
+
+<a id="GDSII_layers"></a>
+
+```python
+def GDSII_layers(fname):
+```
+
+<div class="function_docstring" markdown="1">
+
+Returns a list of integer-valued layer indices for the layers present in
+the specified GDSII file.
+
+```python
+mp.GDSII_layers('python/examples/coupler.gds')
+Out[2]: [0, 1, 2, 3, 4, 5, 31, 32]
+```
+
+</div>
+
+<a id="GDSII_prisms"></a>
+
+```python
+def GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0):
+```
+
+<div class="function_docstring" markdown="1">
+
+Returns a list of `GeometricObject`s with `material` (`mp.Medium`) on layer number
+`layer` of a GDSII file `fname` with `zmin` and `zmax` (default 0).
+
+</div>
+
+<a id="GDSII_vol"></a>
+
+```python
+def GDSII_vol(fname, layer, zmin, zmax):
+```
+
+<div class="function_docstring" markdown="1">
+
+Returns a `mp.Volume` read from a GDSII file `fname` on layer number `layer` with
+`zmin` and `zmax` (default 0). This function is useful for creating a `FluxRegion`
+from a GDSII file as follows:
+
+```python
+fr = mp.FluxRegion(volume=mp.GDSII_vol(fname, layer, zmin, zmax))
+```
+
+</div>
+
+
+### Data Visualization
+
+This module provides basic visualization functionality for the simulation domain. The spirit of the module is to provide functions that can be called with *no customization options whatsoever* and will do useful relevant things by default, but which can also be customized in cases where you *do* want to take the time to spruce up the output. The `Simulation` class provides the following methods:
+
 
 <a id="Simulation.plot2D"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def plot2D(self,
@@ -2253,7 +2406,11 @@ plt.savefig('sim_domain.png')
 
 </div>
 
+</div>
+
 <a id="Simulation.plot3D"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def plot3D(self):
@@ -2266,308 +2423,11 @@ Can also be embedded in Jupyter notebooks.
 
 </div>
 
-<a id="Simulation.plot_fields"></a>
-
-```python
-def plot_fields(self, **kwargs):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.print_times"></a>
-
-```python
-def print_times(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-Call after running a simulation to print the times spent on various types of work.
-Example output:
-
-```
-Field time usage:
-        connecting chunks: 0.0819176 s +/- 0.000428381 s
-            time stepping: 0.198949 s +/- 0.0225551 s
-            communicating: 0.410577 s +/- 0.278853 s
-        outputting fields: 0.512352 s +/- 0.0238399 s
-     Fourier transforming: 0.0738274 s +/- 0.0967926 s
-          everything else: 0.324933 s +/- 0.377573 s
-```
-
-</div>
-
-<a id="Simulation.require_dimensions"></a>
-
-```python
-def require_dimensions(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.reset_meep"></a>
-
-```python
-def reset_meep(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-Reset all of Meep's parameters, deleting the fields, structures, etcetera, from
-memory as if you had not run any computations.
-
-</div>
-
-<a id="Simulation.restart_fields"></a>
-
-```python
-def restart_fields(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-Restart the fields at time zero, with zero fields. Does *not* reset the Fourier
-transforms of the flux planes, which continue to be accumulated.
-
-</div>
-
-<a id="Simulation.round_time"></a>
-
-```python
-def round_time(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.run"></a>
-
-```python
-def run(self, *step_funcs, **kwargs):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.run_k_point"></a>
-
-```python
-def run_k_point(self, t, k):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.run_k_points"></a>
-
-```python
-def run_k_points(self, t, k_points):
-```
-
-<div class="method_docstring" markdown="1">
-
-Given a list of `Vector3`, `k_points` of *k* vectors, runs a simulation for each
-*k* point (i.e. specifying Bloch-periodic boundary conditions) and extracts the
-eigen-frequencies, and returns a list of the complex frequencies. In particular,
-you should have specified one or more Gaussian sources. It will run the simulation
-until the sources are turned off plus an additional $t$ time units. It will run
-[Harminv](#harminv) at the same point/component as the first Gaussian source and
-look for modes in the union of the frequency ranges for all sources. Returns a
-list of lists of frequencies (one list of frequencies for each *k*). Also prints
-out a comma-delimited list of frequencies, prefixed by `freqs:`, and their
-imaginary parts, prefixed by `freqs-im:`. See [Tutorial/Resonant Modes and
-Transmission in a Waveguide
-Cavity](Python_Tutorials/Resonant_Modes_and_Transmission_in_a_Waveguide_Cavity.md).
-
-</div>
-
-<a id="Simulation.save_energy"></a>
-
-```python
-def save_energy(self, fname, energy):
-```
-
-<div class="method_docstring" markdown="1">
-
-Save the Fourier-transformed fields corresponding to the given energy object in an
-HDF5 file of the given `filename` without the ".h5" suffix (the current
-filename-prefix is prepended automatically).
-
-</div>
-
-<a id="Simulation.save_flux"></a>
-
-```python
-def save_flux(self, fname, flux):
-```
-
-<div class="method_docstring" markdown="1">
-
-Save the Fourier-transformed fields corresponding to the given flux object in an
-HDF5 file of the given `filename` without the ".h5" suffix (the current
-filename-prefix is prepended automatically).
-
-</div>
-
-<a id="Simulation.save_force"></a>
-
-```python
-def save_force(self, fname, force):
-```
-
-<div class="method_docstring" markdown="1">
-
-Save the Fourier-transformed fields corresponding to the given force object in an
-HDF5 file of the given `filename` without the ".h5" suffix (the current
-filename-prefix is prepended automatically).
-
-</div>
-
-<a id="Simulation.save_mode"></a>
-
-```python
-def save_mode(self, fname, flux):
-```
-
-<div class="method_docstring" markdown="1">
-
-Save the Fourier-transformed fields corresponding to the given flux object in an
-HDF5 file of the given `filename` without the ".h5" suffix (the current
-filename-prefix is prepended automatically).
-
-</div>
-
-<a id="Simulation.save_near2far"></a>
-
-```python
-def save_near2far(self, fname, near2far):
-```
-
-<div class="method_docstring" markdown="1">
-
-Save the Fourier-transformed fields corresponding to the given `near2far` object
-in an HDF5 file of the given `filename` (without the ".h5" suffix). The current
-filename-prefix is prepended automatically.
-
-</div>
-
-<a id="Simulation.set_boundary"></a>
-
-```python
-def set_boundary(self, side, direction, condition):
-```
-
-<div class="method_docstring" markdown="1">
-
-Sets the condition of the boundary on the specified side in the specified
-direction. See the [Constants (Enumerated Types)](#constants-enumerated-types)
-section for valid `side`, `direction`, and `boundary_condition` values.
-
-</div>
-
-<a id="Simulation.set_epsilon"></a>
-
-```python
-def set_epsilon(self, eps):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.set_materials"></a>
-
-```python
-def set_materials(self, geometry=None, default_material=None):
-```
-
-<div class="method_docstring" markdown="1">
-
-This can be called in a step function, and is useful for changing the geometry or default material as a function of time.
-
-</div>
-
-<a id="Simulation.solve_cw"></a>
-
-```python
-def solve_cw(self, tol=1e-08, maxiters=10000, L=2):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.solve_eigfreq"></a>
-
-```python
-def solve_eigfreq(self,
-                  tol=1e-07,
-                  maxiters=100,
-                  guessfreq=None,
-                  cwtol=None,
-                  cwmaxiters=10000,
-                  L=10):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Simulation.time_spent_on"></a>
-
-```python
-def time_spent_on(self, time_sink):
-```
-
-<div class="method_docstring" markdown="1">
-
-Return a list of times spent by each process for a type of work `time_sink` which
-can be one of nine integer values `0`-`8`: (`0`) connecting chunks, (`1`) time
-stepping, (`2`) boundaries, (`3`) MPI/synchronization, (`4`) field output, (`5`)
-Fourier transforming, (`6`) MPB, (`7`) near to far field transformation, and (`8`)
-other.
-
-</div>
-
-<a id="Simulation.use_output_directory"></a>
-
-```python
-def use_output_directory(self, dname=''):
-```
-
-<div class="method_docstring" markdown="1">
-
-Put output in a subdirectory, which is created if necessary. If the optional
-argument dirname is specified, that is the name of the directory. Otherwise, the
-directory name is the current Python file name with `".py"` replaced by `"-out"`:
-e.g. `test.py` implies a directory of `"test-out"`.
-
 </div>
 
 <a id="Simulation.visualize_chunks"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def visualize_chunks(self):
@@ -2583,56 +2443,1268 @@ Requires [matplotlib](https://matplotlib.org).
 
 </div>
 
+An animated visualization is also possible via the [Animate2D](#Animate2D) class.
 
 
-Predefined Variables
---------------------
+### Run and Step Functions
 
-These are available directly via the `meep` package.
+The actual work in Meep is performed by `run` functions, which time-step the simulation for a given amount of time or until a given condition is satisfied. These are attributes of the `Simulation` class.
 
-**`air`, `vacuum` [`Medium` class ]**
-—
-Two aliases for a predefined material type with a dielectric constant of 1.
+The run functions, in turn, can be modified by use of [step functions](#predefined-step-functions): these are called at every time step and can perform any arbitrary computation on the fields, do outputs and I/O, or even modify the simulation. The step functions can be transformed by many [modifier functions](#step-function-modifiers), like `at_beginning`, `during_sources`, etcetera which cause them to only be called at certain times, etcetera, instead of at every time step.
 
-**`perfect_electric_conductor` or `metal` [`Medium` class ]**
-—
-A predefined material type corresponding to a perfect electric conductor at the boundary of which the parallel electric field is zero. Technically, $\varepsilon = -\infty$.
+A common point of confusion is described in [The Run Function Is Not A Loop](The_Run_Function_Is_Not_A_Loop.md). Read this article if you want to make Meep do some customized action on each time step, as many users make the same mistake. What you really want to in that case is to write a step function, as described below.
 
-**`perfect_magnetic_conductor` [`Medium` class ]**
-—
-A predefined material type corresponding to a perfect magnetic conductor at the boundary of which the parallel magnetic field is zero. Technically, $\mu = -\infty$.
 
-**`inf` [`number`]**
-—
-A big number (10<sup>20</sup>) to use for "infinite" dimensions of objects.
+<a id="Simulation.run"></a>
 
-Constants (Enumerated Types)
-----------------------------
+<div class="class_members" markdown="1">
 
-Several of the functions/classes in Meep ask you to specify e.g. a field component or a direction in the grid. These should be one of the following constants (which are available directly via the `meep` package):
+```python
+def run(self, *step_funcs, **kwargs):
+```
 
-**`direction` constants**
-—
-Specify a direction in the grid. One of `X`, `Y`, `Z`, `R`, `P` for $x$, $y$, $z$, $r$, $\phi$, respectively.
+<div class="method_docstring" markdown="1">
 
-**`side` constants**
-—
-Specify particular boundary in the positive `High` (e.g., +`X`) or negative `Low` (e.g., -`X`) direction.
+`run(step_functions..., until=condition/time)`
 
-**`boundary_condition` constants**
-—
-`Metallic` (i.e., zero electric field) or `Magnetic` (i.e., zero magnetic field).
+Run the simulation until a certain time or condition, calling the given step
+functions (if any) at each timestep. The keyword argument `until` is *either* a
+number, in which case it is an additional time (in Meep units) to run for, *or* it
+is a function (of no arguments) which returns `True` when the simulation should
+stop. `until` can also be a list of stopping conditions which may include a number
+and additional functions.
 
-**`component` constants**
-—
-Specify a particular field or other component. One of `Ex`, `Ey`, `Ez`, `Er`, `Ep`, `Hx`, `Hy`, `Hz`, `Hy`, `Hp`, `Hz`, `Bx`, `By`, `Bz`, `By`, `Bp`, `Bz`, `Dx`, `Dy`, `Dz`, `Dr`, `Dp`, `Dielectric`, `Permeability`, for $E_x$, $E_y$, $E_z$, $E_r$, $E_\phi$, $H_x$, $H_y$, $H_z$, $H_r$, $H_\phi$, $B_x$, $B_y$, $B_z$, $B_r$, $B_\phi$, $D_x$, $D_y$, $D_z$, $D_r$, $D_\phi$, ε, μ, respectively.
+`run(step_functions..., until_after_sources=condition/time)`
 
-**`derived_component` constants**
-—
-These are additional components which are not actually stored by Meep but are computed as needed, mainly for use in output functions. One of `Sx`, `Sy`, `Sz`, `Sr`, `Sp`, `EnergyDensity`, `D_EnergyDensity`, `H_EnergyDensity` for $S_x$, $S_y$, $S_z$, $S_r$, $S_\phi$ (components of the Poynting vector $\mathrm{Re}\,\mathbf{E}^* \times \mathbf{H}$), $(\mathbf{E}^* \cdot \mathbf{D} + \mathbf{H}^* \cdot \mathbf{B})/2$, $\mathbf{E}^* \cdot \mathbf{D}/2$, $\mathbf{H}^* \cdot \mathbf{B}/2$, respectively.
+Run the simulation until all sources have turned off, calling the given step
+functions (if any) at each timestep. The keyword argument `until_after_sources` is
+either a number, in which case it is an *additional* time (in Meep units) to run
+for after the sources are off, *or* it is a function (of no arguments). In the
+latter case, the simulation runs until the sources are off *and* `condition`
+returns `True`. Like `until` above, `until_after_sources` can take a list of
+stopping conditions.
 
-Classes
--------
+</div>
+
+</div>
+
+In particular, a useful value for `until_after_sources` or `until` is often `stop_when_field_decayed`, which is demonstrated in [Tutorial/Basics](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend). These top-level functions are available:
+
+
+<a id="stop_when_fields_decayed"></a>
+
+```python
+def stop_when_fields_decayed(dt, c, pt, decay_by):
+```
+
+<div class="function_docstring" markdown="1">
+
+Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
+or `until_after_sources` parameter, that examines the component `c` (e.g. `Ex`, etc.)
+at the point `pt` (a `Vector3`) and keeps running until its absolute value *squared*
+has decayed by at least `decay_by` from its maximum previous value. In particular, it
+keeps incrementing the run time by `dT` (in Meep units) and checks the maximum value
+over that time period &mdash; in this way, it won't be fooled just because the field
+happens to go through 0 at some instant.
+
+Note that, if you make `decay_by` very small, you may need to increase the `cutoff`
+property of your source(s), to decrease the amplitude of the small high-frequency
+components that are excited when the source turns off. High frequencies near the
+[Nyquist frequency](https://en.wikipedia.org/wiki/Nyquist_frequency) of the grid have
+slow group velocities and are absorbed poorly by [PML](Perfectly_Matched_Layer.md).
+
+</div>
+
+<a id="stop_after_walltime"></a>
+
+```python
+def stop_after_walltime(t):
+```
+
+<div class="function_docstring" markdown="1">
+
+Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
+parameter. Stops the simulation after `t` seconds of wall time have passed.
+
+</div>
+
+<a id="stop_on_interrupt"></a>
+
+```python
+def stop_on_interrupt():
+```
+
+<div class="function_docstring" markdown="1">
+
+Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
+parameter. Instead of terminating when receiving a SIGINT or SIGTERM signal from the
+system, the simulation will abort time stepping and continue executing any code that
+follows the `run` function (e.g., outputting fields).
+
+</div>
+
+
+Finally, another run function, useful for computing ω(**k**) band diagrams, is available via these top-level functions:
+
+@@ meep.run_k_points @@
+@@ meep.run_k_point @@
+
+
+### Predefined Step Functions
+
+Several useful step functions are predefined by Meep. These are available directly via the `meep` package but require a `Simulation` instance as an argument.
+
+#### Output Functions
+
+The most common step function is an output function, which outputs some field component to an [HDF5](https://en.wikipedia.org/wiki/HDF5) file. Normally, you will want to modify this by one of the `at_*` functions, below, as outputting a field at *every* time step can get quite time- and storage-consuming.
+
+Note that although the various field components are stored at different places in the [Yee lattice](Yee_Lattice.md), when they are outputted they are all linearly interpolated to the same grid: to the points at the *centers* of the Yee cells, i.e. $(i+0.5,j+0.5,k+0.5)\cdotΔ$ in 3d.
+
+
+
+<a id="Simulation.output_dft"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def output_dft(self, dft_fields, fname):
+```
+
+<div class="method_docstring" markdown="1">
+
+Output the Fourier-transformed fields in `dft_fields` (created by
+`add_dft_fields`) to an HDF5 file with name `fname` (does *not* include the `.h5`
+suffix).
+
+</div>
+
+</div>
+
+
+<a id="output_epsilon"></a>
+
+```python
+def output_epsilon(sim, *step_func_args, **kwargs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given a frequency `frequency`, (provided as a keyword argument) output ε (relative
+permittivity); for an anisotropic ε tensor the output is the [harmonic
+mean](https://en.wikipedia.org/wiki/Harmonic_mean) of the ε eigenvalues. If
+`frequency` is non-zero, the output is complex; otherwise it is the real,
+frequency-independent part of ε (the $\omega        o\infty$ limit).
+
+</div>
+
+<a id="output_mu"></a>
+
+```python
+def output_mu(sim, *step_func_args, **kwargs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given a frequency `frequency`, (provided as a keyword argument) output μ (relative
+permeability); for an anisotropic μ tensor the output is the [harmonic
+mean](https://en.wikipedia.org/wiki/Harmonic_mean) of the μ eigenvalues. If
+`frequency` is non-zero, the output is complex; otherwise it is the real,
+frequency-independent part of μ (the $\omega        o\infty$ limit).
+
+</div>
+
+<a id="output_poynting"></a>
+
+```python
+def output_poynting(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the Poynting flux $\mathrm{Re}\{\mathbf{E}^* imes\mathbf{H}\}$. Note that you
+might want to wrap this step function in `synchronized_magnetic` to compute it more
+accurately. See [Synchronizing the Magnetic and Electric
+Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
+
+</div>
+
+<a id="output_hpwr"></a>
+
+```python
+def output_hpwr(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the magnetic-field energy density $\mathbf{H}^* \cdot \mathbf{B} / 2$
+
+</div>
+
+<a id="output_dpwr"></a>
+
+```python
+def output_dpwr(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the electric-field energy density $\mathbf{E}^* \cdot \mathbf{D} / 2$
+
+</div>
+
+<a id="output_tot_pwr"></a>
+
+```python
+def output_tot_pwr(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the total electric and magnetic energy density. Note that you might want to
+wrap this step function in `synchronized_magnetic` to compute it more accurately. See
+[Synchronizing the Magnetic and Electric
+Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
+
+</div>
+
+<a id="output_png"></a>
+
+```python
+def output_png(compnt, options, rm_h5=True):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the given field component (e.g. `Ex`, etc.) as a
+[PNG](https://en.wikipedia.org/wiki/PNG) image, by first outputting the HDF5 file,
+then converting to PNG via
+[h5topng](https://github.com/NanoComp/h5utils/blob/master/README.md), then deleting
+the HDF5 file. The second argument is a string giving options to pass to h5topng (e.g.
+`"-Zc bluered"`). See also [Tutorial/Basics/Output Tips and
+Tricks](Python_Tutorials/Basics.md#output-tips-and-tricks).
+
+It is often useful to use the h5topng `-C` or `-A` options to overlay the dielectric
+function when outputting fields. To do this, you need to know the name of the
+dielectric-function `.h5` file which must have been previously output by
+`output_epsilon`. To make this easier, a built-in shell variable `$EPS` is provided
+which refers to the last-output dielectric-function `.h5` file. So, for example
+`output_png(mp.Ez,"-C $EPS")` will output the $E_z$ field and overlay the dielectric
+contours.
+
+By default, `output_png` deletes the `.h5` file when it is done. To preserve the `.h5`
+file requires `output_png(component, h5topng_options, rm_h5=False)`.
+
+</div>
+
+
+<a id="output_hfield"></a>
+
+```python
+def output_hfield(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Outputs *all* the components of the field *h*, (magnetic) to an HDF5 file. That is,
+the different components are stored as different datasets within the *same* file.
+
+</div>
+
+<a id="output_hfield_x"></a>
+
+```python
+def output_hfield_x(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $x$ component of the field *h* (magnetic). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_hfield_y"></a>
+
+```python
+def output_hfield_y(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $y$ component of the field *h* (magnetic). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_hfield_z"></a>
+
+```python
+def output_hfield_z(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $z$ component of the field *h* (magnetic). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_hfield_r"></a>
+
+```python
+def output_hfield_r(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $r$ component of the field *h* (magnetic). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_hfield_p"></a>
+
+```python
+def output_hfield_p(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $\phi$ component of the field *h* (magnetic). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively.
+
+</div>
+
+
+<a id="output_bfield"></a>
+
+```python
+def output_bfield(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Outputs *all* the components of the field *b*, (magnetic) to an HDF5 file. That is,
+the different components are stored as different datasets within the *same* file.
+
+</div>
+
+<a id="output_bfield_x"></a>
+
+```python
+def output_bfield_x(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $x$ component of the field *b* (magnetic). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_bfield_y"></a>
+
+```python
+def output_bfield_y(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $y$ component of the field *b* (magnetic). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_bfield_z"></a>
+
+```python
+def output_bfield_z(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $z$ component of the field *b* (magnetic). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_bfield_r"></a>
+
+```python
+def output_bfield_r(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $r$ component of the field *b* (magnetic). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_bfield_p"></a>
+
+```python
+def output_bfield_p(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $\phi$ component of the field *b* (magnetic). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively. Note that for outputting the Poynting flux, you
+might want to wrap the step function in `synchronized_magnetic` to compute it more
+accurately. See [Synchronizing the Magnetic and Electric
+Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
+
+</div>
+
+
+<a id="output_efield"></a>
+
+```python
+def output_efield(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Outputs *all* the components of the field *e*, (electric) to an HDF5 file. That is,
+the different components are stored as different datasets within the *same* file.
+
+</div>
+
+<a id="output_efield_x"></a>
+
+```python
+def output_efield_x(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $x$ component of the field *e* (electric). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_efield_y"></a>
+
+```python
+def output_efield_y(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $y$ component of the field *e* (electric). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_efield_z"></a>
+
+```python
+def output_efield_z(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $z$ component of the field *e* (electric). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_efield_r"></a>
+
+```python
+def output_efield_r(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $r$ component of the field *e* (electric). If the field is complex, outputs
+two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real and
+imaginary parts, respectively.
+
+</div>
+
+<a id="output_efield_p"></a>
+
+```python
+def output_efield_p(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $\phi$ component of the field *e* (electric). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively. Note that for outputting the Poynting flux, you
+might want to wrap the step function in `synchronized_magnetic` to compute it more
+accurately. See [Synchronizing the Magnetic and Electric
+Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
+
+</div>
+
+
+<a id="output_dfield"></a>
+
+```python
+def output_dfield(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Outputs *all* the components of the field *d*, (displacement) to an HDF5 file. That
+is, the different components are stored as different datasets within the *same* file.
+
+</div>
+
+<a id="output_dfield_x"></a>
+
+```python
+def output_dfield_x(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $x$ component of the field *d* (displacement). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively.
+
+</div>
+
+<a id="output_dfield_y"></a>
+
+```python
+def output_dfield_y(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $y$ component of the field *d* (displacement). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively.
+
+</div>
+
+<a id="output_dfield_z"></a>
+
+```python
+def output_dfield_z(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $z$ component of the field *d* (displacement). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively.
+
+</div>
+
+<a id="output_dfield_r"></a>
+
+```python
+def output_dfield_r(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $r$ component of the field *d* (displacement). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively.
+
+</div>
+
+<a id="output_dfield_p"></a>
+
+```python
+def output_dfield_p(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $\phi$ component of the field *d* (displacement). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively. Note that for outputting the Poynting flux, you
+might want to wrap the step function in `synchronized_magnetic` to compute it more
+accurately. See [Synchronizing the Magnetic and Electric
+Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
+
+</div>
+
+
+<a id="output_sfield"></a>
+
+```python
+def output_sfield(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Outputs *all* the components of the field *s*, (poynting flux) to an HDF5 file. That
+is, the different components are stored as different datasets within the *same* file.
+Note that you might want to wrap this step function in `synchronized_magnetic` to
+compute it more accurately. See [Synchronizing the Magnetic and Electric
+Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
+
+</div>
+
+<a id="output_sfield_x"></a>
+
+```python
+def output_sfield_x(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $x$ component of the field *s* (poynting flux). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively.
+
+</div>
+
+<a id="output_sfield_y"></a>
+
+```python
+def output_sfield_y(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $y$ component of the field *s* (poynting flux). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively.
+
+</div>
+
+<a id="output_sfield_z"></a>
+
+```python
+def output_sfield_z(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $z$ component of the field *s* (poynting flux). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively.
+
+</div>
+
+<a id="output_sfield_r"></a>
+
+```python
+def output_sfield_r(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $r$ component of the field *s* (poynting flux). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively.
+
+</div>
+
+<a id="output_sfield_p"></a>
+
+```python
+def output_sfield_p(sim):
+```
+
+<div class="function_docstring" markdown="1">
+
+Output the $\phi$ component of the field *s* (poynting flux). If the field is complex,
+outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
+and imaginary parts, respectively. Note that for outputting the Poynting flux, you
+might want to wrap the step function in `synchronized_magnetic` to compute it more
+accurately. See [Synchronizing the Magnetic and Electric
+Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
+
+</div>
+
+
+More generally, it is possible to output an arbitrary function of position and zero or more field components, similar to the `Simulation.integrate_field_function` method, described above. This is done by:
+
+
+<a id="Simulation.output_field_function"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def output_field_function(self,
+                          name,
+                          cs,
+                          func,
+                          real_only=False,
+                          h5file=None):
+```
+
+<div class="method_docstring" markdown="1">
+
+Output the field function `func` to an HDF5 file in the datasets named `name*.r`
+and `name*.i` for the real and imaginary parts. Similar to
+`integrate_field_function`, `func` is a function of position (a `Vector3`) and the
+field components corresponding to `cs`: a list of `component` constants. If
+`real_only` is True, only outputs the real part of `func`.
+
+</div>
+
+</div>
+
+See also [Field Functions](Field_Functions.md), and [Synchronizing the Magnetic and Electric Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md) if you want to do computations combining the electric and magnetic fields.
+
+
+#### Array Slices
+
+The output functions described above write the data for the fields and materials for the entire cell to an HDF5 file. This is useful for post-processing as you can later read in the HDF5 file to obtain field/material data as a NumPy array. However, in some cases it is convenient to bypass the disk altogether to obtain the data *directly* in the form of a NumPy array without writing/reading HDF5 files. Additionally, you may want the field/material data on just a subregion (or slice) of the entire volume. This functionality is provided by the `get_array` method which takes as input a subregion of the cell and the field/material component. The method returns a NumPy array containing values of the field/material at the current simulation time.
+
+
+<a id="Simulation.get_array"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_array(self,
+              component=None,
+              vol=None,
+              center=None,
+              size=None,
+              cmplx=None,
+              arr=None,
+              frequency=0,
+              omega=0):
+```
+
+<div class="method_docstring" markdown="1">
+
+Takes as input a subregion of the cell and the field/material component. The
+method returns a NumPy array containing values of the field/material at the
+current simulation time.
+
+**Parameters:**
+
++ `vol`: `Volume`; the orthogonal subregion/slice of the computational volume. The
+  return value of `get_array` has the same dimensions as the `Volume`'s `size`
+  attribute. If `None` (default), then a `size` and `center` must be specified.
+
++ `center`, `size` : `Vector3`; if both are specified, the library will construct
+  an appropriate `Volume`. This is a convenience feature and alternative to
+  supplying a `Volume`.
+
++ `component`: field/material component (i.e., `mp.Ex`, `mp.Hy`, `mp.Sz`,
+  `mp.Dielectric`, etc). Defaults to `mp.Ez`.
+
++ `cmplx`: `boolean`; if `True`, return complex-valued data otherwise return
+  real-valued data (default).
+
++ `arr`: optional field to pass a pre-allocated NumPy array of the correct size,
+  which will be overwritten with the field/material data instead of allocating a
+  new array.  Normally, this will be the array returned from a previous call to
+  `get_array` for a similar slice, allowing one to re-use `arr` (e.g., when
+  fetching the same slice repeatedly at different times).
+
++ `frequency`: optional frequency point over which the average eigenvalue of the
+  dielectric and permeability tensors are evaluated (defaults to 0).
+
+For convenience, the following wrappers for `get_array` over the entire cell are
+available: `get_epsilon()`, `get_mu()`, `get_hpwr()`, `get_dpwr()`,
+`get_tot_pwr()`, `get_Xfield()`, `get_Xfield_x()`, `get_Xfield_y()`,
+`get_Xfield_z()`, `get_Xfield_r()`, `get_Xfield_p()` where `X` is one of `h`, `b`,
+`e`, `d`, or `s`. The routines `get_Xfield_*` all return an array type consistent
+with the fields (real or complex). The routines `get_epsilon()` and `get_mu()`
+accept the optional `frequency` parameter (defaults to 0).
+
+**Note on array-slice dimensions:** The routines `get_epsilon`, `get_Xfield_z`,
+etc. use as default `size=meep.Simulation.fields.total_volume()` which for
+simulations involving Bloch-periodic boundaries (via `k_point`) will result in
+arrays that have slightly *different* dimensions than e.g.
+`get_array(center=meep.Vector3(), size=cell_size, component=meep.Dielectric`, etc.
+(i.e., the slice spans the entire cell volume `cell_size`). Neither of these
+approaches is "wrong", they are just slightly different methods of fetching the
+boundaries. The key point is that if you pass the same value for the `size`
+parameter, or use the default, the slicing routines always give you the same-size
+array for all components. You should *not* try to predict the exact size of these
+arrays; rather, you should simply rely on Meep's output.
+
+</div>
+
+</div>
+
+<a id="Simulation.get_dft_array"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_dft_array(self, dft_obj, component, num_freq):
+```
+
+<div class="method_docstring" markdown="1">
+
+Returns the Fourier-transformed fields as a NumPy array.
+
+**Parameters:**
+
++ `dft_obj`: a `dft_flux`, `dft_force`, `dft_fields`, or `dft_near2far` object
+  obtained from calling the appropriate `add` function (e.g., `mp.add_flux`).
+
++ `component`: a field component (e.g., `mp.Ez`)
+
++ `num_freq`: the index of the frequency: an integer in the range `0...nfreq-1`,
+  where `nfreq` is the number of frequencies stored in `dft_obj` as set by the
+  `nfreq` parameter to `add_dft_fields`, `add_dft_flux`, etc.
+
+</div>
+
+</div>
+
+
+#### Array Metadata
+
+
+<a id="Simulation.get_array_metadata"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_array_metadata(self,
+                       vol=None,
+                       center=None,
+                       size=None,
+                       dft_cell=None,
+                       collapse=False,
+                       snap=False,
+                       return_pw=False):
+```
+
+<div class="method_docstring" markdown="1">
+
+This routine provides geometric information useful for interpreting the arrays
+returned by `get_array` or `get_dft_array` for the spatial region defined by `vol`
+or `center/size`. In both cases, the return value is a tuple `(x,y,z,w)`, where:
+
++ `x,y,z` are 1d NumPy arrays storing the $x,y,z$ coordinates of the points in the
+  grid slice
++ `w` is an array of the same dimensions as the array returned by
+  `get_array`/`get_dft_array`, whose entries are the weights in a cubature rule
+  for integrating over the spatial region (with the points in the cubature rule
+  being just the grid points contained in the region). Thus, if $Q(\mathbf{x})$ is
+  some spatially-varying quantity whose value at the $n$th grid point is $Q_n$,
+  the integral of $Q$ over the region may be approximated by the sum:
+
+$$ \int_{\mathcal V} Q(\mathbf{x})d\mathbf{x} pprox \sum_{n} w_n Q_n.$$
+
+This is a 1-, 2-, or 3-dimensional integral depending on the number of dimensions
+in which $\mathcal{V}$ has zero extent. If the $\{Q_n\}$ samples are stored in an
+array `Q` of the same dimensions as `w`, then evaluating the sum on the RHS is
+just one line: `np.sum(w*Q).`
+
+A convenience parameter `dft_cell` is provided as an alternative to `vol` or
+`center/size`; set `dft_cell` to a `dft_flux` or `dft_fields` object to define the
+region covered by the array. If the `dft` argument is provided then all other
+arguments (`vol`, `center`, and `size`) are ignored. If no arguments are provided,
+then the entire cell is used.
+
+</div>
+
+</div>
+
+This routine provides geometric information useful for interpreting the arrays returned by `get_array` or `get_dft_array` for the spatial region defined by `vol` or `center/size`. Here are some examples of how array metadata can be used:
+
+**Labeling Axes in Plots of Grid Quantities**
+
+```python
+# using the geometry from the bend-flux tutorial example
+import matplotlib.pyplot as plt
+import numpy as np
+
+eps_array=sim.get_epsilon()
+(x,y,z,w)=sim.get_array_metadata()
+plt.figure()
+ax = plt.subplot(111)
+plt.pcolormesh(x,y,np.transpose(eps_array),shading='gouraud')
+ax.set_aspect('equal')
+plt.show()
+```
+
+![](images/PermittivityWithLabeledAxes.png)
+
+**Computing Quantities Defined by Integrals of Field-Dependent Functions Over Grid Regions**
+
++ energy stored in the $\mathbf{E}$-field in a region $\mathcal{V}$:
+      $$ \mathcal{E}=
+         \frac{1}{2}\int_{\mathcal V} \epsilon |\mathbf{E}|^2\,dV
+      $$
+
++ Poynting flux through a surface $\mathcal{S}$:
+      $$\mathcal{S}=\frac{1}{2}\text{Re }\int_{\mathcal S}
+        \Big(\mathbf{E}^*\times \mathbf{H}\Big)\times d\mathbf{A}
+      $$
+
+```python
+  import numpy as np
+
+  # E-field modal volume in box from time-domain fields
+  box            = mp.Volume(center=box_center, size=box_size)
+  (Ex,Ey,Ez)     = [sim.get_array(vol=box, component=c, cmplx=True) for c in [mp.Ex, mp.Ey, mp.Ez]]
+  eps            = sim.get_array(vol=box, component=mp.Dielectric)
+  (x,y,z,w)      = sim.get_array_metadata(vol=box)
+  energy_density = np.real(eps*(np.conj(Ex)*Ex + np.conj(Ey)*Ey + np.conj(Ez)*Ez)) # array
+  energy         = np.sum(w*energy_density)                                        # scalar
+
+  # x-directed Poynting flux through monitor from frequency-domain fields
+  monitor        = mp.FluxRegion(center=mon_center, size=mon_size)
+  dft_cell       = sim.add_flux(freq, freq, 1, monitor)
+  sim.run(...)    # timestep until DFTs converged
+  (Ey,Ez,Hy,Hz)  = [sim.get_dft_array(dft_cell,c,0) for c in [mp.Ey, mp.Ez, mp.Hy, mp.Hz]]
+  (x,y,z,w)      = sim.get_array_metadata(dft=dft_cell)
+  flux_density   = np.real( np.conj(Ey)*Hz - np.conj(Ez)*Hy )    # array
+  flux           = np.sum(w*flux_density)                        # scalar
+```
+
+#### Source Slices
+
+
+<a id="Simulation.get_source"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_source(self,
+               component,
+               vol=None,
+               center=None,
+               size=None):
+```
+
+<div class="method_docstring" markdown="1">
+
+Return an array of complex values of the [source](#source) amplitude for
+`component` over the given `vol` or `center`/`size`. The array has the same
+dimensions as that returned by [`get_array`](#array-slices).
+
+</div>
+
+</div>
+
+
+#### Harminv Step Function
+
+The following step function collects field data from a given point and runs [Harminv](https://github.com/NanoComp/harminv) on that data to extract the frequencies, decay rates, and other information.
+
+* [Harminv class](#Harminv)
+
+
+### Step-Function Modifiers
+
+Rather than writing a brand-new step function every time something a bit different is required, the following "modifier" functions take a bunch of step functions and produce *new* step functions with modified behavior.
+See also [Tutorial/Basics](Python_Tutorials/Basics.md) for examples.
+
+
+#### Miscellaneous Step-Function Modifiers
+
+
+<a id="combine_step_funcs"></a>
+
+```python
+def combine_step_funcs(*step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, return a new step function that on each step calls
+all of the passed step functions.
+
+</div>
+
+<a id="synchronized_magnetic"></a>
+
+```python
+def synchronized_magnetic(*step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, return a new step function that on each step calls
+all of the passed step functions with the magnetic field synchronized in time with the
+electric field. See [Synchronizing the Magnetic and Electric
+Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
+
+</div>
+
+
+#### Controlling When a Step Function Executes
+
+
+<a id="when_true"></a>
+
+```python
+def when_true(cond, *step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions and a condition function `condition` (a function of
+no arguments), evaluate the step functions whenever `condition` returns `True`.
+
+</div>
+
+<a id="when_false"></a>
+
+```python
+def when_false(cond, *step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions and a condition function `condition` (a function of
+no arguments), evaluate the step functions whenever `condition` returns `False`.
+
+</div>
+
+<a id="at_every"></a>
+
+```python
+def at_every(dt, *step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, evaluates them at every time interval of $dT$ units
+(rounded up to the next time step).
+
+</div>
+
+<a id="after_time"></a>
+
+```python
+def after_time(t, *step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, evaluates them only for times after a $T$ time
+units have elapsed from the start of the run.
+
+</div>
+
+<a id="before_time"></a>
+
+```python
+def before_time(t, *step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, evaluates them only for times before a $T$ time
+units have elapsed from the start of the run.
+
+</div>
+
+<a id="at_time"></a>
+
+```python
+def at_time(t, *step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, evaluates them only once, after a $T$ time units
+have elapsed from the start of the run.
+
+</div>
+
+<a id="after_sources"></a>
+
+```python
+def after_sources(*step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, evaluates them only for times after all of the
+sources have turned off.
+
+</div>
+
+<a id="after_sources_and_time"></a>
+
+```python
+def after_sources_and_time(t, *step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, evaluates them only for times after all of the
+sources have turned off, plus an additional $T$ time units have elapsed.
+
+</div>
+
+<a id="during_sources"></a>
+
+```python
+def during_sources(*step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, evaluates them only for times *before* all of the
+sources have turned off.
+
+</div>
+
+<a id="at_beginning"></a>
+
+```python
+def at_beginning(*step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, evaluates them only once, at the beginning of the
+run.
+
+</div>
+
+<a id="at_end"></a>
+
+```python
+def at_end(*step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, evaluates them only once, at the end of the run.
+
+</div>
+
+
+#### Modifying HDF5 Output
+
+
+<a id="in_volume"></a>
+
+```python
+def in_volume(v, *step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, modifies any output functions among them to only
+output a subset (or a superset) of the cell, corresponding to the `meep::volume* v`
+(created by the `Volume` function).
+
+</div>
+
+<a id="in_point"></a>
+
+```python
+def in_point(pt, *step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, modifies any output functions among them to only
+output a single *point* of data, at `pt` (a `Vector3`).
+
+</div>
+
+<a id="to_appended"></a>
+
+```python
+def to_appended(fname, *step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, modifies any output functions among them to
+*append* their data to datasets in a single newly-created file named `filename` (plus
+an `.h5` suffix and the current filename prefix). They append by adding an *extra
+dimension* to their datasets, corresponding to time.
+
+</div>
+
+<a id="with_prefix"></a>
+
+```python
+def with_prefix(pre, *step_funcs):
+```
+
+<div class="function_docstring" markdown="1">
+
+Given zero or more step functions, modifies any output functions among them to prepend
+the string `prefix` to the file names (much like `filename_prefix`, above).
+
+</div>
+
+### Writing Your Own Step Functions
+
+A step function can take two forms. The simplest is just a function with one argument (the simulation instance), which is called at every time step unless modified by one of the modifier functions above. e.g.
+
+```py
+def my_step(sim):
+    print("Hello world!")
+```
+
+If one then does `sim.run(my_step, until=100)`, Meep will run for 100 time units and print "Hello world!" at every time step.
+
+This suffices for most purposes. However, sometimes you need a step function that opens a file, or accumulates some computation, and you need to clean up (e.g. close the file or print the results) at the end of the run. For this case, you can write a step function of two arguments: the second argument will either be `step` when it is called during time-stepping, or `finish` when it is called at the end of the run:
+
+```py
+def my_step(sim, todo):
+    if todo == 'step':
+       # do something
+    elif todo == 'finish':
+       # do something else
+
+    # access simulation attributes
+    sim.fields ...etc.
+```
+
+Low-Level Functions
+-------------------
+
+By default, Meep initializes C++ objects like `meep::structure` and `meep::fields` in the `Simulation` object based on attributes like `sources` and `geometry`. Theses objects are then accessible via `simulation_instance.structure` and `simulation_instance.fields`. Given these, you can then call essentially any function in the C++ interface, because all of the C++ functions are automatically made accessible to Python by the wrapper-generator program [SWIG](https://en.wikipedia.org/wiki/SWIG).
+
+### Initializing the Structure and Fields
+
+The `structure` and `fields` variables are automatically initialized when any of the run functions is called, or by various other functions such as `add_flux`. To initialize them separately, you can call `Simulation.init_sim()` manually, or `Simulation._init_structure(k_point)` to just initialize the structure.
+
+If you want to time step more than one field simultaneously, the easiest way is probably to do something like:
+
+```py
+sim = Simulation(cell_size, resolution).init_sim()
+my_fields = sim.fields
+sim.fields = None
+sim.reset_meep()
+```
+
+and then change the geometry etc. and re-run `sim.init_sim()`. Then you'll have two field objects in memory.
+
+### SWIG Wrappers
+
+If you look at a function in the C++ interface, then there are a few simple rules to infer the name of the corresponding Python function.
+
+-   First, all functions in the `meep::` namespace are available in the Meep Python module from the top-level `meep` package.
+-   Second, any method of a class is accessible via the standard Python class interface. For example, `meep::fields::step`, which is the function that performs a time-step, is exposed to Python as `fields_instance.step()` where a fields instance is usually accessible from Simulation.fields.
+-   C++ constructors are called using the normal Python class instantiation. E.g., `fields = mp.fields(...)` returns a new `meep::fields` object. Calling destructors is not necessary because objects are automatically garbage collected.
+
+Some argument type conversion is performed automatically, e.g. types like complex numbers are converted to `complex<double>`, etcetera. `Vector3` vectors are converted to `meep::vec`, but to do this it is necessary to know the dimensionality of the problem in C++. The problem dimensions are automatically initialized by `Simulation._init_structure`, but if you want to pass vector arguments to C++ before that time you should call `Simulation.require_dimensions()`, which infers the dimensions from the `cell_size`, `k_point`, and `dimensions` variables.
+
+
+
+<a id="classes"></a>
+
+Class Reference
+---------------
 
 Classes are complex datatypes with various properties which may have default values. Classes can be "subclasses" of other classes. Subclasses inherit all the properties of their superclass and can be used in any place the superclass is expected.
 
@@ -2713,10 +3785,11 @@ objects that are subclasses of type `Susceptibility`.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Medium.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -2805,7 +3878,11 @@ Creates a `Medium` object.
 
 </div>
 
+</div>
+
 <a id="Medium.__repr__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __repr__(self):
@@ -2817,7 +3894,11 @@ Return repr(self).
 
 </div>
 
+</div>
+
 <a id="Medium.epsilon"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def epsilon(self, freq):
@@ -2831,7 +3912,11 @@ of a list/array of N frequency points, a Numpy array of size Nx3x3 is returned.
 
 </div>
 
+</div>
+
 <a id="Medium.mu"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def mu(self, freq):
@@ -2845,19 +3930,11 @@ of a list/array of N frequency points, a Numpy array of size Nx3x3 is returned.
 
 </div>
 
-<a id="Medium.rotate"></a>
-
-```python
-def rotate(self, axis, theta):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
 </div>
 
 <a id="Medium.transform"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def transform(self, m):
@@ -2896,10 +3973,11 @@ anisotropic amplitude σ. See [Material Dispersion](Materials.md#material-disper
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Susceptibility.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -2922,18 +4000,6 @@ corresponds to a σ tensor
 
 </div>
 
-<a id="Susceptibility.transform"></a>
-
-```python
-def transform(self, m):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
 </div>
 
 ---
@@ -2953,10 +4019,11 @@ the parameters (in addition to σ):
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="LorentzianSusceptibility.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
@@ -2971,18 +4038,6 @@ def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
 Note: multiple objects with identical values for the `frequency` and `gamma` but
 different `sigma` will appear as a *single* Lorentzian susceptibility term in the
 preliminary simulation info output.
-
-</div>
-
-<a id="LorentzianSusceptibility.eval_susceptibility"></a>
-
-```python
-def eval_susceptibility(self, freq):
-```
-
-<div class="method_docstring" markdown="1">
-
-
 
 </div>
 
@@ -3004,10 +4059,11 @@ Dispersion](Materials.md#material-dispersion), with the parameters (in addition 
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="DrudeSusceptibility.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
@@ -3019,18 +4075,6 @@ def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
   which multiplies σ (not a resonance frequency).
 
 + **`gamma` [`number`]** — The loss rate $γ_n / 2\pi$.
-
-</div>
-
-<a id="DrudeSusceptibility.eval_susceptibility"></a>
-
-```python
-def eval_susceptibility(self, freq):
-```
-
-<div class="method_docstring" markdown="1">
-
-
 
 </div>
 
@@ -3056,10 +4100,11 @@ Absorption](Materials.md#saturable-gain-and-absorption).
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="MultilevelAtom.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -3099,10 +4144,11 @@ A `Transition` is... (TODO)
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Transition.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -3157,10 +4203,11 @@ space and time, zero mean) added to the **P** damped-oscillator equation.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="NoisyLorentzianSusceptibility.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, noise_amp=0.0, **kwargs):
@@ -3207,10 +4254,11 @@ space and time, zero mean) added to the **P** damped-oscillator equation.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="NoisyDrudeSusceptibility.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, noise_amp=0.0, **kwargs):
@@ -3257,10 +4305,11 @@ meanings](#susceptibility), and an additional 3-vector `bias`:
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="GyrotropicLorentzianSusceptibility.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs):
@@ -3295,10 +4344,11 @@ meanings](#susceptibility), and an additional 3-vector `bias`:
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="GyrotropicDrudeSusceptibility.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs):
@@ -3335,10 +4385,11 @@ parameter and an `alpha` parameter:
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="GyrotropicSaturatedSusceptibility.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -3396,23 +4447,11 @@ iterable (e.g., a tuple or list) and automatically convert to a `Vector3`.
 
 </div>
 
-<div class="class_members" markdown="1">
 
-
-<a id="Vector3.__init__"></a>
-
-```python
-def __init__(self, x=0.0, y=0.0, z=0.0):
-```
-
-<div class="method_docstring" markdown="1">
-
-Create a new `Vector3` with the given components. All three components default to
-zero. This can also be represented simply as `(x,y,z)` or `[x,y,z]`.
-
-</div>
 
 <a id="Vector3.__add__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __add__(self, other):
@@ -3428,19 +4467,11 @@ v3 = v1 + v2
 
 </div>
 
-<a id="Vector3.__array__"></a>
-
-```python
-def __array__(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
 </div>
 
 <a id="Vector3.__eq__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __eq__(self, other):
@@ -3458,19 +4489,28 @@ v1 == v2
 
 </div>
 
-<a id="Vector3.__getitem__"></a>
+</div>
+
+<a id="Vector3.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
-def __getitem__(self, i):
+def __init__(self, x=0.0, y=0.0, z=0.0):
 ```
 
 <div class="method_docstring" markdown="1">
 
+Create a new `Vector3` with the given components. All three components default to
+zero. This can also be represented simply as `(x,y,z)` or `[x,y,z]`.
 
+</div>
 
 </div>
 
 <a id="Vector3.__mul__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __mul__(self, other):
@@ -3487,7 +4527,11 @@ c = v1 * other
 
 </div>
 
+</div>
+
 <a id="Vector3.__ne__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __ne__(self, other):
@@ -3505,7 +4549,11 @@ v1 != v2
 
 </div>
 
+</div>
+
 <a id="Vector3.__repr__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __repr__(self):
@@ -3517,7 +4565,11 @@ Return repr(self).
 
 </div>
 
+</div>
+
 <a id="Vector3.__rmul__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __rmul__(self, other):
@@ -3534,7 +4586,11 @@ c = other * v1
 
 </div>
 
+</div>
+
 <a id="Vector3.__sub__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __sub__(self, other):
@@ -3550,19 +4606,11 @@ v3 = v1 - v2
 
 </div>
 
-<a id="Vector3.__truediv__"></a>
-
-```python
-def __truediv__(self, other):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
 </div>
 
 <a id="Vector3.cdot"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def cdot(self, v):
@@ -3574,7 +4622,11 @@ Returns the conjugated dot product: *self*\* dot *v*.
 
 </div>
 
+</div>
+
 <a id="Vector3.close"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def close(self, v, tol=1e-07):
@@ -3591,19 +4643,11 @@ v1.close(v2, [tol])
 
 </div>
 
-<a id="Vector3.conj"></a>
-
-```python
-def conj(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
 </div>
 
 <a id="Vector3.cross"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def cross(self, v):
@@ -3619,7 +4663,11 @@ v3 = v1.cross(v2)
 
 </div>
 
+</div>
+
 <a id="Vector3.dot"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def dot(self, v):
@@ -3635,7 +4683,11 @@ v3 = v1.dot(v2)
 
 </div>
 
+</div>
+
 <a id="Vector3.norm"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def norm(self):
@@ -3651,7 +4703,11 @@ v2 = v1.norm()
 
 </div>
 
+</div>
+
 <a id="Vector3.rotate"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def rotate(self, axis, theta):
@@ -3670,43 +4726,11 @@ v2 = v1.rotate(axis, theta)
 
 </div>
 
-<a id="Vector3.rotate_lattice"></a>
-
-```python
-def rotate_lattice(self, axis, theta, lat):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Vector3.rotate_reciprocal"></a>
-
-```python
-def rotate_reciprocal(self, axis, theta, lat):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Vector3.scale"></a>
-
-```python
-def scale(self, s):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
 </div>
 
 <a id="Vector3.unit"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def unit(self):
@@ -3788,10 +4812,11 @@ geometry = [mp.Prism(vertices, height=1.5, center=mp.Vector3(), material=cSi)]
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="GeometricObject.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -3822,55 +4847,11 @@ constructor via keyword arguments.
 
 </div>
 
-<a id="GeometricObject.__add__"></a>
-
-```python
-def __add__(self, vec):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="GeometricObject.__contains__"></a>
-
-```python
-def __contains__(self, point):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="GeometricObject.__iadd__"></a>
-
-```python
-def __iadd__(self, vec):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="GeometricObject.__radd__"></a>
-
-```python
-def __radd__(self, vec):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
 </div>
 
 <a id="GeometricObject.info"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def info(self, indent_by=0):
@@ -3883,7 +4864,11 @@ Displays all properties and current values of a `GeometricObject`, indented by
 
 </div>
 
+</div>
+
 <a id="GeometricObject.shift"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def shift(self, vec):
@@ -3923,10 +4908,11 @@ Represents a sphere.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Sphere.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, radius, **kwargs):
@@ -3964,10 +4950,11 @@ A cylinder, with circular cross-section and finite height.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Cylinder.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -4000,10 +4987,11 @@ Represents a cylindrical wedge.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Wedge.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -4040,10 +5028,11 @@ is halfway between the two circular ends.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Cone.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, radius, radius2=0, **kwargs):
@@ -4076,10 +5065,11 @@ A parallelepiped (i.e., a brick, possibly with non-orthogonal axes).
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Block.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -4122,10 +5112,11 @@ properties, but defines an ellipsoid inscribed inside the block.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Ellipsoid.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, **kwargs):
@@ -4154,10 +5145,11 @@ Polygonal prism type.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Prism.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -4244,10 +5236,11 @@ Scales the matrix `m` by the number `s`.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Matrix.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -4264,55 +5257,11 @@ Constructs a `Matrix`.
 
 </div>
 
-<a id="Matrix.__add__"></a>
-
-```python
-def __add__(self, m):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.__array__"></a>
-
-```python
-def __array__(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.__getitem__"></a>
-
-```python
-def __getitem__(self, i):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.__mul__"></a>
-
-```python
-def __mul__(self, m):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
 </div>
 
 <a id="Matrix.__repr__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __repr__(self):
@@ -4321,150 +5270,6 @@ def __repr__(self):
 <div class="method_docstring" markdown="1">
 
 Return repr(self).
-
-</div>
-
-<a id="Matrix.__rmul__"></a>
-
-```python
-def __rmul__(self, left_arg):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.__sub__"></a>
-
-```python
-def __sub__(self, m):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.__truediv__"></a>
-
-```python
-def __truediv__(self, scalar):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.conj"></a>
-
-```python
-def conj(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.determinant"></a>
-
-```python
-def determinant(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.getH"></a>
-
-```python
-def getH(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.inverse"></a>
-
-```python
-def inverse(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.mm_mult"></a>
-
-```python
-def mm_mult(self, m):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.mv_mult"></a>
-
-```python
-def mv_mult(self, v):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.row"></a>
-
-```python
-def row(self, i):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.scale"></a>
-
-```python
-def scale(self, s):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Matrix.transpose"></a>
-
-```python
-def transpose(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
 
 </div>
 
@@ -4523,10 +5328,11 @@ the axis of the rotation.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Symmetry.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, direction, phase=1):
@@ -4566,11 +5372,8 @@ rotation.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
-
-</div>
 
 ---
 <a id="Rotate4"></a>
@@ -4588,11 +5391,8 @@ rotation.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
-
-</div>
 
 ---
 <a id="Mirror"></a>
@@ -4609,11 +5409,8 @@ A mirror symmetry plane. `direction` is the direction *normal* to the mirror pla
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
-
-</div>
 
 ---
 <a id="Identity"></a>
@@ -4630,11 +5427,8 @@ class Identity(Symmetry):
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
-
-</div>
 
 ---
 <a id="PML"></a>
@@ -4657,10 +5451,11 @@ properties.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="PML.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -4669,7 +5464,7 @@ def __init__(self,
              side=-1,
              R_asymptotic=1e-15,
              mean_stretch=1.0,
-             pml_profile=<function PML.<lambda> at 0x7fe669109b00>):
+             pml_profile=<function PML.<lambda> at 0x7fa29002fdd0>):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4753,11 +5548,8 @@ The main reason to use `Absorber` is if you have **a case in which PML fails:**
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
-
-</div>
 
 ---
 <a id="Source"></a>
@@ -4792,10 +5584,11 @@ Nanotechnology](https://www.amazon.com/Advances-FDTD-Computational-Electrodynami
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Source.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -4889,10 +5682,11 @@ TODO:
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="SourceTime.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, is_integrated=False):
@@ -4969,10 +5763,11 @@ source, can be one of `ContinuousSource`, `GaussianSource` or `CustomSource`.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="EigenModeSource.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -5074,7 +5869,11 @@ Construct an `EigenModeSource`.
 
 </div>
 
+</div>
+
 <a id="EigenModeSource.eig_power"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def eig_power(self, freq):
@@ -5106,10 +5905,11 @@ response](FAQ.md#why-doesnt-the-continuous-wave-cw-source-produce-an-exact-singl
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="ContinuousSource.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -5181,10 +5981,11 @@ irrelevant.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="GaussianSource.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -5243,18 +6044,6 @@ Construct a `GaussianSource`.
 
 </div>
 
-<a id="GaussianSource.fourier_transform"></a>
-
-```python
-def fourier_transform(self, freq):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
 </div>
 
 ---
@@ -5280,10 +6069,11 @@ demonstration of a [linear-chirped pulse](FAQ.md#how-do-i-create-a-chirped-pulse
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="CustomSource.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -5326,7 +6116,6 @@ Construct a `CustomSource`.
 
 </div>
 
-<a name="fluxregion"></a>
 ---
 <a id="FluxRegion"></a>
 
@@ -5351,10 +6140,11 @@ the box add instead of subtract.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="FluxRegion.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -5415,11 +6205,8 @@ energy density of the Fourier-transformed fields. Its properties are:
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
-
-</div>
 
 ---
 <a id="ForceRegion"></a>
@@ -5457,11 +6244,7 @@ force.
 
 </div>
 
-<div class="class_members" markdown="1">
 
-
-
-</div>
 
 
 ---
@@ -5486,10 +6269,11 @@ specify a list of `Vector3` vertices using the `vertices` parameter. The `center
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="Volume.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -5503,42 +6287,6 @@ def __init__(self,
 <div class="method_docstring" markdown="1">
 
 Construct a Volume.
-
-</div>
-
-<a id="Volume.get_edges"></a>
-
-```python
-def get_edges(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Volume.get_vertices"></a>
-
-```python
-def get_vertices(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Volume.pt_in_volume"></a>
-
-```python
-def pt_in_volume(self, pt):
-```
-
-<div class="method_docstring" markdown="1">
-
-
 
 </div>
 
@@ -5594,10 +6342,11 @@ swigobj_attr and return the property they requested.
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="DftObj.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, func, args):
@@ -5609,19 +6358,8 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 </div>
 
-<a id="DftObj.swigobj_attr"></a>
-
-```python
-def swigobj_attr(self, attr):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
 </div>
 
-</div>
 ---
 <a id="DftFlux"></a>
 
@@ -5637,10 +6375,11 @@ class DftFlux(DftObj):
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="DftFlux.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, func, args):
@@ -5653,6 +6392,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 </div>
 
 </div>
+
 ---
 <a id="DftForce"></a>
 
@@ -5668,10 +6408,11 @@ class DftForce(DftObj):
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="DftForce.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, func, args):
@@ -5684,6 +6425,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 </div>
 
 </div>
+
 ---
 <a id="DftNear2Far"></a>
 
@@ -5699,10 +6441,11 @@ class DftNear2Far(DftObj):
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="DftNear2Far.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, func, args):
@@ -5714,7 +6457,11 @@ Initialize self.  See help(type(self)) for accurate signature.
 
 </div>
 
+</div>
+
 <a id="DftNear2Far.flux"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def flux(self, direction, where, resolution):
@@ -5731,6 +6478,7 @@ is a 1d array of `nfreq` dimensions.
 </div>
 
 </div>
+
 ---
 <a id="DftEnergy"></a>
 
@@ -5746,10 +6494,11 @@ class DftEnergy(DftObj):
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="DftEnergy.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, func, args):
@@ -5762,6 +6511,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 </div>
 
 </div>
+
 ---
 <a id="DftFields"></a>
 
@@ -5777,10 +6527,11 @@ class DftFields(DftObj):
 
 </div>
 
-<div class="class_members" markdown="1">
 
 
 <a id="DftFields.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, func, args):
@@ -5836,10 +6587,27 @@ track different volume locations (using `mp.in_volume`) or field components.
 
 </div>
 
+
+
+<a id="Animate2D.__call__"></a>
+
 <div class="class_members" markdown="1">
 
+```python
+def __call__(self, sim, todo):
+```
+
+<div class="method_docstring" markdown="1">
+
+Call self as a function.
+
+</div>
+
+</div>
 
 <a id="Animate2D.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self,
@@ -5890,55 +6658,11 @@ Construct an `Animate2D` object.
 
 </div>
 
-<a id="Animate2D.__call__"></a>
-
-```python
-def __call__(self, sim, todo):
-```
-
-<div class="method_docstring" markdown="1">
-
-Call self as a function.
-
-</div>
-
-<a id="Animate2D.grab_frame"></a>
-
-```python
-def grab_frame(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Animate2D.reset"></a>
-
-```python
-def reset(self):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
-</div>
-
-<a id="Animate2D.set_figure"></a>
-
-```python
-def set_figure(self, f):
-```
-
-<div class="method_docstring" markdown="1">
-
-
-
 </div>
 
 <a id="Animate2D.to_gif"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def to_gif(self, fps, filename):
@@ -5954,7 +6678,11 @@ format only supports 256 colors from a _predefined_ color palette. Requires
 
 </div>
 
+</div>
+
 <a id="Animate2D.to_jshtml"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def to_jshtml(self, fps):
@@ -5968,7 +6696,11 @@ playback. User must specify a frame rate `fps` in frames per second.
 
 </div>
 
+</div>
+
 <a id="Animate2D.to_mp4"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def to_mp4(self, fps, filename):
@@ -6042,10 +6774,27 @@ sim.run(mp.after_sources(h))
 
 </div>
 
+
+
+<a id="Harminv.__call__"></a>
+
 <div class="class_members" markdown="1">
 
+```python
+def __call__(self, sim, todo):
+```
+
+<div class="method_docstring" markdown="1">
+
+Allows a Haminv instance to be used as astep function.
+
+</div>
+
+</div>
 
 <a id="Harminv.__init__"></a>
+
+<div class="class_members" markdown="1">
 
 ```python
 def __init__(self, c, pt, fcen, df, mxbands=None):
@@ -6065,23 +6814,12 @@ search for. Defaults to 100.
 
 </div>
 
-<a id="Harminv.__call__"></a>
-
-```python
-def __call__(self, sim, todo):
-```
-
-<div class="method_docstring" markdown="1">
-
-Allows a Haminv instance to be used as astep function.
-
-</div>
-
 </div>
 
 
-Miscellaneous Functions
------------------------
+
+Miscellaneous Functions Reference
+---------------------------------
 
 
 <a id="quiet"></a>
@@ -7023,823 +7761,3 @@ accurately. See [Synchronizing the Magnetic and Electric
 Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 
 </div>
-
-
-
-### Output File Names
-
-The output filenames used by Meep, e.g. for HDF5 files, are automatically prefixed by the input variable `filename_prefix`. If `filename_prefix` is `None` (the default), however, then Meep constructs a default prefix based on the current Python filename with `".py"` replaced by `"-"`: e.g. `test.py` implies a prefix of `"test-"`. You can get this prefix, or set the output folder, with these functions:
-
-* [Simulation.get_filename_prefix()](#Simulation.get_filename_prefix)
-* [Simulation.use_output_directory([dirname])](#Simulation.use_output_directory)
-
-
-### Simulation Time
-
-* [Simulation.meep_time()](#Simulation.meep_time)
-* [Simulation.print_times()](#Simulation.print_times)
-* [Simulation.time_spent_on(time_sink)](#Simulation.time_spent_on)
-* [Simulation.mean_time_spent_on(time_sink)](#Simulation.mean_time_spent_on)
-
-
-### Field Computations
-
-Meep supports a large number of functions to perform computations on the fields. Most of them are accessed via the lower-level C++/SWIG interface. Some of them are based on the following simpler, higher-level versions. They are accessible as methods of a `Simulation` instance.
-
-* [Simulation.set_boundary(side, direction, condition)](#Simulation.set_boundary)
-* [Simulation.phase_in_material(newstructure, phasetime)](#Simulation.phase_in_material)
-* [Simulation.get_field_point(c, pt)](#Simulation.get_field_point)
-* [Simulation.get_epsilon_point(pt, frequency=0)](#Simulation.get_epsilon_point)
-* [Simulation.initialize_field(c, func)](#Simulation.initialize_field)
-* [Simulation.add_dft_fields(cs, fcen, df, nfreq, freq, where=None, center=None, size=None, yee_grid=False)](#Simulation.add_dft_fields)
-* [Simulation.flux_in_box(dir, box=None, center=None, size=None)](#Simulation.flux_in_box)
-* [Simulation.electric_energy_in_box(box=None, center=None, size=None)](#Simulation.electric_energy_in_box)
-* [Simulation.magnetic_energy_in_box(box=None, center=None, size=None)](#Simulation.magnetic_energy_in_box)
-* [Simulation.field_energy_in_box(box=None, center=None, size=None)](#Simulation.field_energy_in_box)
-* [Simulation.modal_volume_in_box(box=None, center=None, size=None)](#Simulation.modal_volume_in_box)
-* [Simulation.integrate_field_function(cs, func, where=None, center=None, size=None)](#Simulation.integrate_field_function)
-* [Simulation.max_abs_field_function(cs, func, where=None, center=None, size=None)](#Simulation.max_abs_field_function)
-* [Simulation.integrate2_field_function(fields2, cs1, cs2, func, where=None, center=None, size=None)](#Simulation.integrate2_field_function)
-
-
-### Reloading Parameters
-
-Once the fields/simulation have been initialized, you can change the values of various parameters by using the following functions (which are attributes of the `Simulation` class):
-
-* [Simulation.reset_meep()](#Simulation.reset_meep)
-* [Simulation.restart_fields()](#Simulation.restart_fields)
-* [Simulation.change_k_point(k)](#Simulation.change_k_point)
-* [Simulation.change_sources(new_sources)](#Simulation.change_sources)
-* [Simulation.set_materials(geometry=None, default_material=None)](#Simulation.set_materials)
-
-
-### Flux Spectra
-
-Given a bunch of [`FluxRegion`](#fluxregion) objects, you can tell Meep to accumulate the Fourier transforms of the fields in those regions in order to compute the Poynting flux spectra. (Note: as a matter of convention, the "intensity" of the electromagnetic fields refers to the Poynting flux, *not* to the [energy density](#energy-density-spectra).) See also [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend). These are attributes of the `Simulation` class. The most important function is:
-
-* [Simulation.add_flux(fcen, df, nfreq, freq, FluxRegions...)](#Simulation.add_flux)
-
-As described in the tutorial, you normally use `add_flux` via statements like:
-
-```python
-transmission = sim.add_flux(...)
-```
-
-to store the flux object in a variable.  You can create as many flux objects as you want, e.g. to look at powers flowing in different regions or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the flux region multiplied by the number of electric and magnetic field components required to get the Poynting vector multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
-
-Once you have called `add_flux`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the [run functions](#run-functions). At any time, you can ask for Meep to print out the current flux spectrum via the `display_fluxes` method.
-
-* [Simulation.display_fluxes(fluxes...)](#Simulation.display_fluxes)
-
-You might have to do something lower-level if you have multiple flux regions corresponding to *different* frequency ranges, or have other special needs. `display_fluxes(f1, f2, f3)` is actually equivalent to `meep.display_csv("flux", meep.get_flux_freqs(f1), meep.get_fluxes(f1), meep.get_fluxes(f2), meep.get_fluxes(f3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling two lower-level functions:
-
-* [meep.get_flux_freqs(flux)](#get_flux_freqs)
-* [meep.get_fluxes(flux)](#get_fluxes)
-
-As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend), for a reflection spectrum you often want to save the Fourier-transformed fields from a "normalization" run and then load them into another run to be subtracted. This can be done via:
-
-* [Simulation.save_flux(filename, flux)](#Simulation.save_flux)
-* [Simulation.load_flux(filename, flux)](#Simulation.load_flux)
-* [Simulation.load_minus_flux(filename, flux)](#Simulation.load_minus_flux)
-
-
-
-Sometimes it is more convenient to keep the Fourier-transformed fields in memory rather than writing them to a file and immediately loading them back again. To that end, the `Simulation` class exposes the following three methods:
-
-
-* [Simulation.get_flux_data(flux)](#Simulation.get_flux_data)
-* [Simulation.load_flux_data(flux, fdata)](#Simulation.load_flux_data)
-* [Simulation.load_minus_flux_data(flux, fdata)](#Simulation.load_minus_flux_data)
-
-
-The `Simulation` class also provides some aliases for the corresponding "flux" methods.
-
-* **`save_mode`**
-* **`load_mode`**
-* **`load_minus_mode`**
-* **`get_mode_data`**
-* **`load_mode_data`**
-* **`load_minus_mode_data`**
-
-
-### Mode Decomposition
-
-Given a structure, Meep can decompose the Fourier-transformed fields into a superposition of its harmonic modes. For a theoretical background, see [Mode Decomposition](Mode_Decomposition.md).
-
-* [Simulation.get_eigenmode_coefficients(flux, bands, eig_parity=mp.NO_PARITY, eig_vol=None, eig_resolution=0, eig_tolerance=1e-12, kpoint_func=None, direction=mp.AUTOMATIC)](#Simulation.get_eigenmode_coefficients)
-
-The flux object should be created using `add_mode_monitor`.  (You could also use `add_flux`, but with `add_flux` you need to be more careful about symmetries that bisect the flux plane: the `add_flux` object should only be used with `get_eigenmode_coefficients` for modes of the same symmetry, e.g. constrained via `eig_parity`.  On the other hand, the performance of `add_flux` planes benefits more from symmetry.) `eig_vol` is the volume passed to [MPB](https://mpb.readthedocs.io) for the eigenmode calculation (based on interpolating the discretized materials from the Yee grid); in most cases this will simply be the volume over which the frequency-domain fields are tabulated, which is the default (i.e. `flux.where`). `eig_parity` should be one of [`mp.NO_PARITY` (default), `mp.EVEN_Z`, `mp.ODD_Z`, `mp.EVEN_Y`, `mp.ODD_Y`]. It is the parity (= polarization in 2d) of the mode to calculate, assuming the structure has $z$ and/or $y$ mirror symmetry *in the source region*, just as for `EigenModeSource` above. If the structure has both $y$ and $z$ mirror symmetry, you can combine more than one of these, e.g. `EVEN_Z+ODD_Y`. Default is `NO_PARITY`, in which case MPB computes all of the bands which will still be even or odd if the structure has mirror symmetry, of course. This is especially useful in 2d simulations to restrict yourself to a desired polarization. `eig_resolution` is the spatial resolution to use in MPB for the eigenmode calculations. This defaults to twice the Meep `resolution` in which case the structure is linearly interpolated from the Meep pixels. `eig_tolerance` is the tolerance to use in the MPB eigensolver. MPB terminates when the eigenvalues stop changing to less than this fractional tolerance. Defaults to `1e-12`.  (Note that this is the tolerance for the frequency eigenvalue ω; the tolerance for the mode profile is effectively the square root of this.) For examples, see [Tutorial/Mode Decomposition](Python_Tutorials/Mode_Decomposition.md).
-
-Technically, MPB computes `ωₙ(k)` and then inverts it with Newton's method to find the wavevector `k` normal to `eig_vol` and mode for a given frequency; in rare cases (primarily waveguides with *nonmonotonic* dispersion relations, which doesn't usually happen in simple dielectric waveguides), MPB may need you to supply an initial "guess" for `k` in order for this Newton iteration to converge.  You can supply this initial guess with `kpoint_func`, which is a function `kpoint_func(f, n)` that supplies a rough initial guess for the `k` of band number `n` at frequency `f = ω/2π`. (By default, the **k** components in the plane of the `eig_vol` region are zero.  However, if this region spans the *entire* cell in some directions, and the cell has Bloch-periodic boundary conditions via the `k_point` parameter, then the mode's **k** components in those directions will match `k_point` so that the mode satisfies the Meep boundary conditions, regardless of `kpoint_func`.) If `direction` is set to `mp.NO_DIRECTION`, then `kpoint_func` is not only the initial guess and the search direction of the **k** vectors, but is also taken to be the direction of the waveguide, allowing you to [detect modes in oblique waveguides](Python_Tutorials/Eigenmode_Source.md#oblique-waveguides) (not perpendicular to the flux plane).
-
-**Note:** for planewaves in homogeneous media, the `kpoints` may *not* necessarily be equivalent to the actual wavevector of the mode. This quantity is given by `kdom`.
-
-* [Simulation.add_mode_monitor(fcen, df, nfreq, freq, ModeRegions...)](#Simulation.add_mode_monitor)
-
-`add_mode_monitor` works properly with arbitrary symmetries, but may be suboptimal because the Fourier-transformed region does not exploit the symmetry.  As an optimization, if you have a mirror plane that bisects the mode monitor, you can instead use `add_flux` to gain a factor of two, but in that case you *must* also pass the corresponding `eig_parity` to `get_eigenmode_coefficients` in order to only compute eigenmodes with the corresponding mirror symmetry.
-
-* [Simulation.get_eigenmode(frequency, direction, where, band_num, kpoint, eig_vol=None, match_frequency=True, parity=mp.NO_PARITY, resolution=0, eigensolver_tol=1e-12)](#Simulation.get_eigenmode)
-
-* [meep.get_eigenmode_freqs(flux)](#get_eigenmode_freqs)
-
-
-### Energy Density Spectra
-
-Very similar to flux spectra, you can also compute **energy density spectra**: the energy density of the electromagnetic fields as a function of frequency, computed by Fourier transforming the fields and integrating the energy density:
-
-$$ \frac{1}{2}ε|\mathbf{E}|^2 + \frac{1}{2}μ|\mathbf{H}|^2 $$
-
-The usage is similar to the flux spectra: you define a set of `EnergyRegion` objects telling Meep where it should compute the Fourier-transformed fields and energy densities, and call `add_energy` to add these regions to the current simulation over a specified frequency bandwidth, and then use `display_electric_energy`, `display_magnetic_energy`, or `display_total_energy` to display the energy density spectra at the end. There are also `save_energy`, `load_energy`, and `load_minus_energy` functions that you can use to subtract the fields from two simulation, e.g. in order to compute just the energy from scattered fields, similar to the flux spectra. These types and functions are defined as follows:
-
-* [EnergyRegion](#EnergyRegion)
-* [Simulation.add_energy(fcen, df, nfreq, freq, EnergyRegions...)](#Simulation.add_energy)
-
-As for flux regions, you normally use `add_energy` via statements like:
-
-```py
-En = sim.add_energy(...)
-```
-
-to store the energy object in a variable.  You can create as many energy objects as you want, e.g. to look at the energy densities in different objects or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the energy region multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
-
-Once you have called `add_energy`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the `run` functions. At any time, you can ask for Meep to print out the current energy density spectrum via:
-
-* [Simulation.display_electric_energy(energy...)](#Simulation.display_electric_energy)
-* [Simulation.display_magnetic_energy(energy...)](#Simulation.display_magnetic_energy)
-* [Simulation.display_total_energy(energy...)](#Simulation.display_total_energy)
-
-
-You might have to do something lower-level if you have multiple energy regions corresponding to *different* frequency ranges, or have other special needs. `display_electric_energy(e1, e2, e3)` is actually equivalent to `meep.display_csv("electric_energy", meep.get_energy_freqs(e1), meep.get_electric_energy(e1), meep.get_electric_energy(e2), meep.get_electric_energy(e3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling lower-level functions:
-
-* [meep.get_energy_freqs(energy)](#get_energy_freqs)
-* [meep.get_electric_energy(energy)](#get_electric_energy)
-* [meep.get_magnetic_energy(energy)](#get_magnetic_energy)
-* [meep.get_total_energy(energy)](#get_total_energy)
-
-As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, to compute the energy density from the scattered fields you often want to save the Fourier-transformed fields from a "normalization" run and then load them into another run to be subtracted. This can be done via:
-
-* [Simulation.save_energy(filename, energy)](#Simulation.save_energy)
-* [Simulation.load_energy(filename, energy)](#Simulation.load_energy)
-* [Simulation.load_minus_energy(filename, energy)](#Simulation.load_minus_energy)
-
-
-### Force Spectra
-
-Very similar to flux spectra, you can also compute **force spectra**: forces on an object as a function of frequency, computed by Fourier transforming the fields and integrating the vacuum [Maxwell stress tensor](https://en.wikipedia.org/wiki/Maxwell_stress_tensor):
-
-$$\sigma_{ij} = E_i^*E_j + H_i^*H_j - \frac{1}{2} δ_{ij} \left( |\mathbf{E}|^2 + |\mathbf{H}|^2 \right)$$
-
-over a surface $S$ via $\mathbf{F} = \int_S \sigma d\mathbf{A}$. You should normally **only evaluate the stress tensor over a surface lying in vacuum**, as the interpretation and definition of the stress tensor in arbitrary media is often problematic (the subject of extensive and controversial literature). It is fine if the surface *encloses* an object made of arbitrary materials, as long as the surface itself is in vacuum.
-
-See also [Tutorial/Optical Forces](Python_Tutorials/Optical_Forces.md).
-
-Most commonly, you will want to **normalize** the force spectrum in some way, just as for flux spectra. Most simply, you could divide two different force spectra to compute the ratio of forces on two objects. Often, you will divide a force spectrum by a flux spectrum, to divide the force $F$ by the incident power $P$ on an object, in order to compute the useful dimensionless ratio $Fc$/$P$ where $c=1$ in Meep units. For example, it is a simple exercise to show that the force $F$ on a perfectly reflecting mirror with normal-incident power $P$ satisfies $Fc$/$P=2$, and for a perfectly absorbing (black) surface $Fc$/$P=1$.
-
-The usage is similar to the [flux spectra](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend): you define a set of `ForceRegion` objects telling Meep where it should compute the Fourier-transformed fields and stress tensors, and call `add_force` to add these regions to the current simulation over a specified frequency bandwidth, and then use `display_forces` to display the force spectra at the end. There are also `save_force`, `load_force`, and `load_minus_force` functions that you can use to subtract the fields from two simulation, e.g. in order to compute just the force from scattered fields, similar to the flux spectra. These types and functions are defined as follows:
-
-* [ForceRegion](#ForceRegion)
-* [Simulation.add_force(fcen, df, nfreq, freq, ForceRegions...)](#Simulation.add_force)
-
-As for flux regions, you normally use `add_force` via statements like:
-
-```py
-Fx = sim.add_force(...)
-```
-
-to store the force object in a variable.  You can create as many force objects as you want, e.g. to look at forces on different objects, in different directions, or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the force region, multiplied by the number of electric and magnetic field components required to get the stress vector, multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
-
-Once you have called `add_force`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the `run` functions. At any time, you can ask for Meep to print out the current force spectrum via:
-
-* [Simulation.display_forces(forces...)](#Simulation.display_forces)
-
-You might have to do something lower-level if you have multiple force regions corresponding to *different* frequency ranges, or have other special needs. `display_forces(f1, f2, f3)` is actually equivalent to `meep.display_csv("force", meep.get_force_freqs(f1), meep.get_forces(f1), meep.get_forces(f2), meep.get_forces(f3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling two lower-level functions:
-
-
-* [meep.get_force_freqs(force)](#get_force_freqs)
-* [meep.get_forces(force)](#get_forces)
-
-
-As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, to compute the force from the scattered fields often requires saving the Fourier-transformed fields from a "normalization" run and then loading them into another run to be subtracted. This can be done via:
-
-* [Simulation.save_force(filename, force)](#Simulation.save_force)
-* [Simulation.load_force(filename, force)](#Simulation.load_force)
-* [Simulation.load_minus_force(filename, force)](#Simulation.load_minus_force)
-
-To keep the fields in memory and avoid writing to and reading from a file, use the following three methods:
-
-* [Simulation.get_force_data(force)](#Simulation.get_force_data)
-* [Simulation.load_force_data(force, fdata)](#Simulation.load_force_data)
-* [Simulation.load_minus_force_data(force, fdata)](#Simulation.load_minus_force_data)
-
-### LDOS spectra
-
-Meep can also calculate the LDOS (local density of states) spectrum, as described in [Tutorial/Local Density of States](Python_Tutorials/Local_Density_of_States.md). To do this, you simply pass the following step function to your `run` command:
-
-* [meep.Ldos(fcen, df, nfreq, freq)](#Ldos)
-* [meep.get_ldos_freqs(ldos)](#get_ldos_freqs)
-* [meep.dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)](#dft_ldos)
-
-
-Analytically, the per-polarization LDOS is exactly proportional to the power radiated by an $\ell$-oriented point-dipole current, $p(t)$, at a given position in space. For a more mathematical treatment of the theory behind the LDOS, refer to the relevant discussion in Section 4.4 ("Currents and Fields: The Local Density of States") in [Chapter 4](http://arxiv.org/abs/arXiv:1301.5366) ("Electromagnetic Wave Source Conditions") of the book [Advances in FDTD Computational Electrodynamics: Photonics and Nanotechnology](https://www.amazon.com/Advances-FDTD-Computational-Electrodynamics-Nanotechnology/dp/1608071707), but for now it is defined as:
-
-$$\operatorname{LDOS}_{\ell}(\vec{x}_0,\omega)=-\frac{2}{\pi}\varepsilon(\vec{x}_0)\frac{\operatorname{Re}[\hat{E}_{\ell}(\vec{x}_0,\omega)\hat{p}(\omega)^*]}{|\hat{p}(\omega)|^2}$$
-
-where the $|\hat{p}(\omega)|^2$ normalization is necessary for obtaining the power exerted by a unit-amplitude dipole (assuming linear materials), and hats denote Fourier transforms. It is this quantity that is computed by the `dft_ldos` command for a single dipole source. For a volumetric source, the numerator and denominator are both integrated over the current volume, but "LDOS" computation is less meaningful in this case.
-
-### Near-to-Far-Field Spectra
-
-Meep can compute a near-to-far-field transformation in the frequency domain as described in [Tutorial/Near-to-Far Field Spectra](Python_Tutorials/Near_to_Far_Field_Spectra.md): given the fields on a "near" bounding surface inside the cell, it can compute the fields arbitrarily far away using an analytical transformation, assuming that the "near" surface and the "far" region lie in a single homogeneous non-periodic 2d, 3d, or cylindrical region. That is, in a simulation *surrounded by PML* that absorbs outgoing waves, the near-to-far-field feature can compute the fields outside the cell as if the outgoing waves had not been absorbed (i.e. in the fictitious infinite open volume). Moreover, this operation is performed on the Fourier-transformed fields: like the flux and force spectra above, you specify a set of desired frequencies, Meep accumulates the Fourier transforms, and then Meep computes the fields at *each frequency* for the desired far-field points.
-
-This is based on the principle of equivalence: given the Fourier-transformed tangential fields on the "near" surface, Meep computes equivalent currents and convolves them with the analytical Green's functions in order to compute the fields at any desired point in the "far" region. For details, see Section 4.2.1 ("The Principle of Equivalence") in [Chapter 4](http://arxiv.org/abs/arXiv:1301.5366) ("Electromagnetic Wave Source Conditions") of the book [Advances in FDTD Computational Electrodynamics: Photonics and Nanotechnology](https://www.amazon.com/Advances-FDTD-Computational-Electrodynamics-Nanotechnology/dp/1608071707).
-
-Note: in order for the far-field results to be accurate, the [far region must be separated from the near region](https://en.wikipedia.org/wiki/Near_and_far_field) by *at least* 2D<sup>2</sup>/λ, the Fraunhofer distance, where D is the largest dimension of the radiator and λ is the vacuum wavelength.
-
-There are three steps to using the near-to-far-field feature: first, define the "near" surface(s) as a set of surfaces capturing *all* outgoing radiation in the desired direction(s); second, run the simulation, typically with a pulsed source, to allow Meep to accumulate the Fourier transforms on the near surface(s); third, tell Meep to compute the far fields at any desired points (optionally saving the far fields from a grid of points to an HDF5 file). To define the near surfaces, use:
-
-* [Simulation.add_near2far(fcen, df, nfreq, freq, Near2FarRegions..., nperiods=1)](#Simulation.add_near2far)
-
-Each `Near2FarRegion` is identical to `FluxRegion` except for the name: in 3d, these give a set of planes (**important:** all these "near surfaces" must lie in a single *homogeneous* material with *isotropic* ε and μ &mdash; and they should *not* lie in the PML regions) surrounding the source(s) of outgoing radiation that you want to capture and convert to a far field. Ideally, these should form a closed surface, but in practice it is sufficient for the `Near2FarRegion`s to capture all of the radiation in the direction of the far-field points. **Important:** as for flux computations, each `Near2FarRegion` should be assigned a `weight` of &#177;1 indicating the direction of the outward normal relative to the +coordinate direction. So, for example, if you have six regions defining the six faces of a cube, i.e. the faces in the +x, -x, +y, -y, +z, and -z directions, then they should have weights +1, -1, +1, -1, +1, and -1 respectively. Note that, neglecting discretization errors, all near-field surfaces that enclose the same outgoing fields are equivalent and will yield the same far fields with a discretization-induced difference that vanishes with increasing resolution etc.
-
-After the simulation run is complete, you can compute the far fields. This is usually for a pulsed source so that the fields have decayed away and the Fourier transforms have finished accumulating.
-
-If you have Bloch-periodic boundary conditions, then the corresponding near-to-far transformation actually needs to perform a "lattice sum" of infinitely many periodic copies of the near fields.  This doesn't happen by default, which means the default `near2far` calculation may not be what you want for periodic boundary conditions.  However, if the `Near2FarRegion` spans the entire cell along the periodic directions, you can turn on an approximate lattice sum by passing `nperiods > 1`.  In particular, it then sums `2*nperiods+1` Bloch-periodic copies of the near fields whenever a far field is requested.  You can repeatedly double `nperiods` until the answer converges to your satisfaction; in general, if the far field is at a distance d, and the period is a, then you want `nperiods` to be much larger than d/a.  (Future versions of Meep may use fancier techniques like [Ewald summation](https://en.wikipedia.org/wiki/Ewald_summation) to compute the lattice sum more rapidly at large distances.)
-
-* [Simulation.get_farfield(near2far, x)](#Simulation.get_farfield)
-* [meep.get_near2far_freqs(near2far)](#get_near2far_freqs)
-* [Simulation.output_farfields(near2far, fname, resolution, where=None, center=None, size=None)](#Simulation.output_farfields)
-* [Simulation.get_farfields(near2far, resolution, where=None, center=None, size=None)](#Simulation.get_farfields)
-
-
-(Multi-frequency `get_farfields` and `output_farfields` can be accelerated by
-[compiling Meep](Build_From_Source.md#meep) with `--with-openmp` and using the
-`OMP_NUM_THREADS` environment variable to specify multiple threads.)
-
-For a scattered-field computation, you often want to separate the scattered and incident fields. As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Scheme_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, you can do this by saving the Fourier-transformed incident from a "normalization" run and then load them into another run to be subtracted. This can be done via:
-
-* [Simulation.save_near2far(filename, near2far)](#Simulation.save_near2far)
-* [Simulation.load_near2far(filename, near2far)](#Simulation.load_near2far)
-* [Simulation.load_minus_near2far(filename, near2far)](#Simulation.load_minus_near2far)
-
-
-To keep the fields in memory and avoid writing to and reading from a file, use the following three methods:
-
-* [Simulation.get_near2far_data(near2far)](#Simulation.get_near2far_data)
-* [Simulation.load_near2far_data(near2far, n2fdata)](#Simulation.load_near2far_data)
-* [Simulation.load_minus_near2far_data(near2far, n2fdata)](#Simulation.load_minus_near2far_data)
-* [meep.scale_near2far_fields(s, near2far)](#scale_near2far_fields)
-* [DftNear2Far.flux(direction, where, resolution)](#DftNear2Far.flux)
-
-
-### Load and Dump Structure
-
-These functions dump the raw ε and μ data to disk and load it back for doing multiple simulations with the same materials but different sources etc. The only prerequisite is that the dump/load simulations have the same [chunks](Chunks_and_Symmetry.md) (i.e. the same grid, number of processors, symmetries, and PML). When using `split_chunks_evenly=False`, you must also dump the original chunk layout using `dump_chunk_layout` and load it into the new `Simulation` using the `chunk_layout` parameter. Currently only stores dispersive and non-dispersive ε and μ but not nonlinearities. Note that loading data from a file in this way overwrites any `geometry` data passed to the `Simulation` constructor.
-
-* [Simulation.dump_structure(fname)](#Simulation.dump_structure)
-* [Simulation.load_structure(fname)](#Simulation.load_structure)
-* [Simulation.dump_chunk_layout(fname)](#Simulation.dump_chunk_layout)
-
-
-To load a chunk layout into a `Simulation`, use the `chunk_layout` argument to the constructor, passing either a file obtained from `dump_chunk_layout` or another `Simulation` instance. Note that when using `split_chunks_evenly=False` this parameter is required when saving and loading flux spectra, force spectra, or near-to-far spectra so that the two runs have the same chunk layout. Just pass the `Simulation` object from the first run to the second run:
-
-```python
-# Split chunks based on amount of work instead of size
-sim1 = mp.Simulation(..., split_chunks_evenly=False)
-norm_flux = sim1.add_flux(...)
-sim1.run(...)
-sim1.save_flux(...)
-
-# Make sure the second run uses the same chunk layout as the first
-sim2 = mp.Simulation(..., chunk_layout=sim1)
-flux = sim2.add_flux(...)
-sim2.load_minus_flux(...)
-sim2.run(...)
-```
-
-### Frequency-Domain Solver
-
-Meep contains a frequency-domain solver that computes the fields produced in a geometry in response to a [continuous-wave (CW) source](https://en.wikipedia.org/wiki/Continuous_wave). This is based on an [iterative linear solver](https://en.wikipedia.org/wiki/Iterative_method) instead of time-stepping. For details, see Section 5.3 ("Frequency-domain solver") of [Computer Physics Communications, Vol. 181, pp. 687-702, 2010](http://ab-initio.mit.edu/~oskooi/papers/Oskooi10.pdf). Benchmarking results have shown that in many instances, such as cavities (e.g., [ring resonators](Python_Tutorials/Frequency_Domain_Solver.md)) with long-lived resonant modes, this solver converges much faster than simply running an equivalent time-domain simulation with a CW source (using the default `width` of zero for no transient turn-on), time-stepping until all transient effects from the source turn-on have disappeared, especially if the fields are desired to a very high accuracy.
-
-To use the frequency-domain solver, simply define a `ContinuousSource` with the desired frequency and [initialize the fields and geometry](#initializing-the-structure-and-fields) via `init_sim()`:
-
-```py
-sim = mp.Simulation(...)
-sim.init_sim()
-sim.solve_cw(tol, maxiters, L)
-```
-
-The first two parameters to the frequency-domain solver are the tolerance `tol` for the iterative solver (10<sup>−8</sup>, by default) and a maximum number of iterations `maxiters` (10<sup>4</sup>, by default). Finally, there is a parameter $L$ that determines a tradeoff between memory and work per step and convergence rate of the iterative algorithm, biconjugate gradient stabilized ([BiCGSTAB-L](https://en.wikipedia.org/wiki/Biconjugate_gradient_stabilized_method)), that is used; larger values of $L$ will often lead to faster convergence at the expense of more memory and more work per iteration. Default is $L=2$, and normally a value ≥ 2 should be used.
-
-The frequency-domain solver supports arbitrary geometries, PML, boundary conditions, symmetries, parallelism, conductors, and arbitrary nondispersive materials. Lorentz-Drude dispersive materials are not currently supported in the frequency-domain solver, but since you are solving at a known fixed frequency rather than timestepping, you should be able to pick conductivities etcetera in order to obtain any desired complex ε and μ at that frequency.
-
-The frequency-domain solver requires you to use complex-valued fields, via `force_complex_fields=True`.
-
-After `solve_cw` completes, it should be as if you had just run the simulation for an infinite time with the source at that frequency. You can call the various field-output functions and so on as usual at this point. For examples, see [Tutorial/Frequency Domain Solver](Python_Tutorials/Frequency_Domain_Solver.md) and [Tutorial/Mode Decomposition/Reflectance and Transmittance Spectra for Planewave at Oblique Incidence](Python_Tutorials/Mode_Decomposition.md#reflectance-and-transmittance-spectra-for-planewave-at-oblique-incidence).
-
-**Note:** The convergence of the iterative solver can sometimes encounter difficulties. For example, increasing the diameter of a ring resonator relative to the wavelength increases the [condition number](https://en.wikipedia.org/wiki/Condition_number), which worsens the convergence of iterative solvers. The general way to improve this is to implement a more sophisticated iterative solver that employs [preconditioners](https://en.wikipedia.org/wiki/Preconditioner). Preconditioning wave equations (Helmholtz-like equations) is notoriously difficult to do well, but some possible strategies are discussed in [Issue #548](https://github.com/NanoComp/meep/issues/548). In the meantime, a simpler way improving convergence (at the expense of computational cost) is to increase the $L$ parameter and the number of iterations.
-
-### Frequency-Domain Eigensolver
-
-Building on the frequency-domain solver above, Meep also includes a frequency-domain eigensolver that computes resonant frequencies and modes in the frequency domain.  The usage is very similar to `solve_cw`:
-
-```py
-sim = mp.Simulation(...)
-sim.init_sim()
-eigfreq = sim.solve_eigfreq(tol, maxiters, guessfreq, cwtol, cwmaxiters, L)
-```
-
-The `solve_eig` routine performs repeated calls to `solve_cw` in a way that converges to the resonant mode whose frequency is *closest* to the source frequency.  The complex resonant-mode frequency is returned, and the mode Q can be computed from `eigfreq.real / (-2*eigfreq.imag)`.  Upon return, the fields should be the corresponding resonant mode (with an arbitrary scaling).
-
-The resonant mode is converged to a relative error of roughly `tol`, which defaults to `1e-7`. A maximum of `maxiters` (defaults to `100`) calls to `solve_cw` are performed.  The tolerance for each `solve_cw` call is `cwtol` (defaults to `tol*1e-3`) and the maximum iterations is `cwmaxiters` (10<sup>4</sup>, by default); the `L` parameter (defaults to `10`) is also passed through to `solve_cw`.
-
-The closer the input frequency is to the resonant-mode frequency, the faster `solve_eig` should converge. Instead of using the source frequency, you can instead pass a `guessfreq` argument to `solve_eigfreq` specifying an input frequency (which may even be complex).
-
-Technically, `solve_eig` is using a [shift-and-invert power iteration](https://en.wikipedia.org/wiki/Inverse_iteration) to compute the resonant mode, as reviewed in [Frequency-Domain Eigensolver](Eigensolver_Math.md).
-
-As for `solve_cw` above, you are required to set `force_complex_fields=True` to use `solve_eigfreq`.
-
-### GDSII Support
-
-This feature is only available if Meep is built with [libGDSII](Build_From_Source.md#libgdsii). See:
-
-* [meep.GDSII_layers(fname)](#GDSII_layers)
-* [meep.GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0)](#GDSII_prisms)
-* [meep.GDSII_vol(fname, layer, zmin, zmax)](#GDSII_vol)
-
-
-### Data Visualization
-
-This module provides basic visualization functionality for the simulation domain. The spirit of the module is to provide functions that can be called with *no customization options whatsoever* and will do useful relevant things by default, but which can also be customized in cases where you *do* want to take the time to spruce up the output.
-
-* [Simulation.plot2D(...)](#Simulation.plot2D)
-* [Simulation.plot3D()](#Simulation.plot3D)
-* [Simulation.visualize_chunks()](#Simulation.visualize_chunks)
-
-An animated visualization is also possible via the [Animate2D](#Animate2D) class.
-
-
-Run and Step Functions
-----------------------
-
-The actual work in Meep is performed by `run` functions, which time-step the simulation for a given amount of time or until a given condition is satisfied. These are attributes of the `Simulation` class.
-
-The run functions, in turn, can be modified by use of [step functions](#predefined-step-functions): these are called at every time step and can perform any arbitrary computation on the fields, do outputs and I/O, or even modify the simulation. The step functions can be transformed by many [modifier functions](#step-function-modifiers), like `at_beginning`, `during_sources`, etcetera which cause them to only be called at certain times, etcetera, instead of at every time step.
-
-A common point of confusion is described in [The Run Function Is Not A Loop](The_Run_Function_Is_Not_A_Loop.md). Read this article if you want to make Meep do some customized action on each time step, as many users make the same mistake. What you really want to in that case is to write a step function, as described below.
-
-### Run Functions
-
-**`run(step_functions..., until=condition/time)`**
-—
-Run the simulation until a certain time or condition, calling the given step functions (if any) at each timestep. The keyword argument `until` is *either* a number, in which case it is an additional time (in Meep units) to run for, *or* it is a function (of no arguments) which returns `True` when the simulation should stop. `until` can also be a list of stopping conditions which may include a number and additional functions.
-
-**`run(step_functions..., until_after_sources=condition/time)`**
-—
-Run the simulation until all sources have turned off, calling the given step functions (if any) at each timestep. The keyword argument `until_after_sources` is either a number, in which case it is an *additional* time (in Meep units) to run for after the sources are off, *or* it is a function (of no arguments). In the latter case, the simulation runs until the sources are off *and* `condition` returns `True`. Like `until` above, `until_after_sources` can take a list of stopping conditions.
-
-In particular, a useful value for `until_after_sources` or `until` is often `stop_when_field_decayed`, which is demonstrated in [Tutorial/Basics](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend):
-
-* [meep.stop_when_fields_decayed(dT, c, pt, decay_by)](#stop_when_fields_decayed)
-* [meep.stop_after_walltime(t)](#stop_after_walltime)
-* [meep.stop_on_interrupt()](#stop_on_interrupt)
-
-
-Finally, another run function, useful for computing ω(**k**) band diagrams, is:
-
-* [meep.run_k_points(t, k_points)](#Simulation.run_k_points)
-* [meep.run_k_point(t, k_point)](#Simulation.run_k_point)
-
-
-### Predefined Step Functions
-
-Several useful step functions are predefined by Meep. These are available directly via the `meep` package but require a `Simulation` instance as an argument.
-
-#### Output Functions
-
-The most common step function is an output function, which outputs some field component to an [HDF5](https://en.wikipedia.org/wiki/HDF5) file. Normally, you will want to modify this by one of the `at_*` functions, below, as outputting a field at *every* time step can get quite time- and storage-consuming.
-
-Note that although the various field components are stored at different places in the [Yee lattice](Yee_Lattice.md), when they are outputted they are all linearly interpolated to the same grid: to the points at the *centers* of the Yee cells, i.e. $(i+0.5,j+0.5,k+0.5)\cdotΔ$ in 3d.
-
-* [meep.output_epsilon(frequency=0)](#output_epsilon)
-* [meep.output_mu(frequency=0)](#output_mu)
-* [Simulation.output_dft(dft_fields, fname)](#Simulation.output_dft)
-* [meep.output_poynting()](#output_poynting)
-* [meep.output_hpwr()](#output_hpwr)
-* [meep.output_dpwr()](#output_dpwr)
-* [meep.output_tot_pwr()](#output_tot_pwr)
-* [meep.output_png(component, h5topng_options)](#output_png)
-
-* [meep.output_hfield()](#output_hfield)
-* [meep.output_hfield_x()](#output_hfield_x)
-* [meep.output_hfield_y()](#output_hfield_y)
-* [meep.output_hfield_z()](#output_hfield_z)
-* [meep.output_hfield_r()](#output_hfield_r)
-* [meep.output_hfield_p()](#output_hfield_p)
-
-* [meep.output_bfield()](#output_bfield)
-* [meep.output_bfield_x()](#output_bfield_x)
-* [meep.output_bfield_y()](#output_bfield_y)
-* [meep.output_bfield_z()](#output_bfield_z)
-* [meep.output_bfield_r()](#output_bfield_r)
-* [meep.output_bfield_p()](#output_bfield_p)
-
-* [meep.output_efield()](#output_efield)
-* [meep.output_efield_x()](#output_efield_x)
-* [meep.output_efield_y()](#output_efield_y)
-* [meep.output_efield_z()](#output_efield_z)
-* [meep.output_efield_r()](#output_efield_r)
-* [meep.output_efield_p()](#output_efield_p)
-
-* [meep.output_dfield()](#output_dfield)
-* [meep.output_dfield_x()](#output_dfield_x)
-* [meep.output_dfield_y()](#output_dfield_y)
-* [meep.output_dfield_z()](#output_dfield_z)
-* [meep.output_dfield_r()](#output_dfield_r)
-* [meep.output_dfield_p()](#output_dfield_p)
-
-* [meep.output_sfield()](#output_sfield)
-* [meep.output_sfield_x()](#output_sfield_x)
-* [meep.output_sfield_y()](#output_sfield_y)
-* [meep.output_sfield_z()](#output_sfield_z)
-* [meep.output_sfield_r()](#output_sfield_r)
-* [meep.output_sfield_p()](#output_sfield_p)
-
-
-More generally, it is possible to output an arbitrary function of position and zero or more field components, similar to the `Simulation.integrate_field_function` method, described above. This is done by:
-
-* [Simulation.output_field_function(name, cs, func, real_only=False)](#Simulation.output_field_function)
-
-See also [Field Functions](Field_Functions.md), and [Synchronizing the Magnetic and Electric Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md) if you want to do computations combining the electric and magnetic fields.
-
-
-#### Array Slices
-
-The output functions described above write the data for the fields and materials for the entire cell to an HDF5 file. This is useful for post-processing as you can later read in the HDF5 file to obtain field/material data as a NumPy array. However, in some cases it is convenient to bypass the disk altogether to obtain the data *directly* in the form of a NumPy array without writing/reading HDF5 files. Additionally, you may want the field/material data on just a subregion (or slice) of the entire volume. This functionality is provided by the `get_array` method which takes as input a subregion of the cell and the field/material component. The method returns a NumPy array containing values of the field/material at the current simulation time.
-
-* [Simulation.get_array(vol=None, center=None, size=None, component=mp.Ez, cmplx=False, arr=None, frequency=0)](#Simulation.get_array)
-* [Simulation.get_dft_array(dft_obj, component, num_freq)](#Simulation.get_dft_array)
-
-
-#### Array Metadata
-
-* [Simulation.get_array_metadata(vol=None, center=None, size=None, dft_cell=None)](#Simulation.get_array_metadata)
-
-This routine provides geometric information useful for interpreting the arrays returned by `get_array` or `get_dft_array` for the spatial region defined by `vol` or `center/size`. Here are some examples of how array metadata can be used:
-
-**Labeling Axes in Plots of Grid Quantities**
-
-```python
-# using the geometry from the bend-flux tutorial example
-import matplotlib.pyplot as plt
-import numpy as np
-
-eps_array=sim.get_epsilon()
-(x,y,z,w)=sim.get_array_metadata()
-plt.figure()
-ax = plt.subplot(111)
-plt.pcolormesh(x,y,np.transpose(eps_array),shading='gouraud')
-ax.set_aspect('equal')
-plt.show()
-```
-![](images/PermittivityWithLabeledAxes.png)
-
-**Computing Quantities Defined by Integrals of Field-Dependent Functions Over Grid Regions**
-
-+ energy stored in the $\mathbf{E}$-field in a region $\mathcal{V}$:
-      $$ \mathcal{E}=
-         \frac{1}{2}\int_{\mathcal V} \epsilon |\mathbf{E}|^2\,dV
-      $$
-
-+ Poynting flux through a surface $\mathcal{S}$:
-      $$\mathcal{S}=\frac{1}{2}\text{Re }\int_{\mathcal S}
-        \Big(\mathbf{E}^*\times \mathbf{H}\Big)\times d\mathbf{A}
-      $$
-
-```python
-  import numpy as np
-
-  # E-field modal volume in box from time-domain fields
-  box            = mp.Volume(center=box_center, size=box_size)
-  (Ex,Ey,Ez)     = [sim.get_array(vol=box, component=c, cmplx=True) for c in [mp.Ex, mp.Ey, mp.Ez]]
-  eps            = sim.get_array(vol=box, component=mp.Dielectric)
-  (x,y,z,w)      = sim.get_array_metadata(vol=box)
-  energy_density = np.real(eps*(np.conj(Ex)*Ex + np.conj(Ey)*Ey + np.conj(Ez)*Ez)) # array
-  energy         = np.sum(w*energy_density)                                        # scalar
-
-  # x-directed Poynting flux through monitor from frequency-domain fields
-  monitor        = mp.FluxRegion(center=mon_center, size=mon_size)
-  dft_cell       = sim.add_flux(freq, freq, 1, monitor)
-  sim.run(...)    # timestep until DFTs converged
-  (Ey,Ez,Hy,Hz)  = [sim.get_dft_array(dft_cell,c,0) for c in [mp.Ey, mp.Ez, mp.Hy, mp.Hz]]
-  (x,y,z,w)      = sim.get_array_metadata(dft=dft_cell)
-  flux_density   = np.real( np.conj(Ey)*Hz - np.conj(Ez)*Hy )    # array
-  flux           = np.sum(w*flux_density)                        # scalar
-```
-
-#### Source Slices
-
-* *get_source_slice(component, vol=None, center=None, size=None)* — Deprecated. Use `get_source` below.
-* [Simulation.get_source(component, vol=None, center=None, size=None)](#Simulation.get_source)
-
-
-#### Harminv Step Function
-
-The following step function collects field data from a given point and runs [Harminv](https://github.com/NanoComp/harminv) on that data to extract the frequencies, decay rates, and other information.
-
-* [Harminv class](#Harminv)
-
-
-### Step-Function Modifiers
-
-Rather than writing a brand-new step function every time something a bit different is required, the following "modifier" functions take a bunch of step functions and produce *new* step functions with modified behavior.
-See also [Tutorial/Basics](Python_Tutorials/Basics.md) for examples.
-
-
-#### Miscellaneous Step-Function Modifiers
-
-
-<a id="combine_step_funcs"></a>
-
-```python
-def combine_step_funcs(*step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, return a new step function that on each step calls
-all of the passed step functions.
-
-</div>
-
-<a id="synchronized_magnetic"></a>
-
-```python
-def synchronized_magnetic(*step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, return a new step function that on each step calls
-all of the passed step functions with the magnetic field synchronized in time with the
-electric field. See [Synchronizing the Magnetic and Electric
-Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
-
-</div>
-
-
-#### Controlling When a Step Function Executes
-
-
-<a id="when_true"></a>
-
-```python
-def when_true(cond, *step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions and a condition function `condition` (a function of
-no arguments), evaluate the step functions whenever `condition` returns `True`.
-
-</div>
-
-<a id="when_false"></a>
-
-```python
-def when_false(cond, *step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions and a condition function `condition` (a function of
-no arguments), evaluate the step functions whenever `condition` returns `False`.
-
-</div>
-
-<a id="at_every"></a>
-
-```python
-def at_every(dt, *step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, evaluates them at every time interval of $dT$ units
-(rounded up to the next time step).
-
-</div>
-
-<a id="after_time"></a>
-
-```python
-def after_time(t, *step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, evaluates them only for times after a $T$ time
-units have elapsed from the start of the run.
-
-</div>
-
-<a id="before_time"></a>
-
-```python
-def before_time(t, *step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, evaluates them only for times before a $T$ time
-units have elapsed from the start of the run.
-
-</div>
-
-<a id="at_time"></a>
-
-```python
-def at_time(t, *step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, evaluates them only once, after a $T$ time units
-have elapsed from the start of the run.
-
-</div>
-
-<a id="after_sources"></a>
-
-```python
-def after_sources(*step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, evaluates them only for times after all of the
-sources have turned off.
-
-</div>
-
-<a id="after_sources_and_time"></a>
-
-```python
-def after_sources_and_time(t, *step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, evaluates them only for times after all of the
-sources have turned off, plus an additional $T$ time units have elapsed.
-
-</div>
-
-<a id="during_sources"></a>
-
-```python
-def during_sources(*step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, evaluates them only for times *before* all of the
-sources have turned off.
-
-</div>
-
-<a id="at_beginning"></a>
-
-```python
-def at_beginning(*step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, evaluates them only once, at the beginning of the
-run.
-
-</div>
-
-<a id="at_end"></a>
-
-```python
-def at_end(*step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, evaluates them only once, at the end of the run.
-
-</div>
-
-
-#### Modifying HDF5 Output
-
-
-<a id="in_volume"></a>
-
-```python
-def in_volume(v, *step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, modifies any output functions among them to only
-output a subset (or a superset) of the cell, corresponding to the `meep::volume* v`
-(created by the `Volume` function).
-
-</div>
-
-<a id="in_point"></a>
-
-```python
-def in_point(pt, *step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, modifies any output functions among them to only
-output a single *point* of data, at `pt` (a `Vector3`).
-
-</div>
-
-<a id="to_appended"></a>
-
-```python
-def to_appended(fname, *step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, modifies any output functions among them to
-*append* their data to datasets in a single newly-created file named `filename` (plus
-an `.h5` suffix and the current filename prefix). They append by adding an *extra
-dimension* to their datasets, corresponding to time.
-
-</div>
-
-<a id="with_prefix"></a>
-
-```python
-def with_prefix(pre, *step_funcs):
-```
-
-<div class="function_docstring" markdown="1">
-
-Given zero or more step functions, modifies any output functions among them to prepend
-the string `prefix` to the file names (much like `filename_prefix`, above).
-
-</div>
-
-### Writing Your Own Step Functions
-
-A step function can take two forms. The simplest is just a function with one argument (the simulation instance), which is called at every time step unless modified by one of the modifier functions above. e.g.
-
-```py
-def my_step(sim):
-    print("Hello world!")
-```
-
-If one then does `sim.run(my_step, until=100)`, Meep will run for 100 time units and print "Hello world!" at every time step.
-
-This suffices for most purposes. However, sometimes you need a step function that opens a file, or accumulates some computation, and you need to clean up (e.g. close the file or print the results) at the end of the run. For this case, you can write a step function of two arguments: the second argument will either be `step` when it is called during time-stepping, or `finish` when it is called at the end of the run:
-
-```py
-def my_step(sim, todo):
-    if todo == 'step':
-       # do something
-    elif todo == 'finish':
-       # do something else
-
-    # access simulation attributes
-    sim.fields ...etc.
-```
-
-Low-Level Functions
--------------------
-
-By default, Meep initializes C++ objects like `meep::structure` and `meep::fields` in the `Simulation` object based on attributes like `sources` and `geometry`. Theses objects are then accessible via `simulation_instance.structure` and `simulation_instance.fields`. Given these, you can then call essentially any function in the C++ interface, because all of the C++ functions are automatically made accessible to Python by the wrapper-generator program [SWIG](https://en.wikipedia.org/wiki/SWIG).
-
-### Initializing the Structure and Fields
-
-The `structure` and `fields` variables are automatically initialized when any of the run functions is called, or by various other functions such as `add_flux`. To initialize them separately, you can call `Simulation.init_sim()` manually, or `Simulation._init_structure(k_point)` to just initialize the structure.
-
-If you want to time step more than one field simultaneously, the easiest way is probably to do something like:
-
-```py
-sim = Simulation(cell_size, resolution).init_sim()
-my_fields = sim.fields
-sim.fields = None
-sim.reset_meep()
-```
-
-and then change the geometry etc. and re-run `sim.init_sim()`. Then you'll have two field objects in memory.
-
-### SWIG Wrappers
-
-If you look at a function in the C++ interface, then there are a few simple rules to infer the name of the corresponding Python function.
-
--   First, all functions in the `meep::` namespace are available in the Meep Python module from the top-level `meep` package.
--   Second, any method of a class is accessible via the standard Python class interface. For example, `meep::fields::step`, which is the function that performs a time-step, is exposed to Python as `fields_instance.step()` where a fields instance is usually accessible from Simulation.fields.
--   C++ constructors are called using the normal Python class instantiation. E.g., `fields = mp.fields(...)` returns a new `meep::fields` object. Calling destructors is not necessary because objects are automatically garbage collected.
-
-Some argument type conversion is performed automatically, e.g. types like complex numbers are converted to `complex<double>`, etcetera. `Vector3` vectors are converted to `meep::vec`, but to do this it is necessary to know the dimensionality of the problem in C++. The problem dimensions are automatically initialized by `Simulation._init_structure`, but if you want to pass vector arguments to C++ before that time you should call `Simulation.require_dimensions()`, which infers the dimensions from the `cell_size`, `k_point`, and `dimensions` variables.

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -362,6 +362,39 @@ use. See also [SWIG Wrappers](#swig-wrappers).
 </div>
 
 </div>
+   
+<a id="Simulation.run"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def run(self, *step_funcs, **kwargs):
+```
+
+<div class="method_docstring" markdown="1">
+
+`run(step_functions..., until=condition/time)`
+
+Run the simulation until a certain time or condition, calling the given step
+functions (if any) at each timestep. The keyword argument `until` is *either* a
+number, in which case it is an additional time (in Meep units) to run for, *or* it
+is a function (of no arguments) which returns `True` when the simulation should
+stop. `until` can also be a list of stopping conditions which may include a number
+and additional functions.
+
+`run(step_functions..., until_after_sources=condition/time)`
+
+Run the simulation until all sources have turned off, calling the given step
+functions (if any) at each timestep. The keyword argument `until_after_sources` is
+either a number, in which case it is an *additional* time (in Meep units) to run
+for after the sources are off, *or* it is a function (of no arguments). In the
+latter case, the simulation runs until the sources are off *and* `condition`
+returns `True`. Like `until` above, `until_after_sources` can take a list of
+stopping conditions.
+
+</div>
+
+</div>
 
 
 ### Output File Names
@@ -4140,7 +4173,7 @@ class Transition(object):
 
 <div class="class_docstring" markdown="1">
 
-A `Transition` is... (TODO)
+
 
 </div>
 
@@ -5464,7 +5497,7 @@ def __init__(self,
              side=-1,
              R_asymptotic=1e-15,
              mean_stretch=1.0,
-             pml_profile=<function PML.<lambda> at 0x7fa29002fdd0>):
+             pml_profile=<function PML.<lambda> at 0x7f9aa8547dd0>):
 ```
 
 <div class="method_docstring" markdown="1">

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -8,15 +8,6 @@ The Python API functions and classes can be found in the `meep` module, which sh
 
 [TOC]
 
-The Simulation Class
----------------------
-
-The `Simulation` class is the primary abstraction of the high-level interface. Minimally, a simulation script amounts to passing the desired keyword arguments to the `Simulation` constructor and calling the `run` method on the resulting instance.
-
-
-@@ Simulation @@
-
-
 
 Predefined Variables
 --------------------
@@ -63,6 +54,636 @@ Specify a particular field or other component. One of `Ex`, `Ey`, `Ez`, `Er`, `E
 **`derived_component` constants**
 —
 These are additional components which are not actually stored by Meep but are computed as needed, mainly for use in output functions. One of `Sx`, `Sy`, `Sz`, `Sr`, `Sp`, `EnergyDensity`, `D_EnergyDensity`, `H_EnergyDensity` for $S_x$, $S_y$, $S_z$, $S_r$, $S_\phi$ (components of the Poynting vector $\mathrm{Re}\,\mathbf{E}^* \times \mathbf{H}$), $(\mathbf{E}^* \cdot \mathbf{D} + \mathbf{H}^* \cdot \mathbf{B})/2$, $\mathbf{E}^* \cdot \mathbf{D}/2$, $\mathbf{H}^* \cdot \mathbf{B}/2$, respectively.
+
+
+
+The Simulation Class
+---------------------
+
+The `Simulation` class is the primary abstraction of the high-level interface. Minimally, a simulation script amounts to passing the desired keyword arguments to the `Simulation` constructor and calling the `run` method on the resulting instance.
+
+
+@@ Simulation @@
+   @@ Simulation.__init__ @@
+
+
+### Output File Names
+
+The output filenames used by Meep, e.g. for HDF5 files, are automatically prefixed by the
+input variable `filename_prefix`. If `filename_prefix` is `None` (the default), however,
+then Meep constructs a default prefix based on the current Python filename with `".py"`
+replaced by `"-"`: e.g. `test.py` implies a prefix of `"test-"`. You can get this prefix,
+or set the output folder, with these methods of the `Simulation` class:
+
+@@ Simulation.get_filename_prefix @@
+@@ Simulation.use_output_directory @@
+
+
+### Simulation Time
+
+The `Simulation` class provides the following time-related methods:
+
+@@ Simulation.meep_time @@
+@@ Simulation.print_times @@
+@@ Simulation.time_spent_on @@
+@@ Simulation.mean_time_spent_on @@
+
+
+### Field Computations
+
+Meep supports a large number of functions to perform computations on the fields. Most of them are accessed via the lower-level C++/SWIG interface. Some of them are based on the following simpler, higher-level versions. They are accessible as methods of a `Simulation` instance.
+
+@@ Simulation.set_boundary @@
+@@ Simulation.phase_in_material @@
+@@ Simulation.get_field_point @@
+@@ Simulation.get_epsilon_point @@
+@@ Simulation.initialize_field @@
+@@ Simulation.add_dft_fields @@
+@@ Simulation.flux_in_box @@
+@@ Simulation.electric_energy_in_box @@
+@@ Simulation.magnetic_energy_in_box @@
+@@ Simulation.field_energy_in_box @@
+@@ Simulation.modal_volume_in_box @@
+@@ Simulation.integrate_field_function @@
+@@ Simulation.max_abs_field_function @@
+@@ Simulation.integrate2_field_function @@
+
+
+### Reloading Parameters
+
+Once the fields/simulation have been initialized, you can change the values of various parameters by using the following functions (which are members of the `Simulation` class):
+
+@@ Simulation.reset_meep @@
+@@ Simulation.restart_fields @@
+@@ Simulation.change_k_point @@
+@@ Simulation.change_sources @@
+@@ Simulation.set_materials @@
+
+
+### Flux Spectra
+
+Given a bunch of [`FluxRegion`](#fluxregion) objects, you can tell Meep to accumulate the Fourier transforms of the fields in those regions in order to compute the Poynting flux spectra. (Note: as a matter of convention, the "intensity" of the electromagnetic fields refers to the Poynting flux, *not* to the [energy density](#energy-density-spectra).) See also [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend). These are attributes of the `Simulation` class. The most important function is:
+
+@@ Simulation.add_flux @@
+
+As described in the tutorial, you normally use `add_flux` via statements like:
+
+```python
+transmission = sim.add_flux(...)
+```
+
+to store the flux object in a variable.  You can create as many flux objects as you want, e.g. to look at powers flowing in different regions or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the flux region multiplied by the number of electric and magnetic field components required to get the Poynting vector multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
+
+Once you have called `add_flux`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the [run functions](#run-functions). At any time, you can ask for Meep to print out the current flux spectrum via the `display_fluxes` method.
+
+@@ Simulation.display_fluxes @@
+
+You might have to do something lower-level if you have multiple flux regions corresponding to *different* frequency ranges, or have other special needs. `display_fluxes(f1, f2, f3)` is actually equivalent to `meep.display_csv("flux", meep.get_flux_freqs(f1), meep.get_fluxes(f1), meep.get_fluxes(f2), meep.get_fluxes(f3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling two lower-level functions:
+
+@@ get_flux_freqs @@
+@@ get_fluxes @@
+
+As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend), for a reflection spectrum you often want to save the Fourier-transformed fields from a "normalization" run and then load them into another run to be subtracted. This can be done via:
+
+@@ Simulation.save_flux @@
+@@ Simulation.load_flux @@
+@@ Simulation.load_minus_flux @@
+
+Sometimes it is more convenient to keep the Fourier-transformed fields in memory rather than writing them to a file and immediately loading them back again. To that end, the `Simulation` class exposes the following three methods:
+
+@@ Simulation.get_flux_data @@
+@@ Simulation.load_flux_data @@
+@@ Simulation.load_minus_flux_data @@
+
+
+The `Simulation` class also provides some aliases for the corresponding "flux" methods.
+
+* **`save_mode`**
+* **`load_mode`**
+* **`load_minus_mode`**
+* **`get_mode_data`**
+* **`load_mode_data`**
+* **`load_minus_mode_data`**
+
+
+### Mode Decomposition
+
+Given a structure, Meep can decompose the Fourier-transformed fields into a superposition of its harmonic modes. For a theoretical background, see [Mode Decomposition](Mode_Decomposition.md).
+
+@@ Simulation.get_eigenmode_coefficients @@
+
+The flux object should be created using `add_mode_monitor`.  (You could also use `add_flux`, but with `add_flux` you need to be more careful about symmetries that bisect the flux plane: the `add_flux` object should only be used with `get_eigenmode_coefficients` for modes of the same symmetry, e.g. constrained via `eig_parity`.  On the other hand, the performance of `add_flux` planes benefits more from symmetry.) `eig_vol` is the volume passed to [MPB](https://mpb.readthedocs.io) for the eigenmode calculation (based on interpolating the discretized materials from the Yee grid); in most cases this will simply be the volume over which the frequency-domain fields are tabulated, which is the default (i.e. `flux.where`). `eig_parity` should be one of [`mp.NO_PARITY` (default), `mp.EVEN_Z`, `mp.ODD_Z`, `mp.EVEN_Y`, `mp.ODD_Y`]. It is the parity (= polarization in 2d) of the mode to calculate, assuming the structure has $z$ and/or $y$ mirror symmetry *in the source region*, just as for `EigenModeSource` above. If the structure has both $y$ and $z$ mirror symmetry, you can combine more than one of these, e.g. `EVEN_Z+ODD_Y`. Default is `NO_PARITY`, in which case MPB computes all of the bands which will still be even or odd if the structure has mirror symmetry, of course. This is especially useful in 2d simulations to restrict yourself to a desired polarization. `eig_resolution` is the spatial resolution to use in MPB for the eigenmode calculations. This defaults to twice the Meep `resolution` in which case the structure is linearly interpolated from the Meep pixels. `eig_tolerance` is the tolerance to use in the MPB eigensolver. MPB terminates when the eigenvalues stop changing to less than this fractional tolerance. Defaults to `1e-12`.  (Note that this is the tolerance for the frequency eigenvalue ω; the tolerance for the mode profile is effectively the square root of this.) For examples, see [Tutorial/Mode Decomposition](Python_Tutorials/Mode_Decomposition.md).
+
+Technically, MPB computes `ωₙ(k)` and then inverts it with Newton's method to find the wavevector `k` normal to `eig_vol` and mode for a given frequency; in rare cases (primarily waveguides with *nonmonotonic* dispersion relations, which doesn't usually happen in simple dielectric waveguides), MPB may need you to supply an initial "guess" for `k` in order for this Newton iteration to converge.  You can supply this initial guess with `kpoint_func`, which is a function `kpoint_func(f, n)` that supplies a rough initial guess for the `k` of band number `n` at frequency `f = ω/2π`. (By default, the **k** components in the plane of the `eig_vol` region are zero.  However, if this region spans the *entire* cell in some directions, and the cell has Bloch-periodic boundary conditions via the `k_point` parameter, then the mode's **k** components in those directions will match `k_point` so that the mode satisfies the Meep boundary conditions, regardless of `kpoint_func`.) If `direction` is set to `mp.NO_DIRECTION`, then `kpoint_func` is not only the initial guess and the search direction of the **k** vectors, but is also taken to be the direction of the waveguide, allowing you to [detect modes in oblique waveguides](Python_Tutorials/Eigenmode_Source.md#oblique-waveguides) (not perpendicular to the flux plane).
+
+**Note:** for planewaves in homogeneous media, the `kpoints` may *not* necessarily be equivalent to the actual wavevector of the mode. This quantity is given by `kdom`.
+
+@@ Simulation.add_mode_monitor @@
+
+`add_mode_monitor` works properly with arbitrary symmetries, but may be suboptimal because the Fourier-transformed region does not exploit the symmetry.  As an optimization, if you have a mirror plane that bisects the mode monitor, you can instead use `add_flux` to gain a factor of two, but in that case you *must* also pass the corresponding `eig_parity` to `get_eigenmode_coefficients` in order to only compute eigenmodes with the corresponding mirror symmetry.
+
+@@ Simulation.get_eigenmode @@
+
+The following top-level function is also available:
+
+@@ get_eigenmode_freqs @@
+
+
+
+### Energy Density Spectra
+
+Very similar to flux spectra, you can also compute **energy density spectra**: the energy density of the electromagnetic fields as a function of frequency, computed by Fourier transforming the fields and integrating the energy density:
+
+$$ \frac{1}{2}ε|\mathbf{E}|^2 + \frac{1}{2}μ|\mathbf{H}|^2 $$
+
+The usage is similar to the flux spectra: you define a set of [`EnergyRegion`](#EnergyRegion) objects telling Meep where it should compute the Fourier-transformed fields and energy densities, and call `add_energy` to add these regions to the current simulation over a specified frequency bandwidth, and then use `display_electric_energy`, `display_magnetic_energy`, or `display_total_energy` to display the energy density spectra at the end. There are also `save_energy`, `load_energy`, and `load_minus_energy` functions that you can use to subtract the fields from two simulation, e.g. in order to compute just the energy from scattered fields, similar to the flux spectra. The function used to add an [`EnergyRegion`](#EnergyRegion) is as follows:
+
+@@ Simulation.add_energy @@
+
+As for flux regions, you normally use `add_energy` via statements like:
+
+```py
+En = sim.add_energy(...)
+```
+
+to store the energy object in a variable.  You can create as many energy objects as you want, e.g. to look at the energy densities in different objects or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the energy region multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
+
+Once you have called `add_energy`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the `run` functions. At any time, you can ask for Meep to print out the current energy density spectrum via:
+
+@@ Simulation.display_electric_energy @@
+@@ Simulation.display_magnetic_energy @@
+@@ Simulation.display_total_energy @@
+
+
+You might have to do something lower-level if you have multiple energy regions corresponding to *different* frequency ranges, or have other special needs. `display_electric_energy(e1, e2, e3)` is actually equivalent to `meep.display_csv("electric_energy", meep.get_energy_freqs(e1), meep.get_electric_energy(e1), meep.get_electric_energy(e2), meep.get_electric_energy(e3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling lower-level functions:
+
+@@ get_energy_freqs @@
+@@ get_electric_energy @@
+@@ get_magnetic_energy @@
+@@ get_total_energy @@
+
+As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, to compute the energy density from the scattered fields you often want to save the Fourier-transformed fields from a "normalization" run and then load them into another run to be subtracted. This can be done via:
+
+@@ Simulation.save_energy @@
+@@ Simulation.load_energy @@
+@@ Simulation.load_minus_energy @@
+
+
+### Force Spectra
+
+Very similar to flux spectra, you can also compute **force spectra**: forces on an object as a function of frequency, computed by Fourier transforming the fields and integrating the vacuum [Maxwell stress tensor](https://en.wikipedia.org/wiki/Maxwell_stress_tensor):
+
+$$\sigma_{ij} = E_i^*E_j + H_i^*H_j - \frac{1}{2} δ_{ij} \left( |\mathbf{E}|^2 + |\mathbf{H}|^2 \right)$$
+
+over a surface $S$ via $\mathbf{F} = \int_S \sigma d\mathbf{A}$. You should normally **only evaluate the stress tensor over a surface lying in vacuum**, as the interpretation and definition of the stress tensor in arbitrary media is often problematic (the subject of extensive and controversial literature). It is fine if the surface *encloses* an object made of arbitrary materials, as long as the surface itself is in vacuum.
+
+See also [Tutorial/Optical Forces](Python_Tutorials/Optical_Forces.md).
+
+Most commonly, you will want to **normalize** the force spectrum in some way, just as for flux spectra. Most simply, you could divide two different force spectra to compute the ratio of forces on two objects. Often, you will divide a force spectrum by a flux spectrum, to divide the force $F$ by the incident power $P$ on an object, in order to compute the useful dimensionless ratio $Fc$/$P$ where $c=1$ in Meep units. For example, it is a simple exercise to show that the force $F$ on a perfectly reflecting mirror with normal-incident power $P$ satisfies $Fc$/$P=2$, and for a perfectly absorbing (black) surface $Fc$/$P=1$.
+
+The usage is similar to the [flux spectra](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend): you define a set of [`ForceRegion`](#ForceRegion) objects telling Meep where it should compute the Fourier-transformed fields and stress tensors, and call `add_force` to add these regions to the current simulation over a specified frequency bandwidth, and then use `display_forces` to display the force spectra at the end. There are also `save_force`, `load_force`, and `load_minus_force` functions that you can use to subtract the fields from two simulation, e.g. in order to compute just the force from scattered fields, similar to the flux spectra. The function used to add a [`ForceRegion`](#ForceRegion) object is defined as follows:
+
+@@ Simulation.add_force @@
+
+As for flux regions, you normally use `add_force` via statements like:
+
+```py
+Fx = sim.add_force(...)
+```
+
+to store the force object in a variable.  You can create as many force objects as you want, e.g. to look at forces on different objects, in different directions, or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the force region, multiplied by the number of electric and magnetic field components required to get the stress vector, multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
+
+Once you have called `add_force`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the `run` functions. At any time, you can ask for Meep to print out the current force spectrum via:
+
+@@ Simulation.display_forces @@
+
+You might have to do something lower-level if you have multiple force regions corresponding to *different* frequency ranges, or have other special needs. `display_forces(f1, f2, f3)` is actually equivalent to `meep.display_csv("force", meep.get_force_freqs(f1), meep.get_forces(f1), meep.get_forces(f2), meep.get_forces(f3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling two lower-level functions:
+
+
+@@ get_force_freqs @@
+@@ get_forces @@
+
+
+As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, to compute the force from the scattered fields often requires saving the Fourier-transformed fields from a "normalization" run and then loading them into another run to be subtracted. This can be done via these `Simulation` methods:
+
+@@ Simulation.save_force @@
+@@ Simulation.load_force @@
+@@ Simulation.load_minus_force @@
+
+To keep the fields in memory and avoid writing to and reading from a file, use the following three `Simulation` methods:
+
+@@ Simulation.get_force_data @@
+@@ Simulation.load_force_data @@
+@@ Simulation.load_minus_force_data @@
+
+### LDOS spectra
+
+Meep can also calculate the LDOS (local density of states) spectrum, as described in [Tutorial/Local Density of States](Python_Tutorials/Local_Density_of_States.md). To do this, you simply pass the following step function to your `run` command:
+
+@@ Ldos @@
+@@ get_ldos_freqs @@
+@@ dft_ldos @@
+
+
+Analytically, the per-polarization LDOS is exactly proportional to the power radiated by an $\ell$-oriented point-dipole current, $p(t)$, at a given position in space. For a more mathematical treatment of the theory behind the LDOS, refer to the relevant discussion in Section 4.4 ("Currents and Fields: The Local Density of States") in [Chapter 4](http://arxiv.org/abs/arXiv:1301.5366) ("Electromagnetic Wave Source Conditions") of the book [Advances in FDTD Computational Electrodynamics: Photonics and Nanotechnology](https://www.amazon.com/Advances-FDTD-Computational-Electrodynamics-Nanotechnology/dp/1608071707), but for now it is defined as:
+
+$$\operatorname{LDOS}_{\ell}(\vec{x}_0,\omega)=-\frac{2}{\pi}\varepsilon(\vec{x}_0)\frac{\operatorname{Re}[\hat{E}_{\ell}(\vec{x}_0,\omega)\hat{p}(\omega)^*]}{|\hat{p}(\omega)|^2}$$
+
+where the $|\hat{p}(\omega)|^2$ normalization is necessary for obtaining the power exerted by a unit-amplitude dipole (assuming linear materials), and hats denote Fourier transforms. It is this quantity that is computed by the `dft_ldos` command for a single dipole source. For a volumetric source, the numerator and denominator are both integrated over the current volume, but "LDOS" computation is less meaningful in this case.
+
+### Near-to-Far-Field Spectra
+
+Meep can compute a near-to-far-field transformation in the frequency domain as described in [Tutorial/Near-to-Far Field Spectra](Python_Tutorials/Near_to_Far_Field_Spectra.md): given the fields on a "near" bounding surface inside the cell, it can compute the fields arbitrarily far away using an analytical transformation, assuming that the "near" surface and the "far" region lie in a single homogeneous non-periodic 2d, 3d, or cylindrical region. That is, in a simulation *surrounded by PML* that absorbs outgoing waves, the near-to-far-field feature can compute the fields outside the cell as if the outgoing waves had not been absorbed (i.e. in the fictitious infinite open volume). Moreover, this operation is performed on the Fourier-transformed fields: like the flux and force spectra above, you specify a set of desired frequencies, Meep accumulates the Fourier transforms, and then Meep computes the fields at *each frequency* for the desired far-field points.
+
+This is based on the principle of equivalence: given the Fourier-transformed tangential fields on the "near" surface, Meep computes equivalent currents and convolves them with the analytical Green's functions in order to compute the fields at any desired point in the "far" region. For details, see Section 4.2.1 ("The Principle of Equivalence") in [Chapter 4](http://arxiv.org/abs/arXiv:1301.5366) ("Electromagnetic Wave Source Conditions") of the book [Advances in FDTD Computational Electrodynamics: Photonics and Nanotechnology](https://www.amazon.com/Advances-FDTD-Computational-Electrodynamics-Nanotechnology/dp/1608071707).
+
+Note: in order for the far-field results to be accurate, the [far region must be separated from the near region](https://en.wikipedia.org/wiki/Near_and_far_field) by *at least* 2D<sup>2</sup>/λ, the Fraunhofer distance, where D is the largest dimension of the radiator and λ is the vacuum wavelength.
+
+There are three steps to using the near-to-far-field feature: first, define the "near" surface(s) as a set of surfaces capturing *all* outgoing radiation in the desired direction(s); second, run the simulation, typically with a pulsed source, to allow Meep to accumulate the Fourier transforms on the near surface(s); third, tell Meep to compute the far fields at any desired points (optionally saving the far fields from a grid of points to an HDF5 file). To define the near surfaces, use this `Simulation` method:
+
+@@ Simulation.add_near2far @@
+
+Each `Near2FarRegion` is identical to `FluxRegion` except for the name: in 3d, these give a set of planes (**important:** all these "near surfaces" must lie in a single *homogeneous* material with *isotropic* ε and μ &mdash; and they should *not* lie in the PML regions) surrounding the source(s) of outgoing radiation that you want to capture and convert to a far field. Ideally, these should form a closed surface, but in practice it is sufficient for the `Near2FarRegion`s to capture all of the radiation in the direction of the far-field points. **Important:** as for flux computations, each `Near2FarRegion` should be assigned a `weight` of &#177;1 indicating the direction of the outward normal relative to the +coordinate direction. So, for example, if you have six regions defining the six faces of a cube, i.e. the faces in the +x, -x, +y, -y, +z, and -z directions, then they should have weights +1, -1, +1, -1, +1, and -1 respectively. Note that, neglecting discretization errors, all near-field surfaces that enclose the same outgoing fields are equivalent and will yield the same far fields with a discretization-induced difference that vanishes with increasing resolution etc.
+
+After the simulation run is complete, you can compute the far fields. This is usually for a pulsed source so that the fields have decayed away and the Fourier transforms have finished accumulating.
+
+If you have Bloch-periodic boundary conditions, then the corresponding near-to-far transformation actually needs to perform a "lattice sum" of infinitely many periodic copies of the near fields.  This doesn't happen by default, which means the default `near2far` calculation may not be what you want for periodic boundary conditions.  However, if the `Near2FarRegion` spans the entire cell along the periodic directions, you can turn on an approximate lattice sum by passing `nperiods > 1`.  In particular, it then sums `2*nperiods+1` Bloch-periodic copies of the near fields whenever a far field is requested.  You can repeatedly double `nperiods` until the answer converges to your satisfaction; in general, if the far field is at a distance d, and the period is a, then you want `nperiods` to be much larger than d/a.  (Future versions of Meep may use fancier techniques like [Ewald summation](https://en.wikipedia.org/wiki/Ewald_summation) to compute the lattice sum more rapidly at large distances.)
+
+@@ Simulation.get_farfield @@
+@@ Simulation.output_farfields @@
+@@ Simulation.get_farfields @@
+
+This lower-level function is also available:
+
+@@ get_near2far_freqs @@
+
+
+(Multi-frequency `get_farfields` and `output_farfields` can be accelerated by
+[compiling Meep](Build_From_Source.md#meep) with `--with-openmp` and using the
+`OMP_NUM_THREADS` environment variable to specify multiple threads.)
+
+For a scattered-field computation, you often want to separate the scattered and incident fields. As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Scheme_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, you can do this by saving the Fourier-transformed incident from a "normalization" run and then load them into another run to be subtracted. This can be done via these `Simulation` methods:
+
+@@ Simulation.save_near2far @@
+@@ Simulation.load_near2far @@
+@@ Simulation.load_minus_near2far @@
+
+
+To keep the fields in memory and avoid writing to and reading from a file, use the following three methods:
+
+@@ Simulation.get_near2far_data @@
+@@ Simulation.load_near2far_data @@
+@@ Simulation.load_minus_near2far_data @@
+
+See also this lower-level function:
+
+@@ scale_near2far_fields @@
+
+And this [`DftNear2Far`](#DftNear2Far) method:
+
+@@ DftNear2Far.flux @@
+
+
+### Load and Dump Structure
+
+These functions dump the raw ε and μ data to disk and load it back for doing multiple simulations with the same materials but different sources etc. The only prerequisite is that the dump/load simulations have the same [chunks](Chunks_and_Symmetry.md) (i.e. the same grid, number of processors, symmetries, and PML). When using `split_chunks_evenly=False`, you must also dump the original chunk layout using `dump_chunk_layout` and load it into the new `Simulation` using the `chunk_layout` parameter. Currently only stores dispersive and non-dispersive ε and μ but not nonlinearities. Note that loading data from a file in this way overwrites any `geometry` data passed to the `Simulation` constructor.
+
+@@ Simulation.dump_structure @@
+@@ Simulation.load_structure @@
+@@ Simulation.dump_chunk_layout @@
+
+
+To load a chunk layout into a `Simulation`, use the `chunk_layout` argument to the constructor, passing either a file obtained from `dump_chunk_layout` or another `Simulation` instance. Note that when using `split_chunks_evenly=False` this parameter is required when saving and loading flux spectra, force spectra, or near-to-far spectra so that the two runs have the same chunk layout. Just pass the `Simulation` object from the first run to the second run:
+
+```python
+# Split chunks based on amount of work instead of size
+sim1 = mp.Simulation(..., split_chunks_evenly=False)
+norm_flux = sim1.add_flux(...)
+sim1.run(...)
+sim1.save_flux(...)
+
+# Make sure the second run uses the same chunk layout as the first
+sim2 = mp.Simulation(..., chunk_layout=sim1)
+flux = sim2.add_flux(...)
+sim2.load_minus_flux(...)
+sim2.run(...)
+```
+
+### Frequency-Domain Solver
+
+Meep contains a frequency-domain solver that computes the fields produced in a geometry in response to a [continuous-wave (CW) source](https://en.wikipedia.org/wiki/Continuous_wave). This is based on an [iterative linear solver](https://en.wikipedia.org/wiki/Iterative_method) instead of time-stepping. For details, see Section 5.3 ("Frequency-domain solver") of [Computer Physics Communications, Vol. 181, pp. 687-702, 2010](http://ab-initio.mit.edu/~oskooi/papers/Oskooi10.pdf). Benchmarking results have shown that in many instances, such as cavities (e.g., [ring resonators](Python_Tutorials/Frequency_Domain_Solver.md)) with long-lived resonant modes, this solver converges much faster than simply running an equivalent time-domain simulation with a CW source (using the default `width` of zero for no transient turn-on), time-stepping until all transient effects from the source turn-on have disappeared, especially if the fields are desired to a very high accuracy.
+
+To use the frequency-domain solver, simply define a `ContinuousSource` with the desired frequency and [initialize the fields and geometry](#initializing-the-structure-and-fields) via `init_sim()`:
+
+```py
+sim = mp.Simulation(...)
+sim.init_sim()
+sim.solve_cw(tol, maxiters, L)
+```
+
+The first two parameters to the frequency-domain solver are the tolerance `tol` for the iterative solver (10<sup>−8</sup>, by default) and a maximum number of iterations `maxiters` (10<sup>4</sup>, by default). Finally, there is a parameter $L$ that determines a tradeoff between memory and work per step and convergence rate of the iterative algorithm, biconjugate gradient stabilized ([BiCGSTAB-L](https://en.wikipedia.org/wiki/Biconjugate_gradient_stabilized_method)), that is used; larger values of $L$ will often lead to faster convergence at the expense of more memory and more work per iteration. Default is $L=2$, and normally a value ≥ 2 should be used.
+
+The frequency-domain solver supports arbitrary geometries, PML, boundary conditions, symmetries, parallelism, conductors, and arbitrary nondispersive materials. Lorentz-Drude dispersive materials are not currently supported in the frequency-domain solver, but since you are solving at a known fixed frequency rather than timestepping, you should be able to pick conductivities etcetera in order to obtain any desired complex ε and μ at that frequency.
+
+The frequency-domain solver requires you to use complex-valued fields, via `force_complex_fields=True`.
+
+After `solve_cw` completes, it should be as if you had just run the simulation for an infinite time with the source at that frequency. You can call the various field-output functions and so on as usual at this point. For examples, see [Tutorial/Frequency Domain Solver](Python_Tutorials/Frequency_Domain_Solver.md) and [Tutorial/Mode Decomposition/Reflectance and Transmittance Spectra for Planewave at Oblique Incidence](Python_Tutorials/Mode_Decomposition.md#reflectance-and-transmittance-spectra-for-planewave-at-oblique-incidence).
+
+**Note:** The convergence of the iterative solver can sometimes encounter difficulties. For example, increasing the diameter of a ring resonator relative to the wavelength increases the [condition number](https://en.wikipedia.org/wiki/Condition_number), which worsens the convergence of iterative solvers. The general way to improve this is to implement a more sophisticated iterative solver that employs [preconditioners](https://en.wikipedia.org/wiki/Preconditioner). Preconditioning wave equations (Helmholtz-like equations) is notoriously difficult to do well, but some possible strategies are discussed in [Issue #548](https://github.com/NanoComp/meep/issues/548). In the meantime, a simpler way improving convergence (at the expense of computational cost) is to increase the $L$ parameter and the number of iterations.
+
+### Frequency-Domain Eigensolver
+
+Building on the frequency-domain solver above, Meep also includes a frequency-domain eigensolver that computes resonant frequencies and modes in the frequency domain.  The usage is very similar to `solve_cw`:
+
+```py
+sim = mp.Simulation(...)
+sim.init_sim()
+eigfreq = sim.solve_eigfreq(tol, maxiters, guessfreq, cwtol, cwmaxiters, L)
+```
+
+The `solve_eig` routine performs repeated calls to `solve_cw` in a way that converges to the resonant mode whose frequency is *closest* to the source frequency.  The complex resonant-mode frequency is returned, and the mode Q can be computed from `eigfreq.real / (-2*eigfreq.imag)`.  Upon return, the fields should be the corresponding resonant mode (with an arbitrary scaling).
+
+The resonant mode is converged to a relative error of roughly `tol`, which defaults to `1e-7`. A maximum of `maxiters` (defaults to `100`) calls to `solve_cw` are performed.  The tolerance for each `solve_cw` call is `cwtol` (defaults to `tol*1e-3`) and the maximum iterations is `cwmaxiters` (10<sup>4</sup>, by default); the `L` parameter (defaults to `10`) is also passed through to `solve_cw`.
+
+The closer the input frequency is to the resonant-mode frequency, the faster `solve_eig` should converge. Instead of using the source frequency, you can instead pass a `guessfreq` argument to `solve_eigfreq` specifying an input frequency (which may even be complex).
+
+Technically, `solve_eig` is using a [shift-and-invert power iteration](https://en.wikipedia.org/wiki/Inverse_iteration) to compute the resonant mode, as reviewed in [Frequency-Domain Eigensolver](Eigensolver_Math.md).
+
+As for `solve_cw` above, you are required to set `force_complex_fields=True` to use `solve_eigfreq`.
+
+### GDSII Support
+
+This feature is only available if Meep is built with [libGDSII](Build_From_Source.md#libgdsii). It so, then the following functions are available:
+
+@@ GDSII_layers @@
+@@ GDSII_prisms @@
+@@ GDSII_vol @@
+
+
+### Data Visualization
+
+This module provides basic visualization functionality for the simulation domain. The spirit of the module is to provide functions that can be called with *no customization options whatsoever* and will do useful relevant things by default, but which can also be customized in cases where you *do* want to take the time to spruce up the output. The `Simulation` class provides the following methods:
+
+@@ Simulation.plot2D @@
+@@ Simulation.plot3D @@
+@@ Simulation.visualize_chunks @@
+
+An animated visualization is also possible via the [Animate2D](#Animate2D) class.
+
+
+### Run and Step Functions
+
+The actual work in Meep is performed by `run` functions, which time-step the simulation for a given amount of time or until a given condition is satisfied. These are attributes of the `Simulation` class.
+
+The run functions, in turn, can be modified by use of [step functions](#predefined-step-functions): these are called at every time step and can perform any arbitrary computation on the fields, do outputs and I/O, or even modify the simulation. The step functions can be transformed by many [modifier functions](#step-function-modifiers), like `at_beginning`, `during_sources`, etcetera which cause them to only be called at certain times, etcetera, instead of at every time step.
+
+A common point of confusion is described in [The Run Function Is Not A Loop](The_Run_Function_Is_Not_A_Loop.md). Read this article if you want to make Meep do some customized action on each time step, as many users make the same mistake. What you really want to in that case is to write a step function, as described below.
+
+@@ Simulation.run @@
+
+In particular, a useful value for `until_after_sources` or `until` is often `stop_when_field_decayed`, which is demonstrated in [Tutorial/Basics](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend). These top-level functions are available:
+
+@@ stop_when_fields_decayed @@
+@@ stop_after_walltime @@
+@@ stop_on_interrupt @@
+
+
+Finally, another run function, useful for computing ω(**k**) band diagrams, is available via these top-level functions:
+
+@@ meep.run_k_points @@
+@@ meep.run_k_point @@
+
+
+### Predefined Step Functions
+
+Several useful step functions are predefined by Meep. These are available directly via the `meep` package but require a `Simulation` instance as an argument.
+
+#### Output Functions
+
+The most common step function is an output function, which outputs some field component to an [HDF5](https://en.wikipedia.org/wiki/HDF5) file. Normally, you will want to modify this by one of the `at_*` functions, below, as outputting a field at *every* time step can get quite time- and storage-consuming.
+
+Note that although the various field components are stored at different places in the [Yee lattice](Yee_Lattice.md), when they are outputted they are all linearly interpolated to the same grid: to the points at the *centers* of the Yee cells, i.e. $(i+0.5,j+0.5,k+0.5)\cdotΔ$ in 3d.
+
+
+@@ Simulation.output_dft @@
+
+@@ output_epsilon @@
+@@ output_mu @@
+@@ output_poynting @@
+@@ output_hpwr @@
+@@ output_dpwr @@
+@@ output_tot_pwr @@
+@@ output_png @@
+
+@@ output_hfield @@
+@@ output_hfield_x @@
+@@ output_hfield_y @@
+@@ output_hfield_z @@
+@@ output_hfield_r @@
+@@ output_hfield_p @@
+
+@@ output_bfield @@
+@@ output_bfield_x @@
+@@ output_bfield_y @@
+@@ output_bfield_z @@
+@@ output_bfield_r @@
+@@ output_bfield_p @@
+
+@@ output_efield @@
+@@ output_efield_x @@
+@@ output_efield_y @@
+@@ output_efield_z @@
+@@ output_efield_r @@
+@@ output_efield_p @@
+
+@@ output_dfield @@
+@@ output_dfield_x @@
+@@ output_dfield_y @@
+@@ output_dfield_z @@
+@@ output_dfield_r @@
+@@ output_dfield_p @@
+
+@@ output_sfield @@
+@@ output_sfield_x @@
+@@ output_sfield_y @@
+@@ output_sfield_z @@
+@@ output_sfield_r @@
+@@ output_sfield_p @@
+
+
+More generally, it is possible to output an arbitrary function of position and zero or more field components, similar to the `Simulation.integrate_field_function` method, described above. This is done by:
+
+@@ Simulation.output_field_function @@
+
+See also [Field Functions](Field_Functions.md), and [Synchronizing the Magnetic and Electric Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md) if you want to do computations combining the electric and magnetic fields.
+
+
+#### Array Slices
+
+The output functions described above write the data for the fields and materials for the entire cell to an HDF5 file. This is useful for post-processing as you can later read in the HDF5 file to obtain field/material data as a NumPy array. However, in some cases it is convenient to bypass the disk altogether to obtain the data *directly* in the form of a NumPy array without writing/reading HDF5 files. Additionally, you may want the field/material data on just a subregion (or slice) of the entire volume. This functionality is provided by the `get_array` method which takes as input a subregion of the cell and the field/material component. The method returns a NumPy array containing values of the field/material at the current simulation time.
+
+@@ Simulation.get_array @@
+@@ Simulation.get_dft_array @@
+
+
+#### Array Metadata
+
+@@ Simulation.get_array_metadata @@
+
+This routine provides geometric information useful for interpreting the arrays returned by `get_array` or `get_dft_array` for the spatial region defined by `vol` or `center/size`. Here are some examples of how array metadata can be used:
+
+**Labeling Axes in Plots of Grid Quantities**
+
+```python
+# using the geometry from the bend-flux tutorial example
+import matplotlib.pyplot as plt
+import numpy as np
+
+eps_array=sim.get_epsilon()
+(x,y,z,w)=sim.get_array_metadata()
+plt.figure()
+ax = plt.subplot(111)
+plt.pcolormesh(x,y,np.transpose(eps_array),shading='gouraud')
+ax.set_aspect('equal')
+plt.show()
+```
+
+![](images/PermittivityWithLabeledAxes.png)
+
+**Computing Quantities Defined by Integrals of Field-Dependent Functions Over Grid Regions**
+
++ energy stored in the $\mathbf{E}$-field in a region $\mathcal{V}$:
+      $$ \mathcal{E}=
+         \frac{1}{2}\int_{\mathcal V} \epsilon |\mathbf{E}|^2\,dV
+      $$
+
++ Poynting flux through a surface $\mathcal{S}$:
+      $$\mathcal{S}=\frac{1}{2}\text{Re }\int_{\mathcal S}
+        \Big(\mathbf{E}^*\times \mathbf{H}\Big)\times d\mathbf{A}
+      $$
+
+```python
+  import numpy as np
+
+  # E-field modal volume in box from time-domain fields
+  box            = mp.Volume(center=box_center, size=box_size)
+  (Ex,Ey,Ez)     = [sim.get_array(vol=box, component=c, cmplx=True) for c in [mp.Ex, mp.Ey, mp.Ez]]
+  eps            = sim.get_array(vol=box, component=mp.Dielectric)
+  (x,y,z,w)      = sim.get_array_metadata(vol=box)
+  energy_density = np.real(eps*(np.conj(Ex)*Ex + np.conj(Ey)*Ey + np.conj(Ez)*Ez)) # array
+  energy         = np.sum(w*energy_density)                                        # scalar
+
+  # x-directed Poynting flux through monitor from frequency-domain fields
+  monitor        = mp.FluxRegion(center=mon_center, size=mon_size)
+  dft_cell       = sim.add_flux(freq, freq, 1, monitor)
+  sim.run(...)    # timestep until DFTs converged
+  (Ey,Ez,Hy,Hz)  = [sim.get_dft_array(dft_cell,c,0) for c in [mp.Ey, mp.Ez, mp.Hy, mp.Hz]]
+  (x,y,z,w)      = sim.get_array_metadata(dft=dft_cell)
+  flux_density   = np.real( np.conj(Ey)*Hz - np.conj(Ez)*Hy )    # array
+  flux           = np.sum(w*flux_density)                        # scalar
+```
+
+#### Source Slices
+
+@@ Simulation.get_source @@
+
+
+#### Harminv Step Function
+
+The following step function collects field data from a given point and runs [Harminv](https://github.com/NanoComp/harminv) on that data to extract the frequencies, decay rates, and other information.
+
+* [Harminv class](#Harminv)
+
+
+### Step-Function Modifiers
+
+Rather than writing a brand-new step function every time something a bit different is required, the following "modifier" functions take a bunch of step functions and produce *new* step functions with modified behavior.
+See also [Tutorial/Basics](Python_Tutorials/Basics.md) for examples.
+
+
+#### Miscellaneous Step-Function Modifiers
+
+@@ combine_step_funcs @@
+@@ synchronized_magnetic @@
+
+
+#### Controlling When a Step Function Executes
+
+@@ when_true @@
+@@ when_false @@
+@@ at_every @@
+@@ after_time @@
+@@ before_time @@
+@@ at_time @@
+@@ after_sources @@
+@@ after_sources_and_time @@
+@@ during_sources @@
+@@ at_beginning @@
+@@ at_end @@
+
+
+#### Modifying HDF5 Output
+
+@@ in_volume @@
+@@ in_point @@
+@@ to_appended @@
+@@ with_prefix @@
+
+### Writing Your Own Step Functions
+
+A step function can take two forms. The simplest is just a function with one argument (the simulation instance), which is called at every time step unless modified by one of the modifier functions above. e.g.
+
+```py
+def my_step(sim):
+    print("Hello world!")
+```
+
+If one then does `sim.run(my_step, until=100)`, Meep will run for 100 time units and print "Hello world!" at every time step.
+
+This suffices for most purposes. However, sometimes you need a step function that opens a file, or accumulates some computation, and you need to clean up (e.g. close the file or print the results) at the end of the run. For this case, you can write a step function of two arguments: the second argument will either be `step` when it is called during time-stepping, or `finish` when it is called at the end of the run:
+
+```py
+def my_step(sim, todo):
+    if todo == 'step':
+       # do something
+    elif todo == 'finish':
+       # do something else
+
+    # access simulation attributes
+    sim.fields ...etc.
+```
+
+Low-Level Functions
+-------------------
+
+By default, Meep initializes C++ objects like `meep::structure` and `meep::fields` in the `Simulation` object based on attributes like `sources` and `geometry`. Theses objects are then accessible via `simulation_instance.structure` and `simulation_instance.fields`. Given these, you can then call essentially any function in the C++ interface, because all of the C++ functions are automatically made accessible to Python by the wrapper-generator program [SWIG](https://en.wikipedia.org/wiki/SWIG).
+
+### Initializing the Structure and Fields
+
+The `structure` and `fields` variables are automatically initialized when any of the run functions is called, or by various other functions such as `add_flux`. To initialize them separately, you can call `Simulation.init_sim()` manually, or `Simulation._init_structure(k_point)` to just initialize the structure.
+
+If you want to time step more than one field simultaneously, the easiest way is probably to do something like:
+
+```py
+sim = Simulation(cell_size, resolution).init_sim()
+my_fields = sim.fields
+sim.fields = None
+sim.reset_meep()
+```
+
+and then change the geometry etc. and re-run `sim.init_sim()`. Then you'll have two field objects in memory.
+
+### SWIG Wrappers
+
+If you look at a function in the C++ interface, then there are a few simple rules to infer the name of the corresponding Python function.
+
+-   First, all functions in the `meep::` namespace are available in the Meep Python module from the top-level `meep` package.
+-   Second, any method of a class is accessible via the standard Python class interface. For example, `meep::fields::step`, which is the function that performs a time-step, is exposed to Python as `fields_instance.step()` where a fields instance is usually accessible from Simulation.fields.
+-   C++ constructors are called using the normal Python class instantiation. E.g., `fields = mp.fields(...)` returns a new `meep::fields` object. Calling destructors is not necessary because objects are automatically garbage collected.
+
+Some argument type conversion is performed automatically, e.g. types like complex numbers are converted to `complex<double>`, etcetera. `Vector3` vectors are converted to `meep::vec`, but to do this it is necessary to know the dimensionality of the problem in C++. The problem dimensions are automatically initialized by `Simulation._init_structure`, but if you want to pass vector arguments to C++ before that time you should call `Simulation.require_dimensions()`, which infers the dimensions from the `cell_size`, `k_point`, and `dimensions` variables.
+
+
 
 Classes
 -------
@@ -159,7 +780,6 @@ The following classes are available directly via the `meep` package.
 
 @@ CustomSource @@
 
-<a name="fluxregion"></a>
 @@ FluxRegion @@
 
 @@ EnergyRegion @@
@@ -182,6 +802,7 @@ The following classes are available directly via the `meep` package.
 @@ Animate2D @@
 
 @@ Harminv @@
+
 
 
 Miscellaneous Functions
@@ -289,615 +910,3 @@ Miscellaneous Functions
 @@ output_sfield_z @@
 @@ output_sfield_r @@
 @@ output_sfield_p @@
-
-
-
-### Output File Names
-
-The output filenames used by Meep, e.g. for HDF5 files, are automatically prefixed by the input variable `filename_prefix`. If `filename_prefix` is `None` (the default), however, then Meep constructs a default prefix based on the current Python filename with `".py"` replaced by `"-"`: e.g. `test.py` implies a prefix of `"test-"`. You can get this prefix, or set the output folder, with these functions:
-
-* [Simulation.get_filename_prefix()](#Simulation.get_filename_prefix)
-* [Simulation.use_output_directory([dirname])](#Simulation.use_output_directory)
-
-
-### Simulation Time
-
-* [Simulation.meep_time()](#Simulation.meep_time)
-* [Simulation.print_times()](#Simulation.print_times)
-* [Simulation.time_spent_on(time_sink)](#Simulation.time_spent_on)
-* [Simulation.mean_time_spent_on(time_sink)](#Simulation.mean_time_spent_on)
-
-
-### Field Computations
-
-Meep supports a large number of functions to perform computations on the fields. Most of them are accessed via the lower-level C++/SWIG interface. Some of them are based on the following simpler, higher-level versions. They are accessible as methods of a `Simulation` instance.
-
-* [Simulation.set_boundary(side, direction, condition)](#Simulation.set_boundary)
-* [Simulation.phase_in_material(newstructure, phasetime)](#Simulation.phase_in_material)
-* [Simulation.get_field_point(c, pt)](#Simulation.get_field_point)
-* [Simulation.get_epsilon_point(pt, frequency=0)](#Simulation.get_epsilon_point)
-* [Simulation.initialize_field(c, func)](#Simulation.initialize_field)
-* [Simulation.add_dft_fields(cs, fcen, df, nfreq, freq, where=None, center=None, size=None, yee_grid=False)](#Simulation.add_dft_fields)
-* [Simulation.flux_in_box(dir, box=None, center=None, size=None)](#Simulation.flux_in_box)
-* [Simulation.electric_energy_in_box(box=None, center=None, size=None)](#Simulation.electric_energy_in_box)
-* [Simulation.magnetic_energy_in_box(box=None, center=None, size=None)](#Simulation.magnetic_energy_in_box)
-* [Simulation.field_energy_in_box(box=None, center=None, size=None)](#Simulation.field_energy_in_box)
-* [Simulation.modal_volume_in_box(box=None, center=None, size=None)](#Simulation.modal_volume_in_box)
-* [Simulation.integrate_field_function(cs, func, where=None, center=None, size=None)](#Simulation.integrate_field_function)
-* [Simulation.max_abs_field_function(cs, func, where=None, center=None, size=None)](#Simulation.max_abs_field_function)
-* [Simulation.integrate2_field_function(fields2, cs1, cs2, func, where=None, center=None, size=None)](#Simulation.integrate2_field_function)
-
-
-### Reloading Parameters
-
-Once the fields/simulation have been initialized, you can change the values of various parameters by using the following functions (which are attributes of the `Simulation` class):
-
-* [Simulation.reset_meep()](#Simulation.reset_meep)
-* [Simulation.restart_fields()](#Simulation.restart_fields)
-* [Simulation.change_k_point(k)](#Simulation.change_k_point)
-* [Simulation.change_sources(new_sources)](#Simulation.change_sources)
-* [Simulation.set_materials(geometry=None, default_material=None)](#Simulation.set_materials)
-
-
-### Flux Spectra
-
-Given a bunch of [`FluxRegion`](#fluxregion) objects, you can tell Meep to accumulate the Fourier transforms of the fields in those regions in order to compute the Poynting flux spectra. (Note: as a matter of convention, the "intensity" of the electromagnetic fields refers to the Poynting flux, *not* to the [energy density](#energy-density-spectra).) See also [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend). These are attributes of the `Simulation` class. The most important function is:
-
-* [Simulation.add_flux(fcen, df, nfreq, freq, FluxRegions...)](#Simulation.add_flux)
-
-As described in the tutorial, you normally use `add_flux` via statements like:
-
-```python
-transmission = sim.add_flux(...)
-```
-
-to store the flux object in a variable.  You can create as many flux objects as you want, e.g. to look at powers flowing in different regions or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the flux region multiplied by the number of electric and magnetic field components required to get the Poynting vector multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
-
-Once you have called `add_flux`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the [run functions](#run-functions). At any time, you can ask for Meep to print out the current flux spectrum via the `display_fluxes` method.
-
-* [Simulation.display_fluxes(fluxes...)](#Simulation.display_fluxes)
-
-You might have to do something lower-level if you have multiple flux regions corresponding to *different* frequency ranges, or have other special needs. `display_fluxes(f1, f2, f3)` is actually equivalent to `meep.display_csv("flux", meep.get_flux_freqs(f1), meep.get_fluxes(f1), meep.get_fluxes(f2), meep.get_fluxes(f3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling two lower-level functions:
-
-* [meep.get_flux_freqs(flux)](#get_flux_freqs)
-* [meep.get_fluxes(flux)](#get_fluxes)
-
-As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend), for a reflection spectrum you often want to save the Fourier-transformed fields from a "normalization" run and then load them into another run to be subtracted. This can be done via:
-
-* [Simulation.save_flux(filename, flux)](#Simulation.save_flux)
-* [Simulation.load_flux(filename, flux)](#Simulation.load_flux)
-* [Simulation.load_minus_flux(filename, flux)](#Simulation.load_minus_flux)
-
-
-
-Sometimes it is more convenient to keep the Fourier-transformed fields in memory rather than writing them to a file and immediately loading them back again. To that end, the `Simulation` class exposes the following three methods:
-
-
-* [Simulation.get_flux_data(flux)](#Simulation.get_flux_data)
-* [Simulation.load_flux_data(flux, fdata)](#Simulation.load_flux_data)
-* [Simulation.load_minus_flux_data(flux, fdata)](#Simulation.load_minus_flux_data)
-
-
-The `Simulation` class also provides some aliases for the corresponding "flux" methods.
-
-* **`save_mode`**
-* **`load_mode`**
-* **`load_minus_mode`**
-* **`get_mode_data`**
-* **`load_mode_data`**
-* **`load_minus_mode_data`**
-
-
-### Mode Decomposition
-
-Given a structure, Meep can decompose the Fourier-transformed fields into a superposition of its harmonic modes. For a theoretical background, see [Mode Decomposition](Mode_Decomposition.md).
-
-* [Simulation.get_eigenmode_coefficients(flux, bands, eig_parity=mp.NO_PARITY, eig_vol=None, eig_resolution=0, eig_tolerance=1e-12, kpoint_func=None, direction=mp.AUTOMATIC)](#Simulation.get_eigenmode_coefficients)
-
-The flux object should be created using `add_mode_monitor`.  (You could also use `add_flux`, but with `add_flux` you need to be more careful about symmetries that bisect the flux plane: the `add_flux` object should only be used with `get_eigenmode_coefficients` for modes of the same symmetry, e.g. constrained via `eig_parity`.  On the other hand, the performance of `add_flux` planes benefits more from symmetry.) `eig_vol` is the volume passed to [MPB](https://mpb.readthedocs.io) for the eigenmode calculation (based on interpolating the discretized materials from the Yee grid); in most cases this will simply be the volume over which the frequency-domain fields are tabulated, which is the default (i.e. `flux.where`). `eig_parity` should be one of [`mp.NO_PARITY` (default), `mp.EVEN_Z`, `mp.ODD_Z`, `mp.EVEN_Y`, `mp.ODD_Y`]. It is the parity (= polarization in 2d) of the mode to calculate, assuming the structure has $z$ and/or $y$ mirror symmetry *in the source region*, just as for `EigenModeSource` above. If the structure has both $y$ and $z$ mirror symmetry, you can combine more than one of these, e.g. `EVEN_Z+ODD_Y`. Default is `NO_PARITY`, in which case MPB computes all of the bands which will still be even or odd if the structure has mirror symmetry, of course. This is especially useful in 2d simulations to restrict yourself to a desired polarization. `eig_resolution` is the spatial resolution to use in MPB for the eigenmode calculations. This defaults to twice the Meep `resolution` in which case the structure is linearly interpolated from the Meep pixels. `eig_tolerance` is the tolerance to use in the MPB eigensolver. MPB terminates when the eigenvalues stop changing to less than this fractional tolerance. Defaults to `1e-12`.  (Note that this is the tolerance for the frequency eigenvalue ω; the tolerance for the mode profile is effectively the square root of this.) For examples, see [Tutorial/Mode Decomposition](Python_Tutorials/Mode_Decomposition.md).
-
-Technically, MPB computes `ωₙ(k)` and then inverts it with Newton's method to find the wavevector `k` normal to `eig_vol` and mode for a given frequency; in rare cases (primarily waveguides with *nonmonotonic* dispersion relations, which doesn't usually happen in simple dielectric waveguides), MPB may need you to supply an initial "guess" for `k` in order for this Newton iteration to converge.  You can supply this initial guess with `kpoint_func`, which is a function `kpoint_func(f, n)` that supplies a rough initial guess for the `k` of band number `n` at frequency `f = ω/2π`. (By default, the **k** components in the plane of the `eig_vol` region are zero.  However, if this region spans the *entire* cell in some directions, and the cell has Bloch-periodic boundary conditions via the `k_point` parameter, then the mode's **k** components in those directions will match `k_point` so that the mode satisfies the Meep boundary conditions, regardless of `kpoint_func`.) If `direction` is set to `mp.NO_DIRECTION`, then `kpoint_func` is not only the initial guess and the search direction of the **k** vectors, but is also taken to be the direction of the waveguide, allowing you to [detect modes in oblique waveguides](Python_Tutorials/Eigenmode_Source.md#oblique-waveguides) (not perpendicular to the flux plane).
-
-**Note:** for planewaves in homogeneous media, the `kpoints` may *not* necessarily be equivalent to the actual wavevector of the mode. This quantity is given by `kdom`.
-
-* [Simulation.add_mode_monitor(fcen, df, nfreq, freq, ModeRegions...)](#Simulation.add_mode_monitor)
-
-`add_mode_monitor` works properly with arbitrary symmetries, but may be suboptimal because the Fourier-transformed region does not exploit the symmetry.  As an optimization, if you have a mirror plane that bisects the mode monitor, you can instead use `add_flux` to gain a factor of two, but in that case you *must* also pass the corresponding `eig_parity` to `get_eigenmode_coefficients` in order to only compute eigenmodes with the corresponding mirror symmetry.
-
-* [Simulation.get_eigenmode(frequency, direction, where, band_num, kpoint, eig_vol=None, match_frequency=True, parity=mp.NO_PARITY, resolution=0, eigensolver_tol=1e-12)](#Simulation.get_eigenmode)
-
-* [meep.get_eigenmode_freqs(flux)](#get_eigenmode_freqs)
-
-
-### Energy Density Spectra
-
-Very similar to flux spectra, you can also compute **energy density spectra**: the energy density of the electromagnetic fields as a function of frequency, computed by Fourier transforming the fields and integrating the energy density:
-
-$$ \frac{1}{2}ε|\mathbf{E}|^2 + \frac{1}{2}μ|\mathbf{H}|^2 $$
-
-The usage is similar to the flux spectra: you define a set of `EnergyRegion` objects telling Meep where it should compute the Fourier-transformed fields and energy densities, and call `add_energy` to add these regions to the current simulation over a specified frequency bandwidth, and then use `display_electric_energy`, `display_magnetic_energy`, or `display_total_energy` to display the energy density spectra at the end. There are also `save_energy`, `load_energy`, and `load_minus_energy` functions that you can use to subtract the fields from two simulation, e.g. in order to compute just the energy from scattered fields, similar to the flux spectra. These types and functions are defined as follows:
-
-* [EnergyRegion](#EnergyRegion)
-* [Simulation.add_energy(fcen, df, nfreq, freq, EnergyRegions...)](#Simulation.add_energy)
-
-As for flux regions, you normally use `add_energy` via statements like:
-
-```py
-En = sim.add_energy(...)
-```
-
-to store the energy object in a variable.  You can create as many energy objects as you want, e.g. to look at the energy densities in different objects or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the energy region multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
-
-Once you have called `add_energy`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the `run` functions. At any time, you can ask for Meep to print out the current energy density spectrum via:
-
-* [Simulation.display_electric_energy(energy...)](#Simulation.display_electric_energy)
-* [Simulation.display_magnetic_energy(energy...)](#Simulation.display_magnetic_energy)
-* [Simulation.display_total_energy(energy...)](#Simulation.display_total_energy)
-
-
-You might have to do something lower-level if you have multiple energy regions corresponding to *different* frequency ranges, or have other special needs. `display_electric_energy(e1, e2, e3)` is actually equivalent to `meep.display_csv("electric_energy", meep.get_energy_freqs(e1), meep.get_electric_energy(e1), meep.get_electric_energy(e2), meep.get_electric_energy(e3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling lower-level functions:
-
-* [meep.get_energy_freqs(energy)](#get_energy_freqs)
-* [meep.get_electric_energy(energy)](#get_electric_energy)
-* [meep.get_magnetic_energy(energy)](#get_magnetic_energy)
-* [meep.get_total_energy(energy)](#get_total_energy)
-
-As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, to compute the energy density from the scattered fields you often want to save the Fourier-transformed fields from a "normalization" run and then load them into another run to be subtracted. This can be done via:
-
-* [Simulation.save_energy(filename, energy)](#Simulation.save_energy)
-* [Simulation.load_energy(filename, energy)](#Simulation.load_energy)
-* [Simulation.load_minus_energy(filename, energy)](#Simulation.load_minus_energy)
-
-
-### Force Spectra
-
-Very similar to flux spectra, you can also compute **force spectra**: forces on an object as a function of frequency, computed by Fourier transforming the fields and integrating the vacuum [Maxwell stress tensor](https://en.wikipedia.org/wiki/Maxwell_stress_tensor):
-
-$$\sigma_{ij} = E_i^*E_j + H_i^*H_j - \frac{1}{2} δ_{ij} \left( |\mathbf{E}|^2 + |\mathbf{H}|^2 \right)$$
-
-over a surface $S$ via $\mathbf{F} = \int_S \sigma d\mathbf{A}$. You should normally **only evaluate the stress tensor over a surface lying in vacuum**, as the interpretation and definition of the stress tensor in arbitrary media is often problematic (the subject of extensive and controversial literature). It is fine if the surface *encloses* an object made of arbitrary materials, as long as the surface itself is in vacuum.
-
-See also [Tutorial/Optical Forces](Python_Tutorials/Optical_Forces.md).
-
-Most commonly, you will want to **normalize** the force spectrum in some way, just as for flux spectra. Most simply, you could divide two different force spectra to compute the ratio of forces on two objects. Often, you will divide a force spectrum by a flux spectrum, to divide the force $F$ by the incident power $P$ on an object, in order to compute the useful dimensionless ratio $Fc$/$P$ where $c=1$ in Meep units. For example, it is a simple exercise to show that the force $F$ on a perfectly reflecting mirror with normal-incident power $P$ satisfies $Fc$/$P=2$, and for a perfectly absorbing (black) surface $Fc$/$P=1$.
-
-The usage is similar to the [flux spectra](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend): you define a set of `ForceRegion` objects telling Meep where it should compute the Fourier-transformed fields and stress tensors, and call `add_force` to add these regions to the current simulation over a specified frequency bandwidth, and then use `display_forces` to display the force spectra at the end. There are also `save_force`, `load_force`, and `load_minus_force` functions that you can use to subtract the fields from two simulation, e.g. in order to compute just the force from scattered fields, similar to the flux spectra. These types and functions are defined as follows:
-
-* [ForceRegion](#ForceRegion)
-* [Simulation.add_force(fcen, df, nfreq, freq, ForceRegions...)](#Simulation.add_force)
-
-As for flux regions, you normally use `add_force` via statements like:
-
-```py
-Fx = sim.add_force(...)
-```
-
-to store the force object in a variable.  You can create as many force objects as you want, e.g. to look at forces on different objects, in different directions, or in different frequency ranges. Note, however, that Meep has to store (and update at every time step) a number of Fourier components equal to the number of grid points intersecting the force region, multiplied by the number of electric and magnetic field components required to get the stress vector, multiplied by `nfreq`, so this can get quite expensive (in both memory and time) if you want a lot of frequency points over large regions of space.
-
-Once you have called `add_force`, the Fourier transforms of the fields are accumulated automatically during time-stepping by the `run` functions. At any time, you can ask for Meep to print out the current force spectrum via:
-
-* [Simulation.display_forces(forces...)](#Simulation.display_forces)
-
-You might have to do something lower-level if you have multiple force regions corresponding to *different* frequency ranges, or have other special needs. `display_forces(f1, f2, f3)` is actually equivalent to `meep.display_csv("force", meep.get_force_freqs(f1), meep.get_forces(f1), meep.get_forces(f2), meep.get_forces(f3))`, where `display_csv` takes a bunch of lists of numbers and prints them as a comma-separated table; this involves calling two lower-level functions:
-
-
-* [meep.get_force_freqs(force)](#get_force_freqs)
-* [meep.get_forces(force)](#get_forces)
-
-
-As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, to compute the force from the scattered fields often requires saving the Fourier-transformed fields from a "normalization" run and then loading them into another run to be subtracted. This can be done via:
-
-* [Simulation.save_force(filename, force)](#Simulation.save_force)
-* [Simulation.load_force(filename, force)](#Simulation.load_force)
-* [Simulation.load_minus_force(filename, force)](#Simulation.load_minus_force)
-
-To keep the fields in memory and avoid writing to and reading from a file, use the following three methods:
-
-* [Simulation.get_force_data(force)](#Simulation.get_force_data)
-* [Simulation.load_force_data(force, fdata)](#Simulation.load_force_data)
-* [Simulation.load_minus_force_data(force, fdata)](#Simulation.load_minus_force_data)
-
-### LDOS spectra
-
-Meep can also calculate the LDOS (local density of states) spectrum, as described in [Tutorial/Local Density of States](Python_Tutorials/Local_Density_of_States.md). To do this, you simply pass the following step function to your `run` command:
-
-* [meep.Ldos(fcen, df, nfreq, freq)](#Ldos)
-* [meep.get_ldos_freqs(ldos)](#get_ldos_freqs)
-* [meep.dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)](#dft_ldos)
-
-
-Analytically, the per-polarization LDOS is exactly proportional to the power radiated by an $\ell$-oriented point-dipole current, $p(t)$, at a given position in space. For a more mathematical treatment of the theory behind the LDOS, refer to the relevant discussion in Section 4.4 ("Currents and Fields: The Local Density of States") in [Chapter 4](http://arxiv.org/abs/arXiv:1301.5366) ("Electromagnetic Wave Source Conditions") of the book [Advances in FDTD Computational Electrodynamics: Photonics and Nanotechnology](https://www.amazon.com/Advances-FDTD-Computational-Electrodynamics-Nanotechnology/dp/1608071707), but for now it is defined as:
-
-$$\operatorname{LDOS}_{\ell}(\vec{x}_0,\omega)=-\frac{2}{\pi}\varepsilon(\vec{x}_0)\frac{\operatorname{Re}[\hat{E}_{\ell}(\vec{x}_0,\omega)\hat{p}(\omega)^*]}{|\hat{p}(\omega)|^2}$$
-
-where the $|\hat{p}(\omega)|^2$ normalization is necessary for obtaining the power exerted by a unit-amplitude dipole (assuming linear materials), and hats denote Fourier transforms. It is this quantity that is computed by the `dft_ldos` command for a single dipole source. For a volumetric source, the numerator and denominator are both integrated over the current volume, but "LDOS" computation is less meaningful in this case.
-
-### Near-to-Far-Field Spectra
-
-Meep can compute a near-to-far-field transformation in the frequency domain as described in [Tutorial/Near-to-Far Field Spectra](Python_Tutorials/Near_to_Far_Field_Spectra.md): given the fields on a "near" bounding surface inside the cell, it can compute the fields arbitrarily far away using an analytical transformation, assuming that the "near" surface and the "far" region lie in a single homogeneous non-periodic 2d, 3d, or cylindrical region. That is, in a simulation *surrounded by PML* that absorbs outgoing waves, the near-to-far-field feature can compute the fields outside the cell as if the outgoing waves had not been absorbed (i.e. in the fictitious infinite open volume). Moreover, this operation is performed on the Fourier-transformed fields: like the flux and force spectra above, you specify a set of desired frequencies, Meep accumulates the Fourier transforms, and then Meep computes the fields at *each frequency* for the desired far-field points.
-
-This is based on the principle of equivalence: given the Fourier-transformed tangential fields on the "near" surface, Meep computes equivalent currents and convolves them with the analytical Green's functions in order to compute the fields at any desired point in the "far" region. For details, see Section 4.2.1 ("The Principle of Equivalence") in [Chapter 4](http://arxiv.org/abs/arXiv:1301.5366) ("Electromagnetic Wave Source Conditions") of the book [Advances in FDTD Computational Electrodynamics: Photonics and Nanotechnology](https://www.amazon.com/Advances-FDTD-Computational-Electrodynamics-Nanotechnology/dp/1608071707).
-
-Note: in order for the far-field results to be accurate, the [far region must be separated from the near region](https://en.wikipedia.org/wiki/Near_and_far_field) by *at least* 2D<sup>2</sup>/λ, the Fraunhofer distance, where D is the largest dimension of the radiator and λ is the vacuum wavelength.
-
-There are three steps to using the near-to-far-field feature: first, define the "near" surface(s) as a set of surfaces capturing *all* outgoing radiation in the desired direction(s); second, run the simulation, typically with a pulsed source, to allow Meep to accumulate the Fourier transforms on the near surface(s); third, tell Meep to compute the far fields at any desired points (optionally saving the far fields from a grid of points to an HDF5 file). To define the near surfaces, use:
-
-* [Simulation.add_near2far(fcen, df, nfreq, freq, Near2FarRegions..., nperiods=1)](#Simulation.add_near2far)
-
-Each `Near2FarRegion` is identical to `FluxRegion` except for the name: in 3d, these give a set of planes (**important:** all these "near surfaces" must lie in a single *homogeneous* material with *isotropic* ε and μ &mdash; and they should *not* lie in the PML regions) surrounding the source(s) of outgoing radiation that you want to capture and convert to a far field. Ideally, these should form a closed surface, but in practice it is sufficient for the `Near2FarRegion`s to capture all of the radiation in the direction of the far-field points. **Important:** as for flux computations, each `Near2FarRegion` should be assigned a `weight` of &#177;1 indicating the direction of the outward normal relative to the +coordinate direction. So, for example, if you have six regions defining the six faces of a cube, i.e. the faces in the +x, -x, +y, -y, +z, and -z directions, then they should have weights +1, -1, +1, -1, +1, and -1 respectively. Note that, neglecting discretization errors, all near-field surfaces that enclose the same outgoing fields are equivalent and will yield the same far fields with a discretization-induced difference that vanishes with increasing resolution etc.
-
-After the simulation run is complete, you can compute the far fields. This is usually for a pulsed source so that the fields have decayed away and the Fourier transforms have finished accumulating.
-
-If you have Bloch-periodic boundary conditions, then the corresponding near-to-far transformation actually needs to perform a "lattice sum" of infinitely many periodic copies of the near fields.  This doesn't happen by default, which means the default `near2far` calculation may not be what you want for periodic boundary conditions.  However, if the `Near2FarRegion` spans the entire cell along the periodic directions, you can turn on an approximate lattice sum by passing `nperiods > 1`.  In particular, it then sums `2*nperiods+1` Bloch-periodic copies of the near fields whenever a far field is requested.  You can repeatedly double `nperiods` until the answer converges to your satisfaction; in general, if the far field is at a distance d, and the period is a, then you want `nperiods` to be much larger than d/a.  (Future versions of Meep may use fancier techniques like [Ewald summation](https://en.wikipedia.org/wiki/Ewald_summation) to compute the lattice sum more rapidly at large distances.)
-
-* [Simulation.get_farfield(near2far, x)](#Simulation.get_farfield)
-* [meep.get_near2far_freqs(near2far)](#get_near2far_freqs)
-* [Simulation.output_farfields(near2far, fname, resolution, where=None, center=None, size=None)](#Simulation.output_farfields)
-* [Simulation.get_farfields(near2far, resolution, where=None, center=None, size=None)](#Simulation.get_farfields)
-
-
-(Multi-frequency `get_farfields` and `output_farfields` can be accelerated by
-[compiling Meep](Build_From_Source.md#meep) with `--with-openmp` and using the
-`OMP_NUM_THREADS` environment variable to specify multiple threads.)
-
-For a scattered-field computation, you often want to separate the scattered and incident fields. As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md#transmittancereflectance-spectra) and [Tutorial/Basics/Transmittance Spectrum of a Waveguide Bend](Scheme_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend) for flux computations, you can do this by saving the Fourier-transformed incident from a "normalization" run and then load them into another run to be subtracted. This can be done via:
-
-* [Simulation.save_near2far(filename, near2far)](#Simulation.save_near2far)
-* [Simulation.load_near2far(filename, near2far)](#Simulation.load_near2far)
-* [Simulation.load_minus_near2far(filename, near2far)](#Simulation.load_minus_near2far)
-
-
-To keep the fields in memory and avoid writing to and reading from a file, use the following three methods:
-
-* [Simulation.get_near2far_data(near2far)](#Simulation.get_near2far_data)
-* [Simulation.load_near2far_data(near2far, n2fdata)](#Simulation.load_near2far_data)
-* [Simulation.load_minus_near2far_data(near2far, n2fdata)](#Simulation.load_minus_near2far_data)
-* [meep.scale_near2far_fields(s, near2far)](#scale_near2far_fields)
-* [DftNear2Far.flux(direction, where, resolution)](#DftNear2Far.flux)
-
-
-### Load and Dump Structure
-
-These functions dump the raw ε and μ data to disk and load it back for doing multiple simulations with the same materials but different sources etc. The only prerequisite is that the dump/load simulations have the same [chunks](Chunks_and_Symmetry.md) (i.e. the same grid, number of processors, symmetries, and PML). When using `split_chunks_evenly=False`, you must also dump the original chunk layout using `dump_chunk_layout` and load it into the new `Simulation` using the `chunk_layout` parameter. Currently only stores dispersive and non-dispersive ε and μ but not nonlinearities. Note that loading data from a file in this way overwrites any `geometry` data passed to the `Simulation` constructor.
-
-* [Simulation.dump_structure(fname)](#Simulation.dump_structure)
-* [Simulation.load_structure(fname)](#Simulation.load_structure)
-* [Simulation.dump_chunk_layout(fname)](#Simulation.dump_chunk_layout)
-
-
-To load a chunk layout into a `Simulation`, use the `chunk_layout` argument to the constructor, passing either a file obtained from `dump_chunk_layout` or another `Simulation` instance. Note that when using `split_chunks_evenly=False` this parameter is required when saving and loading flux spectra, force spectra, or near-to-far spectra so that the two runs have the same chunk layout. Just pass the `Simulation` object from the first run to the second run:
-
-```python
-# Split chunks based on amount of work instead of size
-sim1 = mp.Simulation(..., split_chunks_evenly=False)
-norm_flux = sim1.add_flux(...)
-sim1.run(...)
-sim1.save_flux(...)
-
-# Make sure the second run uses the same chunk layout as the first
-sim2 = mp.Simulation(..., chunk_layout=sim1)
-flux = sim2.add_flux(...)
-sim2.load_minus_flux(...)
-sim2.run(...)
-```
-
-### Frequency-Domain Solver
-
-Meep contains a frequency-domain solver that computes the fields produced in a geometry in response to a [continuous-wave (CW) source](https://en.wikipedia.org/wiki/Continuous_wave). This is based on an [iterative linear solver](https://en.wikipedia.org/wiki/Iterative_method) instead of time-stepping. For details, see Section 5.3 ("Frequency-domain solver") of [Computer Physics Communications, Vol. 181, pp. 687-702, 2010](http://ab-initio.mit.edu/~oskooi/papers/Oskooi10.pdf). Benchmarking results have shown that in many instances, such as cavities (e.g., [ring resonators](Python_Tutorials/Frequency_Domain_Solver.md)) with long-lived resonant modes, this solver converges much faster than simply running an equivalent time-domain simulation with a CW source (using the default `width` of zero for no transient turn-on), time-stepping until all transient effects from the source turn-on have disappeared, especially if the fields are desired to a very high accuracy.
-
-To use the frequency-domain solver, simply define a `ContinuousSource` with the desired frequency and [initialize the fields and geometry](#initializing-the-structure-and-fields) via `init_sim()`:
-
-```py
-sim = mp.Simulation(...)
-sim.init_sim()
-sim.solve_cw(tol, maxiters, L)
-```
-
-The first two parameters to the frequency-domain solver are the tolerance `tol` for the iterative solver (10<sup>−8</sup>, by default) and a maximum number of iterations `maxiters` (10<sup>4</sup>, by default). Finally, there is a parameter $L$ that determines a tradeoff between memory and work per step and convergence rate of the iterative algorithm, biconjugate gradient stabilized ([BiCGSTAB-L](https://en.wikipedia.org/wiki/Biconjugate_gradient_stabilized_method)), that is used; larger values of $L$ will often lead to faster convergence at the expense of more memory and more work per iteration. Default is $L=2$, and normally a value ≥ 2 should be used.
-
-The frequency-domain solver supports arbitrary geometries, PML, boundary conditions, symmetries, parallelism, conductors, and arbitrary nondispersive materials. Lorentz-Drude dispersive materials are not currently supported in the frequency-domain solver, but since you are solving at a known fixed frequency rather than timestepping, you should be able to pick conductivities etcetera in order to obtain any desired complex ε and μ at that frequency.
-
-The frequency-domain solver requires you to use complex-valued fields, via `force_complex_fields=True`.
-
-After `solve_cw` completes, it should be as if you had just run the simulation for an infinite time with the source at that frequency. You can call the various field-output functions and so on as usual at this point. For examples, see [Tutorial/Frequency Domain Solver](Python_Tutorials/Frequency_Domain_Solver.md) and [Tutorial/Mode Decomposition/Reflectance and Transmittance Spectra for Planewave at Oblique Incidence](Python_Tutorials/Mode_Decomposition.md#reflectance-and-transmittance-spectra-for-planewave-at-oblique-incidence).
-
-**Note:** The convergence of the iterative solver can sometimes encounter difficulties. For example, increasing the diameter of a ring resonator relative to the wavelength increases the [condition number](https://en.wikipedia.org/wiki/Condition_number), which worsens the convergence of iterative solvers. The general way to improve this is to implement a more sophisticated iterative solver that employs [preconditioners](https://en.wikipedia.org/wiki/Preconditioner). Preconditioning wave equations (Helmholtz-like equations) is notoriously difficult to do well, but some possible strategies are discussed in [Issue #548](https://github.com/NanoComp/meep/issues/548). In the meantime, a simpler way improving convergence (at the expense of computational cost) is to increase the $L$ parameter and the number of iterations.
-
-### Frequency-Domain Eigensolver
-
-Building on the frequency-domain solver above, Meep also includes a frequency-domain eigensolver that computes resonant frequencies and modes in the frequency domain.  The usage is very similar to `solve_cw`:
-
-```py
-sim = mp.Simulation(...)
-sim.init_sim()
-eigfreq = sim.solve_eigfreq(tol, maxiters, guessfreq, cwtol, cwmaxiters, L)
-```
-
-The `solve_eig` routine performs repeated calls to `solve_cw` in a way that converges to the resonant mode whose frequency is *closest* to the source frequency.  The complex resonant-mode frequency is returned, and the mode Q can be computed from `eigfreq.real / (-2*eigfreq.imag)`.  Upon return, the fields should be the corresponding resonant mode (with an arbitrary scaling).
-
-The resonant mode is converged to a relative error of roughly `tol`, which defaults to `1e-7`. A maximum of `maxiters` (defaults to `100`) calls to `solve_cw` are performed.  The tolerance for each `solve_cw` call is `cwtol` (defaults to `tol*1e-3`) and the maximum iterations is `cwmaxiters` (10<sup>4</sup>, by default); the `L` parameter (defaults to `10`) is also passed through to `solve_cw`.
-
-The closer the input frequency is to the resonant-mode frequency, the faster `solve_eig` should converge. Instead of using the source frequency, you can instead pass a `guessfreq` argument to `solve_eigfreq` specifying an input frequency (which may even be complex).
-
-Technically, `solve_eig` is using a [shift-and-invert power iteration](https://en.wikipedia.org/wiki/Inverse_iteration) to compute the resonant mode, as reviewed in [Frequency-Domain Eigensolver](Eigensolver_Math.md).
-
-As for `solve_cw` above, you are required to set `force_complex_fields=True` to use `solve_eigfreq`.
-
-### GDSII Support
-
-This feature is only available if Meep is built with [libGDSII](Build_From_Source.md#libgdsii). See:
-
-* [meep.GDSII_layers(fname)](#GDSII_layers)
-* [meep.GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0)](#GDSII_prisms)
-* [meep.GDSII_vol(fname, layer, zmin, zmax)](#GDSII_vol)
-
-
-### Data Visualization
-
-This module provides basic visualization functionality for the simulation domain. The spirit of the module is to provide functions that can be called with *no customization options whatsoever* and will do useful relevant things by default, but which can also be customized in cases where you *do* want to take the time to spruce up the output.
-
-* [Simulation.plot2D(...)](#Simulation.plot2D)
-* [Simulation.plot3D()](#Simulation.plot3D)
-* [Simulation.visualize_chunks()](#Simulation.visualize_chunks)
-
-An animated visualization is also possible via the [Animate2D](#Animate2D) class.
-
-
-Run and Step Functions
-----------------------
-
-The actual work in Meep is performed by `run` functions, which time-step the simulation for a given amount of time or until a given condition is satisfied. These are attributes of the `Simulation` class.
-
-The run functions, in turn, can be modified by use of [step functions](#predefined-step-functions): these are called at every time step and can perform any arbitrary computation on the fields, do outputs and I/O, or even modify the simulation. The step functions can be transformed by many [modifier functions](#step-function-modifiers), like `at_beginning`, `during_sources`, etcetera which cause them to only be called at certain times, etcetera, instead of at every time step.
-
-A common point of confusion is described in [The Run Function Is Not A Loop](The_Run_Function_Is_Not_A_Loop.md). Read this article if you want to make Meep do some customized action on each time step, as many users make the same mistake. What you really want to in that case is to write a step function, as described below.
-
-### Run Functions
-
-**`run(step_functions..., until=condition/time)`**
-—
-Run the simulation until a certain time or condition, calling the given step functions (if any) at each timestep. The keyword argument `until` is *either* a number, in which case it is an additional time (in Meep units) to run for, *or* it is a function (of no arguments) which returns `True` when the simulation should stop. `until` can also be a list of stopping conditions which may include a number and additional functions.
-
-**`run(step_functions..., until_after_sources=condition/time)`**
-—
-Run the simulation until all sources have turned off, calling the given step functions (if any) at each timestep. The keyword argument `until_after_sources` is either a number, in which case it is an *additional* time (in Meep units) to run for after the sources are off, *or* it is a function (of no arguments). In the latter case, the simulation runs until the sources are off *and* `condition` returns `True`. Like `until` above, `until_after_sources` can take a list of stopping conditions.
-
-In particular, a useful value for `until_after_sources` or `until` is often `stop_when_field_decayed`, which is demonstrated in [Tutorial/Basics](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend):
-
-* [meep.stop_when_fields_decayed(dT, c, pt, decay_by)](#stop_when_fields_decayed)
-* [meep.stop_after_walltime(t)](#stop_after_walltime)
-* [meep.stop_on_interrupt()](#stop_on_interrupt)
-
-
-Finally, another run function, useful for computing ω(**k**) band diagrams, is:
-
-* [meep.run_k_points(t, k_points)](#Simulation.run_k_points)
-* [meep.run_k_point(t, k_point)](#Simulation.run_k_point)
-
-
-### Predefined Step Functions
-
-Several useful step functions are predefined by Meep. These are available directly via the `meep` package but require a `Simulation` instance as an argument.
-
-#### Output Functions
-
-The most common step function is an output function, which outputs some field component to an [HDF5](https://en.wikipedia.org/wiki/HDF5) file. Normally, you will want to modify this by one of the `at_*` functions, below, as outputting a field at *every* time step can get quite time- and storage-consuming.
-
-Note that although the various field components are stored at different places in the [Yee lattice](Yee_Lattice.md), when they are outputted they are all linearly interpolated to the same grid: to the points at the *centers* of the Yee cells, i.e. $(i+0.5,j+0.5,k+0.5)\cdotΔ$ in 3d.
-
-* [meep.output_epsilon(frequency=0)](#output_epsilon)
-* [meep.output_mu(frequency=0)](#output_mu)
-* [Simulation.output_dft(dft_fields, fname)](#Simulation.output_dft)
-* [meep.output_poynting()](#output_poynting)
-* [meep.output_hpwr()](#output_hpwr)
-* [meep.output_dpwr()](#output_dpwr)
-* [meep.output_tot_pwr()](#output_tot_pwr)
-* [meep.output_png(component, h5topng_options)](#output_png)
-
-* [meep.output_hfield()](#output_hfield)
-* [meep.output_hfield_x()](#output_hfield_x)
-* [meep.output_hfield_y()](#output_hfield_y)
-* [meep.output_hfield_z()](#output_hfield_z)
-* [meep.output_hfield_r()](#output_hfield_r)
-* [meep.output_hfield_p()](#output_hfield_p)
-
-* [meep.output_bfield()](#output_bfield)
-* [meep.output_bfield_x()](#output_bfield_x)
-* [meep.output_bfield_y()](#output_bfield_y)
-* [meep.output_bfield_z()](#output_bfield_z)
-* [meep.output_bfield_r()](#output_bfield_r)
-* [meep.output_bfield_p()](#output_bfield_p)
-
-* [meep.output_efield()](#output_efield)
-* [meep.output_efield_x()](#output_efield_x)
-* [meep.output_efield_y()](#output_efield_y)
-* [meep.output_efield_z()](#output_efield_z)
-* [meep.output_efield_r()](#output_efield_r)
-* [meep.output_efield_p()](#output_efield_p)
-
-* [meep.output_dfield()](#output_dfield)
-* [meep.output_dfield_x()](#output_dfield_x)
-* [meep.output_dfield_y()](#output_dfield_y)
-* [meep.output_dfield_z()](#output_dfield_z)
-* [meep.output_dfield_r()](#output_dfield_r)
-* [meep.output_dfield_p()](#output_dfield_p)
-
-* [meep.output_sfield()](#output_sfield)
-* [meep.output_sfield_x()](#output_sfield_x)
-* [meep.output_sfield_y()](#output_sfield_y)
-* [meep.output_sfield_z()](#output_sfield_z)
-* [meep.output_sfield_r()](#output_sfield_r)
-* [meep.output_sfield_p()](#output_sfield_p)
-
-
-More generally, it is possible to output an arbitrary function of position and zero or more field components, similar to the `Simulation.integrate_field_function` method, described above. This is done by:
-
-* [Simulation.output_field_function(name, cs, func, real_only=False)](#Simulation.output_field_function)
-
-See also [Field Functions](Field_Functions.md), and [Synchronizing the Magnetic and Electric Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md) if you want to do computations combining the electric and magnetic fields.
-
-
-#### Array Slices
-
-The output functions described above write the data for the fields and materials for the entire cell to an HDF5 file. This is useful for post-processing as you can later read in the HDF5 file to obtain field/material data as a NumPy array. However, in some cases it is convenient to bypass the disk altogether to obtain the data *directly* in the form of a NumPy array without writing/reading HDF5 files. Additionally, you may want the field/material data on just a subregion (or slice) of the entire volume. This functionality is provided by the `get_array` method which takes as input a subregion of the cell and the field/material component. The method returns a NumPy array containing values of the field/material at the current simulation time.
-
-* [Simulation.get_array(vol=None, center=None, size=None, component=mp.Ez, cmplx=False, arr=None, frequency=0)](#Simulation.get_array)
-* [Simulation.get_dft_array(dft_obj, component, num_freq)](#Simulation.get_dft_array)
-
-
-#### Array Metadata
-
-* [Simulation.get_array_metadata(vol=None, center=None, size=None, dft_cell=None)](#Simulation.get_array_metadata)
-
-This routine provides geometric information useful for interpreting the arrays returned by `get_array` or `get_dft_array` for the spatial region defined by `vol` or `center/size`. Here are some examples of how array metadata can be used:
-
-**Labeling Axes in Plots of Grid Quantities**
-
-```python
-# using the geometry from the bend-flux tutorial example
-import matplotlib.pyplot as plt
-import numpy as np
-
-eps_array=sim.get_epsilon()
-(x,y,z,w)=sim.get_array_metadata()
-plt.figure()
-ax = plt.subplot(111)
-plt.pcolormesh(x,y,np.transpose(eps_array),shading='gouraud')
-ax.set_aspect('equal')
-plt.show()
-```
-![](images/PermittivityWithLabeledAxes.png)
-
-**Computing Quantities Defined by Integrals of Field-Dependent Functions Over Grid Regions**
-
-+ energy stored in the $\mathbf{E}$-field in a region $\mathcal{V}$:
-      $$ \mathcal{E}=
-         \frac{1}{2}\int_{\mathcal V} \epsilon |\mathbf{E}|^2\,dV
-      $$
-
-+ Poynting flux through a surface $\mathcal{S}$:
-      $$\mathcal{S}=\frac{1}{2}\text{Re }\int_{\mathcal S}
-        \Big(\mathbf{E}^*\times \mathbf{H}\Big)\times d\mathbf{A}
-      $$
-
-```python
-  import numpy as np
-
-  # E-field modal volume in box from time-domain fields
-  box            = mp.Volume(center=box_center, size=box_size)
-  (Ex,Ey,Ez)     = [sim.get_array(vol=box, component=c, cmplx=True) for c in [mp.Ex, mp.Ey, mp.Ez]]
-  eps            = sim.get_array(vol=box, component=mp.Dielectric)
-  (x,y,z,w)      = sim.get_array_metadata(vol=box)
-  energy_density = np.real(eps*(np.conj(Ex)*Ex + np.conj(Ey)*Ey + np.conj(Ez)*Ez)) # array
-  energy         = np.sum(w*energy_density)                                        # scalar
-
-  # x-directed Poynting flux through monitor from frequency-domain fields
-  monitor        = mp.FluxRegion(center=mon_center, size=mon_size)
-  dft_cell       = sim.add_flux(freq, freq, 1, monitor)
-  sim.run(...)    # timestep until DFTs converged
-  (Ey,Ez,Hy,Hz)  = [sim.get_dft_array(dft_cell,c,0) for c in [mp.Ey, mp.Ez, mp.Hy, mp.Hz]]
-  (x,y,z,w)      = sim.get_array_metadata(dft=dft_cell)
-  flux_density   = np.real( np.conj(Ey)*Hz - np.conj(Ez)*Hy )    # array
-  flux           = np.sum(w*flux_density)                        # scalar
-```
-
-#### Source Slices
-
-* *get_source_slice(component, vol=None, center=None, size=None)* — Deprecated. Use `get_source` below.
-* [Simulation.get_source(component, vol=None, center=None, size=None)](#Simulation.get_source)
-
-
-#### Harminv Step Function
-
-The following step function collects field data from a given point and runs [Harminv](https://github.com/NanoComp/harminv) on that data to extract the frequencies, decay rates, and other information.
-
-* [Harminv class](#Harminv)
-
-
-### Step-Function Modifiers
-
-Rather than writing a brand-new step function every time something a bit different is required, the following "modifier" functions take a bunch of step functions and produce *new* step functions with modified behavior.
-See also [Tutorial/Basics](Python_Tutorials/Basics.md) for examples.
-
-
-#### Miscellaneous Step-Function Modifiers
-
-@@ combine_step_funcs @@
-@@ synchronized_magnetic @@
-
-
-#### Controlling When a Step Function Executes
-
-@@ when_true @@
-@@ when_false @@
-@@ at_every @@
-@@ after_time @@
-@@ before_time @@
-@@ at_time @@
-@@ after_sources @@
-@@ after_sources_and_time @@
-@@ during_sources @@
-@@ at_beginning @@
-@@ at_end @@
-
-
-#### Modifying HDF5 Output
-
-@@ in_volume @@
-@@ in_point @@
-@@ to_appended @@
-@@ with_prefix @@
-
-### Writing Your Own Step Functions
-
-A step function can take two forms. The simplest is just a function with one argument (the simulation instance), which is called at every time step unless modified by one of the modifier functions above. e.g.
-
-```py
-def my_step(sim):
-    print("Hello world!")
-```
-
-If one then does `sim.run(my_step, until=100)`, Meep will run for 100 time units and print "Hello world!" at every time step.
-
-This suffices for most purposes. However, sometimes you need a step function that opens a file, or accumulates some computation, and you need to clean up (e.g. close the file or print the results) at the end of the run. For this case, you can write a step function of two arguments: the second argument will either be `step` when it is called during time-stepping, or `finish` when it is called at the end of the run:
-
-```py
-def my_step(sim, todo):
-    if todo == 'step':
-       # do something
-    elif todo == 'finish':
-       # do something else
-
-    # access simulation attributes
-    sim.fields ...etc.
-```
-
-Low-Level Functions
--------------------
-
-By default, Meep initializes C++ objects like `meep::structure` and `meep::fields` in the `Simulation` object based on attributes like `sources` and `geometry`. Theses objects are then accessible via `simulation_instance.structure` and `simulation_instance.fields`. Given these, you can then call essentially any function in the C++ interface, because all of the C++ functions are automatically made accessible to Python by the wrapper-generator program [SWIG](https://en.wikipedia.org/wiki/SWIG).
-
-### Initializing the Structure and Fields
-
-The `structure` and `fields` variables are automatically initialized when any of the run functions is called, or by various other functions such as `add_flux`. To initialize them separately, you can call `Simulation.init_sim()` manually, or `Simulation._init_structure(k_point)` to just initialize the structure.
-
-If you want to time step more than one field simultaneously, the easiest way is probably to do something like:
-
-```py
-sim = Simulation(cell_size, resolution).init_sim()
-my_fields = sim.fields
-sim.fields = None
-sim.reset_meep()
-```
-
-and then change the geometry etc. and re-run `sim.init_sim()`. Then you'll have two field objects in memory.
-
-### SWIG Wrappers
-
-If you look at a function in the C++ interface, then there are a few simple rules to infer the name of the corresponding Python function.
-
--   First, all functions in the `meep::` namespace are available in the Meep Python module from the top-level `meep` package.
--   Second, any method of a class is accessible via the standard Python class interface. For example, `meep::fields::step`, which is the function that performs a time-step, is exposed to Python as `fields_instance.step()` where a fields instance is usually accessible from Simulation.fields.
--   C++ constructors are called using the normal Python class instantiation. E.g., `fields = mp.fields(...)` returns a new `meep::fields` object. Calling destructors is not necessary because objects are automatically garbage collected.
-
-Some argument type conversion is performed automatically, e.g. types like complex numbers are converted to `complex<double>`, etcetera. `Vector3` vectors are converted to `meep::vec`, but to do this it is necessary to know the dimensionality of the problem in C++. The problem dimensions are automatically initialized by `Simulation._init_structure`, but if you want to pass vector arguments to C++ before that time you should call `Simulation.require_dimensions()`, which infers the dimensions from the `cell_size`, `k_point`, and `dimensions` variables.

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -449,10 +449,10 @@ In particular, a useful value for `until_after_sources` or `until` is often `sto
 @@ stop_on_interrupt @@
 
 
-Finally, another run function, useful for computing ω(**k**) band diagrams, is available via these top-level functions:
+Finally, another run function, useful for computing ω(**k**) band diagrams, is available via these `Simulation` methods:
 
-@@ meep.run_k_points @@
-@@ meep.run_k_point @@
+@@ Simulation.run_k_points @@
+@@ Simulation.run_k_point @@
 
 
 ### Predefined Step Functions

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -685,8 +685,10 @@ Some argument type conversion is performed automatically, e.g. types like comple
 
 
 
-Classes
--------
+<a id="classes"></a>
+
+Class Reference
+---------------
 
 Classes are complex datatypes with various properties which may have default values. Classes can be "subclasses" of other classes. Subclasses inherit all the properties of their superclass and can be used in any place the superclass is expected.
 
@@ -709,104 +711,154 @@ The following classes are available directly via the `meep` package.
 
 
 @@ Medium @@
+@@ Medium[methods-with-docstrings] @@
 
 @@ Susceptibility @@
+@@ Susceptibility[methods-with-docstrings] @@
 
 @@ LorentzianSusceptibility @@
+@@ LorentzianSusceptibility[methods-with-docstrings] @@
 
 @@ DrudeSusceptibility @@
+@@ DrudeSusceptibility[methods-with-docstrings] @@
 
 @@ MultilevelAtom @@
+@@ MultilevelAtom[methods-with-docstrings] @@
 
 @@ Transition @@
+@@ Transition[methods-with-docstrings] @@
 
 @@ NoisyLorentzianSusceptibility @@
+@@ NoisyLorentzianSusceptibility[methods-with-docstrings] @@
 
 @@ NoisyDrudeSusceptibility @@
+@@ NoisyDrudeSusceptibility[methods-with-docstrings] @@
 
 @@ GyrotropicLorentzianSusceptibility @@
+@@ GyrotropicLorentzianSusceptibility[methods-with-docstrings] @@
 
 @@ GyrotropicDrudeSusceptibility @@
+@@ GyrotropicDrudeSusceptibility[methods-with-docstrings] @@
 
 @@ GyrotropicSaturatedSusceptibility @@
+@@ GyrotropicSaturatedSusceptibility[methods-with-docstrings] @@
 
 @@ Vector3 @@
+@@ Vector3[methods-with-docstrings] @@
 
 @@ GeometricObject @@
+@@ GeometricObject[methods-with-docstrings] @@
 
 @@ Sphere @@
+@@ Sphere[methods-with-docstrings] @@
 
 @@ Cylinder @@
+@@ Cylinder[methods-with-docstrings] @@
 
 @@ Wedge @@
+@@ Wedge[methods-with-docstrings] @@
 
 @@ Cone @@
+@@ Cone[methods-with-docstrings] @@
 
 @@ Block @@
+@@ Block[methods-with-docstrings] @@
 
 @@ Ellipsoid @@
+@@ Ellipsoid[methods-with-docstrings] @@
 
 @@ Prism @@
+@@ Prism[methods-with-docstrings] @@
 
 @@ Matrix @@
+@@ Matrix[methods-with-docstrings] @@
 
 **Related function:**
 @@ get_rotation_matrix @@
 
 
 @@ Symmetry @@
+@@ Symmetry[methods-with-docstrings] @@
 
 @@ Rotate2 @@
+@@ Rotate2[methods-with-docstrings] @@
 
 @@ Rotate4 @@
+@@ Rotate4[methods-with-docstrings] @@
 
 @@ Mirror @@
+@@ Mirror[methods-with-docstrings] @@
 
 @@ Identity @@
+@@ Identity[methods-with-docstrings] @@
 
 @@ PML @@
+@@ PML[methods-with-docstrings] @@
 
 @@ Absorber @@
+@@ Absorber[methods-with-docstrings] @@
 
 @@ Source @@
+@@ Source[methods-with-docstrings] @@
 
 @@ SourceTime @@
+@@ SourceTime[methods-with-docstrings] @@
 
 @@ EigenModeSource @@
+@@ EigenModeSource[methods-with-docstrings] @@
 
 @@ ContinuousSource @@
+@@ ContinuousSource[methods-with-docstrings] @@
 
 @@ GaussianSource @@
+@@ GaussianSource[methods-with-docstrings] @@
 
 @@ CustomSource @@
+@@ CustomSource[methods-with-docstrings] @@
 
 @@ FluxRegion @@
+@@ FluxRegion[methods-with-docstrings] @@
 
 @@ EnergyRegion @@
+@@ EnergyRegion[methods-with-docstrings] @@
 
 @@ ForceRegion @@
-
+@@ ForceRegion[methods-with-docstrings] @@
 
 @@ Volume @@
+@@ Volume[methods-with-docstrings] @@
 
 ** Related function:**
 @@ get_center_and_size @@
 
 @@ DftObj @@
+@@ DftObj[methods-with-docstrings] @@
+
 @@ DftFlux @@
+@@ DftFlux[methods-with-docstrings] @@
+
 @@ DftForce @@
+@@ DftForce[methods-with-docstrings] @@
+
 @@ DftNear2Far @@
+@@ DftNear2Far[methods-with-docstrings] @@
+
 @@ DftEnergy @@
+@@ DftEnergy[methods-with-docstrings] @@
+
 @@ DftFields @@
+@@ DftFields[methods-with-docstrings] @@
 
 @@ Animate2D @@
+@@ Animate2D[methods-with-docstrings] @@
 
 @@ Harminv @@
+@@ Harminv[methods-with-docstrings] @@
 
 
 
-Miscellaneous Functions
------------------------
+Miscellaneous Functions Reference
+---------------------------------
 
 @@ quiet @@
 

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -65,6 +65,7 @@ The `Simulation` class is the primary abstraction of the high-level interface. M
 
 @@ Simulation @@
    @@ Simulation.__init__ @@
+   @@ Simulation.run @@
 
 
 ### Output File Names

--- a/doc/docs/css/extra.css
+++ b/doc/docs/css/extra.css
@@ -3,7 +3,7 @@
 /* Indent the class docstring */
 .class_docstring {
     /* margin-left: 25px; */
-    margin-left: 0px;
+    margin-left: 25px;
 }
 
 /* And the members of the class (the methods) */
@@ -22,7 +22,7 @@
 /* Indent the method docstrings a little more */
 .method_docstring {
     /* margin-left: 35px; */
-    margin-left: 0px;
+    margin-left: 25px;
 }
 
 /* code blocks inside of method docstrings */
@@ -35,7 +35,7 @@
 /* And similar settings for top-level functions */
 .function_docstring {
     /* margin-left: 35px; */
-    margin-left: 0px;
+    margin-left: 25px;
 }
 .function_docstring code.python.hljs {
     border: none;

--- a/doc/docs/css/extra.css
+++ b/doc/docs/css/extra.css
@@ -40,8 +40,14 @@
 
 
 /* Turn off the ugly boxes around inline code in paragraphs and in list items */
-p code, li code {
+p code, li code, .rst-content code {
     border:  none;
-    font-size: 80%;
+    font-size: 75%;
     padding: 0 2px;
+}
+
+/* Turn the border back on for code blocks */
+pre code.python {
+    border: solid 1px #e1e4e5;
+    font-size: 70%;
 }

--- a/doc/docs/css/extra.css
+++ b/doc/docs/css/extra.css
@@ -2,12 +2,14 @@
 
 /* Indent the class docstring */
 .class_docstring {
-    margin-left: 25px;
+    /* margin-left: 25px; */
+    margin-left: 0px;
 }
 
 /* And the members of the class (the methods) */
 .class_members {
-    margin-left: 25px;
+    /* margin-left: 25px; */
+    margin-left: 0px;
 }
 
 /* Tweak the style of the code blocks inside of class docstrings */
@@ -19,7 +21,8 @@
 
 /* Indent the method docstrings a little more */
 .method_docstring {
-    margin-left: 35px;
+    /* margin-left: 35px; */
+    margin-left: 0px;
 }
 
 /* code blocks inside of method docstrings */
@@ -31,7 +34,8 @@
 
 /* And similar settings for top-level functions */
 .function_docstring {
-    margin-left: 35px;
+    /* margin-left: 35px; */
+    margin-left: 0px;
 }
 .function_docstring code.python.hljs {
     border: none;

--- a/doc/generate_py_api.py
+++ b/doc/generate_py_api.py
@@ -117,11 +117,13 @@ class MethodItem(FunctionItem):
     def __init__(self, name, obj, klass):
         super(MethodItem, self).__init__(name, obj)
         self.klass = klass
+        self.method_name = name
+        self.name = '{}.{}'.format(klass.name, name)
 
     def create_markdown(self):
         # pull relevant attributes into local variables
         class_name = self.klass.name
-        method_name = self.name
+        method_name = self.method_name
         method_name_escaped = method_name.replace('_', '\_')
         docstring = self.docstring if self.docstring else ''
         parameters = self.get_parameters(4 + len(method_name) + 1)
@@ -162,25 +164,25 @@ class ClassItem(Item):
         base_classes = [base.__name__ for base in self.obj.__bases__]
         base_classes = ', '.join(base_classes)
 
-        method_docs = []
-        if self.methods:
-            # reorder self.methods so __init__ comes first, if it isn't already
-            methods = self.methods[:]
-            for idx, meth in enumerate(self.methods):
-                if meth.name == '__init__':
-                    if idx != 0:
-                        methods.remove(meth)
-                        methods.insert(0, meth)
-                    break
+        # method_docs = []
+        # if self.methods:
+        #     # reorder self.methods so __init__ comes first, if it isn't already
+        #     methods = self.methods[:]
+        #     for idx, meth in enumerate(self.methods):
+        #         if meth.name == '__init__':
+        #             if idx != 0:
+        #                 methods.remove(meth)
+        #                 methods.insert(0, meth)
+        #             break
 
-            for item in methods:
-                if not check_excluded(item.name) and \
-                   not check_excluded('{}.{}'.format(self.name, item.name)):
-                     doc = item.create_markdown()
-                     method_docs.append(doc)
+        #     for item in methods:
+        #         if not check_excluded(item.name) and \
+        #            not check_excluded('{}.{}'.format(self.name, item.name)):
+        #              doc = item.create_markdown()
+        #              method_docs.append(doc)
 
-        # join the methods into a single string
-        method_docs = '\n'.join(method_docs)
+        # # join the methods into a single string
+        # method_docs = '\n'.join(method_docs)
 
         # Substitute values into the template
         doc = self.template.format(**locals())
@@ -206,7 +208,9 @@ def load_module(module):
 
     for name, member in members:
         if inspect.isclass(member):
-            items.append(ClassItem(name, member))
+            item = ClassItem(name, member)
+            items.append(item)
+            items += item.methods
         if inspect.isfunction(member):
             items.append(FunctionItem(name, member))
 

--- a/doc/generate_py_api.py
+++ b/doc/generate_py_api.py
@@ -17,6 +17,16 @@ In order to keep the noise in the module to a minimum, some markdown
 snippets/templates used in the generation of the API documentation files can be
 found in {project_folder}/doc/_api_snippets, and will be loaded as needed while
 processing the docstrings.
+
+The folling tag patterns are used to indicate where in the input template that docstrings
+will be inserted:
+
+  - @@ top_level_function_name @@
+  - @@ ClassName @@
+  - @@ ClassName.method_name @@
+  - @@ ClassName[all-methods] @@
+  - @@ ClassName[methods-with-docstrings] @@
+
 """
 
 import sys

--- a/python/geom.py
+++ b/python/geom.py
@@ -539,7 +539,7 @@ class MaterialGrid(object):
         if grid_type not in grid_type_dict:
             raise ValueError("Invalid grid_type: {}. Must be either U_MIN, U_PROD, U_SUM, or U_DEFAULT".format(grid_type_dict))
         self.grid_type = grid_type_dict[grid_type]
-        
+
         self.swigobj = None
     def update_parameters(self,x):
         if x.size != self.num_params:
@@ -779,7 +779,6 @@ class MultilevelAtom(Susceptibility):
 
 class Transition(object):
     """
-    A `Transition` is... (TODO)
     """
 
     def __init__(self,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1731,7 +1731,8 @@ class Simulation(object):
 
     def set_materials(self, geometry=None, default_material=None):
         """
-        This can be called in a step function, and is useful for changing the geometry or default material as a function of time.
+        This can be called in a step function, and is useful for changing the geometry or
+        default material as a function of time.
         """
         if self.fields:
             self.fields.remove_susceptibilities()
@@ -1963,9 +1964,7 @@ class Simulation(object):
         simulation script is in
         [examples/phase_in_material.py](https://github.com/NanoComp/meep/blob/master/python/examples/phase_in_material.py)).
 
-        <center>
         ![](images/phase-in-material.png)
-        </center>
         """
         if self.fields is None:
             self.init_sim()
@@ -2338,6 +2337,8 @@ class Simulation(object):
 
     def add_energy(self, *args):
         """
+        add_energy(fcen, df, nfreq, freq, EnergyRegions...)
+
         Add a bunch of `EnergyRegion`s to the current simulation (initializing the fields
         if they have not yet been initialized), telling Meep to accumulate the appropriate
         field Fourier transforms for `nfreq` equally spaced frequencies covering the
@@ -2550,6 +2551,8 @@ class Simulation(object):
 
     def add_force(self, *args):
         """
+        add_force(fcen, df, nfreq, freq, ForceRegions...)
+
         Add a bunch of `ForceRegion`s to the current simulation (initializing the fields
         if they have not yet been initialized), telling Meep to accumulate the appropriate
         field Fourier transforms for `nfreq` equally spaced frequencies covering the
@@ -3405,6 +3408,26 @@ class Simulation(object):
             self.init_sim()
 
     def run(self, *step_funcs, **kwargs):
+        """
+        `run(step_functions..., until=condition/time)`
+
+        Run the simulation until a certain time or condition, calling the given step
+        functions (if any) at each timestep. The keyword argument `until` is *either* a
+        number, in which case it is an additional time (in Meep units) to run for, *or* it
+        is a function (of no arguments) which returns `True` when the simulation should
+        stop. `until` can also be a list of stopping conditions which may include a number
+        and additional functions.
+
+        `run(step_functions..., until_after_sources=condition/time)`
+
+        Run the simulation until all sources have turned off, calling the given step
+        functions (if any) at each timestep. The keyword argument `until_after_sources` is
+        either a number, in which case it is an *additional* time (in Meep units) to run
+        for after the sources are off, *or* it is a function (of no arguments). In the
+        latter case, the simulation runs until the sources are off *and* `condition`
+        returns `True`. Like `until` above, `until_after_sources` can take a list of
+        stopping conditions.
+        """
         until = kwargs.pop('until', None)
         until_after_sources = kwargs.pop('until_after_sources', None)
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2132,6 +2132,11 @@ class Simulation(object):
         self._run_sources_until(self, 0, step_funcs)
 
     def run_k_point(self, t, k):
+        """
+        Lower level function called by `run_k_points` that runs a simulation for a single
+        *k* point `k_point` and returns a `Harminv` instance. Useful when you need to
+        access more `Harminv` data than just the frequencies.
+        """
         components = [s.component for s in self.sources]
         pts = [s.center for s in self.sources]
 
@@ -2337,7 +2342,7 @@ class Simulation(object):
 
     def add_energy(self, *args):
         """
-        add_energy(fcen, df, nfreq, freq, EnergyRegions...)
+        `add_energy(fcen, df, nfreq, freq, EnergyRegions...)`
 
         Add a bunch of `EnergyRegion`s to the current simulation (initializing the fields
         if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -2551,7 +2556,7 @@ class Simulation(object):
 
     def add_force(self, *args):
         """
-        add_force(fcen, df, nfreq, freq, ForceRegions...)
+        `add_force(fcen, df, nfreq, freq, ForceRegions...)`
 
         Add a bunch of `ForceRegion`s to the current simulation (initializing the fields
         if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -4614,7 +4619,7 @@ def output_sfield_p(sim):
 
 def Ldos(*args):
     """
-    Ldos(fcen, df, nfreq, freq)
+    `Ldos(fcen, df, nfreq, freq)`
 
     Create an LDOS object with either frequency bandwidth `df` centered at `fcen` and
     `nfreq` equally spaced frequency points or an array/list `freq` for arbitrarily spaced
@@ -4629,7 +4634,7 @@ def Ldos(*args):
 
 def dft_ldos(*args, **kwargs):
     """
-    dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)
+    `dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)`
 
     Compute the power spectrum of the sources (usually a single point dipole source),
     normalized to correspond to the LDOS, in either a frequency bandwidth `df` centered at


### PR DESCRIPTION
Fixes #1284 

Lots of changes for the API document generation templates and tools, mostly inline with #1284.

* I changed the order of some things to improve readability and searchability of the document
  - The"prose" sections are first, with the docstrings for the mentioned methods injected in this section along with the prose discussing that group of methods. This brings it back to be more like the original document.
  - The "reference" sections are moved to the end. This includes all the documented classes and functions, with their docstrings injected.

* Tags used for positioning the injected docstrings can be: 
  - `@@ top_level_function_name @@`
  - `@@ ClassName @@`
  - `@@ ClassName.method_name @@`
  - `@@ ClassName[all-methods] @@`
  - `@@ ClassName[methods-with-docstrings] @@`

  The latter is used in the "reference" section mentioned above and pulls in the docstrings for all methods in a class, but only for those which actually have a docstring.

* I left the markdown headers for the classes, although there is a code block immediately following with the class def, otherwise they would not get put into the TOC and the outline in the sidebar. The headers in the function and method templates were removed as discussed.

* I experimented with removing all indentation, but ended up putting some of it back because IMO it greatly aids readability, and subtly indicates what is docstring and what is prose text from the document. It's easy to experiment and fine tune the indentation, if needed, just by editing the `.../css/extra.css` file and reloading the page.
