### PR TITLE
docstrings for DiffractedPlanewave

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1393,7 +1393,7 @@ class DiffractedPlanewave(object):
 
 <div class="class_docstring" markdown="1">
 
-For mode decomposition, specify a diffracted planewave in homogeneous media. Passed as the argument `bands` of `get_eigenmode_coefficients` or `band_num` of `get_eigenmode`.
+For mode decomposition, specify a diffracted planewave in homogeneous media. Should be passed as the `bands` argument of `get_eigenmode_coefficients` or `band_num` of `get_eigenmode`.
 
 </div>
 
@@ -1411,9 +1411,9 @@ def __init__(self, g=None, axis=None, s=None, p=None):
 
 Construct a `DiffractedPlanewave`.
 
-+ **`g` [ list/tuple of `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. Elements should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor extends the entire length of the cell.
++ **`g` [ list of 3 `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. Elements should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor extends the entire length of the cell.
 
-+ **`axis` [ `Vector3` ]** — The reference axis used in combination with the mode's wavevector (via the cross product) to define the plane of incidence. If `None`, defaults to the first direction that lies in the plane of the monitor/source (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
++ **`axis` [ `Vector3` ]** — The reference axis used in combination with the mode's wavevector (via the cross product) to define the plane of incidence. If `None`, defaults to the first direction that lies in the plane of the monitor (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
 
 + **`s` [ `complex` ]** — The complex amplitude of the $\mathcal{S}$ polarziation (i.e., electric field perpendicular to the plane of incidence).
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1382,7 +1382,46 @@ spectrum for.
 
 </div>
 
+---
+<a id="DiffractedPlanewave"></a>
 
+### DiffractedPlanewave
+
+```python
+class DiffractedPlanewave(object):
+```
+
+<div class="class_docstring" markdown="1">
+
+For mode decomposition, specify a diffracted planewave in homogeneous media. Passed as the argument `bands` of `get_eigenmode_coefficients` or `band_num` of `get_eigenmode`.
+
+</div>
+
+
+
+<a id="DiffractedPlanewave.__init__"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def __init__(self, g=None, axis=None, s=None, p=None):
+```
+
+<div class="method_docstring" markdown="1">
+
+Construct a `DiffractedPlanewave`.
+
++ **`g` [ list/tuple of `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. Elements should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor extends the entire length of the cell.
+
++ **`axis` [ `Vector3` ]** — The reference axis used in combination with the mode's wavevector (via the cross product) to define the plane of incidence. If `None`, defaults to the first direction that lies in the plane of the monitor/source (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
+
++ **`s` [ `complex` ]** — The complex amplitude of the $\mathcal{S}$ polarziation (i.e., electric field perpendicular to the plane of incidence).
+
++ **`p` [ `complex` ]** — The complex amplitude of the $\mathcal{P}$ polarziation (i.e., electric field parallel to the plane of incidence).
+
+</div>
+
+</div>
 
 ### Energy Density Spectra
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1411,9 +1411,9 @@ def __init__(self, g=None, axis=None, s=None, p=None):
 
 Construct a `DiffractedPlanewave`.
 
-+ **`g` [ list of 3 `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. Elements should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor extends the entire length of the cell.
++ **`g` [ list of 3 `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. The diffraction order $m_{x,y,z}$ should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor extends the entire length of the cell.
 
-+ **`axis` [ `Vector3` ]** — The reference axis used in combination with the mode's wavevector (via the cross product) to define the plane of incidence. If `None`, defaults to the first direction that lies in the plane of the monitor (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
++ **`axis` [ `Vector3` ]** — The plane of incidence for each planewave (used to define the $\mathcal{S}$ and $\mathcal{P}$ polarizations below) is defined to be the plane that contains the `axis` vector and the planewave's wavevector. If `None`, `axis` defaults to the first direction that lies in the plane of the monitor (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
 
 + **`s` [ `complex` ]** — The complex amplitude of the $\mathcal{S}$ polarziation (i.e., electric field perpendicular to the plane of incidence).
 

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -190,7 +190,7 @@ The following top-level function is also available:
 
 @@ get_eigenmode_freqs @@
 
-
+@@ DiffractedPlanewave[methods-with-docstrings] @@
 
 ### Energy Density Spectra
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -101,7 +101,7 @@ def py_v3_to_vec(dims, iterable, is_cylindrical=False):
 
 class DiffractedPlanewave(object):
     """
-    For mode decomposition, specify a diffracted planewave in homogeneous media. Passed as the argument `bands` of `get_eigenmode_coefficients` or `band_num` of `get_eigenmode`.
+    For mode decomposition, specify a diffracted planewave in homogeneous media. Should be passed as the `bands` argument of `get_eigenmode_coefficients` or `band_num` of `get_eigenmode`.
     """
     def __init__(self,
                  g=None,
@@ -111,9 +111,9 @@ class DiffractedPlanewave(object):
         """
         Construct a `DiffractedPlanewave`.
 
-        + **`g` [ list/tuple of `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. Elements should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor extends the entire length of the cell.
+        + **`g` [ list of 3 `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. Elements should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor extends the entire length of the cell.
 
-        + **`axis` [ `Vector3` ]** — The reference axis used in combination with the mode's wavevector (via the cross product) to define the plane of incidence. If `None`, defaults to the first direction that lies in the plane of the monitor/source (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
+        + **`axis` [ `Vector3` ]** — The reference axis used in combination with the mode's wavevector (via the cross product) to define the plane of incidence. If `None`, defaults to the first direction that lies in the plane of the monitor (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
 
         + **`s` [ `complex` ]** — The complex amplitude of the $\mathcal{S}$ polarziation (i.e., electric field perpendicular to the plane of incidence).
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -111,9 +111,9 @@ class DiffractedPlanewave(object):
         """
         Construct a `DiffractedPlanewave`.
 
-        + **`g` [ list of 3 `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. Elements should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor extends the entire length of the cell.
+        + **`g` [ list of 3 `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. The diffraction order $m_{x,y,z}$ should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor extends the entire length of the cell.
 
-        + **`axis` [ `Vector3` ]** — The reference axis used in combination with the mode's wavevector (via the cross product) to define the plane of incidence. If `None`, defaults to the first direction that lies in the plane of the monitor (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
+        + **`axis` [ `Vector3` ]** — The plane of incidence for each planewave (used to define the $\mathcal{S}$ and $\mathcal{P}$ polarizations below) is defined to be the plane that contains the `axis` vector and the planewave's wavevector. If `None`, `axis` defaults to the first direction that lies in the plane of the monitor (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
 
         + **`s` [ `complex` ]** — The complex amplitude of the $\mathcal{S}$ polarziation (i.e., electric field perpendicular to the plane of incidence).
 


### PR DESCRIPTION
Closes #291. Closes #604.

Also sets the default `axis` to the "first" direction that lies in the monitor plane as proposed in #1326:[comment](https://github.com/NanoComp/meep/pull/1326#issuecomment-680412669).

(We still need to extend this feature to `EigenModeSource` which will happen as a separate PR.)
