### PR TITLE
Escape backslashes and other minor tweaks

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -5542,7 +5542,7 @@ def __init__(self,
              side=-1,
              R_asymptotic=1e-15,
              mean_stretch=1.0,
-             pml_profile=<function PML.<lambda> at 0x7fc5a1075440>):
+             pml_profile=<function PML.<lambda> at 0x7fbde152c440>):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6849,7 +6849,7 @@ def __call__(self, sim, todo):
 
 <div class="method_docstring" markdown="1">
 
-Allows a Haminv instance to be used as astep function.
+Allows a Haminv instance to be used as a step function.
 
 </div>
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -625,7 +625,7 @@ def get_epsilon_point(self, pt, frequency=0, omega=0):
 Given a frequency `frequency` and a `Vector3` `pt`, returns the average eigenvalue
 of the permittivity tensor at that location and frequency. If `frequency` is
 non-zero, the result is complex valued; otherwise it is the real,
-frequency-independent part of ε (the $\omega    o\infty$ limit).
+frequency-independent part of ε (the $\omega\to\infty$ limit).
 
 </div>
 
@@ -684,9 +684,11 @@ def flux_in_box(self, d, box=None, center=None, size=None):
 <div class="method_docstring" markdown="1">
 
 Given a `direction` constant, and a `mp.Volume`, returns the flux (the integral of
-$\Re [\mathbf{E}^*      imes \mathbf{H}]$) in that volume. Most commonly, you specify
+$\Re [\mathbf{E}^* \times \mathbf{H}]$) in that volume. Most commonly, you specify
 a volume that is a plane or a line, and a direction perpendicular to it, e.g.
-`flux_in_box(d=mp.X,mp.Volume(center=mp.Vector3(0,0,0),size=mp.Vector3(0,1,1)))`.
+
+`flux_in_box(d=mp.X,mp.Volume(center=mp.Vector3(0,0,0),size=mp.Vector3(0,1,1)))`
+
 If the `center` and `size` arguments are provided instead of `box`, Meep will
 construct the appropriate volume for you.
 
@@ -2433,7 +2435,7 @@ plt.savefig('sim_domain.png')
     - `post_process=np.real`: post processing function to apply to fields (must be
       a function object)
 * `frequency`: for materials with a [frequency-dependent
-  permittivity](Materials.md#material-dispersion) $arepsilon(f)$, specifies the
+  permittivity](Materials.md#material-dispersion) $\varepsilon(f)$, specifies the
   frequency $f$ (in Meep units) of the real part of the permittivity to use in the
   plot. Defaults to the `frequency` parameter of the [Source](#source) object.
 
@@ -2669,7 +2671,7 @@ Given a frequency `frequency`, (provided as a keyword argument) output ε (relat
 permittivity); for an anisotropic ε tensor the output is the [harmonic
 mean](https://en.wikipedia.org/wiki/Harmonic_mean) of the ε eigenvalues. If
 `frequency` is non-zero, the output is complex; otherwise it is the real,
-frequency-independent part of ε (the $\omega        o\infty$ limit).
+frequency-independent part of ε (the $\omega\to\infty$ limit).
 
 </div>
 
@@ -2685,7 +2687,7 @@ Given a frequency `frequency`, (provided as a keyword argument) output μ (relat
 permeability); for an anisotropic μ tensor the output is the [harmonic
 mean](https://en.wikipedia.org/wiki/Harmonic_mean) of the μ eigenvalues. If
 `frequency` is non-zero, the output is complex; otherwise it is the real,
-frequency-independent part of μ (the $\omega        o\infty$ limit).
+frequency-independent part of μ (the $\omega\to\infty$ limit).
 
 </div>
 
@@ -2697,7 +2699,7 @@ def output_poynting(sim):
 
 <div class="function_docstring" markdown="1">
 
-Output the Poynting flux $\mathrm{Re}\{\mathbf{E}^* imes\mathbf{H}\}$. Note that you
+Output the Poynting flux $\mathrm{Re}\{\mathbf{E}^*\times\mathbf{H}\}$. Note that you
 might want to wrap this step function in `synchronized_magnetic` to compute it more
 accurately. See [Synchronizing the Magnetic and Electric
 Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
@@ -3376,7 +3378,7 @@ or `center/size`. In both cases, the return value is a tuple `(x,y,z,w)`, where:
   some spatially-varying quantity whose value at the $n$th grid point is $Q_n$,
   the integral of $Q$ over the region may be approximated by the sum:
 
-$$ \int_{\mathcal V} Q(\mathbf{x})d\mathbf{x} pprox \sum_{n} w_n Q_n.$$
+$$ \int_{\mathcal V} Q(\mathbf{x})d\mathbf{x} \approx \sum_{n} w_n Q_n.$$
 
 This is a 1-, 2-, or 3-dimensional integral depending on the number of dimensions
 in which $\mathcal{V}$ has zero extent. If the $\{Q_n\}$ samples are stored in an
@@ -3904,7 +3906,7 @@ Creates a `Medium` object.
 + **`epsilon` [`number`]** The frequency-independent isotropic relative
   permittivity or dielectric constant. Default is 1. You can also use `index=n` as
   a synonym for `epsilon=n*n`; note that this is not really the refractive index
-  if you also specify μ, since the true index is $\sqrt{\muarepsilon}$. Using
+  if you also specify μ, since the true index is $\sqrt{\mu\varepsilon}$. Using
   `epsilon=ep` is actually a synonym for `epsilon_diag=mp.Vector3(ep, ep, ep)`.
 
 + **`epsilon_diag` and `epsilon_offdiag` [`Vector3`]** — These properties allow
@@ -4291,7 +4293,7 @@ def __init__(self, noise_amp=0.0, **kwargs):
 
 <div class="method_docstring" markdown="1">
 
-+ **`noise_amp` [`number`]** — The noise has root-mean square amplitude σ $     imes$
++ **`noise_amp` [`number`]** — The noise has root-mean square amplitude σ $\times$
   `noise_amp`.
 
 This is a somewhat unusual polarizable medium, a Lorentzian susceptibility with a
@@ -4342,7 +4344,7 @@ def __init__(self, noise_amp=0.0, **kwargs):
 
 <div class="method_docstring" markdown="1">
 
-+ **`noise_amp` [`number`]** — The noise has root-mean square amplitude σ $     imes$
++ **`noise_amp` [`number`]** — The noise has root-mean square amplitude σ $\times$
   `noise_amp`.
 
 This is a somewhat unusual polarizable medium, a Lorentzian susceptibility with a
@@ -4490,7 +4492,7 @@ def __init__(self,
 + **`gamma` [`number`]** — The loss rate $\gamma_n / 2\pi$ in the off-diagonal
   response.
 
-+ **`alpha` [`number`]** — The loss factor $lpha_n$ in the diagonal response.
++ **`alpha` [`number`]** — The loss factor $\alpha_n$ in the diagonal response.
   Note that this parameter is dimensionless and contains no 2π factor.
 
 + **`bias` [`Vector3`]** — Vector specifying the orientation of the gyrotropic
@@ -5540,7 +5542,7 @@ def __init__(self,
              side=-1,
              R_asymptotic=1e-15,
              mean_stretch=1.0,
-             pml_profile=<function PML.<lambda> at 0x7ff729b8fdd0>):
+             pml_profile=<function PML.<lambda> at 0x7fc5a1075440>):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5754,27 +5756,12 @@ class SourceTime(object):
 
 <div class="class_docstring" markdown="1">
 
-TODO:
+This is the parent for classes describing the time dependence of sources; it should
+not be instantiated directly.
 
 </div>
 
 
-
-<a id="SourceTime.__init__"></a>
-
-<div class="class_members" markdown="1">
-
-```python
-def __init__(self, is_integrated=False):
-```
-
-<div class="method_docstring" markdown="1">
-
-TODO:
-
-</div>
-
-</div>
 
 ---
 <a id="EigenModeSource"></a>
@@ -6051,7 +6038,7 @@ class GaussianSource(SourceTime):
 
 A Gaussian-pulse source roughly proportional to $\exp(-i\omega t - (t-t_0)^2/2w^2)$.
 Technically, the "Gaussian" sources in Meep are the (discrete-time) derivative of a
-Gaussian, i.e. they are $(-i\omega)^{-1} rac{\partial}{\partial t} \exp(-i\omega t -
+Gaussian, i.e. they are $(-i\omega)^{-1} \frac{\partial}{\partial t} \exp(-i\omega t -
 (t-t_0)^2/2w^2)$, but the difference between this and a true Gaussian is usually
 irrelevant.
 
@@ -6108,10 +6095,10 @@ Construct a `GaussianSource`.
 + **`fourier_transform(f)`** — Returns the Fourier transform of the current
   evaluated at frequency `f` (`ω=2πf`) given by:
   $$
-  \widetilde G(\omega) \equiv rac{1}{\sqrt{2\pi}}
+  \widetilde G(\omega) \equiv \frac{1}{\sqrt{2\pi}}
   \int e^{i\omega t}G(t)\,dt \equiv
-  rac{1}{\Delta f}
-  e^{i\omega t_0 -rac{(\omega-\omega_0)^2}{2\Delta f^2}}
+  \frac{1}{\Delta f}
+  e^{i\omega t_0 -\frac{(\omega-\omega_0)^2}{2\Delta f^2}}
   $$
   where $G(t)$ is the current (not the dipole moment). In this formula, $\Delta f$
   is the `fwidth` of the source, $\omega_0$ is $2\pi$ times its `frequency,` and
@@ -7300,7 +7287,7 @@ Given a frequency `frequency`, (provided as a keyword argument) output ε (relat
 permittivity); for an anisotropic ε tensor the output is the [harmonic
 mean](https://en.wikipedia.org/wiki/Harmonic_mean) of the ε eigenvalues. If
 `frequency` is non-zero, the output is complex; otherwise it is the real,
-frequency-independent part of ε (the $\omega        o\infty$ limit).
+frequency-independent part of ε (the $\omega\to\infty$ limit).
 
 </div>
 
@@ -7316,7 +7303,7 @@ Given a frequency `frequency`, (provided as a keyword argument) output μ (relat
 permeability); for an anisotropic μ tensor the output is the [harmonic
 mean](https://en.wikipedia.org/wiki/Harmonic_mean) of the μ eigenvalues. If
 `frequency` is non-zero, the output is complex; otherwise it is the real,
-frequency-independent part of μ (the $\omega        o\infty$ limit).
+frequency-independent part of μ (the $\omega\to\infty$ limit).
 
 </div>
 
@@ -7328,7 +7315,7 @@ def output_poynting(sim):
 
 <div class="function_docstring" markdown="1">
 
-Output the Poynting flux $\mathrm{Re}\{\mathbf{E}^* imes\mathbf{H}\}$. Note that you
+Output the Poynting flux $\mathrm{Re}\{\mathbf{E}^*\times\mathbf{H}\}$. Note that you
 might want to wrap this step function in `synchronized_magnetic` to compute it more
 accurately. See [Synchronizing the Magnetic and Electric
 Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -803,7 +803,6 @@ The following classes are available directly via the `meep` package.
 @@ Source[methods-with-docstrings] @@
 
 @@ SourceTime @@
-@@ SourceTime[methods-with-docstrings] @@
 
 @@ EigenModeSource @@
 @@ EigenModeSource[methods-with-docstrings] @@

--- a/python/geom.py
+++ b/python/geom.py
@@ -176,7 +176,7 @@ class Vector3(object):
         return self.x * v.x + self.y * v.y + self.z * v.z
 
     def cdot(self, v):
-        """Returns the conjugated dot product: *self*\* dot *v*."""
+        """Returns the conjugated dot product: *self*\\* dot *v*."""
         return self.conj().dot(v)
 
     def cross(self, v):
@@ -337,7 +337,7 @@ class Medium(object):
         + **`epsilon` [`number`]** The frequency-independent isotropic relative
           permittivity or dielectric constant. Default is 1. You can also use `index=n` as
           a synonym for `epsilon=n*n`; note that this is not really the refractive index
-          if you also specify μ, since the true index is $\sqrt{\mu\varepsilon}$. Using
+          if you also specify μ, since the true index is $\\sqrt{\\mu\\varepsilon}$. Using
           `epsilon=ep` is actually a synonym for `epsilon_diag=mp.Vector3(ep, ep, ep)`.
 
         + **`epsilon_diag` and `epsilon_offdiag` [`Vector3`]** — These properties allow
@@ -356,23 +356,23 @@ class Medium(object):
           offdiagonal parts exactly as for ε above. Default is the identity matrix.
 
         + **`D_conductivity` [`number`]** — The frequency-independent electric
-          conductivity $\sigma_D$. Default is 0. You can also specify a diagonal
+          conductivity $\\sigma_D$. Default is 0. You can also specify a diagonal
           anisotropic conductivity tensor by using the property `D_conductivity_diag`
-          which takes a `Vector3` to give the $\sigma_D$ tensor diagonal. See also
+          which takes a `Vector3` to give the $\\sigma_D$ tensor diagonal. See also
           [Conductivity](Materials.md#conductivity-and-complex).
 
         + **`B_conductivity` [`number`]** — The frequency-independent magnetic
-          conductivity $\sigma_B$. Default is 0. You can also specify a diagonal
+          conductivity $\\sigma_B$. Default is 0. You can also specify a diagonal
           anisotropic conductivity tensor by using the property `B_conductivity_diag`
-          which takes a `Vector3` to give the $\sigma_B$ tensor diagonal. See also
+          which takes a `Vector3` to give the $\\sigma_B$ tensor diagonal. See also
           [Conductivity](Materials.md#conductivity-and-complex).
 
         + **`chi2` [`number`]** — The nonlinear
           [Pockels](https://en.wikipedia.org/wiki/Pockels_effect) susceptibility
-          $\chi^{(2)}$. Default is 0. See also [Nonlinearity](Materials.md#nonlinearity).
+          $\\chi^{(2)}$. Default is 0. See also [Nonlinearity](Materials.md#nonlinearity).
 
         + **`chi3` [`number`]** — The nonlinear
-          [Kerr](https://en.wikipedia.org/wiki/Kerr_effect) susceptibility $\chi^{(3)}$.
+          [Kerr](https://en.wikipedia.org/wiki/Kerr_effect) susceptibility $\\chi^{(3)}$.
           Default is 0. See also [Nonlinearity](Materials.md#nonlinearity).
 
         + **`E_susceptibilities` [ list of `Susceptibility` class ]** — List of dispersive
@@ -581,9 +581,9 @@ class LorentzianSusceptibility(Susceptibility):
     """
     def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
         """
-        + **`frequency` [`number`]** — The resonance frequency $f_n = \omega_n / 2\pi$.
+        + **`frequency` [`number`]** — The resonance frequency $f_n = \\omega_n / 2\\pi$.
 
-        + **`gamma` [`number`]** — The resonance loss rate $γ_n / 2\pi$.
+        + **`gamma` [`number`]** — The resonance loss rate $γ_n / 2\\pi$.
 
         Note: multiple objects with identical values for the `frequency` and `gamma` but
         different `sigma` will appear as a *single* Lorentzian susceptibility term in the
@@ -608,10 +608,10 @@ class DrudeSusceptibility(Susceptibility):
     """
     def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
         """
-        + **`frequency` [`number`]** — The frequency scale factor $f_n = \omega_n / 2\pi$
+        + **`frequency` [`number`]** — The frequency scale factor $f_n = \\omega_n / 2\\pi$
           which multiplies σ (not a resonance frequency).
 
-        + **`gamma` [`number`]** — The loss rate $γ_n / 2\pi$.
+        + **`gamma` [`number`]** — The loss rate $γ_n / 2\\pi$.
         """
         super(DrudeSusceptibility, self).__init__(**kwargs)
         self.frequency = frequency
@@ -635,7 +635,7 @@ class NoisyLorentzianSusceptibility(LorentzianSusceptibility):
     """
     def __init__(self, noise_amp=0.0, **kwargs):
         """
-        + **`noise_amp` [`number`]** — The noise has root-mean square amplitude σ $\times$
+        + **`noise_amp` [`number`]** — The noise has root-mean square amplitude σ $\\times$
           `noise_amp`.
 
         This is a somewhat unusual polarizable medium, a Lorentzian susceptibility with a
@@ -665,7 +665,7 @@ class NoisyDrudeSusceptibility(DrudeSusceptibility):
     """
     def __init__(self, noise_amp=0.0, **kwargs):
         """
-        + **`noise_amp` [`number`]** — The noise has root-mean square amplitude σ $\times$
+        + **`noise_amp` [`number`]** — The noise has root-mean square amplitude σ $\\times$
           `noise_amp`.
 
         This is a somewhat unusual polarizable medium, a Lorentzian susceptibility with a
@@ -697,7 +697,7 @@ class GyrotropicLorentzianSusceptibility(LorentzianSusceptibility):
         """
         + **`bias` [`Vector3`]** — The gyrotropy vector.  Its direction determines the
           orientation of the gyrotropic response, and the magnitude is the precession
-          frequency $|\mathbf{b}_n|/2\pi$.
+          frequency $|\\mathbf{b}_n|/2\\pi$.
         """
         super(GyrotropicLorentzianSusceptibility, self).__init__(**kwargs)
         self.bias = bias
@@ -715,7 +715,7 @@ class GyrotropicDrudeSusceptibility(DrudeSusceptibility):
         """
         + **`bias` [`Vector3`]** — The gyrotropy vector.  Its direction determines the
           orientation of the gyrotropic response, and the magnitude is the precession
-          frequency $|\mathbf{b}_n|/2\pi$.
+          frequency $|\\mathbf{b}_n|/2\\pi$.
         """
         super(GyrotropicDrudeSusceptibility, self).__init__(**kwargs)
         self.bias = bias
@@ -733,19 +733,19 @@ class GyrotropicSaturatedSusceptibility(Susceptibility):
     """
     def __init__(self, bias=Vector3(), frequency=0.0, gamma=0.0, alpha=0.0, **kwargs):
         """
-        + **`sigma` [`number`]** — The coupling factor $\sigma_n / 2\pi$ between the
+        + **`sigma` [`number`]** — The coupling factor $\\sigma_n / 2\\pi$ between the
           polarization and the driving field. In [magnetic
           ferrites](https://en.wikipedia.org/wiki/Ferrite_(magnet)), this is the Larmor
           precession frequency at the saturation field.
 
         + **`frequency` [`number`]** — The [Larmor
           precession](https://en.wikipedia.org/wiki/Larmor_precession) frequency,
-          $f_n = \omega_n / 2\pi$.
+          $f_n = \\omega_n / 2\\pi$.
 
-        + **`gamma` [`number`]** — The loss rate $\gamma_n / 2\pi$ in the off-diagonal
+        + **`gamma` [`number`]** — The loss rate $\\gamma_n / 2\\pi$ in the off-diagonal
           response.
 
-        + **`alpha` [`number`]** — The loss factor $\alpha_n$ in the diagonal response.
+        + **`alpha` [`number`]** — The loss factor $\\alpha_n$ in the diagonal response.
           Note that this parameter is dimensionless and contains no 2π factor.
 
         + **`bias` [`Vector3`]** — Vector specifying the orientation of the gyrotropic
@@ -792,20 +792,20 @@ class Transition(object):
         """
         Construct a `Transition`.
 
-        + **`frequency` [`number`]** — The radiative transition frequency $f = \omega / 2\pi$.
+        + **`frequency` [`number`]** — The radiative transition frequency $f = \\omega / 2\\pi$.
 
-        + **`gamma` [`number`]** — The loss rate $\gamma = \gamma / 2\pi$.
+        + **`gamma` [`number`]** — The loss rate $\\gamma = \\gamma / 2\\pi$.
 
-        + **`sigma_diag` [`Vector3`]** — The per-polarization coupling strength $\sigma$.
+        + **`sigma_diag` [`Vector3`]** — The per-polarization coupling strength $\\sigma$.
 
         + **`from_level` [`number`]** — The atomic level from which the transition occurs.
 
         + **`to_level` [`number`]** — The atomic level to which the transition occurs.
 
         + **`transition_rate` [`number`]** — The non-radiative transition rate
-          $f = \omega / 2\pi$. Default is 0.
+          $f = \\omega / 2\\pi$. Default is 0.
 
-        + **`pumping_rate` [`number`]** — The pumping rate $f = \omega / 2\pi$. Default is 0.
+        + **`pumping_rate` [`number`]** — The pumping rate $f = \\omega / 2\\pi$. Default is 0.
         """
         self.from_level = check_nonnegative('from_level', from_level)
         self.to_level = check_nonnegative('to_level', to_level)

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -780,7 +780,7 @@ class Harminv(object):
 
     def __call__(self, sim, todo):
         """
-        Allows a Haminv instance to be used as astep function.
+        Allows a Haminv instance to be used as a step function.
         """
         self.step_func(sim, todo)
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -120,7 +120,7 @@ class PML(object):
 
         + **`direction` [`direction` constant ]** — Specify the direction of the
           boundaries to put the PML layers next to. e.g. if `X`, then specifies PML on the
-          $\pm x$ boundaries (depending on the value of `side`, below). Default is the
+          $\\pm x$ boundaries (depending on the value of `side`, below). Default is the
           special value `ALL`, which puts PML layers on the boundaries in all directions.
 
         + **`side` [`side` constant ]** — Specify which side, `Low` or `High` of the
@@ -718,7 +718,7 @@ class Harminv(object):
     In particular, Harminv takes the time series $f(t)$ corresponding to the given field
     component as a function of time and decomposes it (within the specified bandwidth) as:
 
-    $$f(t) = \sum_n a_n e^{-i\omega_n t}$$
+    $$f(t) = \\sum_n a_n e^{-i\\omega_n t}$$
 
     The results are stored in the list `Harminv.modes`, which is a list of tuples holding
     the frequency, amplitude, and error of the modes. Given one of these tuples (e.g.,
@@ -729,7 +729,7 @@ class Harminv(object):
     + **`decay`** — The imaginary part of the frequency ω.
 
     + **`Q`** — The dimensionless lifetime, or quality factor defined as
-      $-\mathrm{Re}\,\omega / 2 \mathrm{Im}\,\omega$.
+      $-\\mathrm{Re}\\,\\omega / 2 \\mathrm{Im}\\,\\omega$.
 
     + **`amp`** — The complex amplitude $a$.
 
@@ -973,13 +973,13 @@ class Simulation(object):
           permitted. If `dimensions` is 2, then the cell must be in the $xy$ plane.
 
         + **`m` [`number`]** — For `CYLINDRICAL` simulations, specifies that the angular
-          $\phi$ dependence of the fields is of the form $e^{im\phi}$ (default is `m=0`).
+          $\\phi$ dependence of the fields is of the form $e^{im\\phi}$ (default is `m=0`).
           If the simulation cell includes the origin $r=0$, then `m` must be an integer.
 
         + **`accurate_fields_near_cylorigin` [`boolean`]** — For `CYLINDRICAL` simulations
           with |*m*| &gt; 1, compute more accurate fields near the origin $r=0$ at the
           expense of requiring a smaller Courant factor. Empirically, when this option is
-          set to `True`, a Courant factor of roughly $\min[0.5, 1 / (|m| + 0.5)]$ or
+          set to `True`, a Courant factor of roughly $\\min[0.5, 1 / (|m| + 0.5)]$ or
           smaller seems to be needed. Default is `False`, in which case the $D_r$, $D_z$,
           and $B_r$ fields within |*m*| pixels of the origin are forced to zero, which
           usually ensures stability with the default Courant factor of 0.5, at the expense
@@ -991,8 +991,8 @@ class Simulation(object):
         + **`k_point` [`False` or `Vector3`]** — If `False` (the default), then the
           boundaries are perfect metallic (zero electric field). If a `Vector3`, then the
           boundaries are Bloch-periodic: the fields at one side are
-          $\exp(i\mathbf{k}\cdot\mathbf{R})$ times the fields at the other side, separated
-          by the lattice vector $\mathbf{R}$. A non-zero `Vector3` will produce complex
+          $\\exp(i\\mathbf{k}\\cdot\\mathbf{R})$ times the fields at the other side, separated
+          by the lattice vector $\\mathbf{R}$. A non-zero `Vector3` will produce complex
           fields. The `k_point` vector is specified in Cartesian coordinates in units of
           2π/distance. Note: this is *different* from [MPB](https://mpb.readthedocs.io),
           equivalent to taking MPB's `k_points` through its function
@@ -1056,7 +1056,7 @@ class Simulation(object):
           [Courant factor](https://en.wikipedia.org/wiki/Courant%E2%80%93Friedrichs%E2%80%93Lewy_condition)
           $S$ which relates the time step size to the spatial discretization: $cΔ t = SΔ x$.
           Default is 0.5. For numerical stability, the Courant factor must be *at
-          most* $n_\\textrm{min}/\sqrt{\\textrm{# dimensions}}$, where $n_\\textrm{min}$ is
+          most* $n_\\textrm{min}/\\sqrt{\\textrm{# dimensions}}$, where $n_\\textrm{min}$ is
           the minimum refractive index (usually 1), and in practice $S$ should be slightly
           smaller.
 
@@ -1995,7 +1995,7 @@ class Simulation(object):
         Given a frequency `frequency` and a `Vector3` `pt`, returns the average eigenvalue
         of the permittivity tensor at that location and frequency. If `frequency` is
         non-zero, the result is complex valued; otherwise it is the real,
-        frequency-independent part of ε (the $\omega\to\infty$ limit).
+        frequency-independent part of ε (the $\\omega\\to\\infty$ limit).
         """
         v3 = py_v3_to_vec(self.dimensions, pt, self.is_cylindrical)
         if omega != 0:
@@ -2787,9 +2787,11 @@ class Simulation(object):
     def flux_in_box(self, d, box=None, center=None, size=None):
         """
         Given a `direction` constant, and a `mp.Volume`, returns the flux (the integral of
-        $\Re [\mathbf{E}^* \times \mathbf{H}]$) in that volume. Most commonly, you specify
+        $\\Re [\\mathbf{E}^* \\times \\mathbf{H}]$) in that volume. Most commonly, you specify
         a volume that is a plane or a line, and a direction perpendicular to it, e.g.
-        `flux_in_box(d=mp.X,mp.Volume(center=mp.Vector3(0,0,0),size=mp.Vector3(0,1,1)))`.
+
+        `flux_in_box(d=mp.X,mp.Volume(center=mp.Vector3(0,0,0),size=mp.Vector3(0,1,1)))`
+
         If the `center` and `size` arguments are provided instead of `box`, Meep will
         construct the appropriate volume for you.
         """
@@ -2803,13 +2805,13 @@ class Simulation(object):
     def electric_energy_in_box(self, box=None, center=None, size=None):
         """
         Given a `mp.Volume`, returns the integral of the electric-field energy
-        $\mathbf{E}^* \cdot \mathbf{D}/2$ in the given volume. If the volume has zero size
+        $\\mathbf{E}^* \\cdot \\mathbf{D}/2$ in the given volume. If the volume has zero size
         along a dimension, a lower-dimensional integral is used. If the `center` and
         `size` arguments are provided instead of `box`, Meep will construct the
-        appropriate volume for you. Note: in cylindrical coordinates $(r,\phi,z)$, the
+        appropriate volume for you. Note: in cylindrical coordinates $(r,\\phi,z)$, the
         integrand is
         [multiplied](https://en.wikipedia.org/wiki/Cylindrical_coordinate_system#Line_and_volume_elements)
-        by the circumference $2\pi r$, or equivalently the integral is over an annular
+        by the circumference $2\\pi r$, or equivalently the integral is over an annular
         volume.
         """
         if self.fields is None:
@@ -2822,13 +2824,13 @@ class Simulation(object):
     def magnetic_energy_in_box(self, box=None, center=None, size=None):
         """
         Given a `mp.Volume`, returns the integral of the magnetic-field energy
-        $\mathbf{H}^* \cdot \mathbf{B}/2$ in the given volume. If the volume has zero size
+        $\\mathbf{H}^* \\cdot \\mathbf{B}/2$ in the given volume. If the volume has zero size
         along a dimension, a lower-dimensional integral is used. If the `center` and
         `size` arguments are provided instead of `box`, Meep will construct the
-        appropriate volume for you. Note: in cylindrical coordinates $(r,\phi,z)$, the
+        appropriate volume for you. Note: in cylindrical coordinates $(r,\\phi,z)$, the
         integrand is
         [multiplied](https://en.wikipedia.org/wiki/Cylindrical_coordinate_system#Line_and_volume_elements)
-        by the circumference $2\pi r$, or equivalently the integral is over an annular
+        by the circumference $2\\pi r$, or equivalently the integral is over an annular
         volume.
         """
         if self.fields is None:
@@ -2841,13 +2843,13 @@ class Simulation(object):
     def field_energy_in_box(self, box=None, center=None, size=None):
         """
         Given a `mp.Volume`, returns the integral of the electric- and magnetic-field
-        energy $\mathbf{E}^* \cdot \mathbf{D}/2 + \mathbf{H}^* \cdot \mathbf{B}/2$ in the
+        energy $\\mathbf{E}^* \\cdot \\mathbf{D}/2 + \\mathbf{H}^* \\cdot \\mathbf{B}/2$ in the
         given volume. If the volume has zero size along a dimension, a lower-dimensional
         integral is used. If the `center` and `size` arguments are provided instead of
         `box`, Meep will construct the appropriate volume for you. Note: in cylindrical
-        coordinates $(r,\phi,z)$, the integrand is
+        coordinates $(r,\\phi,z)$, the integrand is
         [multiplied](https://en.wikipedia.org/wiki/Cylindrical_coordinate_system#Line_and_volume_elements)
-        by the circumference $2\pi r$, or equivalently the integral is over an annular
+        by the circumference $2\\pi r$, or equivalently the integral is over an annular
         volume.
         """
         if self.fields is None:
@@ -2875,8 +2877,8 @@ class Simulation(object):
         `Simulation.total_volume()`.
 
         One versatile feature is that you can supply an arbitrary function
-        $f(\mathbf{x},c_1,c_2,\ldots)$ of position $\mathbf{x}$ and various field
-        components $c_1,\ldots$ and ask Meep to integrate it over a given volume, find its
+        $f(\\mathbf{x},c_1,c_2,\\ldots)$ of position $\\mathbf{x}$ and various field
+        components $c_1,\\ldots$ and ask Meep to integrate it over a given volume, find its
         maximum, or output it (via `output_field_function`, described later). This is done
         via the functions:
         """
@@ -3127,14 +3129,14 @@ class Simulation(object):
         + `w` is an array of the same dimensions as the array returned by
           `get_array`/`get_dft_array`, whose entries are the weights in a cubature rule
           for integrating over the spatial region (with the points in the cubature rule
-          being just the grid points contained in the region). Thus, if $Q(\mathbf{x})$ is
+          being just the grid points contained in the region). Thus, if $Q(\\mathbf{x})$ is
           some spatially-varying quantity whose value at the $n$th grid point is $Q_n$,
           the integral of $Q$ over the region may be approximated by the sum:
 
-        $$ \int_{\mathcal V} Q(\mathbf{x})d\mathbf{x} \approx \sum_{n} w_n Q_n.$$
+        $$ \\int_{\\mathcal V} Q(\\mathbf{x})d\\mathbf{x} \\approx \\sum_{n} w_n Q_n.$$
 
         This is a 1-, 2-, or 3-dimensional integral depending on the number of dimensions
-        in which $\mathcal{V}$ has zero extent. If the $\{Q_n\}$ samples are stored in an
+        in which $\\mathcal{V}$ has zero extent. If the $\\{Q_n\\}$ samples are stored in an
         array `Q` of the same dimensions as `w`, then evaluating the sum on the RHS is
         just one line: `np.sum(w*Q).`
 
@@ -3298,9 +3300,9 @@ class Simulation(object):
         If any dimension of `where` is zero, that dimension is not integrated over. In
         this way you can specify 1d, 2d, or 3d integrals.
 
-        Note: in cylindrical coordinates $(r,\phi,z)$, the integrand is
+        Note: in cylindrical coordinates $(r,\\phi,z)$, the integrand is
         [multiplied](https://en.wikipedia.org/wiki/Cylindrical_coordinate_system#Line_and_volume_elements)
-        by the circumference $2\pi r$, or equivalently the integral is over an annular
+        by the circumference $2\\pi r$, or equivalently the integral is over an annular
         volume.
         """
         where = self._get_field_function_volume(where, center, size)
@@ -3719,7 +3721,7 @@ class Simulation(object):
             - `post_process=np.real`: post processing function to apply to fields (must be
               a function object)
         * `frequency`: for materials with a [frequency-dependent
-          permittivity](Materials.md#material-dispersion) $\varepsilon(f)$, specifies the
+          permittivity](Materials.md#material-dispersion) $\\varepsilon(f)$, specifies the
           frequency $f$ (in Meep units) of the real part of the permittivity to use in the
           plot. Defaults to the `frequency` parameter of the [Source](#source) object.
 
@@ -4256,7 +4258,7 @@ def output_epsilon(sim,*step_func_args,**kwargs):
     permittivity); for an anisotropic ε tensor the output is the [harmonic
     mean](https://en.wikipedia.org/wiki/Harmonic_mean) of the ε eigenvalues. If
     `frequency` is non-zero, the output is complex; otherwise it is the real,
-    frequency-independent part of ε (the $\omega\to\infty$ limit).
+    frequency-independent part of ε (the $\\omega\\to\\infty$ limit).
     """
     frequency = kwargs.pop('frequency', 0.0)
     omega = kwargs.pop('omega', 0.0)
@@ -4272,7 +4274,7 @@ def output_mu(sim,*step_func_args,**kwargs):
     permeability); for an anisotropic μ tensor the output is the [harmonic
     mean](https://en.wikipedia.org/wiki/Harmonic_mean) of the μ eigenvalues. If
     `frequency` is non-zero, the output is complex; otherwise it is the real,
-    frequency-independent part of μ (the $\omega\to\infty$ limit).
+    frequency-independent part of μ (the $\\omega\\to\\infty$ limit).
     """
     frequency = kwargs.pop('frequency', 0.0)
     omega = kwargs.pop('omega', 0.0)
@@ -4284,14 +4286,14 @@ def output_mu(sim,*step_func_args,**kwargs):
 
 def output_hpwr(sim):
     """
-    Output the magnetic-field energy density $\mathbf{H}^* \cdot \mathbf{B} / 2$
+    Output the magnetic-field energy density $\\mathbf{H}^* \\cdot \\mathbf{B} / 2$
     """
     sim.output_component(mp.H_EnergyDensity)
 
 
 def output_dpwr(sim):
     """
-    Output the electric-field energy density $\mathbf{E}^* \cdot \mathbf{D} / 2$
+    Output the electric-field energy density $\\mathbf{E}^* \\cdot \\mathbf{D} / 2$
     """
     sim.output_component(mp.D_EnergyDensity)
 
@@ -4352,7 +4354,7 @@ def output_hfield_r(sim):
 
 def output_hfield_p(sim):
     """
-    Output the $\phi$ component of the field *h* (magnetic). If the field is complex,
+    Output the $\\phi$ component of the field *h* (magnetic). If the field is complex,
     outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
     and imaginary parts, respectively.
     """
@@ -4405,7 +4407,7 @@ def output_bfield_r(sim):
 
 def output_bfield_p(sim):
     """
-    Output the $\phi$ component of the field *b* (magnetic). If the field is complex,
+    Output the $\\phi$ component of the field *b* (magnetic). If the field is complex,
     outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
     and imaginary parts, respectively. Note that for outputting the Poynting flux, you
     might want to wrap the step function in `synchronized_magnetic` to compute it more
@@ -4461,7 +4463,7 @@ def output_efield_r(sim):
 
 def output_efield_p(sim):
     """
-    Output the $\phi$ component of the field *e* (electric). If the field is complex,
+    Output the $\\phi$ component of the field *e* (electric). If the field is complex,
     outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
     and imaginary parts, respectively. Note that for outputting the Poynting flux, you
     might want to wrap the step function in `synchronized_magnetic` to compute it more
@@ -4517,7 +4519,7 @@ def output_dfield_r(sim):
 
 def output_dfield_p(sim):
     """
-    Output the $\phi$ component of the field *d* (displacement). If the field is complex,
+    Output the $\\phi$ component of the field *d* (displacement). If the field is complex,
     outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
     and imaginary parts, respectively. Note that for outputting the Poynting flux, you
     might want to wrap the step function in `synchronized_magnetic` to compute it more
@@ -4530,7 +4532,7 @@ def output_dfield_p(sim):
 # MPB compatibility
 def output_poynting(sim):
     """
-    Output the Poynting flux $\mathrm{Re}\{\mathbf{E}^*\times\mathbf{H}\}$. Note that you
+    Output the Poynting flux $\\mathrm{Re}\\{\\mathbf{E}^*\\times\\mathbf{H}\\}$. Note that you
     might want to wrap this step function in `synchronized_magnetic` to compute it more
     accurately. See [Synchronizing the Magnetic and Electric
     Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
@@ -4607,7 +4609,7 @@ def output_sfield_r(sim):
 
 def output_sfield_p(sim):
     """
-    Output the $\phi$ component of the field *s* (poynting flux). If the field is complex,
+    Output the $\\phi$ component of the field *s* (poynting flux). If the field is complex,
     outputs two datasets, e.g. `ex.r` and `ex.i`, within the same HDF5 file for the real
     and imaginary parts, respectively. Note that for outputting the Poynting flux, you
     might want to wrap the step function in `synchronized_magnetic` to compute it more

--- a/python/source.py
+++ b/python/source.py
@@ -117,12 +117,10 @@ class Source(object):
 
 class SourceTime(object):
     """
-    TODO:
+    This is the parent for classes describing the time dependence of sources; it should
+    not be instantiated directly.
     """
     def __init__(self, is_integrated=False):
-        """
-        TODO:
-        """
         self.is_integrated = is_integrated
 
 

--- a/python/source.py
+++ b/python/source.py
@@ -18,8 +18,8 @@ class Source(object):
     """
     The `Source` class is used to specify the current sources via the `Simulation.sources`
     attribute. Note that all sources in Meep are separable in time and space, i.e. of the
-    form $\mathbf{J}(\mathbf{x},t) = \mathbf{A}(\mathbf{x}) \cdot f(t)$ for some functions
-    $\mathbf{A}$ and $f$. Non-separable sources can be simulated, however, by modifying
+    form $\\mathbf{J}(\\mathbf{x},t) = \\mathbf{A}(\\mathbf{x}) \\cdot f(t)$ for some functions
+    $\\mathbf{A}$ and $f$. Non-separable sources can be simulated, however, by modifying
     the sources after each time step. When real fields are being used (which is the
     default in many cases; see `Simulation.force_complex_fields`), only the real part of
     the current source is used.
@@ -126,7 +126,7 @@ class SourceTime(object):
 
 class ContinuousSource(SourceTime):
     """
-    A continuous-wave (CW) source is proportional to $\exp(-i\omega t)$, possibly with a
+    A continuous-wave (CW) source is proportional to $\\exp(-i\\omega t)$, possibly with a
     smooth (exponential/tanh) turn-on/turn-off. In practice, the CW source [never produces
     an exact single-frequency
     response](FAQ.md#why-doesnt-the-continuous-wave-cw-source-produce-an-exact-single-frequency-response).
@@ -185,9 +185,9 @@ class ContinuousSource(SourceTime):
 
 class GaussianSource(SourceTime):
     """
-    A Gaussian-pulse source roughly proportional to $\exp(-i\omega t - (t-t_0)^2/2w^2)$.
+    A Gaussian-pulse source roughly proportional to $\\exp(-i\\omega t - (t-t_0)^2/2w^2)$.
     Technically, the "Gaussian" sources in Meep are the (discrete-time) derivative of a
-    Gaussian, i.e. they are $(-i\omega)^{-1} \frac{\partial}{\partial t} \exp(-i\omega t -
+    Gaussian, i.e. they are $(-i\\omega)^{-1} \\frac{\\partial}{\\partial t} \\exp(-i\\omega t -
     (t-t_0)^2/2w^2)$, but the difference between this and a true Gaussian is usually
     irrelevant.
     """
@@ -226,13 +226,13 @@ class GaussianSource(SourceTime):
         + **`fourier_transform(f)`** — Returns the Fourier transform of the current
           evaluated at frequency `f` (`ω=2πf`) given by:
           $$
-          \widetilde G(\omega) \equiv \frac{1}{\sqrt{2\pi}}
-          \int e^{i\omega t}G(t)\,dt \equiv
-          \frac{1}{\Delta f}
-          e^{i\omega t_0 -\frac{(\omega-\omega_0)^2}{2\Delta f^2}}
+          \\widetilde G(\\omega) \\equiv \\frac{1}{\\sqrt{2\\pi}}
+          \\int e^{i\\omega t}G(t)\\,dt \\equiv
+          \\frac{1}{\\Delta f}
+          e^{i\\omega t_0 -\\frac{(\\omega-\\omega_0)^2}{2\\Delta f^2}}
           $$
-          where $G(t)$ is the current (not the dipole moment). In this formula, $\Delta f$
-          is the `fwidth` of the source, $\omega_0$ is $2\pi$ times its `frequency,` and
+          where $G(t)$ is the current (not the dipole moment). In this formula, $\\Delta f$
+          is the `fwidth` of the source, $\\omega_0$ is $2\\pi$ times its `frequency,` and
           $t_0$ is the peak time discussed above. Note that this does not include any
           `amplitude` or `amp_func` factor that you specified for the source.
         """
@@ -275,7 +275,7 @@ class CustomSource(SourceTime):
           complex number.
 
         + **`start_time` [`number`]** — The starting time for the source. Default is
-          -10<sup>20</sup>: turn on at $t=-\infty$. Note, however, that the simulation
+          -10<sup>20</sup>: turn on at $t=-\\infty$. Note, however, that the simulation
           normally starts at $t=0$ with zero fields as the initial condition, so there is
           implicitly a sharp turn-on at $t=0$ whether you specify it or not.
 
@@ -308,7 +308,7 @@ class EigenModeSource(Source):
     This is a subclass of `Source` and has **all of the properties** of `Source` above.
     However, you normally do not specify a `component`. Instead of `component`, the
     current source components and amplitude profile are computed by calling MPB to compute
-    the modes, $\mathbf{u}_{n,\mathbf{k}}(\mathbf{r}) e^{i \mathbf{k} \cdot \mathbf{r}}$,
+    the modes, $\\mathbf{u}_{n,\\mathbf{k}}(\\mathbf{r}) e^{i \\mathbf{k} \\cdot \\mathbf{r}}$,
     of the dielectric profile in the region given by the `size` and `center` of the
     source, with the modes computed as if the *source region were repeated periodically in
     all directions*. If an `amplitude` and/or `amp_func` are supplied, they are
@@ -316,7 +316,7 @@ class EigenModeSource(Source):
     specified by the properties shown in `__init__`.
 
     Eigenmode sources are normalized so that in the case of a time-harmonic simulation
-    with all sources and fields having monochromatic time dependence $e^{-i 2\pi f_m t}$
+    with all sources and fields having monochromatic time dependence $e^{-i 2\\pi f_m t}$
     where $f_m$ is the frequency of the eigenmode, the total time-average power of the
     fields — the integral of the normal Poynting vector over the entire cross-sectional
     line or plane — is equal to 1. This convention has two use cases:
@@ -327,15 +327,15 @@ class EigenModeSource(Source):
 
     + For time-domain calculations involving a time dependence $W(t)$ which is typically a
       [Gaussian](#gaussiansource), the amplitude of the fields at frequency $f$ will be
-      multiplied by $\widetilde W(f)$, the Fourier transform of $W(t)$, while
+      multiplied by $\\widetilde W(f)$, the Fourier transform of $W(t)$, while
       field-bilinear quantities like the [Poynting flux](#flux-spectra) and [energy
-      density](#energy-density-spectra) are multiplied by $|\widetilde W(f)|^2$. For the
+      density](#energy-density-spectra) are multiplied by $|\\widetilde W(f)|^2$. For the
       particular case of a Gaussian time dependence, the Fourier transform at $f$ can be
       obtained via the `fourier_transform` class method.
 
     In either case, the `eig_power` method returns the total power at frequency `f`.
     However, for a user-defined [`CustomSource`](#customsource), `eig_power` will *not*
-    include the $|\widetilde W(f)|^2$ factor since Meep does not know the Fourier
+    include the $|\\widetilde W(f)|^2$ factor since Meep does not know the Fourier
     transform of your source function $W(t)$. You will have to multiply by this yourself
     if you need it.
 
@@ -402,8 +402,8 @@ class EigenModeSource(Source):
           regardless of `eig_kpoint`. Note that once **k** is either found by MPB, or
           specified by `eig_kpoint`, the field profile used to create the current sources
           corresponds to the [Bloch mode](https://en.wikipedia.org/wiki/Bloch_wave),
-          $\mathbf{u}_{n,\mathbf{k}}(\mathbf{r})$, multiplied by the appropriate
-          exponential factor, $e^{i \mathbf{k} \cdot \mathbf{r}}$.
+          $\\mathbf{u}_{n,\\mathbf{k}}(\\mathbf{r})$, multiplied by the appropriate
+          exponential factor, $e^{i \\mathbf{k} \\cdot \\mathbf{r}}$.
 
         + **`eig_parity` [`mp.NO_PARITY` (default), `mp.EVEN_Z`, `mp.ODD_Z`, `mp.EVEN_Y`,
           `mp.ODD_Y`]** — The parity (= polarization in 2d) of the mode to calculate,


### PR DESCRIPTION
* Adds a docstring for SourceTime
* Escape all backslashes in docstrings

@stevengj, I suggest merging this asap in order to get the corrected formulas pushed out to readthedocs. I'll do the other changes discussed in the meeting in a separate PR.