### PR TITLE
Pin mkdocs to the new version we are now using

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs==0.17.5
+mkdocs==1.1.2
 python-markdown-math
 mkdocs-material


### PR DESCRIPTION
I think this will fix the problem of the alphabetic ordering of the sidebar in the readthedocs version of the MEEP docs. I had changed the deprecated `pages` directive to the new `nav` directive in mkdocs.yml due to warnings produced when running mkdocs. If RTD is using this file to set up the doc build environment then it's using a version of mkdocs that doesn't know about the `nav` directive.