### PR TITLE
launching diffracted planewave using eigenmode source

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -1393,7 +1393,7 @@ class DiffractedPlanewave(object):
 
 <div class="class_docstring" markdown="1">
 
-For mode decomposition, specify a diffracted planewave in homogeneous media. Should be passed as the `bands` argument of `get_eigenmode_coefficients` or `band_num` of `get_eigenmode`.
+For mode decomposition or eigenmode source, specify a diffracted planewave in homogeneous media. Should be passed as the `bands` argument of `get_eigenmode_coefficients`, `band_num` of `get_eigenmode`, or `eig_band` of `EigenModeSource`.
 
 </div>
 
@@ -1411,9 +1411,9 @@ def __init__(self, g=None, axis=None, s=None, p=None):
 
 Construct a `DiffractedPlanewave`.
 
-+ **`g` [ list of 3 `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. The diffraction order $m_{x,y,z}$ should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor extends the entire length of the cell.
++ **`g` [ list of 3 `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. The diffraction order $m_{x,y,z}$ should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor or source extends the entire length of the cell.
 
-+ **`axis` [ `Vector3` ]** — The plane of incidence for each planewave (used to define the $\mathcal{S}$ and $\mathcal{P}$ polarizations below) is defined to be the plane that contains the `axis` vector and the planewave's wavevector. If `None`, `axis` defaults to the first direction that lies in the plane of the monitor (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
++ **`axis` [ `Vector3` ]** — The plane of incidence for each planewave (used to define the $\mathcal{S}$ and $\mathcal{P}$ polarizations below) is defined to be the plane that contains the `axis` vector and the planewave's wavevector. If `None`, `axis` defaults to the first direction that lies in the plane of the monitor or source (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
 
 + **`s` [ `complex` ]** — The complex amplitude of the $\mathcal{S}$ polarziation (i.e., electric field perpendicular to the plane of incidence).
 
@@ -5922,9 +5922,9 @@ def __init__(self,
 
 Construct an `EigenModeSource`.
 
-+ **`eig_band` [`integer`]** — The index *n* (1,2,3,...) of the desired band
++ **`eig_band` [`integer` or `DiffractedPlanewave`]** — Either the index *n* (1,2,3,...) of the desired band
   ω<sub>*n*</sub>(**k**) to compute in MPB where 1 denotes the lowest-frequency
-  band at a given **k** point, and so on.
+  band at a given **k** point, and so on, or alternatively a diffracted planewaeve in homogeneous media.
 
 + **`direction` [`mp.X`, `mp.Y`, or `mp.Z;` default `mp.AUTOMATIC`],
   `eig_match_freq` [`boolean;` default `True`], `eig_kpoint` [`Vector3`]** — By

--- a/python/meep.i
+++ b/python/meep.i
@@ -696,13 +696,17 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 // Typemap suite for amplitude function
 
 %typecheck(SWIG_TYPECHECK_POINTER) std::complex<double> (*)(const meep::vec &) {
-  $1 = PyCallable_Check($input);
+  $1 = $input == Py_None || PyCallable_Check($input);
 }
 
 %typemap(in) std::complex<double> (*)(const meep::vec &) {
-    $1 = py_amp_func_wrap;
-    py_amp_func = $input;
-    Py_INCREF(py_amp_func);
+     if ($input != Py_None) {
+          $1 = py_amp_func_wrap;
+          py_amp_func = $input;
+          Py_INCREF(py_amp_func);
+     }
+     else
+          $1 = NULL;
 }
 
 %typemap(freearg) std::complex<double> (*)(const meep::vec &) {

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2313,15 +2313,9 @@ class Simulation(object):
             add_eig_src = functools.partial(self.fields.add_eigenmode_source, *add_eig_src_args)
 
             if isinstance(src.eig_band, DiffractedPlanewave):
-                if src.amp_func is None:
-                    add_eig_src(lambda v: 1.0, diffractedplanewave)
-                else:
-                    add_eig_src(src.amp_func, diffractedplanewave)
+                add_eig_src(src.amp_func, diffractedplanewave)
             else:
-                if src.amp_func is None:
-                    add_eig_src()
-                else:
-                    add_eig_src(src.amp_func)
+                add_eig_src(src.amp_func)
         elif isinstance (src, GaussianBeamSource):
             gaussianbeam_args = [
                 py_v3_to_vec(self.dimensions, src.beam_x0, is_cylindrical=self.is_cylindrical),

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -133,9 +133,9 @@ class DiffractedPlanewave(object):
         """
         Construct a `DiffractedPlanewave`.
 
-        + **`g` [ list of 3 `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. The diffraction order $m_{x,y,z}$ should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor extends the entire length of the cell.
+        + **`g` [ list of 3 `integer`s ]** — The diffraction order $(m_x,m_y,m_z)$ corresponding to the wavevector $(k_x+2\pi m_x/\Lambda_x,k_y+2\pi m_y/\Lambda_y,k_z+2\pi m_z/\Lambda_z)$. The diffraction order $m_{x,y,z}$ should be non-zero only in the $d$-1 periodic directions of a $d$ dimensional cell (e.g., a plane in 3d) in which the mode monitor or source extends the entire length of the cell.
 
-        + **`axis` [ `Vector3` ]** — The plane of incidence for each planewave (used to define the $\mathcal{S}$ and $\mathcal{P}$ polarizations below) is defined to be the plane that contains the `axis` vector and the planewave's wavevector. If `None`, `axis` defaults to the first direction that lies in the plane of the monitor (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
+        + **`axis` [ `Vector3` ]** — The plane of incidence for each planewave (used to define the $\mathcal{S}$ and $\mathcal{P}$ polarizations below) is defined to be the plane that contains the `axis` vector and the planewave's wavevector. If `None`, `axis` defaults to the first direction that lies in the plane of the monitor or source (e.g., $y$ direction for a $yz$ plane in 3d, either $x$ or $y$ in 2d).
 
         + **`s` [ `complex` ]** — The complex amplitude of the $\mathcal{S}$ polarziation (i.e., electric field perpendicular to the plane of incidence).
 

--- a/python/source.py
+++ b/python/source.py
@@ -373,9 +373,9 @@ class EigenModeSource(Source):
         """
         Construct an `EigenModeSource`.
 
-        + **`eig_band` [`integer`]** — The index *n* (1,2,3,...) of the desired band
+        + **`eig_band` [`integer` or `DiffractedPlanewave`]** — Either the index *n* (1,2,3,...) of the desired band
           ω<sub>*n*</sub>(**k**) to compute in MPB where 1 denotes the lowest-frequency
-          band at a given **k** point, and so on.
+          band at a given **k** point, and so on, or alternatively a diffracted planewave in homogeneous media.
 
         + **`direction` [`mp.X`, `mp.Y`, or `mp.Z;` default `mp.AUTOMATIC`],
           `eig_match_freq` [`boolean;` default `True`], `eig_kpoint` [`Vector3`]** — By
@@ -500,7 +500,10 @@ class EigenModeSource(Source):
 
     @eig_band.setter
     def eig_band(self, val):
-        self._eig_band = check_positive('EigenModeSource.eig_band', val)
+        if isinstance(val, int):
+            self._eig_band = check_positive('EigenModeSource.eig_band', val)
+        else:
+            self._eig_band = val
 
     @property
     def eig_resolution(self):

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1732,7 +1732,8 @@ public:
                             const volume &eig_vol, int band_num, const vec &kpoint,
                             bool match_frequency, int parity, double eig_resolution,
                             double eigensolver_tol, std::complex<double> amp,
-                            std::complex<double> A(const vec &) = 0);
+                            std::complex<double> A(const vec &) = 0,
+                            diffractedplanewave *dp = 0);
 
   void get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, int *bands, int num_bands,
                                   int parity, double eig_resolution, double eigensolver_tol,

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -789,7 +789,8 @@ void fields::add_eigenmode_source(component c0, const src_time &src, direction d
                                   const volume &where, const volume &eig_vol, int band_num,
                                   const vec &kpoint, bool match_frequency, int parity,
                                   double resolution, double eigensolver_tol, complex<double> amp,
-                                  complex<double> A(const vec &)) {
+                                  complex<double> A(const vec &),
+                                  diffractedplanewave *dp) {
   /*--------------------------------------------------------------*/
   /* step 1: call MPB to compute the eigenmode                    */
   /*--------------------------------------------------------------*/
@@ -798,7 +799,8 @@ void fields::add_eigenmode_source(component c0, const src_time &src, direction d
   am_now_working_on(MPBTime);
   global_eigenmode_data =
       (eigenmode_data *)get_eigenmode(frequency, d, where, eig_vol, band_num, kpoint,
-                                      match_frequency, parity, resolution, eigensolver_tol);
+                                      match_frequency, parity, resolution, eigensolver_tol,
+                                      NULL, NULL, dp);
   finished_working();
 
   /* add_volume_source amp_fun coordinates are relative to where.center();
@@ -979,7 +981,7 @@ void fields::add_eigenmode_source(component c0, const src_time &src, direction d
                                   const volume &where, const volume &eig_vol, int band_num,
                                   const vec &kpoint, bool match_frequency, int parity,
                                   double resolution, double eigensolver_tol, complex<double> amp,
-                                  complex<double> A(const vec &)) {
+                                  complex<double> A(const vec &), diffractedplanewave *dp) {
   (void)c0;
   (void)src;
   (void)d;
@@ -993,6 +995,7 @@ void fields::add_eigenmode_source(component c0, const src_time &src, direction d
   (void)eigensolver_tol;
   (void)amp;
   (void)A;
+  (void)dp;
   abort("Meep must be configured/compiled with MPB for add_eigenmode_source");
 }
 


### PR DESCRIPTION
Extends the `DiffractedPlanewave` feature from #1316 to the eigenmode source as described in #291:[comment](https://github.com/NanoComp/meep/issues/291#issuecomment-672444352). Also includes documentation.

As a validation, the following test involves launching a diffracted planewave for three different diffraction orders and verifying that the resulting field profiles are as expected.
```py
import meep as mp
import numpy as np

import matplotlib
matplotlib.use('agg')
import matplotlib.pyplot as plt

resolution = 25 # pixels/μm

cell_size = mp.Vector3(14,14)

pml_layers = [mp.PML(thickness=2)]

fsrc = 1.0  # frequency   
order = -5  # diffraction order   

sources = [mp.EigenModeSource(src=mp.ContinuousSource(fsrc,is_integrated=True),
                              center=mp.Vector3(),
	                      size=mp.Vector3(y=14),
                              eig_band=mp.DiffractedPlanewave((0,order,0),mp.Vector3(0,1,0),1,0))]

sim = mp.Simulation(cell_size=cell_size,
                    resolution=resolution,
                    boundary_layers=pml_layers,
                    sources=sources,
                    symmetries=[mp.Mirror(mp.Y)] if order == 0 else [])

sim.run(until=20)
sim.plot2D(output_plane=mp.Volume(center=mp.Vector3(), size=mp.Vector3(10,10)),
           fields=mp.Ez)
plt.show()
```

**1. `order = 4`**

![diffpw-source-order4](https://user-images.githubusercontent.com/7152530/91796544-51bb1d00-ebd5-11ea-9618-ce969e3707f4.png)

**2. `order = 0`**

![diffpw-source-order0](https://user-images.githubusercontent.com/7152530/91796554-58499480-ebd5-11ea-80fc-8a71e4750f8d.png)

**3. `order = -5`**

![diffpw-source-order-5](https://user-images.githubusercontent.com/7152530/91796566-60093900-ebd5-11ea-88b1-fafe11599f24.png)
