### PR TITLE
Singleton DFT fix

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -443,7 +443,7 @@ PyObject *_get_dft_array(meep::fields *f, dft_type dft, meep::component c, int n
      return PyArray_SimpleNewFromData(0, 0, NPY_CDOUBLE, d);
     }
 
-    if ((rank == 0) && (dims[0] == 0)) // singleton results
+    if (rank == 0) // singleton results
      return PyArray_SimpleNewFromData(0, 0, NPY_CDOUBLE, dft_arr);
 
     size_t length = 1;

--- a/python/meep.i
+++ b/python/meep.i
@@ -438,10 +438,13 @@ PyObject *_get_dft_array(meep::fields *f, dft_type dft, meep::component c, int n
     size_t dims[3];
     std::complex<double> *dft_arr = f->get_dft_array(dft, c, num_freq, &rank, dims);
 
-    if (rank==0 || dft_arr==NULL){ // this can happen e.g. if component c vanishes by symmetry
+    if (dft_arr==NULL){ // this can happen e.g. if component c vanishes by symmetry
      std::complex<double> d[1] = {std::complex<double>(0,0)};
      return PyArray_SimpleNewFromData(0, 0, NPY_CDOUBLE, d);
     }
+
+    if ((rank == 0) && (dims[0] == 0)) // singleton results
+     return PyArray_SimpleNewFromData(0, 0, NPY_CDOUBLE, dft_arr);
 
     size_t length = 1;
     npy_intp *arr_dims = new npy_intp[rank];

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -652,7 +652,7 @@ double *collapse_array(double *array, int *rank, size_t dims[3], direction dirs[
   if (full_rank == 0) return array;
 
   int reduced_rank = 0;
-  size_t reduced_dims[3] = {0}, reduced_stride[3] = {1, 1, 1};
+  size_t reduced_dims[3], reduced_stride[3] = {1, 1, 1};
   direction reduced_dirs[3];
   for (int r = 0; r < full_rank; r++) {
     if (where.in_direction(dirs[r]) == 0.0)
@@ -677,11 +677,8 @@ double *collapse_array(double *array, int *rank, size_t dims[3], direction dirs[
   else if (full_rank == 3) {
     stride[0] = dims[1] * dims[2];
     stride[1] = dims[2];
-    if (reduced_stride[0] != 0)
-      reduced_stride[0] = reduced_dims[1];
-    else if (reduced_stride[1] != 0)
-      reduced_stride[1] = reduced_dims[1];
-    // else: two degenerate dimensions->reduced array is 1-diml, no strides needed
+    if (reduced_rank == 2)
+      reduced_stride[reduced_stride[0] != 0 ? 0 : 1] = reduced_dims[1];
   }
 
   /*--------------------------------------------------------------*/

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -652,7 +652,7 @@ double *collapse_array(double *array, int *rank, size_t dims[3], direction dirs[
   if (full_rank == 0) return array;
 
   int reduced_rank = 0;
-  size_t reduced_dims[3] = {0,0,0}, reduced_stride[3] = {1, 1, 1};
+  size_t reduced_dims[3] = {0}, reduced_stride[3] = {1, 1, 1};
   direction reduced_dirs[3];
   for (int r = 0; r < full_rank; r++) {
     if (where.in_direction(dirs[r]) == 0.0)
@@ -661,6 +661,10 @@ double *collapse_array(double *array, int *rank, size_t dims[3], direction dirs[
       reduced_dirs[reduced_rank] = dirs[r];
       reduced_dims[reduced_rank++] = dims[r];
     }
+  }
+  if (reduced_rank==0) {
+    *rank = 0;
+    return array; // return array as is for singleton use case
   }
   if (reduced_rank == full_rank) return array; // nothing to collapse
 
@@ -685,11 +689,6 @@ double *collapse_array(double *array, int *rank, size_t dims[3], direction dirs[
   /*--------------------------------------------------------------*/
   size_t reduced_grid_size = reduced_dims[0] * (reduced_rank == 2 ? reduced_dims[1] : 1);
   size_t reduced_array_size = data_size * reduced_grid_size;
-  if (reduced_array_size==0) {
-    *rank = 0;
-    dims[0] = 0; dims[1] = 0; dims[2] = 0;
-    return array; // return array as is for singleton use case
-  }
   double *reduced_array = new double[reduced_array_size];
   if (!reduced_array) abort("%s:%i: out of memory (%zu)", __FILE__, __LINE__, reduced_array_size);
   memset(reduced_array, 0, reduced_array_size * sizeof(double));

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -652,7 +652,7 @@ double *collapse_array(double *array, int *rank, size_t dims[3], direction dirs[
   if (full_rank == 0) return array;
 
   int reduced_rank = 0;
-  size_t reduced_dims[3], reduced_stride[3] = {1, 1, 1};
+  size_t reduced_dims[3] = {0,0,0}, reduced_stride[3] = {1, 1, 1};
   direction reduced_dirs[3];
   for (int r = 0; r < full_rank; r++) {
     if (where.in_direction(dirs[r]) == 0.0)
@@ -685,6 +685,11 @@ double *collapse_array(double *array, int *rank, size_t dims[3], direction dirs[
   /*--------------------------------------------------------------*/
   size_t reduced_grid_size = reduced_dims[0] * (reduced_rank == 2 ? reduced_dims[1] : 1);
   size_t reduced_array_size = data_size * reduced_grid_size;
+  if (reduced_array_size==0) {
+    *rank = 0;
+    dims[0] = 0; dims[1] = 0; dims[2] = 0;
+    return array; // return array as is for singleton use case
+  }
   double *reduced_array = new double[reduced_array_size];
   if (!reduced_array) abort("%s:%i: out of memory (%zu)", __FILE__, __LINE__, reduced_array_size);
   memset(reduced_array, 0, reduced_array_size * sizeof(double));


### PR DESCRIPTION
Fixes #1269 

There were actually two bugs here. First, a collapsed array size counter (`reduced_dims`) was uninitialized. If the array to be collapsed only consisted of a single element, it wouldn't update to the correct value. Consequently, the routine would try to create an array the size of whatever garbage was in memory (which would occasionally cause a segfault).

Next, the actual singleton DFT calculation was never copied to the garbage array (assuming no segfault occurred).

Note there are still probably some other bugs in the `collapse_array()` routine (`array_slice.cpp`). If we see more odd behavior with DFT fields (e.g. when symmetries are applied, weird field components, etc.) we should first look here. Then we should look in `_get_dft_array()` inside of `meep.i`.

