### PR TITLE
More python doc updates

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -10,6 +10,17 @@ install `mkdocs` as well as two auxiliary packages via e.g.:
 % pip3 install --user mkdocs python-markdown-math mkdocs-material
 ```
 
+The main Python API document (`Python_User_Interface.md`) is generated from a
+template file (named the same, with a `.in` extension), and the docstrings
+located in the Python source code. Changes or additions for any text that is not
+part of a docstring should be added or edited in the
+`Python_User_Interface.md.in` file. Anything that is specifically about a
+function, class or method should be documented in the docstring for that
+function, class or method. The docstrings are expected to use MarkDown
+formatting. To control where the docstrings are inserted into the documentation
+a simple tagging system is used. See the documentation in the
+`doc/generate_py_api.py` file for details.
+
 To (re)generate the Python API documentation (extracted from the docstrings)
 run the following command in the project root folder. Note that this requires
 that the Python extension for the meep library has been built:
@@ -18,10 +29,12 @@ that the Python extension for the meep library has been built:
 % PYTHONPATH=./python python doc/generate_py_api.py
 ```
 
-Rerun this after making any changes to the docstrings in the source and
-rebuilding the project, in order to update the documentation.
+Note that this command should be rerun after making any changes to main template
+file or the docstrings in the source, and rebuilding the project, in order to
+update the documentation.
 
-Next, run the following command from the top-level MEEP repository tree:
+The view an auto-updating version of the documentation, run the following
+command from the top-level MEEP repository tree:
 
 ```
 % mkdocs serve
@@ -36,7 +49,7 @@ rebuilding the documentation tree automatically whenever any .md file is
 modified. This enables viewing the HTML documentation in real time as the
 source files are edited.
 
-To build the HTML version of the documentation, run:
+To build the static HTML version of the documentation, run:
 
 ```
 % mkdocs build

--- a/doc/README.md
+++ b/doc/README.md
@@ -21,9 +21,30 @@ formatting. To control where the docstrings are inserted into the documentation
 a simple tagging system is used. See the documentation in the
 `doc/generate_py_api.py` file for details.
 
+If a docstring contains an "alternate function signature", usually to make
+functions that accept a variety of positional or keyword arguments more clear to
+the reader. Functions that fall into this category typically use Python's `*` or
+`**` syntax. These lines can be tagged to indicate to the tool that they should
+be moved or copied to the code block in the documentation where they function
+signature is declared.  For example:
+
+```python
+    def add_flux(self, *args):
+        """
+        `add_flux(fcen, df, nfreq, freq, FluxRegions...)` ##sig
+
+        ...
+        """
+```
+
+Notice the use of  the `##sig` tag at the end of the line. If the alternate
+signature is located in the middle of the docstring, and needs to remain there,
+then the `##sig-keep` tag can be used instead. For an example of this usage, see
+the `Simulation.run` method.
+
 To (re)generate the Python API documentation (extracted from the docstrings)
 run the following command in the project root folder. Note that this requires
-that the Python extension for the meep library has been built:
+that the Python extension for the meep library has been built and is importable:
 
 ```
 % PYTHONPATH=./python python doc/generate_py_api.py

--- a/doc/_api_snippets/function_template.md
+++ b/doc/_api_snippets/function_template.md
@@ -2,7 +2,7 @@
 <a id="{function_name}"></a>
 
 ```python
-def {function_name}{parameters}:
+def {function_name}{parameters}: {other_signatures}
 ```
 
 <div class="function_docstring" markdown="1">

--- a/doc/_api_snippets/method_template.md
+++ b/doc/_api_snippets/method_template.md
@@ -4,7 +4,7 @@
 <div class="class_members" markdown="1">
 
 ```python
-def {method_name}{parameters}:
+def {method_name}{parameters}: {other_signatures}
 ```
 
 <div class="method_docstring" markdown="1">

--- a/doc/docs/Python_Tutorials/Basics.md
+++ b/doc/docs/Python_Tutorials/Basics.md
@@ -1000,7 +1000,7 @@ plt.savefig('power_density_map.png',dpi=150,bbox_inches='tight')
 
 There is one important item to note: in order to eliminate discretization artifacts when computing the $\mathbf{E}^* \cdot \mathbf{D}$ dot-product, the `add_dft_fields` definition includes `yee_grid=True` which ensures that the $E_z$ and $D_z$ fields are computed on the Yee grid rather than interpolated to the centered grid. As a corollary, we cannot use [`get_array_metadata`](../Python_User_Interface.md#array-metadata) to obtain the coordinates of the `dft_fields` region or its interpolation weights because this involves the centered grid.
 
-A schematic of the simulation layout generated using [`plot2D`](Python_User_Interface.md#data-visualization) shows the line source (red), PMLs (green hatch region), `dft_flux` box (solid blue contour line), and `dft_fields` surface (blue hatch region).
+A schematic of the simulation layout generated using [`plot2D`](../Python_User_Interface.md#data-visualization) shows the line source (red), PMLs (green hatch region), `dft_flux` box (solid blue contour line), and `dft_fields` surface (blue hatch region).
 
 <center>
 ![](../images/power_density_cell.png)

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -127,7 +127,7 @@ def __init__(self,
              force_all_components=False,
              split_chunks_evenly=True,
              chunk_layout=None,
-             collect_stats=False):
+             collect_stats=False): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -368,7 +368,9 @@ use. See also [SWIG Wrappers](#swig-wrappers).
 <div class="class_members" markdown="1">
 
 ```python
-def run(self, *step_funcs, **kwargs):
+def run(self, *step_funcs, **kwargs): 
+def run(step_functions..., until=condition/time):
+def run(step_functions..., until_after_sources=condition/time):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -411,7 +413,7 @@ or set the output folder, with these methods of the `Simulation` class:
 <div class="class_members" markdown="1">
 
 ```python
-def get_filename_prefix(self):
+def get_filename_prefix(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -434,7 +436,7 @@ by calling `Simulation.use_output_directory([dirname])`
 <div class="class_members" markdown="1">
 
 ```python
-def use_output_directory(self, dname=''):
+def use_output_directory(self, dname=''): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -459,7 +461,7 @@ The `Simulation` class provides the following time-related methods:
 <div class="class_members" markdown="1">
 
 ```python
-def meep_time(self):
+def meep_time(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -483,7 +485,7 @@ rounded to single precision.
 <div class="class_members" markdown="1">
 
 ```python
-def print_times(self):
+def print_times(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -510,7 +512,7 @@ Field time usage:
 <div class="class_members" markdown="1">
 
 ```python
-def time_spent_on(self, time_sink):
+def time_spent_on(self, time_sink): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -530,7 +532,7 @@ other.
 <div class="class_members" markdown="1">
 
 ```python
-def mean_time_spent_on(self, time_sink):
+def mean_time_spent_on(self, time_sink): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -556,7 +558,7 @@ Meep supports a large number of functions to perform computations on the fields.
 <div class="class_members" markdown="1">
 
 ```python
-def set_boundary(self, side, direction, condition):
+def set_boundary(self, side, direction, condition): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -574,7 +576,7 @@ section for valid `side`, `direction`, and `boundary_condition` values.
 <div class="class_members" markdown="1">
 
 ```python
-def phase_in_material(self, structure, time):
+def phase_in_material(self, structure, time): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -600,7 +602,7 @@ simulation script is in
 <div class="class_members" markdown="1">
 
 ```python
-def get_field_point(self, c, pt):
+def get_field_point(self, c, pt): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -617,7 +619,7 @@ returns the value of that component at that point.
 <div class="class_members" markdown="1">
 
 ```python
-def get_epsilon_point(self, pt, frequency=0, omega=0):
+def get_epsilon_point(self, pt, frequency=0, omega=0): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -636,7 +638,7 @@ frequency-independent part of ε (the $\omega\to\infty$ limit).
 <div class="class_members" markdown="1">
 
 ```python
-def initialize_field(self, cmpnt, amp_func):
+def initialize_field(self, cmpnt, amp_func): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -654,10 +656,12 @@ of the field at that point.
 <div class="class_members" markdown="1">
 
 ```python
-def add_dft_fields(self, *args, **kwargs):
+def add_dft_fields(self, *args, **kwargs): 
+def add_dft_fields(cs, fcen, df, nfreq, freq, where=None, center=None, size=None, yee_grid=False):
 ```
 
 <div class="method_docstring" markdown="1">
+
 
 Given a list of field components `cs`, compute the Fourier transform of these
 fields for `nfreq` equally spaced frequencies covering the frequency range
@@ -678,7 +682,7 @@ fields evaluated at each corresponding Yee grid point is available by setting
 <div class="class_members" markdown="1">
 
 ```python
-def flux_in_box(self, d, box=None, center=None, size=None):
+def flux_in_box(self, d, box=None, center=None, size=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -701,7 +705,7 @@ construct the appropriate volume for you.
 <div class="class_members" markdown="1">
 
 ```python
-def electric_energy_in_box(self, box=None, center=None, size=None):
+def electric_energy_in_box(self, box=None, center=None, size=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -725,7 +729,7 @@ volume.
 <div class="class_members" markdown="1">
 
 ```python
-def magnetic_energy_in_box(self, box=None, center=None, size=None):
+def magnetic_energy_in_box(self, box=None, center=None, size=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -749,7 +753,7 @@ volume.
 <div class="class_members" markdown="1">
 
 ```python
-def field_energy_in_box(self, box=None, center=None, size=None):
+def field_energy_in_box(self, box=None, center=None, size=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -773,7 +777,7 @@ volume.
 <div class="class_members" markdown="1">
 
 ```python
-def modal_volume_in_box(self, box=None, center=None, size=None):
+def modal_volume_in_box(self, box=None, center=None, size=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -813,7 +817,7 @@ def integrate_field_function(self,
                              func,
                              where=None,
                              center=None,
-                             size=None):
+                             size=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -847,7 +851,7 @@ def max_abs_field_function(self,
                            func,
                            where=None,
                            center=None,
-                           size=None):
+                           size=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -885,7 +889,7 @@ def integrate2_field_function(self,
                               func,
                               where=None,
                               center=None,
-                              size=None):
+                              size=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -933,7 +937,7 @@ Once the fields/simulation have been initialized, you can change the values of v
 <div class="class_members" markdown="1">
 
 ```python
-def reset_meep(self):
+def reset_meep(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -950,7 +954,7 @@ memory as if you had not run any computations.
 <div class="class_members" markdown="1">
 
 ```python
-def restart_fields(self):
+def restart_fields(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -967,7 +971,7 @@ transforms of the flux planes, which continue to be accumulated.
 <div class="class_members" markdown="1">
 
 ```python
-def change_k_point(self, k):
+def change_k_point(self, k): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -983,7 +987,7 @@ Change the `k_point` (the Bloch periodicity).
 <div class="class_members" markdown="1">
 
 ```python
-def change_sources(self, new_sources):
+def change_sources(self, new_sources): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1001,7 +1005,7 @@ the sources used for the current simulation. `new_sources` must be a list of
 <div class="class_members" markdown="1">
 
 ```python
-def set_materials(self, geometry=None, default_material=None):
+def set_materials(self, geometry=None, default_material=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1024,10 +1028,12 @@ Given a bunch of [`FluxRegion`](#fluxregion) objects, you can tell Meep to accum
 <div class="class_members" markdown="1">
 
 ```python
-def add_flux(self, *args):
+def add_flux(self, *args): 
+def add_flux(fcen, df, nfreq, freq, FluxRegions...):
 ```
 
 <div class="method_docstring" markdown="1">
+
 
 Add a bunch of `FluxRegion`s to the current simulation (initializing the fields if
 they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -1056,7 +1062,7 @@ Once you have called `add_flux`, the Fourier transforms of the fields are accumu
 <div class="class_members" markdown="1">
 
 ```python
-def display_fluxes(self, *fluxes):
+def display_fluxes(self, *fluxes): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1077,7 +1083,7 @@ You might have to do something lower-level if you have multiple flux regions cor
 <a id="get_flux_freqs"></a>
 
 ```python
-def get_flux_freqs(f):
+def get_flux_freqs(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1090,7 +1096,7 @@ spectrum for.
 <a id="get_fluxes"></a>
 
 ```python
-def get_fluxes(f):
+def get_fluxes(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1108,7 +1114,7 @@ As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md
 <div class="class_members" markdown="1">
 
 ```python
-def save_flux(self, fname, flux):
+def save_flux(self, fname, flux): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1126,7 +1132,7 @@ filename-prefix is prepended automatically).
 <div class="class_members" markdown="1">
 
 ```python
-def load_flux(self, fname, flux):
+def load_flux(self, fname, flux): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1147,7 +1153,7 @@ processors.
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_flux(self, fname, flux):
+def load_minus_flux(self, fname, flux): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1168,7 +1174,7 @@ Sometimes it is more convenient to keep the Fourier-transformed fields in memory
 <div class="class_members" markdown="1">
 
 ```python
-def get_flux_data(self, flux):
+def get_flux_data(self, flux): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1186,7 +1192,7 @@ only useful for passing to `load_flux_data` below and should be considered opaqu
 <div class="class_members" markdown="1">
 
 ```python
-def load_flux_data(self, flux, fdata):
+def load_flux_data(self, flux, fdata): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1205,7 +1211,7 @@ object that was created by `get_flux_data` in a simulation of the same dimension
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_flux_data(self, flux, fdata):
+def load_minus_flux_data(self, flux, fdata): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1247,7 +1253,7 @@ def get_eigenmode_coefficients(self,
                                eig_resolution=0,
                                eig_tolerance=1e-12,
                                kpoint_func=None,
-                               direction=-1):
+                               direction=-1): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1282,10 +1288,12 @@ Technically, MPB computes `ωₙ(k)` and then inverts it with Newton's method to
 <div class="class_members" markdown="1">
 
 ```python
-def add_mode_monitor(self, *args):
+def add_mode_monitor(self, *args): 
+def add_mode_monitor(fcen, df, nfreq, freq, ModeRegions...):
 ```
 
 <div class="method_docstring" markdown="1">
+
 
 Similar to `add_flux`, but for use with `get_eigenmode_coefficients`.
 
@@ -1311,7 +1319,7 @@ def get_eigenmode(self,
                   match_frequency=True,
                   parity=0,
                   resolution=0,
-                  eigensolver_tol=1e-12):
+                  eigensolver_tol=1e-12): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1345,7 +1353,7 @@ The following top-level function is also available:
 <a id="get_eigenmode_freqs"></a>
 
 ```python
-def get_eigenmode_freqs(f):
+def get_eigenmode_freqs(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1371,12 +1379,12 @@ The usage is similar to the flux spectra: you define a set of [`EnergyRegion`](#
 <div class="class_members" markdown="1">
 
 ```python
-def add_energy(self, *args):
+def add_energy(self, *args): 
+def add_energy(fcen, df, nfreq, freq, EnergyRegions...):
 ```
 
 <div class="method_docstring" markdown="1">
 
-`add_energy(fcen, df, nfreq, freq, EnergyRegions...)`
 
 Add a bunch of `EnergyRegion`s to the current simulation (initializing the fields
 if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -1405,7 +1413,7 @@ Once you have called `add_energy`, the Fourier transforms of the fields are accu
 <div class="class_members" markdown="1">
 
 ```python
-def display_electric_energy(self, *energys):
+def display_electric_energy(self, *energys): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1425,7 +1433,7 @@ column are the frequencies, and subsequent columns are the energy density spectr
 <div class="class_members" markdown="1">
 
 ```python
-def display_magnetic_energy(self, *energys):
+def display_magnetic_energy(self, *energys): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1445,7 +1453,7 @@ column are the frequencies, and subsequent columns are the energy density spectr
 <div class="class_members" markdown="1">
 
 ```python
-def display_total_energy(self, *energys):
+def display_total_energy(self, *energys): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1467,7 +1475,7 @@ You might have to do something lower-level if you have multiple energy regions c
 <a id="get_energy_freqs"></a>
 
 ```python
-def get_energy_freqs(f):
+def get_energy_freqs(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1480,7 +1488,7 @@ spectrum for.
 <a id="get_electric_energy"></a>
 
 ```python
-def get_electric_energy(f):
+def get_electric_energy(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1493,7 +1501,7 @@ electric fields that it has accumulated.
 <a id="get_magnetic_energy"></a>
 
 ```python
-def get_magnetic_energy(f):
+def get_magnetic_energy(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1506,7 +1514,7 @@ magnetic fields that it has accumulated.
 <a id="get_total_energy"></a>
 
 ```python
-def get_total_energy(f):
+def get_total_energy(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1524,7 +1532,7 @@ As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md
 <div class="class_members" markdown="1">
 
 ```python
-def save_energy(self, fname, energy):
+def save_energy(self, fname, energy): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1542,7 +1550,7 @@ filename-prefix is prepended automatically).
 <div class="class_members" markdown="1">
 
 ```python
-def load_energy(self, fname, energy):
+def load_energy(self, fname, energy): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1563,7 +1571,7 @@ processors.
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_energy(self, fname, energy):
+def load_minus_energy(self, fname, energy): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1597,12 +1605,12 @@ The usage is similar to the [flux spectra](Python_Tutorials/Basics.md#transmitta
 <div class="class_members" markdown="1">
 
 ```python
-def add_force(self, *args):
+def add_force(self, *args): 
+def add_force(fcen, df, nfreq, freq, ForceRegions...):
 ```
 
 <div class="method_docstring" markdown="1">
 
-`add_force(fcen, df, nfreq, freq, ForceRegions...)`
 
 Add a bunch of `ForceRegion`s to the current simulation (initializing the fields
 if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -1631,7 +1639,7 @@ Once you have called `add_force`, the Fourier transforms of the fields are accum
 <div class="class_members" markdown="1">
 
 ```python
-def display_forces(self, *forces):
+def display_forces(self, *forces): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1653,7 +1661,7 @@ You might have to do something lower-level if you have multiple force regions co
 <a id="get_force_freqs"></a>
 
 ```python
-def get_force_freqs(f):
+def get_force_freqs(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1666,7 +1674,7 @@ spectrum for.
 <a id="get_forces"></a>
 
 ```python
-def get_forces(f):
+def get_forces(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1685,7 +1693,7 @@ As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md
 <div class="class_members" markdown="1">
 
 ```python
-def save_force(self, fname, force):
+def save_force(self, fname, force): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1703,7 +1711,7 @@ filename-prefix is prepended automatically).
 <div class="class_members" markdown="1">
 
 ```python
-def load_force(self, fname, force):
+def load_force(self, fname, force): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1724,7 +1732,7 @@ processors.
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_force(self, fname, force):
+def load_minus_force(self, fname, force): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1745,7 +1753,7 @@ To keep the fields in memory and avoid writing to and reading from a file, use t
 <div class="class_members" markdown="1">
 
 ```python
-def get_force_data(self, force):
+def get_force_data(self, force): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1764,7 +1772,7 @@ opaque.
 <div class="class_members" markdown="1">
 
 ```python
-def load_force_data(self, force, fdata):
+def load_force_data(self, force, fdata): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1783,7 +1791,7 @@ object that was created by `get_force_data` in a simulation of the same dimensio
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_force_data(self, force, fdata):
+def load_minus_force_data(self, force, fdata): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1804,12 +1812,12 @@ Meep can also calculate the LDOS (local density of states) spectrum, as describe
 <a id="Ldos"></a>
 
 ```python
-def Ldos(*args):
+def Ldos(*args): 
+def Ldos(fcen, df, nfreq, freq):
 ```
 
 <div class="function_docstring" markdown="1">
 
-`Ldos(fcen, df, nfreq, freq)`
 
 Create an LDOS object with either frequency bandwidth `df` centered at `fcen` and
 `nfreq` equally spaced frequency points or an array/list `freq` for arbitrarily spaced
@@ -1821,7 +1829,7 @@ argument.
 <a id="get_ldos_freqs"></a>
 
 ```python
-def get_ldos_freqs(l):
+def get_ldos_freqs(l): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1834,12 +1842,12 @@ spectrum for.
 <a id="dft_ldos"></a>
 
 ```python
-def dft_ldos(*args, **kwargs):
+def dft_ldos(*args, **kwargs): 
+def dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None):
 ```
 
 <div class="function_docstring" markdown="1">
 
-`dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)`
 
 Compute the power spectrum of the sources (usually a single point dipole source),
 normalized to correspond to the LDOS, in either a frequency bandwidth `df` centered at
@@ -1876,12 +1884,12 @@ There are three steps to using the near-to-far-field feature: first, define the 
 <div class="class_members" markdown="1">
 
 ```python
-def add_near2far(self, *args, **kwargs):
+def add_near2far(self, *args, **kwargs): 
+def add_near2far(fcen, df, nfreq, freq, Near2FarRegions..., nperiods=1):
 ```
 
 <div class="method_docstring" markdown="1">
 
-add_near2far(fcen, df, nfreq, freq, Near2FarRegions..., nperiods=1)
 
 Add a bunch of `Near2FarRegion`s to the current simulation (initializing the
 fields if they have not yet been initialized), telling Meep to accumulate the
@@ -1906,7 +1914,7 @@ If you have Bloch-periodic boundary conditions, then the corresponding near-to-f
 <div class="class_members" markdown="1">
 
 ```python
-def get_farfield(self, near2far, x):
+def get_farfield(self, near2far, x): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1933,7 +1941,7 @@ def output_farfields(self,
                      resolution,
                      where=None,
                      center=None,
-                     size=None):
+                     size=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1963,7 +1971,7 @@ def get_farfields(self,
                   resolution,
                   where=None,
                   center=None,
-                  size=None):
+                  size=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1988,7 +1996,7 @@ This lower-level function is also available:
 <a id="get_near2far_freqs"></a>
 
 ```python
-def get_near2far_freqs(f):
+def get_near2far_freqs(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2011,7 +2019,7 @@ For a scattered-field computation, you often want to separate the scattered and 
 <div class="class_members" markdown="1">
 
 ```python
-def save_near2far(self, fname, near2far):
+def save_near2far(self, fname, near2far): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2029,7 +2037,7 @@ filename-prefix is prepended automatically.
 <div class="class_members" markdown="1">
 
 ```python
-def load_near2far(self, fname, near2far):
+def load_near2far(self, fname, near2far): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2050,7 +2058,7 @@ processors.
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_near2far(self, fname, near2far):
+def load_minus_near2far(self, fname, near2far): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2072,7 +2080,7 @@ To keep the fields in memory and avoid writing to and reading from a file, use t
 <div class="class_members" markdown="1">
 
 ```python
-def get_near2far_data(self, near2far):
+def get_near2far_data(self, near2far): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2091,7 +2099,7 @@ considered opaque.
 <div class="class_members" markdown="1">
 
 ```python
-def load_near2far_data(self, near2far, n2fdata):
+def load_near2far_data(self, near2far, n2fdata): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2111,7 +2119,7 @@ processors.
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_near2far_data(self, near2far, n2fdata):
+def load_minus_near2far_data(self, near2far, n2fdata): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2130,7 +2138,7 @@ See also this lower-level function:
 <a id="scale_near2far_fields"></a>
 
 ```python
-def scale_near2far_fields(s, near2far):
+def scale_near2far_fields(s, near2far): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2149,7 +2157,7 @@ And this [`DftNear2Far`](#DftNear2Far) method:
 <div class="class_members" markdown="1">
 
 ```python
-def flux(self, direction, where, resolution):
+def flux(self, direction, where, resolution): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2175,7 +2183,7 @@ These functions dump the raw ε and μ data to disk and load it back for doing m
 <div class="class_members" markdown="1">
 
 ```python
-def dump_structure(self, fname):
+def dump_structure(self, fname): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2191,7 +2199,7 @@ Dumps the structure to the file `fname`.
 <div class="class_members" markdown="1">
 
 ```python
-def load_structure(self, fname):
+def load_structure(self, fname): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2208,7 +2216,7 @@ the `Simulation` constructor via the `load_structure` keyword argument.
 <div class="class_members" markdown="1">
 
 ```python
-def dump_chunk_layout(self, fname):
+def dump_chunk_layout(self, fname): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2286,7 +2294,7 @@ This feature is only available if Meep is built with [libGDSII](Build_From_Sourc
 <a id="GDSII_layers"></a>
 
 ```python
-def GDSII_layers(fname):
+def GDSII_layers(fname): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2304,7 +2312,7 @@ Out[2]: [0, 1, 2, 3, 4, 5, 31, 32]
 <a id="GDSII_prisms"></a>
 
 ```python
-def GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0):
+def GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2317,7 +2325,7 @@ Returns a list of `GeometricObject`s with `material` (`mp.Medium`) on layer numb
 <a id="GDSII_vol"></a>
 
 ```python
-def GDSII_vol(fname, layer, zmin, zmax):
+def GDSII_vol(fname, layer, zmin, zmax): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2358,7 +2366,7 @@ def plot2D(self,
            plot_sources_flag=True,
            plot_monitors_flag=True,
            plot_boundaries_flag=True,
-           **kwargs):
+           **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2448,7 +2456,7 @@ plt.savefig('sim_domain.png')
 <div class="class_members" markdown="1">
 
 ```python
-def plot3D(self):
+def plot3D(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2465,7 +2473,7 @@ Can also be embedded in Jupyter notebooks.
 <div class="class_members" markdown="1">
 
 ```python
-def visualize_chunks(self):
+def visualize_chunks(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2495,7 +2503,9 @@ A common point of confusion is described in [The Run Function Is Not A Loop](The
 <div class="class_members" markdown="1">
 
 ```python
-def run(self, *step_funcs, **kwargs):
+def run(self, *step_funcs, **kwargs): 
+def run(step_functions..., until=condition/time):
+def run(step_functions..., until_after_sources=condition/time):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2529,7 +2539,7 @@ In particular, a useful value for `until_after_sources` or `until` is often `sto
 <a id="stop_when_fields_decayed"></a>
 
 ```python
-def stop_when_fields_decayed(dt, c, pt, decay_by):
+def stop_when_fields_decayed(dt, c, pt, decay_by): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2553,7 +2563,7 @@ slow group velocities and are absorbed poorly by [PML](Perfectly_Matched_Layer.m
 <a id="stop_after_walltime"></a>
 
 ```python
-def stop_after_walltime(t):
+def stop_after_walltime(t): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2566,7 +2576,7 @@ parameter. Stops the simulation after `t` seconds of wall time have passed.
 <a id="stop_on_interrupt"></a>
 
 ```python
-def stop_on_interrupt():
+def stop_on_interrupt(): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2587,7 +2597,7 @@ Finally, another run function, useful for computing ω(**k**) band diagrams, is 
 <div class="class_members" markdown="1">
 
 ```python
-def run_k_points(self, t, k_points):
+def run_k_points(self, t, k_points): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2614,7 +2624,7 @@ Cavity](Python_Tutorials/Resonant_Modes_and_Transmission_in_a_Waveguide_Cavity.m
 <div class="class_members" markdown="1">
 
 ```python
-def run_k_point(self, t, k):
+def run_k_point(self, t, k): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2645,7 +2655,7 @@ Note that although the various field components are stored at different places i
 <div class="class_members" markdown="1">
 
 ```python
-def output_dft(self, dft_fields, fname):
+def output_dft(self, dft_fields, fname): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2662,7 +2672,7 @@ suffix).
 <a id="output_epsilon"></a>
 
 ```python
-def output_epsilon(sim, *step_func_args, **kwargs):
+def output_epsilon(sim, *step_func_args, **kwargs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2678,7 +2688,7 @@ frequency-independent part of ε (the $\omega\to\infty$ limit).
 <a id="output_mu"></a>
 
 ```python
-def output_mu(sim, *step_func_args, **kwargs):
+def output_mu(sim, *step_func_args, **kwargs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2694,7 +2704,7 @@ frequency-independent part of μ (the $\omega\to\infty$ limit).
 <a id="output_poynting"></a>
 
 ```python
-def output_poynting(sim):
+def output_poynting(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2709,7 +2719,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_hpwr"></a>
 
 ```python
-def output_hpwr(sim):
+def output_hpwr(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2721,7 +2731,7 @@ Output the magnetic-field energy density $\mathbf{H}^* \cdot \mathbf{B} / 2$
 <a id="output_dpwr"></a>
 
 ```python
-def output_dpwr(sim):
+def output_dpwr(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2733,7 +2743,7 @@ Output the electric-field energy density $\mathbf{E}^* \cdot \mathbf{D} / 2$
 <a id="output_tot_pwr"></a>
 
 ```python
-def output_tot_pwr(sim):
+def output_tot_pwr(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2748,7 +2758,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_png"></a>
 
 ```python
-def output_png(compnt, options, rm_h5=True):
+def output_png(compnt, options, rm_h5=True): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2778,7 +2788,7 @@ file requires `output_png(component, h5topng_options, rm_h5=False)`.
 <a id="output_hfield"></a>
 
 ```python
-def output_hfield(sim):
+def output_hfield(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2791,7 +2801,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_hfield_x"></a>
 
 ```python
-def output_hfield_x(sim):
+def output_hfield_x(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2805,7 +2815,7 @@ imaginary parts, respectively.
 <a id="output_hfield_y"></a>
 
 ```python
-def output_hfield_y(sim):
+def output_hfield_y(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2819,7 +2829,7 @@ imaginary parts, respectively.
 <a id="output_hfield_z"></a>
 
 ```python
-def output_hfield_z(sim):
+def output_hfield_z(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2833,7 +2843,7 @@ imaginary parts, respectively.
 <a id="output_hfield_r"></a>
 
 ```python
-def output_hfield_r(sim):
+def output_hfield_r(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2847,7 +2857,7 @@ imaginary parts, respectively.
 <a id="output_hfield_p"></a>
 
 ```python
-def output_hfield_p(sim):
+def output_hfield_p(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2862,7 +2872,7 @@ and imaginary parts, respectively.
 <a id="output_bfield"></a>
 
 ```python
-def output_bfield(sim):
+def output_bfield(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2875,7 +2885,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_bfield_x"></a>
 
 ```python
-def output_bfield_x(sim):
+def output_bfield_x(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2889,7 +2899,7 @@ imaginary parts, respectively.
 <a id="output_bfield_y"></a>
 
 ```python
-def output_bfield_y(sim):
+def output_bfield_y(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2903,7 +2913,7 @@ imaginary parts, respectively.
 <a id="output_bfield_z"></a>
 
 ```python
-def output_bfield_z(sim):
+def output_bfield_z(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2917,7 +2927,7 @@ imaginary parts, respectively.
 <a id="output_bfield_r"></a>
 
 ```python
-def output_bfield_r(sim):
+def output_bfield_r(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2931,7 +2941,7 @@ imaginary parts, respectively.
 <a id="output_bfield_p"></a>
 
 ```python
-def output_bfield_p(sim):
+def output_bfield_p(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2949,7 +2959,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_efield"></a>
 
 ```python
-def output_efield(sim):
+def output_efield(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2962,7 +2972,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_efield_x"></a>
 
 ```python
-def output_efield_x(sim):
+def output_efield_x(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2976,7 +2986,7 @@ imaginary parts, respectively.
 <a id="output_efield_y"></a>
 
 ```python
-def output_efield_y(sim):
+def output_efield_y(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2990,7 +3000,7 @@ imaginary parts, respectively.
 <a id="output_efield_z"></a>
 
 ```python
-def output_efield_z(sim):
+def output_efield_z(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3004,7 +3014,7 @@ imaginary parts, respectively.
 <a id="output_efield_r"></a>
 
 ```python
-def output_efield_r(sim):
+def output_efield_r(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3018,7 +3028,7 @@ imaginary parts, respectively.
 <a id="output_efield_p"></a>
 
 ```python
-def output_efield_p(sim):
+def output_efield_p(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3036,7 +3046,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_dfield"></a>
 
 ```python
-def output_dfield(sim):
+def output_dfield(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3049,7 +3059,7 @@ is, the different components are stored as different datasets within the *same* 
 <a id="output_dfield_x"></a>
 
 ```python
-def output_dfield_x(sim):
+def output_dfield_x(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3063,7 +3073,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_y"></a>
 
 ```python
-def output_dfield_y(sim):
+def output_dfield_y(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3077,7 +3087,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_z"></a>
 
 ```python
-def output_dfield_z(sim):
+def output_dfield_z(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3091,7 +3101,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_r"></a>
 
 ```python
-def output_dfield_r(sim):
+def output_dfield_r(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3105,7 +3115,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_p"></a>
 
 ```python
-def output_dfield_p(sim):
+def output_dfield_p(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3123,7 +3133,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_sfield"></a>
 
 ```python
-def output_sfield(sim):
+def output_sfield(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3139,7 +3149,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_sfield_x"></a>
 
 ```python
-def output_sfield_x(sim):
+def output_sfield_x(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3153,7 +3163,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_y"></a>
 
 ```python
-def output_sfield_y(sim):
+def output_sfield_y(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3167,7 +3177,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_z"></a>
 
 ```python
-def output_sfield_z(sim):
+def output_sfield_z(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3181,7 +3191,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_r"></a>
 
 ```python
-def output_sfield_r(sim):
+def output_sfield_r(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3195,7 +3205,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_p"></a>
 
 ```python
-def output_sfield_p(sim):
+def output_sfield_p(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3223,7 +3233,7 @@ def output_field_function(self,
                           cs,
                           func,
                           real_only=False,
-                          h5file=None):
+                          h5file=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3259,7 +3269,7 @@ def get_array(self,
               cmplx=None,
               arr=None,
               frequency=0,
-              omega=0):
+              omega=0): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3322,7 +3332,7 @@ arrays; rather, you should simply rely on Meep's output.
 <div class="class_members" markdown="1">
 
 ```python
-def get_dft_array(self, dft_obj, component, num_freq):
+def get_dft_array(self, dft_obj, component, num_freq): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3360,7 +3370,7 @@ def get_array_metadata(self,
                        dft_cell=None,
                        collapse=False,
                        snap=False,
-                       return_pw=False):
+                       return_pw=False): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3460,7 +3470,7 @@ def get_source(self,
                component,
                vol=None,
                center=None,
-               size=None):
+               size=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3493,7 +3503,7 @@ See also [Tutorial/Basics](Python_Tutorials/Basics.md) for examples.
 <a id="combine_step_funcs"></a>
 
 ```python
-def combine_step_funcs(*step_funcs):
+def combine_step_funcs(*step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3506,7 +3516,7 @@ all of the passed step functions.
 <a id="synchronized_magnetic"></a>
 
 ```python
-def synchronized_magnetic(*step_funcs):
+def synchronized_magnetic(*step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3525,7 +3535,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="when_true"></a>
 
 ```python
-def when_true(cond, *step_funcs):
+def when_true(cond, *step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3538,7 +3548,7 @@ no arguments), evaluate the step functions whenever `condition` returns `True`.
 <a id="when_false"></a>
 
 ```python
-def when_false(cond, *step_funcs):
+def when_false(cond, *step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3551,7 +3561,7 @@ no arguments), evaluate the step functions whenever `condition` returns `False`.
 <a id="at_every"></a>
 
 ```python
-def at_every(dt, *step_funcs):
+def at_every(dt, *step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3564,7 +3574,7 @@ Given zero or more step functions, evaluates them at every time interval of $dT$
 <a id="after_time"></a>
 
 ```python
-def after_time(t, *step_funcs):
+def after_time(t, *step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3577,7 +3587,7 @@ units have elapsed from the start of the run.
 <a id="before_time"></a>
 
 ```python
-def before_time(t, *step_funcs):
+def before_time(t, *step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3590,7 +3600,7 @@ units have elapsed from the start of the run.
 <a id="at_time"></a>
 
 ```python
-def at_time(t, *step_funcs):
+def at_time(t, *step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3603,7 +3613,7 @@ have elapsed from the start of the run.
 <a id="after_sources"></a>
 
 ```python
-def after_sources(*step_funcs):
+def after_sources(*step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3616,7 +3626,7 @@ sources have turned off.
 <a id="after_sources_and_time"></a>
 
 ```python
-def after_sources_and_time(t, *step_funcs):
+def after_sources_and_time(t, *step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3629,7 +3639,7 @@ sources have turned off, plus an additional $T$ time units have elapsed.
 <a id="during_sources"></a>
 
 ```python
-def during_sources(*step_funcs):
+def during_sources(*step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3642,7 +3652,7 @@ sources have turned off.
 <a id="at_beginning"></a>
 
 ```python
-def at_beginning(*step_funcs):
+def at_beginning(*step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3655,7 +3665,7 @@ run.
 <a id="at_end"></a>
 
 ```python
-def at_end(*step_funcs):
+def at_end(*step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3671,7 +3681,7 @@ Given zero or more step functions, evaluates them only once, at the end of the r
 <a id="in_volume"></a>
 
 ```python
-def in_volume(v, *step_funcs):
+def in_volume(v, *step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3685,7 +3695,7 @@ output a subset (or a superset) of the cell, corresponding to the `meep::volume*
 <a id="in_point"></a>
 
 ```python
-def in_point(pt, *step_funcs):
+def in_point(pt, *step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3698,7 +3708,7 @@ output a single *point* of data, at `pt` (a `Vector3`).
 <a id="to_appended"></a>
 
 ```python
-def to_appended(fname, *step_funcs):
+def to_appended(fname, *step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3713,7 +3723,7 @@ dimension* to their datasets, corresponding to time.
 <a id="with_prefix"></a>
 
 ```python
-def with_prefix(pre, *step_funcs):
+def with_prefix(pre, *step_funcs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3896,7 +3906,7 @@ def __init__(self,
              E_chi3=None,
              H_chi2=None,
              H_chi3=None,
-             valid_freq_range=FreqRange(min=-1e+20, max=1e+20)):
+             valid_freq_range=FreqRange(min=-1e+20, max=1e+20)): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3963,7 +3973,7 @@ Creates a `Medium` object.
 <div class="class_members" markdown="1">
 
 ```python
-def __repr__(self):
+def __repr__(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3979,7 +3989,7 @@ Return repr(self).
 <div class="class_members" markdown="1">
 
 ```python
-def epsilon(self, freq):
+def epsilon(self, freq): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3997,7 +4007,7 @@ of a list/array of N frequency points, a Numpy array of size Nx3x3 is returned.
 <div class="class_members" markdown="1">
 
 ```python
-def mu(self, freq):
+def mu(self, freq): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4015,7 +4025,7 @@ of a list/array of N frequency points, a Numpy array of size Nx3x3 is returned.
 <div class="class_members" markdown="1">
 
 ```python
-def transform(self, m):
+def transform(self, m): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4061,7 +4071,7 @@ anisotropic amplitude σ. See [Material Dispersion](Materials.md#material-disper
 def __init__(self,
              sigma_diag=Vector3<0.0, 0.0, 0.0>,
              sigma_offdiag=Vector3<0.0, 0.0, 0.0>,
-             sigma=None):
+             sigma=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4104,7 +4114,7 @@ the parameters (in addition to σ):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
+def __init__(self, frequency=0.0, gamma=0.0, **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4144,7 +4154,7 @@ Dispersion](Materials.md#material-dispersion), with the parameters (in addition 
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
+def __init__(self, frequency=0.0, gamma=0.0, **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4188,7 +4198,7 @@ Absorption](Materials.md#saturable-gain-and-absorption).
 def __init__(self,
              initial_populations=[],
              transitions=[],
-             **kwargs):
+             **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4236,7 +4246,7 @@ def __init__(self,
              frequency=0,
              sigma_diag=Vector3<1.0, 1.0, 1.0>,
              gamma=0,
-             pumping_rate=0):
+             pumping_rate=0): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4288,7 +4298,7 @@ space and time, zero mean) added to the **P** damped-oscillator equation.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, noise_amp=0.0, **kwargs):
+def __init__(self, noise_amp=0.0, **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4339,7 +4349,7 @@ space and time, zero mean) added to the **P** damped-oscillator equation.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, noise_amp=0.0, **kwargs):
+def __init__(self, noise_amp=0.0, **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4390,7 +4400,7 @@ meanings](#susceptibility), and an additional 3-vector `bias`:
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs):
+def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4429,7 +4439,7 @@ meanings](#susceptibility), and an additional 3-vector `bias`:
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs):
+def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4475,7 +4485,7 @@ def __init__(self,
              frequency=0.0,
              gamma=0.0,
              alpha=0.0,
-             **kwargs):
+             **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4532,7 +4542,7 @@ iterable (e.g., a tuple or list) and automatically convert to a `Vector3`.
 <div class="class_members" markdown="1">
 
 ```python
-def __add__(self, other):
+def __add__(self, other): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4552,7 +4562,7 @@ v3 = v1 + v2
 <div class="class_members" markdown="1">
 
 ```python
-def __eq__(self, other):
+def __eq__(self, other): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4574,7 +4584,7 @@ v1 == v2
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, x=0.0, y=0.0, z=0.0):
+def __init__(self, x=0.0, y=0.0, z=0.0): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4591,7 +4601,7 @@ zero. This can also be represented simply as `(x,y,z)` or `[x,y,z]`.
 <div class="class_members" markdown="1">
 
 ```python
-def __mul__(self, other):
+def __mul__(self, other): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4612,7 +4622,7 @@ c = v1 * other
 <div class="class_members" markdown="1">
 
 ```python
-def __ne__(self, other):
+def __ne__(self, other): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4634,7 +4644,7 @@ v1 != v2
 <div class="class_members" markdown="1">
 
 ```python
-def __repr__(self):
+def __repr__(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4650,7 +4660,7 @@ Return repr(self).
 <div class="class_members" markdown="1">
 
 ```python
-def __rmul__(self, other):
+def __rmul__(self, other): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4671,7 +4681,7 @@ c = other * v1
 <div class="class_members" markdown="1">
 
 ```python
-def __sub__(self, other):
+def __sub__(self, other): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4691,7 +4701,7 @@ v3 = v1 - v2
 <div class="class_members" markdown="1">
 
 ```python
-def cdot(self, v):
+def cdot(self, v): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4707,7 +4717,7 @@ Returns the conjugated dot product: *self*\* dot *v*.
 <div class="class_members" markdown="1">
 
 ```python
-def close(self, v, tol=1e-07):
+def close(self, v, tol=1e-07): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4728,7 +4738,7 @@ v1.close(v2, [tol])
 <div class="class_members" markdown="1">
 
 ```python
-def cross(self, v):
+def cross(self, v): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4748,7 +4758,7 @@ v3 = v1.cross(v2)
 <div class="class_members" markdown="1">
 
 ```python
-def dot(self, v):
+def dot(self, v): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4768,7 +4778,7 @@ v3 = v1.dot(v2)
 <div class="class_members" markdown="1">
 
 ```python
-def norm(self):
+def norm(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4788,7 +4798,7 @@ v2 = v1.norm()
 <div class="class_members" markdown="1">
 
 ```python
-def rotate(self, axis, theta):
+def rotate(self, axis, theta): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4811,7 +4821,7 @@ v2 = v1.rotate(axis, theta)
 <div class="class_members" markdown="1">
 
 ```python
-def unit(self):
+def unit(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4900,7 +4910,7 @@ geometry = [mp.Prism(vertices, height=1.5, center=mp.Vector3(), material=cSi)]
 def __init__(self,
              material=Medium(),
              center=Vector3<0.0, 0.0, 0.0>,
-             epsilon_func=None):
+             epsilon_func=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4932,7 +4942,7 @@ constructor via keyword arguments.
 <div class="class_members" markdown="1">
 
 ```python
-def info(self, indent_by=0):
+def info(self, indent_by=0): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4949,7 +4959,7 @@ Displays all properties and current values of a `GeometricObject`, indented by
 <div class="class_members" markdown="1">
 
 ```python
-def shift(self, vec):
+def shift(self, vec): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4993,7 +5003,7 @@ Represents a sphere.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, radius, **kwargs):
+def __init__(self, radius, **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5039,7 +5049,7 @@ def __init__(self,
              radius,
              axis=Vector3<0.0, 0.0, 1.0>,
              height=1e+20,
-             **kwargs):
+             **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5076,7 +5086,7 @@ def __init__(self,
              radius,
              wedge_angle=6.283185307179586,
              wedge_start=Vector3<1.0, 0.0, 0.0>,
-             **kwargs):
+             **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5113,7 +5123,7 @@ is halfway between the two circular ends.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, radius, radius2=0, **kwargs):
+def __init__(self, radius, radius2=0, **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5155,7 +5165,7 @@ def __init__(self,
              e1=Vector3<1.0, 0.0, 0.0>,
              e2=Vector3<0.0, 1.0, 0.0>,
              e3=Vector3<0.0, 0.0, 1.0>,
-             **kwargs):
+             **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5197,7 +5207,7 @@ properties, but defines an ellipsoid inscribed inside the block.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, **kwargs):
+def __init__(self, **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5236,7 +5246,7 @@ def __init__(self,
              axis=Vector3<0.0, 0.0, 1.0>,
              center=None,
              sidewall_angle=0,
-             **kwargs):
+             **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5326,7 +5336,7 @@ def __init__(self,
              c2=Vector3<0.0, 0.0, 0.0>,
              c3=Vector3<0.0, 0.0, 0.0>,
              diag=Vector3<0.0, 0.0, 0.0>,
-             offdiag=Vector3<0.0, 0.0, 0.0>):
+             offdiag=Vector3<0.0, 0.0, 0.0>): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5342,7 +5352,7 @@ Constructs a `Matrix`.
 <div class="class_members" markdown="1">
 
 ```python
-def __repr__(self):
+def __repr__(self): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5358,7 +5368,7 @@ Return repr(self).
 <a id="get_rotation_matrix"></a>
 
 ```python
-def get_rotation_matrix(axis, theta):
+def get_rotation_matrix(axis, theta): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -5413,7 +5423,7 @@ the axis of the rotation.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, direction, phase=1):
+def __init__(self, direction, phase=1): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5542,7 +5552,7 @@ def __init__(self,
              side=-1,
              R_asymptotic=1e-15,
              mean_stretch=1.0,
-             pml_profile=<function PML.<lambda> at 0x7fbde152c440>):
+             pml_profile=<function PML.<lambda> at 0x7fde513557a0>): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5678,7 +5688,7 @@ def __init__(self,
              amplitude=1.0,
              amp_func=None,
              amp_func_file='',
-             amp_data=None):
+             amp_data=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5847,7 +5857,7 @@ def __init__(self,
              eig_parity=0,
              eig_resolution=0,
              eig_tolerance=1e-12,
-             **kwargs):
+             **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5939,7 +5949,7 @@ Construct an `EigenModeSource`.
 <div class="class_members" markdown="1">
 
 ```python
-def eig_power(self, freq):
+def eig_power(self, freq): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5983,7 +5993,7 @@ def __init__(self,
              fwidth=inf,
              cutoff=3.0,
              wavelength=None,
-             **kwargs):
+             **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6058,7 +6068,7 @@ def __init__(self,
              start_time=0,
              cutoff=5.0,
              wavelength=None,
-             **kwargs):
+             **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6144,7 +6154,7 @@ def __init__(self,
              start_time=-1e+20,
              end_time=1e+20,
              center_frequency=0,
-             **kwargs):
+             **kwargs): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6215,7 +6225,7 @@ def __init__(self,
              size=Vector3<0.0, 0.0, 0.0>,
              direction=-1,
              weight=1.0,
-             volume=None):
+             volume=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6344,7 +6354,7 @@ def __init__(self,
              size=Vector3<0.0, 0.0, 0.0>,
              dims=2,
              is_cylindrical=False,
-             vertices=[]):
+             vertices=[]): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6360,7 +6370,7 @@ Construct a Volume.
 <a id="get_center_and_size"></a>
 
 ```python
-def get_center_and_size(vol):
+def get_center_and_size(vol): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -6412,7 +6422,7 @@ swigobj_attr and return the property they requested.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args):
+def __init__(self, func, args): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6445,7 +6455,7 @@ class DftFlux(DftObj):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args):
+def __init__(self, func, args): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6478,7 +6488,7 @@ class DftForce(DftObj):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args):
+def __init__(self, func, args): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6511,7 +6521,7 @@ class DftNear2Far(DftObj):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args):
+def __init__(self, func, args): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6527,7 +6537,7 @@ Initialize self.  See help(type(self)) for accurate signature.
 <div class="class_members" markdown="1">
 
 ```python
-def flux(self, direction, where, resolution):
+def flux(self, direction, where, resolution): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6564,7 +6574,7 @@ class DftEnergy(DftObj):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args):
+def __init__(self, func, args): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6597,7 +6607,7 @@ class DftFields(DftObj):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args):
+def __init__(self, func, args): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6657,7 +6667,7 @@ track different volume locations (using `mp.in_volume`) or field components.
 <div class="class_members" markdown="1">
 
 ```python
-def __call__(self, sim, todo):
+def __call__(self, sim, todo): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6680,7 +6690,7 @@ def __init__(self,
              realtime=False,
              normalize=False,
              plot_modifiers=None,
-             **customization_args):
+             **customization_args): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6728,7 +6738,7 @@ Construct an `Animate2D` object.
 <div class="class_members" markdown="1">
 
 ```python
-def to_gif(self, fps, filename):
+def to_gif(self, fps, filename): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6748,7 +6758,7 @@ format only supports 256 colors from a _predefined_ color palette. Requires
 <div class="class_members" markdown="1">
 
 ```python
-def to_jshtml(self, fps):
+def to_jshtml(self, fps): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6766,7 +6776,7 @@ playback. User must specify a frame rate `fps` in frames per second.
 <div class="class_members" markdown="1">
 
 ```python
-def to_mp4(self, fps, filename):
+def to_mp4(self, fps, filename): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6844,7 +6854,7 @@ sim.run(mp.after_sources(h))
 <div class="class_members" markdown="1">
 
 ```python
-def __call__(self, sim, todo):
+def __call__(self, sim, todo): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6860,7 +6870,7 @@ Allows a Haminv instance to be used as a step function.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, c, pt, fcen, df, mxbands=None):
+def __init__(self, c, pt, fcen, df, mxbands=None): 
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6888,7 +6898,7 @@ Miscellaneous Functions Reference
 <a id="quiet"></a>
 
 ```python
-def quiet(quietval=True):
+def quiet(quietval=True): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -6904,7 +6914,7 @@ value will persist across runs within the same script.
 <a id="verbosity"></a>
 
 ```python
-def verbosity(v=1):
+def verbosity(v=1): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -6919,7 +6929,7 @@ output.
 <a id="interpolate"></a>
 
 ```python
-def interpolate(n, nums):
+def interpolate(n, nums): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -6936,7 +6946,7 @@ original list.
 <a id="get_flux_freqs"></a>
 
 ```python
-def get_flux_freqs(f):
+def get_flux_freqs(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -6950,7 +6960,7 @@ spectrum for.
 <a id="get_fluxes"></a>
 
 ```python
-def get_fluxes(f):
+def get_fluxes(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -6964,7 +6974,7 @@ accumulated.
 <a id="scale_flux_fields"></a>
 
 ```python
-def scale_flux_fields(s, flux):
+def scale_flux_fields(s, flux): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -6979,7 +6989,7 @@ Scale the Fourier-transformed fields in `flux` by the complex number `s`. e.g.
 <a id="get_eigenmode_freqs"></a>
 
 ```python
-def get_eigenmode_freqs(f):
+def get_eigenmode_freqs(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -6996,7 +7006,7 @@ spectrum for.
 <a id="get_energy_freqs"></a>
 
 ```python
-def get_energy_freqs(f):
+def get_energy_freqs(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7009,7 +7019,7 @@ spectrum for.
 <a id="get_electric_energy"></a>
 
 ```python
-def get_electric_energy(f):
+def get_electric_energy(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7022,7 +7032,7 @@ electric fields that it has accumulated.
 <a id="get_magnetic_energy"></a>
 
 ```python
-def get_magnetic_energy(f):
+def get_magnetic_energy(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7035,7 +7045,7 @@ magnetic fields that it has accumulated.
 <a id="get_total_energy"></a>
 
 ```python
-def get_total_energy(f):
+def get_total_energy(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7052,7 +7062,7 @@ total fields that it has accumulated.
 <a id="get_force_freqs"></a>
 
 ```python
-def get_force_freqs(f):
+def get_force_freqs(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7065,7 +7075,7 @@ spectrum for.
 <a id="get_forces"></a>
 
 ```python
-def get_forces(f):
+def get_forces(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7082,12 +7092,12 @@ accumulated.
 <a id="Ldos"></a>
 
 ```python
-def Ldos(*args):
+def Ldos(*args): 
+def Ldos(fcen, df, nfreq, freq):
 ```
 
 <div class="function_docstring" markdown="1">
 
-`Ldos(fcen, df, nfreq, freq)`
 
 Create an LDOS object with either frequency bandwidth `df` centered at `fcen` and
 `nfreq` equally spaced frequency points or an array/list `freq` for arbitrarily spaced
@@ -7099,7 +7109,7 @@ argument.
 <a id="get_ldos_freqs"></a>
 
 ```python
-def get_ldos_freqs(l):
+def get_ldos_freqs(l): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7112,12 +7122,12 @@ spectrum for.
 <a id="dft_ldos"></a>
 
 ```python
-def dft_ldos(*args, **kwargs):
+def dft_ldos(*args, **kwargs): 
+def dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None):
 ```
 
 <div class="function_docstring" markdown="1">
 
-`dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)`
 
 Compute the power spectrum of the sources (usually a single point dipole source),
 normalized to correspond to the LDOS, in either a frequency bandwidth `df` centered at
@@ -7138,7 +7148,7 @@ is complete.
 <a id="get_near2far_freqs"></a>
 
 ```python
-def get_near2far_freqs(f):
+def get_near2far_freqs(f): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7151,7 +7161,7 @@ spectrum for.
 <a id="scale_near2far_fields"></a>
 
 ```python
-def scale_near2far_fields(s, near2far):
+def scale_near2far_fields(s, near2far): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7169,7 +7179,7 @@ Scale the Fourier-transformed fields in `near2far` by the complex number `s`. e.
 <a id="GDSII_layers"></a>
 
 ```python
-def GDSII_layers(fname):
+def GDSII_layers(fname): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7187,7 +7197,7 @@ Out[2]: [0, 1, 2, 3, 4, 5, 31, 32]
 <a id="GDSII_prisms"></a>
 
 ```python
-def GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0):
+def GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7200,7 +7210,7 @@ Returns a list of `GeometricObject`s with `material` (`mp.Medium`) on layer numb
 <a id="GDSII_vol"></a>
 
 ```python
-def GDSII_vol(fname, layer, zmin, zmax):
+def GDSII_vol(fname, layer, zmin, zmax): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7222,7 +7232,7 @@ fr = mp.FluxRegion(volume=mp.GDSII_vol(fname, layer, zmin, zmax))
 <a id="stop_when_fields_decayed"></a>
 
 ```python
-def stop_when_fields_decayed(dt, c, pt, decay_by):
+def stop_when_fields_decayed(dt, c, pt, decay_by): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7246,7 +7256,7 @@ slow group velocities and are absorbed poorly by [PML](Perfectly_Matched_Layer.m
 <a id="stop_after_walltime"></a>
 
 ```python
-def stop_after_walltime(t):
+def stop_after_walltime(t): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7259,7 +7269,7 @@ parameter. Stops the simulation after `t` seconds of wall time have passed.
 <a id="stop_on_interrupt"></a>
 
 ```python
-def stop_on_interrupt():
+def stop_on_interrupt(): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7278,7 +7288,7 @@ follows the `run` function (e.g., outputting fields).
 <a id="output_epsilon"></a>
 
 ```python
-def output_epsilon(sim, *step_func_args, **kwargs):
+def output_epsilon(sim, *step_func_args, **kwargs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7294,7 +7304,7 @@ frequency-independent part of ε (the $\omega\to\infty$ limit).
 <a id="output_mu"></a>
 
 ```python
-def output_mu(sim, *step_func_args, **kwargs):
+def output_mu(sim, *step_func_args, **kwargs): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7310,7 +7320,7 @@ frequency-independent part of μ (the $\omega\to\infty$ limit).
 <a id="output_poynting"></a>
 
 ```python
-def output_poynting(sim):
+def output_poynting(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7325,7 +7335,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_hpwr"></a>
 
 ```python
-def output_hpwr(sim):
+def output_hpwr(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7337,7 +7347,7 @@ Output the magnetic-field energy density $\mathbf{H}^* \cdot \mathbf{B} / 2$
 <a id="output_dpwr"></a>
 
 ```python
-def output_dpwr(sim):
+def output_dpwr(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7349,7 +7359,7 @@ Output the electric-field energy density $\mathbf{E}^* \cdot \mathbf{D} / 2$
 <a id="output_tot_pwr"></a>
 
 ```python
-def output_tot_pwr(sim):
+def output_tot_pwr(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7364,7 +7374,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_png"></a>
 
 ```python
-def output_png(compnt, options, rm_h5=True):
+def output_png(compnt, options, rm_h5=True): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7394,7 +7404,7 @@ file requires `output_png(component, h5topng_options, rm_h5=False)`.
 <a id="output_hfield"></a>
 
 ```python
-def output_hfield(sim):
+def output_hfield(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7407,7 +7417,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_hfield_x"></a>
 
 ```python
-def output_hfield_x(sim):
+def output_hfield_x(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7421,7 +7431,7 @@ imaginary parts, respectively.
 <a id="output_hfield_y"></a>
 
 ```python
-def output_hfield_y(sim):
+def output_hfield_y(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7435,7 +7445,7 @@ imaginary parts, respectively.
 <a id="output_hfield_z"></a>
 
 ```python
-def output_hfield_z(sim):
+def output_hfield_z(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7449,7 +7459,7 @@ imaginary parts, respectively.
 <a id="output_hfield_r"></a>
 
 ```python
-def output_hfield_r(sim):
+def output_hfield_r(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7463,7 +7473,7 @@ imaginary parts, respectively.
 <a id="output_hfield_p"></a>
 
 ```python
-def output_hfield_p(sim):
+def output_hfield_p(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7478,7 +7488,7 @@ and imaginary parts, respectively.
 <a id="output_bfield"></a>
 
 ```python
-def output_bfield(sim):
+def output_bfield(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7491,7 +7501,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_bfield_x"></a>
 
 ```python
-def output_bfield_x(sim):
+def output_bfield_x(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7505,7 +7515,7 @@ imaginary parts, respectively.
 <a id="output_bfield_y"></a>
 
 ```python
-def output_bfield_y(sim):
+def output_bfield_y(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7519,7 +7529,7 @@ imaginary parts, respectively.
 <a id="output_bfield_z"></a>
 
 ```python
-def output_bfield_z(sim):
+def output_bfield_z(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7533,7 +7543,7 @@ imaginary parts, respectively.
 <a id="output_bfield_r"></a>
 
 ```python
-def output_bfield_r(sim):
+def output_bfield_r(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7547,7 +7557,7 @@ imaginary parts, respectively.
 <a id="output_bfield_p"></a>
 
 ```python
-def output_bfield_p(sim):
+def output_bfield_p(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7565,7 +7575,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_efield"></a>
 
 ```python
-def output_efield(sim):
+def output_efield(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7578,7 +7588,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_efield_x"></a>
 
 ```python
-def output_efield_x(sim):
+def output_efield_x(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7592,7 +7602,7 @@ imaginary parts, respectively.
 <a id="output_efield_y"></a>
 
 ```python
-def output_efield_y(sim):
+def output_efield_y(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7606,7 +7616,7 @@ imaginary parts, respectively.
 <a id="output_efield_z"></a>
 
 ```python
-def output_efield_z(sim):
+def output_efield_z(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7620,7 +7630,7 @@ imaginary parts, respectively.
 <a id="output_efield_r"></a>
 
 ```python
-def output_efield_r(sim):
+def output_efield_r(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7634,7 +7644,7 @@ imaginary parts, respectively.
 <a id="output_efield_p"></a>
 
 ```python
-def output_efield_p(sim):
+def output_efield_p(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7652,7 +7662,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_dfield"></a>
 
 ```python
-def output_dfield(sim):
+def output_dfield(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7665,7 +7675,7 @@ is, the different components are stored as different datasets within the *same* 
 <a id="output_dfield_x"></a>
 
 ```python
-def output_dfield_x(sim):
+def output_dfield_x(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7679,7 +7689,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_y"></a>
 
 ```python
-def output_dfield_y(sim):
+def output_dfield_y(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7693,7 +7703,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_z"></a>
 
 ```python
-def output_dfield_z(sim):
+def output_dfield_z(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7707,7 +7717,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_r"></a>
 
 ```python
-def output_dfield_r(sim):
+def output_dfield_r(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7721,7 +7731,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_p"></a>
 
 ```python
-def output_dfield_p(sim):
+def output_dfield_p(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7739,7 +7749,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_sfield"></a>
 
 ```python
-def output_sfield(sim):
+def output_sfield(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7755,7 +7765,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_sfield_x"></a>
 
 ```python
-def output_sfield_x(sim):
+def output_sfield_x(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7769,7 +7779,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_y"></a>
 
 ```python
-def output_sfield_y(sim):
+def output_sfield_y(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7783,7 +7793,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_z"></a>
 
 ```python
-def output_sfield_z(sim):
+def output_sfield_z(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7797,7 +7807,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_r"></a>
 
 ```python
-def output_sfield_r(sim):
+def output_sfield_r(sim): 
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7811,7 +7821,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_p"></a>
 
 ```python
-def output_sfield_p(sim):
+def output_sfield_p(sim): 
 ```
 
 <div class="function_docstring" markdown="1">

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -2488,6 +2488,7 @@ Requires [matplotlib](https://matplotlib.org).
 
 An animated visualization is also possible via the [Animate2D](#Animate2D) class.
 
+<a id="run-functions"></a>
 
 ### Run and Step Functions
 
@@ -5552,7 +5553,7 @@ def __init__(self,
              side=-1,
              R_asymptotic=1e-15,
              mean_stretch=1.0,
-             pml_profile=<function PML.<lambda> at 0x7fde513557a0>): 
+             pml_profile=<function PML.<lambda> at 0x7fc840abd7a0>): 
 ```
 
 <div class="method_docstring" markdown="1">

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -711,148 +711,103 @@ More information, including their property types and default values, is availabl
 The following classes are available directly via the `meep` package.
 
 
-@@ Medium @@
 @@ Medium[methods-with-docstrings] @@
 
-@@ Susceptibility @@
 @@ Susceptibility[methods-with-docstrings] @@
 
-@@ LorentzianSusceptibility @@
 @@ LorentzianSusceptibility[methods-with-docstrings] @@
 
-@@ DrudeSusceptibility @@
 @@ DrudeSusceptibility[methods-with-docstrings] @@
 
-@@ MultilevelAtom @@
 @@ MultilevelAtom[methods-with-docstrings] @@
 
-@@ Transition @@
 @@ Transition[methods-with-docstrings] @@
 
-@@ NoisyLorentzianSusceptibility @@
 @@ NoisyLorentzianSusceptibility[methods-with-docstrings] @@
 
-@@ NoisyDrudeSusceptibility @@
 @@ NoisyDrudeSusceptibility[methods-with-docstrings] @@
 
-@@ GyrotropicLorentzianSusceptibility @@
 @@ GyrotropicLorentzianSusceptibility[methods-with-docstrings] @@
 
-@@ GyrotropicDrudeSusceptibility @@
 @@ GyrotropicDrudeSusceptibility[methods-with-docstrings] @@
 
-@@ GyrotropicSaturatedSusceptibility @@
 @@ GyrotropicSaturatedSusceptibility[methods-with-docstrings] @@
 
-@@ Vector3 @@
 @@ Vector3[methods-with-docstrings] @@
 
-@@ GeometricObject @@
 @@ GeometricObject[methods-with-docstrings] @@
 
-@@ Sphere @@
 @@ Sphere[methods-with-docstrings] @@
 
-@@ Cylinder @@
 @@ Cylinder[methods-with-docstrings] @@
 
-@@ Wedge @@
 @@ Wedge[methods-with-docstrings] @@
 
-@@ Cone @@
 @@ Cone[methods-with-docstrings] @@
 
-@@ Block @@
 @@ Block[methods-with-docstrings] @@
 
-@@ Ellipsoid @@
 @@ Ellipsoid[methods-with-docstrings] @@
 
-@@ Prism @@
 @@ Prism[methods-with-docstrings] @@
 
-@@ Matrix @@
 @@ Matrix[methods-with-docstrings] @@
 
 **Related function:**
 @@ get_rotation_matrix @@
 
 
-@@ Symmetry @@
 @@ Symmetry[methods-with-docstrings] @@
 
-@@ Rotate2 @@
 @@ Rotate2[methods-with-docstrings] @@
 
-@@ Rotate4 @@
 @@ Rotate4[methods-with-docstrings] @@
 
-@@ Mirror @@
 @@ Mirror[methods-with-docstrings] @@
 
-@@ Identity @@
 @@ Identity[methods-with-docstrings] @@
 
-@@ PML @@
 @@ PML[methods-with-docstrings] @@
 
-@@ Absorber @@
 @@ Absorber[methods-with-docstrings] @@
 
-@@ Source @@
 @@ Source[methods-with-docstrings] @@
 
 @@ SourceTime @@
 
-@@ EigenModeSource @@
 @@ EigenModeSource[methods-with-docstrings] @@
 
-@@ ContinuousSource @@
 @@ ContinuousSource[methods-with-docstrings] @@
 
-@@ GaussianSource @@
 @@ GaussianSource[methods-with-docstrings] @@
 
-@@ CustomSource @@
 @@ CustomSource[methods-with-docstrings] @@
 
-@@ FluxRegion @@
 @@ FluxRegion[methods-with-docstrings] @@
 
-@@ EnergyRegion @@
 @@ EnergyRegion[methods-with-docstrings] @@
 
-@@ ForceRegion @@
 @@ ForceRegion[methods-with-docstrings] @@
 
-@@ Volume @@
 @@ Volume[methods-with-docstrings] @@
 
 ** Related function:**
 @@ get_center_and_size @@
 
-@@ DftObj @@
 @@ DftObj[methods-with-docstrings] @@
 
-@@ DftFlux @@
 @@ DftFlux[methods-with-docstrings] @@
 
-@@ DftForce @@
 @@ DftForce[methods-with-docstrings] @@
 
-@@ DftNear2Far @@
 @@ DftNear2Far[methods-with-docstrings] @@
 
-@@ DftEnergy @@
 @@ DftEnergy[methods-with-docstrings] @@
 
-@@ DftFields @@
 @@ DftFields[methods-with-docstrings] @@
 
-@@ Animate2D @@
 @@ Animate2D[methods-with-docstrings] @@
 
-@@ Harminv @@
 @@ Harminv[methods-with-docstrings] @@
 
 

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -431,6 +431,7 @@ This module provides basic visualization functionality for the simulation domain
 
 An animated visualization is also possible via the [Animate2D](#Animate2D) class.
 
+<a id="run-functions"></a>
 
 ### Run and Step Functions
 

--- a/doc/generate_py_api.py
+++ b/doc/generate_py_api.py
@@ -18,8 +18,8 @@ snippets/templates used in the generation of the API documentation files can be
 found in {project_folder}/doc/_api_snippets, and will be loaded as needed while
 processing the docstrings.
 
-The folling tag patterns are used to indicate where in the input template that docstrings
-will be inserted:
+The following tag patterns are used to indicate where in the input template that
+docstrings will be inserted:
 
   - @@ top_level_function_name @@
   - @@ ClassName @@

--- a/doc/generate_py_api.py
+++ b/doc/generate_py_api.py
@@ -217,8 +217,8 @@ class ClassItem(Item):
         docs = dict()
         class_doc = self.template.format(**locals())
         docs[class_name] = class_doc
-        docs[class_name+'[all-methods]'] = self.create_method_markdown(False)
-        docs[class_name+'[methods-with-docstrings]'] = self.create_method_markdown(True)
+        docs[class_name+'[all-methods]'] = class_doc + '\n' + self.create_method_markdown(False)
+        docs[class_name+'[methods-with-docstrings]'] = class_doc + '\n' + self.create_method_markdown(True)
 
         return docs
 
@@ -240,8 +240,8 @@ class ClassItem(Item):
                     continue
                 if not check_excluded(item.name) and \
                    not check_excluded('{}.{}'.format(self.name, item.name)):
-                     doc = item.create_markdown()
-                     method_docs.append(doc)
+                        doc = item.create_markdown()
+                        method_docs.append(doc)
 
         # join the methods into a single string
         method_docs = '\n'.join(method_docs)

--- a/doc/generate_py_api.py
+++ b/doc/generate_py_api.py
@@ -27,6 +27,13 @@ docstrings will be inserted:
   - @@ ClassName[all-methods] @@
   - @@ ClassName[methods-with-docstrings] @@
 
+If a docstring containes text that should be treated as an alternate function
+signature, then those lines can be marked with tags like `##sig` (to move the
+line to the header) or `##sig-keep` to copy the line, but not remove it from the
+docstring, keeping it in place.
+
+    NOTE: Currently the signature tags functionality assumes that the signature
+          does not span more than one line.
 """
 
 import sys
@@ -106,12 +113,43 @@ class FunctionItem(Item):
             param_str += ')'
         return param_str
 
+    def check_other_signatures(self, docstring):
+        """ Search for alternate function signatures in the docstring """
+        SIG = '##sig'
+        SIG_KEEP = '##sig-keep'
+        other_signatures = ''
+
+        if SIG in docstring or SIG_KEEP in docstring:
+            other_sigs = []
+            docstring_lines = []
+            for line in docstring.split('\n'):
+                if line.endswith(SIG):
+                    line = line.replace(SIG, '')
+                    line = line.strip()
+                    line = line.replace('`', '')
+                    other_sigs.append(line)
+
+                elif line.endswith(SIG_KEEP):
+                    line = line.replace(SIG_KEEP, '')
+                    line = line.strip()
+                    docstring_lines.append(line)
+                    line = line.replace('`', '')
+                    other_sigs.append(line)
+
+                else:
+                    docstring_lines.append(line)
+
+            docstring = '\n'.join(docstring_lines)
+            other_signatures = ''.join(['\ndef {}:'.format(item) for item in other_sigs])
+        return docstring, other_signatures
+
     def create_markdown(self):
         # pull relevant attributes into local variables
         function_name = self.name
-        function_name_escaped = function_name.replace('_', '\_')
+        function_name_escaped = function_name.replace('_', '\\_')
         docstring = self.docstring if self.docstring else ''
         parameters = self.get_parameters(len(function_name) + 1)
+        docstring, other_signatures = self.check_other_signatures(docstring)
 
         # Substitute values into the template
         return self.template.format(**locals())
@@ -134,9 +172,10 @@ class MethodItem(FunctionItem):
         # pull relevant attributes into local variables
         class_name = self.klass.name
         method_name = self.method_name
-        method_name_escaped = method_name.replace('_', '\_')
+        method_name_escaped = method_name.replace('_', '\\_')
         docstring = self.docstring if self.docstring else ''
         parameters = self.get_parameters(4 + len(method_name) + 1)
+        docstring, other_signatures = self.check_other_signatures(docstring)
 
         # Substitute values into the template
         return self.template.format(**locals())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,7 @@ markdown_extensions:
 extra_javascript:
  - 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML'
 
-pages:
+nav:
 - 'Manual': 'index.md'
 - 'Introduction': 'Introduction.md'
 - 'Download': 'Download.md'

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2261,6 +2261,8 @@ class Simulation(object):
 
     def add_dft_fields(self, *args, **kwargs):
         """
+        `add_dft_fields(cs, fcen, df, nfreq, freq, where=None, center=None, size=None, yee_grid=False)` ##sig
+
         Given a list of field components `cs`, compute the Fourier transform of these
         fields for `nfreq` equally spaced frequencies covering the frequency range
         `fcen-df/2` to `fcen+df/2` or an array/list `freq` for arbitrarily spaced
@@ -2318,7 +2320,7 @@ class Simulation(object):
 
     def add_near2far(self, *args, **kwargs):
         """
-        add_near2far(fcen, df, nfreq, freq, Near2FarRegions..., nperiods=1)
+        `add_near2far(fcen, df, nfreq, freq, Near2FarRegions..., nperiods=1)`  ##sig
 
         Add a bunch of `Near2FarRegion`s to the current simulation (initializing the
         fields if they have not yet been initialized), telling Meep to accumulate the
@@ -2342,7 +2344,7 @@ class Simulation(object):
 
     def add_energy(self, *args):
         """
-        `add_energy(fcen, df, nfreq, freq, EnergyRegions...)`
+        `add_energy(fcen, df, nfreq, freq, EnergyRegions...)`  #sig
 
         Add a bunch of `EnergyRegion`s to the current simulation (initializing the fields
         if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -2556,7 +2558,7 @@ class Simulation(object):
 
     def add_force(self, *args):
         """
-        `add_force(fcen, df, nfreq, freq, ForceRegions...)`
+        `add_force(fcen, df, nfreq, freq, ForceRegions...)`  #sig
 
         Add a bunch of `ForceRegion`s to the current simulation (initializing the fields
         if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -2653,6 +2655,8 @@ class Simulation(object):
 
     def add_flux(self, *args):
         """
+        `add_flux(fcen, df, nfreq, freq, FluxRegions...)` ##sig
+
         Add a bunch of `FluxRegion`s to the current simulation (initializing the fields if
         they have not yet been initialized), telling Meep to accumulate the appropriate
         field Fourier transforms for `nfreq` equally spaced frequencies covering the
@@ -2674,6 +2678,8 @@ class Simulation(object):
 
     def add_mode_monitor(self, *args):
         """
+        `add_mode_monitor(fcen, df, nfreq, freq, ModeRegions...)`  ##sig
+
         Similar to `add_flux`, but for use with `get_eigenmode_coefficients`.
         """
         args = fix_dft_args(args, 0)
@@ -3416,7 +3422,7 @@ class Simulation(object):
 
     def run(self, *step_funcs, **kwargs):
         """
-        `run(step_functions..., until=condition/time)`
+        `run(step_functions..., until=condition/time)`  ##sig-keep
 
         Run the simulation until a certain time or condition, calling the given step
         functions (if any) at each timestep. The keyword argument `until` is *either* a
@@ -3425,7 +3431,7 @@ class Simulation(object):
         stop. `until` can also be a list of stopping conditions which may include a number
         and additional functions.
 
-        `run(step_functions..., until_after_sources=condition/time)`
+        `run(step_functions..., until_after_sources=condition/time)`  ##sig-keep
 
         Run the simulation until all sources have turned off, calling the given step
         functions (if any) at each timestep. The keyword argument `until_after_sources` is

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2344,7 +2344,7 @@ class Simulation(object):
 
     def add_energy(self, *args):
         """
-        `add_energy(fcen, df, nfreq, freq, EnergyRegions...)`  #sig
+        `add_energy(fcen, df, nfreq, freq, EnergyRegions...)`  ##sig
 
         Add a bunch of `EnergyRegion`s to the current simulation (initializing the fields
         if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -2558,7 +2558,7 @@ class Simulation(object):
 
     def add_force(self, *args):
         """
-        `add_force(fcen, df, nfreq, freq, ForceRegions...)`  #sig
+        `add_force(fcen, df, nfreq, freq, ForceRegions...)`  ##sig
 
         Add a bunch of `ForceRegion`s to the current simulation (initializing the fields
         if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -4627,7 +4627,7 @@ def output_sfield_p(sim):
 
 def Ldos(*args):
     """
-    `Ldos(fcen, df, nfreq, freq)`
+    `Ldos(fcen, df, nfreq, freq)`  ##sig
 
     Create an LDOS object with either frequency bandwidth `df` centered at `fcen` and
     `nfreq` equally spaced frequency points or an array/list `freq` for arbitrarily spaced
@@ -4642,7 +4642,7 @@ def Ldos(*args):
 
 def dft_ldos(*args, **kwargs):
     """
-    `dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)`
+    `dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None)`   ##sig
 
     Compute the power spectrum of the sources (usually a single point dipole source),
     normalized to correspond to the LDOS, in either a frequency bandwidth `df` centered at


### PR DESCRIPTION
* Add ability to insert alternate function signatures into the header for functions or methods
* Fixed tag injection to include the class docstring for things like "@@ ClassName[all-methods] @@" include the class declaration and docstring, making it so you don't also need to include a "@@ ClassName @@" tag
* Update `doc/Readme.md` to give more info about regenerating the docs.
* Various other fixes and tweaks