### PR TITLE
docstrings for class GaussianBeamSource

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -627,7 +627,26 @@ def get_epsilon_point(self, pt, frequency=0, omega=0):
 Given a frequency `frequency` and a `Vector3` `pt`, returns the average eigenvalue
 of the permittivity tensor at that location and frequency. If `frequency` is
 non-zero, the result is complex valued; otherwise it is the real,
-frequency-independent part of ε (the $\omega\to\infty$ limit).
+frequency-independent part of $\varepsilon$ (the $\omega\to\infty$ limit).
+
+</div>
+
+</div>
+
+<a id="Simulation.get_mu_point"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_mu_point(self, pt, frequency=0, omega=0):
+```
+
+<div class="method_docstring" markdown="1">
+
+Given a frequency `frequency` and a `Vector3` `pt`, returns the average eigenvalue
+of the permeability tensor at that location and frequency. If `frequency` is
+non-zero, the result is complex valued; otherwise it is the real,
+frequency-independent part of $\mu$ (the $\omega\to\infty$ limit).
 
 </div>
 
@@ -1288,7 +1307,7 @@ Technically, MPB computes `ωₙ(k)` and then inverts it with Newton's method to
 <div class="class_members" markdown="1">
 
 ```python
-def add_mode_monitor(self, *args): 
+def add_mode_monitor(self, *args, **kwargs):
 def add_mode_monitor(fcen, df, nfreq, freq, ModeRegions...):
 ```
 
@@ -5553,7 +5572,7 @@ def __init__(self,
              side=-1,
              R_asymptotic=1e-15,
              mean_stretch=1.0,
-             pml_profile=<function PML.<lambda> at 0x7fc840abd7a0>): 
+             pml_profile=lambda u: u * u):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5961,7 +5980,6 @@ Returns the total power of the fields from the eigenmode source at frequency `fr
 
 </div>
 
-
 ---
 <a id="GaussianBeamSource"></a>
 
@@ -5981,6 +5999,8 @@ The `SourceTime` object (`Source.src`), which specifies the time dependence of t
 
 </div>
 
+
+
 <a id="GaussianBeamSource.__init__"></a>
 
 <div class="class_members" markdown="1">
@@ -5990,11 +6010,11 @@ def __init__(self,
              src,
              center=None,
              volume=None,
-             component=mp.ALL_COMPONENTS,
-             beam_x0=Vector3(),
-             beam_kdir=Vector3(),
+             component=20,
+             beam_x0=Vector3<0.0, 0.0, 0.0>,
+             beam_kdir=Vector3<0.0, 0.0, 0.0>,
              beam_w0=None,
-             beam_E0=Vector3(),
+             beam_E0=Vector3<0.0, 0.0, 0.0>,
              **kwargs):
 ```
 
@@ -6002,9 +6022,9 @@ def __init__(self,
 
 Construct a `GaussianBeamSource`.
 
-+ **`beam_x0` [`Vector3`]** — The location of the beam focus *relative* to the center of the source. This does *not* need to lie within the source region (i.e., the beam focus can be anywhere, inside or outside the cell, independent of position of the source).
++ **`beam_x0` [`Vector3`]** — The location of the beam focus *relative* to the center of the source. The beam focus does *not* need to lie within the source region (i.e., the beam focus can be anywhere, inside or outside the cell, independent of the position of the source).
 
-+ **`beam_kdir` [`Vector3`]** — The propagation direction of the beam. The length is *ignored*. The wavelength of the beam is determined by the center frequency of the `Source.src` object and the refractive index of the homogeneous medium by its value at the center of the source region.
++ **`beam_kdir` [`Vector3`]** — The propagation direction of the beam. The length is *ignored*. The wavelength of the beam is determined by the center frequency of the `Source.src` object and the refractive index (real part only) at the center of the source region.
 
 + **`beam_w0` [`number`]** — The beam waist radius.
 

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -98,6 +98,7 @@ Meep supports a large number of functions to perform computations on the fields.
 @@ Simulation.phase_in_material @@
 @@ Simulation.get_field_point @@
 @@ Simulation.get_epsilon_point @@
+@@ Simulation.get_mu_point @@
 @@ Simulation.initialize_field @@
 @@ Simulation.add_dft_fields @@
 @@ Simulation.flux_in_box @@
@@ -777,6 +778,8 @@ The following classes are available directly via the `meep` package.
 @@ SourceTime @@
 
 @@ EigenModeSource[methods-with-docstrings] @@
+
+@@ GaussianBeamSource[methods-with-docstrings] @@
 
 @@ ContinuousSource[methods-with-docstrings] @@
 

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -17,7 +17,7 @@
 -   [Perfectly matched layer](Perfectly_Matched_Layer/) (**PML**) absorbing boundaries as well as **Bloch-periodic** and perfect-conductor boundary conditions.
 -   Exploitation of [symmetries](Exploiting_Symmetry) to reduce the computation size, including even/odd mirror planes and 90°/180° rotations.
 -   [Subpixel smoothing](Subpixel_Smoothing.md) for improving accuracy and shape optimization.
--   [Custom current sources](Python_Tutorials/Custom_Source.md) with arbitrary time and spatial profile as well as a [mode launcher](Python_Tutorials/Eigenmode_Source.md) for waveguides and planewaves.
+-   [Custom current sources](Python_Tutorials/Custom_Source.md) with arbitrary time and spatial profile as well as a [mode launcher](Python_Tutorials/Eigenmode_Source.md) for waveguides and planewaves and [Gaussian beams](Python_User_Interface.md#gaussianbeamsource).
 -   [Frequency-domain solver](Python_User_Interface.md#frequency-domain-solver) for finding the response to a [continuous-wave](https://en.wikipedia.org/wiki/Continuous_wave) (CW) source as well as a [frequency-domain eigensolver](Python_User_Interface.md#frequency-domain-eigensolver) for finding resonant modes.
 -   ε/μ and field import/export in the [HDF5](https://en.wikipedia.org/wiki/HDF5) data format.
 -   [GDSII](Python_User_Interface.md#gdsii-support) file import for planar geometries.

--- a/python/source.py
+++ b/python/source.py
@@ -352,7 +352,7 @@ class EigenModeSource(Source):
     conductivities σ, or dispersive polarizations in your materials will be *ignored* when
     computing the eigenmode source. PML will also be ignored.
 
-    The `src_time` object (`Source.src`), which specifies the time dependence of the
+    The `SourceTime` object (`Source.src`), which specifies the time dependence of the
     source, can be one of `ContinuousSource`, `GaussianSource` or `CustomSource`.
     """
     def __init__(self,
@@ -530,11 +530,11 @@ class EigenModeSource(Source):
 
 class GaussianBeamSource(Source):
     """
-    This is a subclass of `Source` and has **all of the properties** of `Source` above.
+    This is a subclass of `Source` and has **all of the properties** of `Source` above. However, the `component` parameter of the `Source` object is ignored. The [Gaussian beam](https://en.wikipedia.org/wiki/Gaussian_beam) is a transverse electromagnetic mode for which the source region must be a *line* (in 2d) or *plane* (in 3d). For a beam polarized in the $x$ direction with propagation along $+z$, the electric field is defined by $\\mathbf{E}(r,z)=E_0\\hat{x}\\frac{w_0}{w(z)}\\exp\\left(\\frac{-r^2}{w(z)^2}\\right)\\exp\\left(-i\\left(kz + k\\frac{r^2}{2R(z)}\\right)\\right)$ where $r$ is the radial distance from the center axis of the beam, $z$ is the axial distance from the beam's focus (or "waist"), $k=2\\pi n/\\lambda$ is the wavenumber (for a free-space wavelength $\lambda$ and refractive index $n$ of the homogeneous, lossless medium in which the beam propagates), $E_0$ is the electric field amplitude at the origin, $w(z)$ is the radius at which the field amplitude decays by $1/e$ of its axial values, $w_0$ is the beam waist radius, and $R(z)$ is the radius of curvature of the beam's wavefront at $z$. The only independent parameters that need to be specified are $w_0$, $E_0$, $k$, and the location of the beam focus (i.e., the origin: $r=z=0$).
 
-    The [Gaussian beam](https://en.wikipedia.org/wiki/Gaussian_beam) is a transverse electromagnetic mode for which the source region *must* be a line in 2d or plane in 3d. For a beam polarized in the $x$ direction with propagation along $+z$, the electric field is defined by $\\mathbf{E}(r,z)=E_0\\hat{x}\\frac{w_0}{w(z)}\\exp\\left(\\frac{-r^2}{w(z)^2}\\right)\\exp\\left(-i\\left(kz + k\\frac{r^2}{2R(z)}\\right)\\right)$ where $r$ is the radial distance from the center axis of the beam, $z$ is the axial distance from the beam's focus (or "waist"), $k=2\pi n/\lambda$ is the wavenumber (for a free-space wavelength $\lambda$ and refractive index $n$ of the homogeneous, lossless medium in which the beam propagates), $E_0$ is the electric field amplitude at the origin, $w(z)$ is the radius at which the field amplitude decays by $1/e$ of its axial values, $w_0$ is the beam waist radius, and $R(z)$ is the radius of curvature of the beam's wavefront at $z$. In Meep, the only parameters that need to be specified are $w_0$, $E_0$, $k$, and the location of the beam focus (i.e., the origin $r=z=0$ from the previous formula). The `component` parameter of the `Source` object is ignored.
+    (In 3d, we use a ["complex point-source" method](https://doi.org/10.1364/JOSAA.16.001381) to define a source that generates an exact Gaussian-beam solution.  In 2d, we currently use the simple approximation of taking a cross-section of the 3d beam.  In both cases, the beam is most accurate near the source's center frequency.)
 
-    The `src_time` object (`Source.src`), which specifies the time dependence of the source, can be one of `ContinuousSource` or `GaussianSource`.
+    The `SourceTime` object (`Source.src`), which specifies the time dependence of the source, should normally be a narrow-band `ContinuousSource` or `GaussianSource`.  (For a `CustomSource`, the beam frequency is determined by the source's `center_frequency` parameter.)
     """
 
     def __init__(self,
@@ -548,15 +548,15 @@ class GaussianBeamSource(Source):
                  beam_E0=Vector3(),
                  **kwargs):
         """
-        Construct an `GaussianBeamSource`.
+        Construct a `GaussianBeamSource`.
 
-        + **`beam_x0` [`Vector3`]** — The location of the beam focus. This does *not* need to lie within the source region (i.e., the beam can be focused at any arbitrary point, inside or outside the cell, independent of where the source is positioned).
+        + **`beam_x0` [`Vector3`]** — The location of the beam focus *relative* to the center of the source. The beam focus does *not* need to lie within the source region (i.e., the beam focus can be anywhere, inside or outside the cell, independent of the position of the source).
 
-        + **`beam_kdir` [`Vector3`]** — The propagation direction of the beam. The length is *ignored*. (The wavelength of the beam is determined by the center frequency of the `src_time` object and the refractive index of the homogeneous medium by its value at the center of the source region.)
+        + **`beam_kdir` [`Vector3`]** — The propagation direction of the beam. The length is *ignored*. The wavelength of the beam is determined by the center frequency of the `Source.src` object and the refractive index (real part only) at the center of the source region.
 
         + **`beam_w0` [`number`]** — The beam waist radius.
 
-        + **`beam_E0` [`Vector3`]** — The polarization vector of the beam. Elements can be complex valued (i.e., for circular polarization). The polarization vector must be *parallel* to the source region (i.e., in order to generate a transverse mode).
+        + **`beam_E0` [`Vector3`]** — The polarization vector of the beam. Elements can be complex valued (i.e., for circular polarization). The polarization vector must be *parallel* to the source region in order to generate a transverse mode.
         """
 
         super(GaussianBeamSource, self).__init__(src, component, center, volume, **kwargs)


### PR DESCRIPTION
This was left out of #1310 as described in [comment](https://github.com/NanoComp/meep/pull/1310#issuecomment-672390893).

(The docstrings was used to generate the `Python_User_Interface.md` markdown page using `docs/generate_py_api.py`.)