### PR TITLE
Plug reference leaks

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -542,8 +542,8 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
     }
 
     if (min_max_loc){
-        PyObject * py_min = vec2py(min_max_loc_vec[0]);
-        PyObject * py_max = vec2py(min_max_loc_vec[1]);
+        PyObject * py_min = vec2py(min_max_loc_vec[0],true);
+        PyObject * py_max = vec2py(min_max_loc_vec[1],true);
         PyList_Append(min_max_loc, py_min);
         PyList_Append(min_max_loc, py_max);
         Py_DECREF(py_min);
@@ -635,12 +635,10 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
     PyObject *py_kdom = PyList_New($1.num_bands);
 
     for (size_t i = 0; i < $1.n; ++i) {
-        // SetItem steals the vec2pyref, so no need to decref
-        PyList_SetItem(py_kpoints, i, vec2py($1.kpoints[i]));
+        PyList_SetItem(py_kpoints, i, vec2py($1.kpoints[i], true));
     }
     for (size_t i = 0; i < $1.num_bands; ++i) {
-        // SetItem steals the vec2pyref, so no need to decref
-        PyList_SetItem(py_kdom, i, vec2py($1.kdom[i]));
+        PyList_SetItem(py_kdom, i, vec2py($1.kdom[i], true));
     }
 
     $result = Py_BuildValue("(O,O)", py_kpoints, py_kdom);
@@ -1822,7 +1820,7 @@ meep::structure *create_structure_and_set_materials(vector3 cell_size,
 
 PyObject *test_vec2py(const meep::vec &v, bool newobj = false) {
     PyObject * obj;
-    obj = vec2py(v); //, newobj);
+    obj = vec2py(v, newobj);
     return obj;
 }
 

--- a/python/meep.i
+++ b/python/meep.i
@@ -89,6 +89,7 @@ typedef struct {
 #include "typemap_utils.cpp"
 
 static PyObject *py_source_time_object() {
+    // Return value: Borrowed reference
     static PyObject *source_time_object = NULL;
     if (source_time_object == NULL) {
         PyObject *source_mod = PyImport_ImportModule("meep.source");
@@ -99,6 +100,7 @@ static PyObject *py_source_time_object() {
 }
 
 static PyObject *py_meep_src_time_object() {
+    // Return value: Borrowed reference
     static PyObject *src_time = NULL;
     if (src_time == NULL) {
         PyObject *meep_mod = PyImport_ImportModule("meep");
@@ -273,6 +275,7 @@ double py_pml_profile(double u, void *f) {
 PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, int maxbands,
                      double spectral_density, double Q_thresh, double rel_err_thresh,
                      double err_thresh, double rel_amp_thresh, double amp_thresh) {
+    // Return value: New reference
 
     std::complex<double> *amp = new std::complex<double>[maxbands];
     double *freq_re = new double[maxbands];
@@ -314,6 +317,7 @@ PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, i
 
 // Wrapper around meep::dft_near2far::farfield
 PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v) {
+    // Return value: New reference
     Py_ssize_t len = f->freq.size() * 6;
     PyObject *res = PyList_New(len);
 
@@ -331,6 +335,7 @@ PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v) {
 // Wrapper around meep::dft_near2far::get_farfields_array
  PyObject *_get_farfields_array(meep::dft_near2far *n2f, const meep::volume &where,
                                 double resolution) {
+    // Return value: New reference
     size_t dims[4] = {1, 1, 1, 1};
     int rank = 0;
     size_t N = 1;
@@ -364,6 +369,7 @@ PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v) {
 
 // Wrapper around meep::dft_ldos::ldos
 PyObject *_dft_ldos_ldos(meep::dft_ldos *f) {
+    // Return value: New reference
     Py_ssize_t len = f->freq.size();
     PyObject *res = PyList_New(len);
 
@@ -380,6 +386,7 @@ PyObject *_dft_ldos_ldos(meep::dft_ldos *f) {
 
 // Wrapper around meep::dft_ldos_F
 PyObject *_dft_ldos_F(meep::dft_ldos *f) {
+    // Return value: New reference
     Py_ssize_t len = f->freq.size();
     PyObject *res = PyList_New(len);
 
@@ -396,6 +403,7 @@ PyObject *_dft_ldos_F(meep::dft_ldos *f) {
 
 // Wrapper arond meep::dft_ldos_J
 PyObject *_dft_ldos_J(meep::dft_ldos *f) {
+    // Return value: New reference
     Py_ssize_t len = f->freq.size();
     PyObject *res = PyList_New(len);
 
@@ -425,6 +433,7 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 
 template<typename dft_type>
 PyObject *_get_dft_array(meep::fields *f, dft_type dft, meep::component c, int num_freq) {
+    // Return value: New reference
     int rank;
     size_t dims[3];
     std::complex<double> *dft_arr = f->get_dft_array(dft, c, num_freq, &rank, dims);
@@ -518,6 +527,7 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
 PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where, size_t dims[3],
                                       bool collapse_empty_dimensions, bool snap_empty_dimensions,
                                       meep::component cgrid = Centered, PyObject *min_max_loc = NULL) {
+    // Return value: New reference
     meep::direction dirs[3] = {meep::X, meep::X, meep::X};
 
     meep::vec min_max_loc_vec[2];
@@ -555,6 +565,7 @@ meep::eigenmode_data *_get_eigenmode(meep::fields *f, double frequency, meep::di
 }
 
 PyObject *_get_eigenmode_Gk(meep::eigenmode_data *emdata) {
+    // Return value: New reference
     PyObject *v3_class = py_vector3_object();
     PyObject *args = Py_BuildValue("(ddd)", emdata->Gk[0], emdata->Gk[1], emdata->Gk[2]);
     PyObject *result = PyObject_Call(v3_class, args, NULL);

--- a/python/meep.i
+++ b/python/meep.i
@@ -1816,12 +1816,3 @@ meep::structure *create_structure_and_set_materials(vector3 cell_size,
 %}
 
 
-%inline %{
-
-PyObject *test_vec2py(const meep::vec &v, bool newobj = false) {
-    PyObject * obj;
-    obj = vec2py(v, newobj);
-    return obj;
-}
-
-%}

--- a/python/meep.i
+++ b/python/meep.i
@@ -205,7 +205,7 @@ static meep::vec py_kpoint_func_wrap(double freq, int mode, void *user_data) {
 }
 
 static void _do_master_printf(const char* stream_name, const char* text) {
-    PyObject* py_stream = PySys_GetObject((char*)stream_name); // arg is non-const on Python2
+    PyObject *py_stream = PySys_GetObject((char*)stream_name); // arg is non-const on Python2
 
     Py_XDECREF(PyObject_CallMethod(py_stream, "write", "(s)", text));
     Py_XDECREF(PyObject_CallMethod(py_stream, "flush", NULL));
@@ -550,7 +550,9 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         Py_DECREF(py_max);
     }
 
-    return Py_BuildValue("(iO)", rank, py_dirs);
+    PyObject *rval = Py_BuildValue("(iO)", rank, py_dirs);
+    Py_DECREF(py_dirs);
+    return rval;
 }
 
 #ifdef HAVE_MPB
@@ -643,6 +645,8 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 
     $result = Py_BuildValue("(O,O)", py_kpoints, py_kdom);
 
+    Py_DECREF(py_kpoints);
+    Py_DECREF(py_kdom);
     delete[] $1.kpoints;
     delete[] $1.kdom;
 }
@@ -825,7 +829,7 @@ void _get_gradient(PyObject *grad, PyObject *fields_a, PyObject *fields_f, PyObj
     // clean the volume object
     void* where;
 
-    PyObject* swigobj = PyObject_GetAttrString(grid_volume, "swigobj");
+    PyObject *swigobj = PyObject_GetAttrString(grid_volume, "swigobj");
     SWIG_ConvertPtr(swigobj,&where,NULL,NULL);
     const meep::volume* where_vol = (const meep::volume*)where;
 
@@ -854,7 +858,7 @@ void _get_gradient(PyObject *grad, PyObject *fields_a, PyObject *fields_f, PyObj
 
     destroy_geom_box_tree(geometry_tree);
     delete[] l;
-
+    Py_DECREF(swigobj);
 }
 %}
 //--------------------------------------------------
@@ -1811,4 +1815,15 @@ meep::structure *create_structure_and_set_materials(vector3 cell_size,
 
     return s;
 }
+%}
+
+
+%inline %{
+
+PyObject *test_vec2py(const meep::vec &v, bool newobj = false) {
+    PyObject * obj;
+    obj = vec2py(v); //, newobj);
+    return obj;
+}
+
 %}

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -58,12 +58,14 @@ static char *py2_string_as_utf8(PyObject *po) {
 #endif
 
 static PyObject *get_geom_mod() {
+  // Return value: Borrowed reference
   static PyObject *geom_mod = NULL;
   if (geom_mod == NULL) { geom_mod = PyImport_ImportModule("meep.geom"); }
   return geom_mod;
 }
 
 static PyObject *py_material_object() {
+  // Return value; Borrowed reference
   static PyObject *material_object = NULL;
   if (material_object == NULL) {
     PyObject *geom_mod = get_geom_mod();
@@ -73,6 +75,7 @@ static PyObject *py_material_object() {
 }
 
 static PyObject *py_material_grid_object() {
+  // Return value: Borrowed reference
   static PyObject *material_object = NULL;
   if (material_object == NULL) {
     PyObject *geom_mod = get_geom_mod();
@@ -82,6 +85,7 @@ static PyObject *py_material_grid_object() {
 }
 
 static PyObject *py_vector3_object() {
+  // Return value: Borrowed reference
   static PyObject *vector3_object = NULL;
   if (vector3_object == NULL) {
     PyObject *geom_mod = get_geom_mod();
@@ -91,6 +95,7 @@ static PyObject *py_vector3_object() {
 }
 
 static PyObject *py_volume_object() {
+  // Return value: Borrowed reference
   static PyObject *volume_object = NULL;
   if (volume_object == NULL) {
     PyObject *geom_mod = get_geom_mod();
@@ -223,6 +228,7 @@ static int pyv3_to_cv3(PyObject *po, cvector3 *v) {
 }
 
 static PyObject *v3_to_pyv3(vector3 *v) {
+  // Return value: New reference
   PyObject *v3_class = py_vector3_object();
   PyObject *args = Py_BuildValue("(ddd)", v->x, v->y, v->z);
   PyObject *py_v = PyObject_Call(v3_class, args, NULL);
@@ -528,6 +534,7 @@ template <class T> static void set_v3_on_pyobj(PyObject *py_obj, T *v3, const ch
 }
 
 static PyObject *susceptibility_to_py_obj(susceptibility_struct *s) {
+  // Return value: New reference
   PyObject *geom_mod = get_geom_mod();
 
   PyObject *res;
@@ -605,6 +612,7 @@ static PyObject *susceptibility_to_py_obj(susceptibility_struct *s) {
 }
 
 static PyObject *susceptibility_list_to_py_list(susceptibility_list *sl) {
+  // Return value: New reference
   PyObject *res = PyList_New(sl->num_items);
 
   for (Py_ssize_t i = 0; i < sl->num_items; ++i) {
@@ -615,6 +623,7 @@ static PyObject *susceptibility_list_to_py_list(susceptibility_list *sl) {
 }
 
 static PyObject *material_to_py_material(material_type mat) {
+  // Return value: New reference
   switch (mat->which_subclass) {
     case meep_geom::material_data::MEDIUM: {
       PyObject *geom_mod = get_geom_mod();
@@ -899,6 +908,7 @@ static int py_list_to_gobj_list(PyObject *po, geometric_object_list *l) {
 }
 
 static PyObject *gobj_to_py_obj(geometric_object *gobj) {
+  // Return value: New reference
   switch (gobj->which_subclass) {
     case geometric_object::PRISM: {
       PyObject *geom_mod = get_geom_mod();
@@ -943,7 +953,7 @@ static PyObject *gobj_to_py_obj(geometric_object *gobj) {
 }
 
 static PyObject *gobj_list_to_py_list(geometric_object_list *objs) {
-
+  // Return value: New reference
   PyObject *py_res = PyList_New(objs->num_items);
 
   for (int i = 0; i < objs->num_items; ++i) {


### PR DESCRIPTION
Fixes #1296 

* Follow Python's example and document whether it's a New or Borrowed reference for any function returning a `PyObject*`.
* Make vec2py always return a new reference even if it's just reusing the global instance.
* Plug a couple dozen potential leaks.

Methodology: I just carefully combed through `meep.i` and `typmap_utils.cpp` looking for places that create a new object, or do something with an object that will increment the object's refcount, for which there was no corresponding `Py_DECREF` or the object was not returned from the function to be used and/or decref'd by the caller.