### PR TITLE
complex source point Gaussian beam

### DIFF
--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1490,6 +1490,7 @@ public:
   gaussianbeam(const vec &x0, const vec &kdir, double w0, double freq,
                double eps, double mu, std::complex<double> EO[3]);
   void get_fields(std::complex<double> *EH, const vec &x);
+  std::complex<double> get_E0(int n) { return E0[n]; };
 
 private:
   vec x0;           // beam center
@@ -2009,6 +2010,10 @@ private:
   void step_source(field_type ft, bool including_integrated = false);
   void update_pols(field_type ft);
   void calc_sources(double tim);
+  // mpb.cpp
+  void add_volume_source_check(component c, const src_time &src, const volume &where,
+                               std::complex<double> A(const vec &), std::complex<double> amp,
+                               component c0, direction d, int has_tm, int has_te);
 
 public:
   // monitor.cpp

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1697,7 +1697,7 @@ public:
                          std::complex<double> A(const vec &), std::complex<double> amp = 1.0);
   void add_volume_source(component c, const src_time &src, const volume &,
                          std::complex<double> amp = 1.0);
-  void add_volume_source(const src_time &src, direction d, const volume &, gaussianbeam beam);
+  void add_volume_source(const src_time &src, const volume &, gaussianbeam beam);
   void require_component(component c);
 
   // mpb.cpp

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1484,6 +1484,22 @@ public:
   std::vector<std::complex<double> > values; // updated by update_values(idx)
 };
 
+class gaussianbeam {
+
+public:
+  gaussianbeam(const vec &x0, const vec &kdir, double w0, double freq,
+               double eps, double mu, std::complex<double> EO[3]);
+  void get_fields(std::complex<double> *EH, const vec &x);
+
+private:
+  vec x0;           // beam center
+  vec kdir;         // beam propagation direction
+  double w0;        // beam waist radius
+  double freq;      // beam frequency
+  double eps, mu;   // permittivity/permeability of homogeneous medium
+  std::complex<double> E0[3]; // electric field-strength vector
+};
+
 /***************************************************************/
 /* prototype for optional user-supplied function to provide an */
 /* initial estimate of the wavevector of mode #mode at         */
@@ -1681,10 +1697,8 @@ public:
                          std::complex<double> A(const vec &), std::complex<double> amp = 1.0);
   void add_volume_source(component c, const src_time &src, const volume &,
                          std::complex<double> amp = 1.0);
+  void add_volume_source(const src_time &src, direction d, const volume &, gaussianbeam beam);
   void require_component(component c);
-  void gaussianbeam_3d(std::complex<double> *EH, const vec &x0, const vec &x,
-                       const vec &kdir, double w0, double freq, double eps,
-                       double mu, const vec &E0);
 
   // mpb.cpp
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -2010,7 +2010,7 @@ private:
   void step_source(field_type ft, bool including_integrated = false);
   void update_pols(field_type ft);
   void calc_sources(double tim);
-  // mpb.cpp
+  // sources.cpp
   void add_volume_source_check(component c, const src_time &src, const volume &where,
                                std::complex<double> A(const vec &), std::complex<double> amp,
                                component c0, direction d, int has_tm, int has_te);

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1489,8 +1489,8 @@ class gaussianbeam {
 public:
   gaussianbeam(const vec &x0, const vec &kdir, double w0, double freq,
                double eps, double mu, std::complex<double> EO[3]);
-  void get_fields(std::complex<double> *EH, const vec &x);
-  std::complex<double> get_E0(int n) { return E0[n]; };
+  void get_fields(std::complex<double> *EH, const vec &x) const;
+  std::complex<double> get_E0(int n) const { return E0[n]; };
 
 private:
   vec x0;           // beam center
@@ -1498,7 +1498,7 @@ private:
   double w0;        // beam waist radius
   double freq;      // beam frequency
   double eps, mu;   // permittivity/permeability of homogeneous medium
-  std::complex<double> E0[3]; // electric field-strength vector
+  std::complex<double> E0[3]; // polarization vector
 };
 
 /***************************************************************/

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1682,6 +1682,9 @@ public:
   void add_volume_source(component c, const src_time &src, const volume &,
                          std::complex<double> amp = 1.0);
   void require_component(component c);
+  void gaussianbeam_3d(std::complex<double> *EH, const vec &x0, const vec &x,
+                       const vec &kdir, double w0, double freq, double eps,
+                       double mu, const vec &E0);
 
   // mpb.cpp
 

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -732,18 +732,18 @@ vec get_k(void *vedata) {
 /* helper routine for add_eigenmode_source that calls          */
 /* add_volume_source only if certain conditions are met        */
 /***************************************************************/
-void add_volume_source_check(component c, const src_time &src, const volume &where,
-                             cdouble A(const vec &), cdouble amp, fields *f, component c0,
-                             direction d, int parity) {
-  if (!f->gv.has_field(c)) return;
+void fields::add_volume_source_check(component c, const src_time &src, const volume &where,
+                                     cdouble A(const vec &), cdouble amp, component c0,
+                                     direction d, int has_tm, int has_te) {
+  if (!gv.has_field(c)) return;
   if (c0 != Centered && c0 != c) return;
   if (component_direction(c) == d) return;
-  if (f->gv.dim == D2) // parity checks
+  if (gv.dim == D2) // parity checks
   {
-    if ((parity & EVEN_Z_PARITY) && is_tm(c)) return;
-    if ((parity & ODD_Z_PARITY) && !is_tm(c)) return;
+    if (has_te && is_tm(c)) return;
+    if (has_tm && !is_tm(c)) return;
   };
-  f->add_volume_source(c, src, where, A, amp);
+  add_volume_source(c, src, where, A, amp);
 }
 
 /***************************************************************/
@@ -803,14 +803,18 @@ void fields::add_eigenmode_source(component c0, const src_time &src, direction d
   int np2 = (n + 2) % 3;
   // Kx = -Hy, Ky = Hx   (for d==Z)
   global_eigenmode_component = cH[np1];
-  add_volume_source_check(cE[np2], *src_mpb, where, meep_mpb_A, +1.0 * amp, this, c0, d, parity);
+  add_volume_source_check(cE[np2], *src_mpb, where, meep_mpb_A, +1.0 * amp, c0, d,
+                          parity & ODD_Z_PARITY, parity & EVEN_Z_PARITY);
   global_eigenmode_component = cH[np2];
-  add_volume_source_check(cE[np1], *src_mpb, where, meep_mpb_A, -1.0 * amp, this, c0, d, parity);
+  add_volume_source_check(cE[np1], *src_mpb, where, meep_mpb_A, -1.0 * amp, c0, d,
+                          parity & ODD_Z_PARITY, parity & EVEN_Z_PARITY);
   // Nx = +Ey, Ny = -Ex  (for d==Z)
   global_eigenmode_component = cE[np1];
-  add_volume_source_check(cH[np2], *src_mpb, where, meep_mpb_A, -1.0 * amp, this, c0, d, parity);
+  add_volume_source_check(cH[np2], *src_mpb, where, meep_mpb_A, -1.0 * amp, c0, d,
+                          parity & ODD_Z_PARITY, parity & EVEN_Z_PARITY);
   global_eigenmode_component = cE[np2];
-  add_volume_source_check(cH[np1], *src_mpb, where, meep_mpb_A, +1.0 * amp, this, c0, d, parity);
+  add_volume_source_check(cH[np1], *src_mpb, where, meep_mpb_A, +1.0 * amp, c0, d,
+                          parity & ODD_Z_PARITY, parity & EVEN_Z_PARITY);
 
   delete src_mpb;
   destroy_eigenmode_data((void *)global_eigenmode_data);

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -729,24 +729,6 @@ vec get_k(void *vedata) {
 }
 
 /***************************************************************/
-/* helper routine for add_eigenmode_source that calls          */
-/* add_volume_source only if certain conditions are met        */
-/***************************************************************/
-void fields::add_volume_source_check(component c, const src_time &src, const volume &where,
-                                     cdouble A(const vec &), cdouble amp, component c0,
-                                     direction d, int has_tm, int has_te) {
-  if (!gv.has_field(c)) return;
-  if (c0 != Centered && c0 != c) return;
-  if (component_direction(c) == d) return;
-  if (gv.dim == D2) // parity checks
-  {
-    if (has_te && is_tm(c)) return;
-    if (has_tm && !is_tm(c)) return;
-  };
-  add_volume_source(c, src, where, A, amp);
-}
-
-/***************************************************************/
 /* call get_eigenmode() to solve for the specified eigenmode,  */
 /* then call add_volume_source() to add current sources whose  */
 /* radiated fields reproduce the eigenmode fields              */

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -436,6 +436,24 @@ void fields::add_volume_source(component c, const src_time &src, const volume &w
   require_component(c);
 }
 
+/***************************************************************/
+/* helper routine for add_eigenmode_source that calls          */
+/* add_volume_source only if certain conditions are met        */
+/***************************************************************/
+void fields::add_volume_source_check(component c, const src_time &src, const volume &where,
+                                     complex<double> A(const vec &), complex<double> amp, component c0,
+                                     direction d, int has_tm, int has_te) {
+  if (!gv.has_field(c)) return;
+  if (c0 != Centered && c0 != c) return;
+  if (component_direction(c) == d) return;
+  if (gv.dim == D2) // parity checks
+  {
+    if (has_te && is_tm(c)) return;
+    if (has_tm && !is_tm(c)) return;
+  };
+  add_volume_source(c, src, where, A, amp);
+}
+
 static gaussianbeam *global_gaussianbeam_object = 0;
 static component global_gaussianbeam_component;
 

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -453,6 +453,14 @@ static std::complex<double> gaussianbeam_ampfunc(const vec &p) {
   }
 }
 
+static int gaussianbeam_has_tm() {
+  return abs(global_gaussianbeam_object->get_E0(2)) > 0;
+}
+
+static int gaussianbeam_has_te() {
+  return abs(global_gaussianbeam_object->get_E0(0)) > 0 || abs(global_gaussianbeam_object->get_E0(1)) > 0;
+}
+
 void fields::add_volume_source(const src_time &src, const volume &where, gaussianbeam beam) {
   global_gaussianbeam_object = &beam;
   direction d = normal_direction(where);
@@ -470,14 +478,18 @@ void fields::add_volume_source(const src_time &src, const volume &where, gaussia
   int np2 = (n + 2) % 3;
   // Kx = -Hy, Ky = Hx   (for d==Z)
   global_gaussianbeam_component = cH[np1];
-  add_volume_source(cE[np2], src, where, gaussianbeam_ampfunc, +1.0);
+  add_volume_source_check(cE[np2], src, where, gaussianbeam_ampfunc, +1.0, cE[np2], d,
+                          gaussianbeam_has_tm(), gaussianbeam_has_te());
   global_gaussianbeam_component = cH[np2];
-  add_volume_source(cE[np1], src, where, gaussianbeam_ampfunc, -1.0);
+  add_volume_source_check(cE[np1], src, where, gaussianbeam_ampfunc, -1.0, cE[np1], d,
+                          gaussianbeam_has_tm(), gaussianbeam_has_te());
   // Nx = +Ey, Ny = -Ex  (for d==Z)
   global_gaussianbeam_component = cE[np1];
-  add_volume_source(cH[np2], src, where, gaussianbeam_ampfunc, -1.0);
+  add_volume_source_check(cH[np2], src, where, gaussianbeam_ampfunc, -1.0, cH[np2], d,
+                          gaussianbeam_has_tm(), gaussianbeam_has_te());
   global_gaussianbeam_component = cE[np2];
-  add_volume_source(cH[np1], src, where, gaussianbeam_ampfunc, +1.0);
+  add_volume_source_check(cH[np1], src, where, gaussianbeam_ampfunc, +1.0, cH[np1], d,
+                          gaussianbeam_has_tm(), gaussianbeam_has_te());
 }
 
 gaussianbeam::gaussianbeam(const vec &x0_, const vec &kdir_, double w0_, double freq_,

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -439,7 +439,7 @@ void fields::add_volume_source(component c, const src_time &src, const volume &w
 static gaussianbeam *global_gaussianbeam_object = 0;
 static component global_gaussianbeam_component;
 
-static complex<double> gaussianbeam_ampfunc(const vec &p) {
+static std::complex<double> gaussianbeam_ampfunc(const vec &p) {
   std::complex<double> EH[6];
   global_gaussianbeam_object->get_fields(EH, p);
   switch (global_gaussianbeam_component) {
@@ -453,8 +453,9 @@ static complex<double> gaussianbeam_ampfunc(const vec &p) {
   }
 }
 
-void fields::add_volume_source(const src_time &src, direction d, const volume &where, gaussianbeam beam) {
+void fields::add_volume_source(const src_time &src, const volume &where, gaussianbeam beam) {
   global_gaussianbeam_object = &beam;
+  direction d = normal_direction(where);
   component cE[3] = {Ex, Ey, Ez}, cH[3] = {Hx, Hy, Hz};
   int n = (d == X ? 0 : (d == Y ? 1 : 2));
   if (d == NO_DIRECTION) {
@@ -600,9 +601,9 @@ void gaussianbeam::get_fields(std::complex<double> *EH, const vec &x) {
 
   double Eorig;
   if (UseRescaledFG)
-    Eorig = 3/(2*kz0*kz0*kz0) * (kz0*(kz0-1) + 0.5*(1.0-exp(-2.0*kz0)));
+    Eorig = 3.0/(2*kz0*kz0*kz0) * (kz0*(kz0-1) + 0.5*(1.0-exp(-2.0*kz0)));
   else
-    Eorig = 3/(2*kz0*kz0*kz0) * (exp(kz0)*kz0*(kz0-1) + sinh(kz0));
+    Eorig = 3.0/(2*kz0*kz0*kz0) * (exp(kz0)*kz0*(kz0-1) + sinh(kz0));
 
   EH[0] = E[0] / Eorig;
   EH[1] = E[1] / Eorig;


### PR DESCRIPTION
Fixes #711.

This PR adds a new function `gaussianbeam_3d` to the `fields` class which computes the fields for a Gaussian beam using the complex source point method. The new function is based on @HomerReid's implementation from SCUFF-EM in [`GaussianBeam::GetFields`](https://github.com/HomerReid/scuff-em/blob/master/libs/libIncField/GaussianBeam.cc#L78-L218). The main difference is that the user-specified field-strength vector `E0` is real (because it is based on Meep's `vec` object which only supports [real-valued elements](https://github.com/NanoComp/meep/blob/master/src/meep/vec.hpp#L600)) whereas Homer supported the more general case of complex numbers. We could support a complex field-strength vector but this does not seem to be necessary.

The next thing to do is to add the function `add_gaussianbeam_source` which calls `gaussianbeam_3d` for every point in a given user-specified region `where` and uses these fields to compute the equivalent currents. 

A couple of issues regarding the API for `add_gaussianbeam_source`:
- for a 3d simulation involving a 2d source object, should the center of the Gaussian beam be an input parameter (with arbitrary values) or just be set to the geometric center of the user-specified `where` object? Under what scenario would the beam center *not* lie in the 2d plane?
- is there a requirement that the source object be positioned within a lossless medium or should the imaginary part of ε be ignored along with a warning message?
- should we support a 3d source object?
- how can quantify how much more accurate generating a Gaussian beam is using this complex source point method versus just an amplitude function? this could form the basis for a test that we can add to the `make check` suite.
