### PR TITLE
Add warnings for non-whole number usage with grid_volume

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -199,24 +199,22 @@ static meep::vec py_kpoint_func_wrap(double freq, int mode, void *user_data) {
     return result;
 }
 
-void py_master_printf_wrap(const char *s) {
-    PySys_WriteStdout("%s", s);
-    static PyObject *py_stdout = NULL;
-    if (py_stdout == NULL) {
-      py_stdout = PySys_GetObject("stdout");
-    }
-    PyObject *result = PyObject_CallMethod(py_stdout, "flush", NULL);
+static void _do_master_printf(const char* stream_name, const char* text) {
+    PyObject* py_stream = PySys_GetObject(stream_name);
+    PyObject* result;
+
+    result = PyObject_CallMethod(py_stream, "write", "(s)", text);
+    Py_XDECREF(result);
+    result = PyObject_CallMethod(py_stream, "flush", NULL);
     Py_XDECREF(result);
 }
 
+void py_master_printf_wrap(const char *s) {
+    _do_master_printf("stdout", s);
+}
+
 void py_master_printf_stderr_wrap(const char *s) {
-    PySys_WriteStderr("%s", s);
-    static PyObject *py_stderr = NULL;
-    if (py_stderr == NULL) {
-      py_stderr = PySys_GetObject("stderr");
-    }
-    PyObject *result = PyObject_CallMethod(py_stderr, "flush", NULL);
-    Py_XDECREF(result);
+    _do_master_printf("stderr", s);
 }
 
 void set_ctl_printf_callback(void (*callback)(const char *s)) {

--- a/python/meep.i
+++ b/python/meep.i
@@ -200,7 +200,7 @@ static meep::vec py_kpoint_func_wrap(double freq, int mode, void *user_data) {
 }
 
 static void _do_master_printf(const char* stream_name, const char* text) {
-    PyObject* py_stream = PySys_GetObject(stream_name);
+    PyObject* py_stream = PySys_GetObject((char*)stream_name); // arg is non-const on Python2
     PyObject* result;
 
     result = PyObject_CallMethod(py_stream, "write", "(s)", text);

--- a/python/meep.i
+++ b/python/meep.i
@@ -209,6 +209,16 @@ void py_master_printf_wrap(const char *s) {
     Py_XDECREF(result);
 }
 
+void py_master_printf_stderr_wrap(const char *s) {
+    PySys_WriteStderr("%s", s);
+    static PyObject *py_stderr = NULL;
+    if (py_stderr == NULL) {
+      py_stderr = PySys_GetObject("stderr");
+    }
+    PyObject *result = PyObject_CallMethod(py_stderr, "flush", NULL);
+    Py_XDECREF(result);
+}
+
 void set_ctl_printf_callback(void (*callback)(const char *s)) {
 #if HAVE_CTL_PRINTF_CALLBACK
   ctl_printf_callback = callback;
@@ -508,14 +518,14 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
 }
 
 PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where, size_t dims[3],
-                                      bool collapse_empty_dimensions, bool snap_empty_dimensions, 
+                                      bool collapse_empty_dimensions, bool snap_empty_dimensions,
                                       meep::component cgrid = Centered, PyObject *min_max_loc = NULL) {
     meep::direction dirs[3] = {meep::X, meep::X, meep::X};
 
     meep::vec min_max_loc_vec[2];
     meep::vec* min_max_loc_vec_ptr = min_max_loc_vec;
     if (!min_max_loc) min_max_loc_vec_ptr = NULL;
-    
+
     int rank = f->get_array_slice_dimensions(where, dims, dirs, collapse_empty_dimensions, snap_empty_dimensions, min_max_loc_vec_ptr, 0, cgrid);
 
     PyObject *py_dirs = PyList_New(3);
@@ -583,6 +593,7 @@ void _get_eigenmode(meep::fields *f, double frequency, meep::direction d, const 
 double py_pml_profile(double u, void *f);
 
 %constant void py_master_printf_wrap(const char *s);
+%constant void py_master_printf_stderr_wrap(const char *s);
 void set_ctl_printf_callback(void (*callback)(const char *s));
 void set_mpb_printf_callback(void (*callback)(const char *s));
 
@@ -801,7 +812,7 @@ void _get_gradient(PyObject *grad, PyObject *fields_a, PyObject *fields_f, PyObj
 
     // clean the volume object
     void* where;
-    
+
     PyObject* swigobj = PyObject_GetAttrString(grid_volume, "swigobj");
     SWIG_ConvertPtr(swigobj,&where,NULL,NULL);
     const meep::volume* where_vol = (const meep::volume*)where;
@@ -828,7 +839,7 @@ void _get_gradient(PyObject *grad, PyObject *fields_a, PyObject *fields_f, PyObj
 
     // calculate the gradient
     meep_geom::material_grids_addgradient(grad_c,ng,fields_a_c,fields_f_c,frequencies_c,nf,scalegrad,*where_vol,geometry_tree,f_c);
-    
+
     destroy_geom_box_tree(geometry_tree);
     delete[] l;
 

--- a/python/meep.i
+++ b/python/meep.i
@@ -201,12 +201,9 @@ static meep::vec py_kpoint_func_wrap(double freq, int mode, void *user_data) {
 
 static void _do_master_printf(const char* stream_name, const char* text) {
     PyObject* py_stream = PySys_GetObject((char*)stream_name); // arg is non-const on Python2
-    PyObject* result;
 
-    result = PyObject_CallMethod(py_stream, "write", "(s)", text);
-    Py_XDECREF(result);
-    result = PyObject_CallMethod(py_stream, "flush", NULL);
-    Py_XDECREF(result);
+    Py_XDECREF(PyObject_CallMethod(py_stream, "write", "(s)", text));
+    Py_XDECREF(PyObject_CallMethod(py_stream, "flush", NULL));
 }
 
 void py_master_printf_wrap(const char *s) {

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -39,6 +39,7 @@ verbosity = Verbosity(mp.cvar, 1)
 
 # Send output from Meep, ctlgeom, and MPB to Python's stdout
 mp.set_meep_printf_callback(mp.py_master_printf_wrap)
+mp.set_meep_printf_stderr_callback(mp.py_master_printf_stderr_wrap)
 mp.set_ctl_printf_callback(mp.py_master_printf_wrap)
 mp.set_mpb_printf_callback(mp.py_master_printf_wrap)
 
@@ -313,7 +314,7 @@ class Volume(object):
             z_size = 0 if z_list.size == 1 else np.abs(np.diff(z_list)[0])
 
             self.size = Vector3(x_size,y_size,z_size)
-    
+
         self.dims = dims
 
         v1 = self.center - self.size.scale(0.5)
@@ -3207,12 +3208,12 @@ class Simulation(object):
                       DeprecationWarning)
         return self.get_array_metadata(vol=dft_cell.where if dft_cell is not None else vol,
                                        center=center, size=size, collapse=True)
-    
+
     def get_array_slice_dimensions(self, component, vol=None, center=None, size=None):
         """
         Computes the dimensions of a dft array for a particular `component` (`mp.Ez`, `mp.Ey`, etc.).
 
-        Accepts either a volume object (`vol`), or a `center` and `size` `Vector3` pair. 
+        Accepts either a volume object (`vol`), or a `center` and `size` `Vector3` pair.
 
         Returns a tuple containing the dimensions (`dim_sizes`), a `Vector3` object
         corresponding to the minimum corner of the volume DFT volume object (`min_corner`),
@@ -3229,7 +3230,7 @@ class Simulation(object):
         min_corner = corners[0]
         max_corner = corners[1]
         return dim_sizes, min_corner, max_corner
-    
+
     def get_eigenmode_coefficients(self, flux, bands, eig_parity=mp.NO_PARITY, eig_vol=None,
                                    eig_resolution=0, eig_tolerance=1e-12, kpoint_func=None, direction=mp.AUTOMATIC):
         """

--- a/python/vec.i
+++ b/python/vec.i
@@ -71,3 +71,19 @@
 %rename(vec_dim) meep::vec::vec(ndim);
 
 %include "meep/vec.hpp"
+
+%extend meep::vec {
+    const char *__repr__() { return $self->str(); }
+}
+
+%extend meep::ivec {
+    const char *__repr__() { return $self->str(); }
+}
+
+%extend meep::volume {
+    const char *__repr__() { return $self->str(); }
+}
+
+%extend meep::grid_volume {
+    const char *__repr__() { return $self->str(); }
+}

--- a/python/vec.i
+++ b/python/vec.i
@@ -70,6 +70,30 @@
 %rename(vec_dim_val) meep::vec::vec(ndim, double);
 %rename(vec_dim) meep::vec::vec(ndim);
 
+// Inject some code to give warnings about non-whole numbers
+%pythoncode {
+    import warnings
+
+    class GridVolumeWarning(UserWarning):
+        pass
+
+    def _check_wholenumbers(*args):
+        for arg in args:
+            if not float(arg).is_integer():
+                warnings.warn(
+                    "Creating a grid_volume with non-whole numbers may result in rounding errors.",
+                    GridVolumeWarning, stacklevel=3)
+                break
+}
+%pythonprepend volcyl { _check_wholenumbers(rsize, zsize, a) }
+%pythonprepend volone { _check_wholenumbers(zsize, a) }
+%pythonprepend vol1d  { _check_wholenumbers(zsize, a) }
+%pythonprepend voltwo { _check_wholenumbers(xsize, ysize, a) }
+%pythonprepend vol2d  { _check_wholenumbers(xsize, ysize, a) }
+%pythonprepend vol3d  { _check_wholenumbers(xsize, ysize, zsize, a) }
+
+
+// Include the C++ class declarations
 %include "meep/vec.hpp"
 
 %extend meep::vec {

--- a/python/vec.i
+++ b/python/vec.i
@@ -70,23 +70,6 @@
 %rename(vec_dim_val) meep::vec::vec(ndim, double);
 %rename(vec_dim) meep::vec::vec(ndim);
 
-// Inject some code to give warnings about non-whole numbers
-%pythoncode {
-    import sys
-    def _check_wholenumbers(*args):
-        for arg in args:
-            if not float(arg).is_integer():
-                sys.stderr.write(
-                    "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
-                break
-}
-%pythonprepend volcyl { _check_wholenumbers(rsize, zsize, a) }
-%pythonprepend volone { _check_wholenumbers(zsize, a) }
-%pythonprepend vol1d  { _check_wholenumbers(zsize, a) }
-%pythonprepend voltwo { _check_wholenumbers(xsize, ysize, a) }
-%pythonprepend vol2d  { _check_wholenumbers(xsize, ysize, a) }
-%pythonprepend vol3d  { _check_wholenumbers(xsize, ysize, zsize, a) }
-
 
 // Include the C++ class declarations
 %include "meep/vec.hpp"

--- a/python/vec.i
+++ b/python/vec.i
@@ -72,17 +72,12 @@
 
 // Inject some code to give warnings about non-whole numbers
 %pythoncode {
-    import warnings
-
-    class GridVolumeWarning(UserWarning):
-        pass
-
+    import sys
     def _check_wholenumbers(*args):
         for arg in args:
             if not float(arg).is_integer():
-                warnings.warn(
-                    "Creating a grid_volume with non-whole numbers may result in rounding errors.",
-                    GridVolumeWarning, stacklevel=3)
+                sys.stderr.write(
+                    "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
                 break
 }
 %pythonprepend volcyl { _check_wholenumbers(rsize, zsize, a) }

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -95,12 +95,14 @@ void and_to_all(const int *in, int *out, int size);
 
 // IO routines:
 void master_printf(const char *fmt, ...) PRINTF_ATTR(1, 2);
+void master_printf_stderr(const char *fmt, ...) PRINTF_ATTR(1, 2);
 void debug_printf(const char *fmt, ...) PRINTF_ATTR(1, 2);
 void master_fprintf(FILE *f, const char *fmt, ...) PRINTF_ATTR(2, 3);
 FILE *master_fopen(const char *name, const char *mode);
 void master_fclose(FILE *f);
 typedef void (*meep_printf_callback_func)(const char *s);
 meep_printf_callback_func set_meep_printf_callback(meep_printf_callback_func func);
+meep_printf_callback_func set_meep_printf_stderr_callback(meep_printf_callback_func func);
 
 void begin_critical_section(int tag);
 void end_critical_section(int tag);

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -869,6 +869,8 @@ public:
   vec get_max_corner() const { return max_corner; };
   direction normal_direction() const;
 
+  const char *str(char *buffer = 0, size_t buflen = 0);
+
 private:
   vec min_corner, max_corner;
 };
@@ -1025,6 +1027,8 @@ public:
   double origin_x() const { return origin.x(); }
   double origin_y() const { return origin.y(); }
   double origin_z() const { return origin.z(); }
+
+  const char *str(char *buffer = 0, size_t buflen = 0);
 
 private:
   std::complex<double> get_split_costs(direction d, int split_point) const;

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -27,6 +27,12 @@ using namespace std;
 
 namespace meep {
 
+static bool _wholenumber(double value) {
+  double intpart;
+  return modf(value, &intpart) == 0.0;
+}
+
+
 ivec grid_volume::round_vec(const vec &p) const {
   ivec result(dim);
   LOOP_OVER_DIRECTIONS(dim, d) { result.set_direction(d, my_round(p.in_direction(d) * 2 * a)); }
@@ -899,10 +905,16 @@ vec grid_volume::dz() const {
 }
 
 grid_volume volone(double zsize, double a) {
+  if (!_wholenumber(zsize) || !_wholenumber(a))
+    master_printf_stderr(
+      "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
   return grid_volume(D1, a, 0, 0, (int)(zsize * a + 0.5));
 }
 
 grid_volume voltwo(double xsize, double ysize, double a) {
+  if (!_wholenumber(xsize) || !_wholenumber(ysize) || !_wholenumber(a))
+    master_printf_stderr(
+      "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
   return grid_volume(D2, a, (xsize == 0) ? 1 : (int)(xsize * a + 0.5),
                      (ysize == 0) ? 1 : (int)(ysize * a + 0.5), 0);
 }
@@ -912,12 +924,19 @@ grid_volume vol1d(double zsize, double a) { return volone(zsize, a); }
 grid_volume vol2d(double xsize, double ysize, double a) { return voltwo(xsize, ysize, a); }
 
 grid_volume vol3d(double xsize, double ysize, double zsize, double a) {
+  if (!_wholenumber(xsize) || !_wholenumber(ysize) || !_wholenumber(zsize) || !_wholenumber(a))
+    master_printf_stderr(
+      "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
   return grid_volume(D3, a, (xsize == 0) ? 1 : (int)(xsize * a + 0.5),
                      (ysize == 0) ? 1 : (int)(ysize * a + 0.5),
                      (zsize == 0) ? 1 : (int)(zsize * a + 0.5));
 }
 
 grid_volume volcyl(double rsize, double zsize, double a) {
+  if (!_wholenumber(rsize) || !_wholenumber(zsize) || !_wholenumber(a))
+    master_printf_stderr(
+      "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
+
   if (zsize == 0.0)
     return grid_volume(Dcyl, a, (int)(rsize * a + 0.5), 0, 1);
   else

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -901,14 +901,14 @@ vec grid_volume::dz() const {
 }
 
 grid_volume volone(double zsize, double a) {
-  if (!isinteger(zsize) || !isinteger(a))
+  if (!isinteger(zsize))
     master_printf_stderr(
       "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
   return grid_volume(D1, a, 0, 0, (int)(zsize * a + 0.5));
 }
 
 grid_volume voltwo(double xsize, double ysize, double a) {
-  if (!isinteger(xsize) || !isinteger(ysize) || !isinteger(a))
+  if (!isinteger(xsize) || !isinteger(ysize))
     master_printf_stderr(
       "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
   return grid_volume(D2, a, (xsize == 0) ? 1 : (int)(xsize * a + 0.5),
@@ -920,7 +920,7 @@ grid_volume vol1d(double zsize, double a) { return volone(zsize, a); }
 grid_volume vol2d(double xsize, double ysize, double a) { return voltwo(xsize, ysize, a); }
 
 grid_volume vol3d(double xsize, double ysize, double zsize, double a) {
-  if (!isinteger(xsize) || !isinteger(ysize) || !isinteger(zsize) || !isinteger(a))
+  if (!isinteger(xsize) || !isinteger(ysize) || !isinteger(zsize))
     master_printf_stderr(
       "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
   return grid_volume(D3, a, (xsize == 0) ? 1 : (int)(xsize * a + 0.5),
@@ -929,7 +929,7 @@ grid_volume vol3d(double xsize, double ysize, double zsize, double a) {
 }
 
 grid_volume volcyl(double rsize, double zsize, double a) {
-  if (!isinteger(rsize) || !isinteger(zsize) || !isinteger(a))
+  if (!isinteger(rsize) || !isinteger(zsize))
     master_printf_stderr(
       "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
 

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -27,11 +27,7 @@ using namespace std;
 
 namespace meep {
 
-static bool _wholenumber(double value) {
-  double intpart;
-  return modf(value, &intpart) == 0.0;
-}
-
+static bool isinteger(double value) { return value == floor(value); }
 
 ivec grid_volume::round_vec(const vec &p) const {
   ivec result(dim);
@@ -905,14 +901,14 @@ vec grid_volume::dz() const {
 }
 
 grid_volume volone(double zsize, double a) {
-  if (!_wholenumber(zsize) || !_wholenumber(a))
+  if (!isinteger(zsize) || !isinteger(a))
     master_printf_stderr(
       "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
   return grid_volume(D1, a, 0, 0, (int)(zsize * a + 0.5));
 }
 
 grid_volume voltwo(double xsize, double ysize, double a) {
-  if (!_wholenumber(xsize) || !_wholenumber(ysize) || !_wholenumber(a))
+  if (!isinteger(xsize) || !isinteger(ysize) || !isinteger(a))
     master_printf_stderr(
       "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
   return grid_volume(D2, a, (xsize == 0) ? 1 : (int)(xsize * a + 0.5),
@@ -924,7 +920,7 @@ grid_volume vol1d(double zsize, double a) { return volone(zsize, a); }
 grid_volume vol2d(double xsize, double ysize, double a) { return voltwo(xsize, ysize, a); }
 
 grid_volume vol3d(double xsize, double ysize, double zsize, double a) {
-  if (!_wholenumber(xsize) || !_wholenumber(ysize) || !_wholenumber(zsize) || !_wholenumber(a))
+  if (!isinteger(xsize) || !isinteger(ysize) || !isinteger(zsize) || !isinteger(a))
     master_printf_stderr(
       "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
   return grid_volume(D3, a, (xsize == 0) ? 1 : (int)(xsize * a + 0.5),
@@ -933,7 +929,7 @@ grid_volume vol3d(double xsize, double ysize, double zsize, double a) {
 }
 
 grid_volume volcyl(double rsize, double zsize, double a) {
-  if (!_wholenumber(rsize) || !_wholenumber(zsize) || !_wholenumber(a))
+  if (!isinteger(rsize) || !isinteger(zsize) || !isinteger(a))
     master_printf_stderr(
       "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
 

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -901,16 +901,16 @@ vec grid_volume::dz() const {
 }
 
 grid_volume volone(double zsize, double a) {
-  if (!isinteger(zsize))
+  if (!isinteger(zsize * a))
     master_printf_stderr(
-      "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
+      "Warning: grid volume is not an integer number of pixels; cell size will be rounded to nearest pixel.\n");
   return grid_volume(D1, a, 0, 0, (int)(zsize * a + 0.5));
 }
 
 grid_volume voltwo(double xsize, double ysize, double a) {
-  if (!isinteger(xsize) || !isinteger(ysize))
+  if (!isinteger(xsize * a) || !isinteger(ysize * a))
     master_printf_stderr(
-      "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
+      "Warning: grid volume is not an integer number of pixels; cell size will be rounded to nearest pixel.\n");
   return grid_volume(D2, a, (xsize == 0) ? 1 : (int)(xsize * a + 0.5),
                      (ysize == 0) ? 1 : (int)(ysize * a + 0.5), 0);
 }
@@ -920,9 +920,9 @@ grid_volume vol1d(double zsize, double a) { return volone(zsize, a); }
 grid_volume vol2d(double xsize, double ysize, double a) { return voltwo(xsize, ysize, a); }
 
 grid_volume vol3d(double xsize, double ysize, double zsize, double a) {
-  if (!isinteger(xsize) || !isinteger(ysize) || !isinteger(zsize))
+  if (!isinteger(xsize * a) || !isinteger(ysize * a) || !isinteger(zsize * a))
     master_printf_stderr(
-      "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
+      "Warning: grid volume is not an integer number of pixels; cell size will be rounded to nearest pixel.\n");
   return grid_volume(D3, a, (xsize == 0) ? 1 : (int)(xsize * a + 0.5),
                      (ysize == 0) ? 1 : (int)(ysize * a + 0.5),
                      (zsize == 0) ? 1 : (int)(zsize * a + 0.5));
@@ -931,7 +931,7 @@ grid_volume vol3d(double xsize, double ysize, double zsize, double a) {
 grid_volume volcyl(double rsize, double zsize, double a) {
   if (!isinteger(rsize) || !isinteger(zsize))
     master_printf_stderr(
-      "WARNING: Creating a grid_volume with non-whole numbers may result in rounding errors.\n");
+      "Warning: grid volume is not an integer number of pixels; cell size will be rounded to nearest pixel.\n");
 
   if (zsize == 0.0)
     return grid_volume(Dcyl, a, (int)(rsize * a + 0.5), 0, 1);

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1659,6 +1659,42 @@ const char *vec::str(char *buffer, size_t buflen) {
   return buffer;
 }
 
+const char *volume::str(char *buffer, size_t buflen) {
+  static char sbuf[1024]; // TODO: Use a bufring like the above?
+  if (buffer == 0) {
+    buffer = sbuf;
+    buflen = sizeof(sbuf);
+  }
+  snprintf(buffer, buflen, "min_corner:%s, max_corner:%s",
+           min_corner.str(), max_corner.str());
+  return buffer;
+}
+
+const char *grid_volume::str(char *buffer, size_t buflen) {
+  static char sbuf[1024]; // TODO: is this big enough?
+  int written = 0;
+  if (buffer == 0) {
+    buffer = sbuf;
+    buflen = sizeof(sbuf);
+  }
+
+  written += snprintf(buffer+written, buflen-written,
+                      "grid_volume {\n  dim:%s, a:%f, inva:%f, num:{%d, %d, %d}\n",
+                      dimension_name(dim), a, inva, num[0], num[1], num[2]);
+
+  // Adapted from the print() method
+  LOOP_OVER_DIRECTIONS(dim, d) {
+    written += snprintf(buffer+written, buflen-written,
+              "  %s =%5g - %5g (%5g) \t", direction_name(d), origin.in_direction(d),
+              origin.in_direction(d) + num_direction(d) / a, num_direction(d) / a);
+    if (buflen-written <=0)
+        break;
+  }
+  snprintf(buffer+written, buflen-written, "\n}");
+  return buffer;
+}
+
+
 /********************************************************************/
 /********************************************************************/
 /********************************************************************/


### PR DESCRIPTION
Fixes #1291 

I started with using Python Warnings as an experiment, which can be seen in 42be907 if interested. This has the advantage that warnings can be suppressed or promoted to exceptions, if the user is interested in doing so. The downside is that the actual warning for any one location is displayed only once by default, which is not very useful in an interactive environment like a notebook.

For the final implementation the warning is checked for and printed in the C++ code in the various `grid_volume` factory functions as discussed. I also added a `master_printf_stderr` function that forwards the text to `sys.stderr`, which has the nice effect of printing the text with a background color in the notebook.

![Snap007](https://user-images.githubusercontent.com/808502/90194938-3484f280-dd7d-11ea-95e4-fdc8bfe3ebb6.png)


Also included in this PR is the addition of `__repr__` and related methods for `vec`, `ivec`, `volume` and `grid_volume`.