### PR TITLE
extend LED tutorial involving cosine series source terms to 2d

### DIFF
--- a/doc/docs/Python_Tutorials/Custom_Source.md
+++ b/doc/docs/Python_Tutorials/Custom_Source.md
@@ -304,7 +304,7 @@ if mp.am_master():
 
 There are three items to note in this script. (1) The line source spans the entire length of the cell in the $x$ direction (i.e., $L$ is `sx`). (2) The number of point dipoles in Method 2 is `sx*resolution`, one per pixel. (3) The source amplitude function in Method 3 is specified by the `amp_func` property of the [`Source`](../Python_User_Interface.md#source) object. In the case of a Fourier cosine series as conventionally written, $\cos (m\pi x)/L$ is defined over the interval $x=[0,L]$ such that $x=0$ corresponds to the *edge* of the source, not the center. Since the source region in this example is defined in $[-L/2,+L/2]$, the amplitude function must shift its $x$ coordinate argument by $+L/2$ or `0.5*sx`.
 
-Method 3 requires a convergence check in which $M$ (`nsrc`) is repeatedly doubled until the change in the results are within a desired tolerance of e.g., < 1%. For this example, $M=15$ was found to be sufficient.
+Method 3 requires a convergence check in which $M$ (`nsrc` in the script) is repeatedly doubled until the change in the results are within a desired tolerance of e.g., < 1%. For this example, $M=15$ was found to be sufficient.
 
 Results for Methods 2 and 3 for the two cases of a flat and textured surface are generated using the following shell script:
 ```sh
@@ -355,3 +355,11 @@ Results for Method 2 and 3 are shown in the following figure. The agreement is g
 <center>
 ![](../images/stochastic_emitter_line_normalized_flux_comparison.png)
 </center>
+
+Method 3 can be extended to 3d using a planar source layer ($L_x \times L_y$) involving the *product* of two cosine series:
+
+$$f_{m,n}(x,y) = \sqrt{\frac{c_m c_n}{L_x L_y}} \cos \left(\frac{m\pi x}{L_x}\right) \cos \left(\frac{n\pi y}{L_y}\right), ~m = 0,1,\ldots, M-1; n = 0,1,\ldots, N-1 $$
+
+where $c_m = c_n = 1$ if $m=n=0$ and $c_m = c_n = 2$ otherwise, $L_x$ and $L_y$ are the lengths of the planar source in the $x$ and $y$ directions. This requires two nested loops to sum over $m$ and $n$ separately. For example, if $M=N=10$, there are a total of 100 simulations. A 3d emission volume would require the product of 3 cosine series leading to e.g. 1000 simulations if there are 10 different sources in each dimension.
+
+The previous examples involved emission in the *normal* direction. To investigate emission in *all* directions for a periodic surface requires integrating over $k_x$ and $k_y$ (the Bloch wavevectors of the unit cell; specified using `k_point`). Each ($k_x,k_y$) corresponds to a different emission direction. However, if you have designed your periodic emitter to emit mostly vertically (via a resonance at $k_x=k_y=0$), then the emission drops off rapidly at other $k$ points. Thus, you can probably estimate the angular width of the resonance by sampling only a few $k$ points near (0,0).


### PR DESCRIPTION
Extends the presentation of Method 3 of [Tutorial/Custom Sources/Stochastic Dipole Emission in Light Emitting Diodes](https://meep.readthedocs.io/en/latest/Python_Tutorials/Custom_Source/#stochastic-dipole-emission-in-light-emitting-diodes) to 2d/3d following @stevengj's [comment](https://github.com/NanoComp/meep/pull/1266#issuecomment-652139470) in #1266.