### PR TITLE
API generator updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,8 @@ matrix:
           - *common_deps
           - libhdf5-serial-dev
     install:
-      - pip install numpy mpi4py scipy h5py coverage==4.5.4 coveralls matplotlib mkdocs==0.17.5 python-markdown-math mkdocs-material
+      - pip install numpy mpi4py scipy h5py coverage==4.5.4 coveralls matplotlib
+      - pip install -r doc/requirements.txt
   - python: "3.7"
     env:
       - MPICONF="--with-mpi"
@@ -131,7 +132,8 @@ matrix:
           - *common_deps
           - libhdf5-serial-dev
     install:
-      - pip install numpy mpi4py scipy h5py matplotlib mkdocs==0.17.5 python-markdown-math mkdocs-material
+      - pip install numpy mpi4py scipy h5py matplotlib
+      - pip install -r doc/requirements.txt
   - python: "3.5"
     env:
       - MPICONF="--with-mpi"
@@ -150,7 +152,8 @@ matrix:
           - libhdf5-openmpi-dev
           - python3-h5py
     install:
-      - pip install numpy mpi4py scipy matplotlib ipython mkdocs==0.17.5 python-markdown-math mkdocs-material
+      - pip install numpy mpi4py scipy matplotlib ipython
+      - pip install -r doc/requirements.txt
 
 
 ##################################################

--- a/doc/_api_snippets/function_template.md
+++ b/doc/_api_snippets/function_template.md
@@ -2,7 +2,7 @@
 <a id="{function_name}"></a>
 
 ```python
-def {function_name}{parameters}: {other_signatures}
+def {function_name}{parameters}:{other_signatures}
 ```
 
 <div class="function_docstring" markdown="1">

--- a/doc/_api_snippets/method_template.md
+++ b/doc/_api_snippets/method_template.md
@@ -4,7 +4,7 @@
 <div class="class_members" markdown="1">
 
 ```python
-def {method_name}{parameters}: {other_signatures}
+def {method_name}{parameters}:{other_signatures}
 ```
 
 <div class="method_docstring" markdown="1">

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -127,7 +127,7 @@ def __init__(self,
              force_all_components=False,
              split_chunks_evenly=True,
              chunk_layout=None,
-             collect_stats=False): 
+             collect_stats=False):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -179,12 +179,12 @@ Python. `Vector3` is a `meep` class.
   as the default material, use the `material_function` keyword argument (below).
 
 + **`material_function` [ function ]** — A Python function that takes a `Vector3`
-  and returns a `Medium`. See also [Material Function](#medium).
+  and returns a `Medium`. See also [Material Function](#material-function).
   Defaults to `None`.
 
 + **`epsilon_func` [ function ]** — A Python function that takes a `Vector3` and
   returns the dielectric constant at that point. See also [Material
-  Function](#medium). Defaults to `None`.
+  Function](#material-function). Defaults to `None`.
 
 + **`epsilon_input_file` [`string`]** — If this string is not empty (the default),
   then it should be the name of an HDF5 file whose first/only dataset defines a
@@ -254,7 +254,7 @@ Python. `Vector3` is a `meep` class.
 
 + **`eps_averaging` [`boolean`]** — If `True` (the default), then [subpixel
   averaging](Subpixel_Smoothing.md) is used when initializing the dielectric
-  function. For simulations involving a [material function](#medium),
+  function. For simulations involving a [material function](#material-function),
   `eps_averaging` is `False` (the default) and must be
   [enabled](Subpixel_Smoothing.md#enabling-averaging-for-material-function) in
   which case the input variables `subpixel_maxeval` (default 10<sup>4</sup>) and
@@ -368,7 +368,7 @@ use. See also [SWIG Wrappers](#swig-wrappers).
 <div class="class_members" markdown="1">
 
 ```python
-def run(self, *step_funcs, **kwargs): 
+def run(self):
 def run(step_functions..., until=condition/time):
 def run(step_functions..., until_after_sources=condition/time):
 ```
@@ -413,7 +413,7 @@ or set the output folder, with these methods of the `Simulation` class:
 <div class="class_members" markdown="1">
 
 ```python
-def get_filename_prefix(self): 
+def get_filename_prefix(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -436,7 +436,7 @@ by calling `Simulation.use_output_directory([dirname])`
 <div class="class_members" markdown="1">
 
 ```python
-def use_output_directory(self, dname=''): 
+def use_output_directory(self, dname=''):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -461,7 +461,7 @@ The `Simulation` class provides the following time-related methods:
 <div class="class_members" markdown="1">
 
 ```python
-def meep_time(self): 
+def meep_time(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -485,7 +485,7 @@ rounded to single precision.
 <div class="class_members" markdown="1">
 
 ```python
-def print_times(self): 
+def print_times(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -512,7 +512,7 @@ Field time usage:
 <div class="class_members" markdown="1">
 
 ```python
-def time_spent_on(self, time_sink): 
+def time_spent_on(self, time_sink):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -532,7 +532,7 @@ other.
 <div class="class_members" markdown="1">
 
 ```python
-def mean_time_spent_on(self, time_sink): 
+def mean_time_spent_on(self, time_sink):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -558,7 +558,7 @@ Meep supports a large number of functions to perform computations on the fields.
 <div class="class_members" markdown="1">
 
 ```python
-def set_boundary(self, side, direction, condition): 
+def set_boundary(self, side, direction, condition):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -576,7 +576,7 @@ section for valid `side`, `direction`, and `boundary_condition` values.
 <div class="class_members" markdown="1">
 
 ```python
-def phase_in_material(self, structure, time): 
+def phase_in_material(self, structure, time):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -602,7 +602,7 @@ simulation script is in
 <div class="class_members" markdown="1">
 
 ```python
-def get_field_point(self, c, pt): 
+def get_field_point(self, c, pt):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -619,7 +619,7 @@ returns the value of that component at that point.
 <div class="class_members" markdown="1">
 
 ```python
-def get_epsilon_point(self, pt, frequency=0, omega=0): 
+def get_epsilon_point(self, pt, frequency=0, omega=0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -657,7 +657,7 @@ frequency-independent part of $\mu$ (the $\omega\to\infty$ limit).
 <div class="class_members" markdown="1">
 
 ```python
-def initialize_field(self, cmpnt, amp_func): 
+def initialize_field(self, cmpnt, amp_func):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -675,7 +675,7 @@ of the field at that point.
 <div class="class_members" markdown="1">
 
 ```python
-def add_dft_fields(self, *args, **kwargs): 
+def add_dft_fields(self):
 def add_dft_fields(cs, fcen, df, nfreq, freq, where=None, center=None, size=None, yee_grid=False):
 ```
 
@@ -701,7 +701,7 @@ fields evaluated at each corresponding Yee grid point is available by setting
 <div class="class_members" markdown="1">
 
 ```python
-def flux_in_box(self, d, box=None, center=None, size=None): 
+def flux_in_box(self, d, box=None, center=None, size=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -724,7 +724,7 @@ construct the appropriate volume for you.
 <div class="class_members" markdown="1">
 
 ```python
-def electric_energy_in_box(self, box=None, center=None, size=None): 
+def electric_energy_in_box(self, box=None, center=None, size=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -748,7 +748,7 @@ volume.
 <div class="class_members" markdown="1">
 
 ```python
-def magnetic_energy_in_box(self, box=None, center=None, size=None): 
+def magnetic_energy_in_box(self, box=None, center=None, size=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -772,7 +772,7 @@ volume.
 <div class="class_members" markdown="1">
 
 ```python
-def field_energy_in_box(self, box=None, center=None, size=None): 
+def field_energy_in_box(self, box=None, center=None, size=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -796,7 +796,7 @@ volume.
 <div class="class_members" markdown="1">
 
 ```python
-def modal_volume_in_box(self, box=None, center=None, size=None): 
+def modal_volume_in_box(self, box=None, center=None, size=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -836,7 +836,7 @@ def integrate_field_function(self,
                              func,
                              where=None,
                              center=None,
-                             size=None): 
+                             size=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -870,7 +870,7 @@ def max_abs_field_function(self,
                            func,
                            where=None,
                            center=None,
-                           size=None): 
+                           size=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -908,7 +908,7 @@ def integrate2_field_function(self,
                               func,
                               where=None,
                               center=None,
-                              size=None): 
+                              size=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -956,7 +956,7 @@ Once the fields/simulation have been initialized, you can change the values of v
 <div class="class_members" markdown="1">
 
 ```python
-def reset_meep(self): 
+def reset_meep(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -973,7 +973,7 @@ memory as if you had not run any computations.
 <div class="class_members" markdown="1">
 
 ```python
-def restart_fields(self): 
+def restart_fields(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -990,7 +990,7 @@ transforms of the flux planes, which continue to be accumulated.
 <div class="class_members" markdown="1">
 
 ```python
-def change_k_point(self, k): 
+def change_k_point(self, k):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1006,7 +1006,7 @@ Change the `k_point` (the Bloch periodicity).
 <div class="class_members" markdown="1">
 
 ```python
-def change_sources(self, new_sources): 
+def change_sources(self, new_sources):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1024,7 +1024,7 @@ the sources used for the current simulation. `new_sources` must be a list of
 <div class="class_members" markdown="1">
 
 ```python
-def set_materials(self, geometry=None, default_material=None): 
+def set_materials(self, geometry=None, default_material=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1047,7 +1047,7 @@ Given a bunch of [`FluxRegion`](#fluxregion) objects, you can tell Meep to accum
 <div class="class_members" markdown="1">
 
 ```python
-def add_flux(self, *args): 
+def add_flux(self):
 def add_flux(fcen, df, nfreq, freq, FluxRegions...):
 ```
 
@@ -1081,7 +1081,7 @@ Once you have called `add_flux`, the Fourier transforms of the fields are accumu
 <div class="class_members" markdown="1">
 
 ```python
-def display_fluxes(self, *fluxes): 
+def display_fluxes(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1102,7 +1102,7 @@ You might have to do something lower-level if you have multiple flux regions cor
 <a id="get_flux_freqs"></a>
 
 ```python
-def get_flux_freqs(f): 
+def get_flux_freqs(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1115,7 +1115,7 @@ spectrum for.
 <a id="get_fluxes"></a>
 
 ```python
-def get_fluxes(f): 
+def get_fluxes(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1133,7 +1133,7 @@ As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md
 <div class="class_members" markdown="1">
 
 ```python
-def save_flux(self, fname, flux): 
+def save_flux(self, fname, flux):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1151,7 +1151,7 @@ filename-prefix is prepended automatically).
 <div class="class_members" markdown="1">
 
 ```python
-def load_flux(self, fname, flux): 
+def load_flux(self, fname, flux):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1172,7 +1172,7 @@ processors.
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_flux(self, fname, flux): 
+def load_minus_flux(self, fname, flux):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1193,7 +1193,7 @@ Sometimes it is more convenient to keep the Fourier-transformed fields in memory
 <div class="class_members" markdown="1">
 
 ```python
-def get_flux_data(self, flux): 
+def get_flux_data(self, flux):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1211,7 +1211,7 @@ only useful for passing to `load_flux_data` below and should be considered opaqu
 <div class="class_members" markdown="1">
 
 ```python
-def load_flux_data(self, flux, fdata): 
+def load_flux_data(self, flux, fdata):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1230,7 +1230,7 @@ object that was created by `get_flux_data` in a simulation of the same dimension
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_flux_data(self, flux, fdata): 
+def load_minus_flux_data(self, flux, fdata):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1267,12 +1267,12 @@ Given a structure, Meep can decompose the Fourier-transformed fields into a supe
 def get_eigenmode_coefficients(self,
                                flux,
                                bands,
-                               eig_parity=0,
+                               eig_parity=mp.NO_PARITY,
                                eig_vol=None,
                                eig_resolution=0,
                                eig_tolerance=1e-12,
                                kpoint_func=None,
-                               direction=-1): 
+                               direction=mp.AUTOMATIC):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1307,7 +1307,7 @@ Technically, MPB computes `ωₙ(k)` and then inverts it with Newton's method to
 <div class="class_members" markdown="1">
 
 ```python
-def add_mode_monitor(self, *args, **kwargs):
+def add_mode_monitor(self):
 def add_mode_monitor(fcen, df, nfreq, freq, ModeRegions...):
 ```
 
@@ -1336,9 +1336,9 @@ def get_eigenmode(self,
                   kpoint,
                   eig_vol=None,
                   match_frequency=True,
-                  parity=0,
+                  parity=mp.NO_PARITY,
                   resolution=0,
-                  eigensolver_tol=1e-12): 
+                  eigensolver_tol=1e-12):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1372,7 +1372,7 @@ The following top-level function is also available:
 <a id="get_eigenmode_freqs"></a>
 
 ```python
-def get_eigenmode_freqs(f): 
+def get_eigenmode_freqs(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1437,7 +1437,7 @@ The usage is similar to the flux spectra: you define a set of [`EnergyRegion`](#
 <div class="class_members" markdown="1">
 
 ```python
-def add_energy(self, *args): 
+def add_energy(self):
 def add_energy(fcen, df, nfreq, freq, EnergyRegions...):
 ```
 
@@ -1471,7 +1471,7 @@ Once you have called `add_energy`, the Fourier transforms of the fields are accu
 <div class="class_members" markdown="1">
 
 ```python
-def display_electric_energy(self, *energys): 
+def display_electric_energy(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1491,7 +1491,7 @@ column are the frequencies, and subsequent columns are the energy density spectr
 <div class="class_members" markdown="1">
 
 ```python
-def display_magnetic_energy(self, *energys): 
+def display_magnetic_energy(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1511,7 +1511,7 @@ column are the frequencies, and subsequent columns are the energy density spectr
 <div class="class_members" markdown="1">
 
 ```python
-def display_total_energy(self, *energys): 
+def display_total_energy(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1533,7 +1533,7 @@ You might have to do something lower-level if you have multiple energy regions c
 <a id="get_energy_freqs"></a>
 
 ```python
-def get_energy_freqs(f): 
+def get_energy_freqs(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1546,7 +1546,7 @@ spectrum for.
 <a id="get_electric_energy"></a>
 
 ```python
-def get_electric_energy(f): 
+def get_electric_energy(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1559,7 +1559,7 @@ electric fields that it has accumulated.
 <a id="get_magnetic_energy"></a>
 
 ```python
-def get_magnetic_energy(f): 
+def get_magnetic_energy(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1572,7 +1572,7 @@ magnetic fields that it has accumulated.
 <a id="get_total_energy"></a>
 
 ```python
-def get_total_energy(f): 
+def get_total_energy(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1590,7 +1590,7 @@ As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md
 <div class="class_members" markdown="1">
 
 ```python
-def save_energy(self, fname, energy): 
+def save_energy(self, fname, energy):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1608,7 +1608,7 @@ filename-prefix is prepended automatically).
 <div class="class_members" markdown="1">
 
 ```python
-def load_energy(self, fname, energy): 
+def load_energy(self, fname, energy):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1629,7 +1629,7 @@ processors.
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_energy(self, fname, energy): 
+def load_minus_energy(self, fname, energy):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1663,7 +1663,7 @@ The usage is similar to the [flux spectra](Python_Tutorials/Basics.md#transmitta
 <div class="class_members" markdown="1">
 
 ```python
-def add_force(self, *args): 
+def add_force(self):
 def add_force(fcen, df, nfreq, freq, ForceRegions...):
 ```
 
@@ -1697,7 +1697,7 @@ Once you have called `add_force`, the Fourier transforms of the fields are accum
 <div class="class_members" markdown="1">
 
 ```python
-def display_forces(self, *forces): 
+def display_forces(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1719,7 +1719,7 @@ You might have to do something lower-level if you have multiple force regions co
 <a id="get_force_freqs"></a>
 
 ```python
-def get_force_freqs(f): 
+def get_force_freqs(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1732,7 +1732,7 @@ spectrum for.
 <a id="get_forces"></a>
 
 ```python
-def get_forces(f): 
+def get_forces(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1751,7 +1751,7 @@ As described in [Introduction/Transmittance/Reflectance Spectra](Introduction.md
 <div class="class_members" markdown="1">
 
 ```python
-def save_force(self, fname, force): 
+def save_force(self, fname, force):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1769,7 +1769,7 @@ filename-prefix is prepended automatically).
 <div class="class_members" markdown="1">
 
 ```python
-def load_force(self, fname, force): 
+def load_force(self, fname, force):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1790,7 +1790,7 @@ processors.
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_force(self, fname, force): 
+def load_minus_force(self, fname, force):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1811,7 +1811,7 @@ To keep the fields in memory and avoid writing to and reading from a file, use t
 <div class="class_members" markdown="1">
 
 ```python
-def get_force_data(self, force): 
+def get_force_data(self, force):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1830,7 +1830,7 @@ opaque.
 <div class="class_members" markdown="1">
 
 ```python
-def load_force_data(self, force, fdata): 
+def load_force_data(self, force, fdata):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1849,7 +1849,7 @@ object that was created by `get_force_data` in a simulation of the same dimensio
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_force_data(self, force, fdata): 
+def load_minus_force_data(self, force, fdata):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1870,7 +1870,7 @@ Meep can also calculate the LDOS (local density of states) spectrum, as describe
 <a id="Ldos"></a>
 
 ```python
-def Ldos(*args): 
+def Ldos():
 def Ldos(fcen, df, nfreq, freq):
 ```
 
@@ -1887,7 +1887,7 @@ argument.
 <a id="get_ldos_freqs"></a>
 
 ```python
-def get_ldos_freqs(l): 
+def get_ldos_freqs(l):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -1900,7 +1900,7 @@ spectrum for.
 <a id="dft_ldos"></a>
 
 ```python
-def dft_ldos(*args, **kwargs): 
+def dft_ldos():
 def dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None):
 ```
 
@@ -1942,7 +1942,7 @@ There are three steps to using the near-to-far-field feature: first, define the 
 <div class="class_members" markdown="1">
 
 ```python
-def add_near2far(self, *args, **kwargs): 
+def add_near2far(self):
 def add_near2far(fcen, df, nfreq, freq, Near2FarRegions..., nperiods=1):
 ```
 
@@ -1972,7 +1972,7 @@ If you have Bloch-periodic boundary conditions, then the corresponding near-to-f
 <div class="class_members" markdown="1">
 
 ```python
-def get_farfield(self, near2far, x): 
+def get_farfield(self, near2far, x):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1999,7 +1999,7 @@ def output_farfields(self,
                      resolution,
                      where=None,
                      center=None,
-                     size=None): 
+                     size=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2029,7 +2029,7 @@ def get_farfields(self,
                   resolution,
                   where=None,
                   center=None,
-                  size=None): 
+                  size=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2054,7 +2054,7 @@ This lower-level function is also available:
 <a id="get_near2far_freqs"></a>
 
 ```python
-def get_near2far_freqs(f): 
+def get_near2far_freqs(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2077,7 +2077,7 @@ For a scattered-field computation, you often want to separate the scattered and 
 <div class="class_members" markdown="1">
 
 ```python
-def save_near2far(self, fname, near2far): 
+def save_near2far(self, fname, near2far):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2095,7 +2095,7 @@ filename-prefix is prepended automatically.
 <div class="class_members" markdown="1">
 
 ```python
-def load_near2far(self, fname, near2far): 
+def load_near2far(self, fname, near2far):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2116,7 +2116,7 @@ processors.
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_near2far(self, fname, near2far): 
+def load_minus_near2far(self, fname, near2far):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2138,7 +2138,7 @@ To keep the fields in memory and avoid writing to and reading from a file, use t
 <div class="class_members" markdown="1">
 
 ```python
-def get_near2far_data(self, near2far): 
+def get_near2far_data(self, near2far):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2157,7 +2157,7 @@ considered opaque.
 <div class="class_members" markdown="1">
 
 ```python
-def load_near2far_data(self, near2far, n2fdata): 
+def load_near2far_data(self, near2far, n2fdata):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2177,7 +2177,7 @@ processors.
 <div class="class_members" markdown="1">
 
 ```python
-def load_minus_near2far_data(self, near2far, n2fdata): 
+def load_minus_near2far_data(self, near2far, n2fdata):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2196,7 +2196,7 @@ See also this lower-level function:
 <a id="scale_near2far_fields"></a>
 
 ```python
-def scale_near2far_fields(s, near2far): 
+def scale_near2far_fields(s, near2far):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2215,7 +2215,7 @@ And this [`DftNear2Far`](#DftNear2Far) method:
 <div class="class_members" markdown="1">
 
 ```python
-def flux(self, direction, where, resolution): 
+def flux(self, direction, where, resolution):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2241,7 +2241,7 @@ These functions dump the raw ε and μ data to disk and load it back for doing m
 <div class="class_members" markdown="1">
 
 ```python
-def dump_structure(self, fname): 
+def dump_structure(self, fname):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2257,7 +2257,7 @@ Dumps the structure to the file `fname`.
 <div class="class_members" markdown="1">
 
 ```python
-def load_structure(self, fname): 
+def load_structure(self, fname):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2274,7 +2274,7 @@ the `Simulation` constructor via the `load_structure` keyword argument.
 <div class="class_members" markdown="1">
 
 ```python
-def dump_chunk_layout(self, fname): 
+def dump_chunk_layout(self, fname):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2352,7 +2352,7 @@ This feature is only available if Meep is built with [libGDSII](Build_From_Sourc
 <a id="GDSII_layers"></a>
 
 ```python
-def GDSII_layers(fname): 
+def GDSII_layers(fname):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2370,7 +2370,7 @@ Out[2]: [0, 1, 2, 3, 4, 5, 31, 32]
 <a id="GDSII_prisms"></a>
 
 ```python
-def GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0): 
+def GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2383,7 +2383,7 @@ Returns a list of `GeometricObject`s with `material` (`mp.Medium`) on layer numb
 <a id="GDSII_vol"></a>
 
 ```python
-def GDSII_vol(fname, layer, zmin, zmax): 
+def GDSII_vol(fname, layer, zmin, zmax):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2423,8 +2423,7 @@ def plot2D(self,
            plot_eps_flag=True,
            plot_sources_flag=True,
            plot_monitors_flag=True,
-           plot_boundaries_flag=True,
-           **kwargs): 
+           plot_boundaries_flag=True):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2514,7 +2513,7 @@ plt.savefig('sim_domain.png')
 <div class="class_members" markdown="1">
 
 ```python
-def plot3D(self): 
+def plot3D(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2531,7 +2530,7 @@ Can also be embedded in Jupyter notebooks.
 <div class="class_members" markdown="1">
 
 ```python
-def visualize_chunks(self): 
+def visualize_chunks(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2562,7 +2561,7 @@ A common point of confusion is described in [The Run Function Is Not A Loop](The
 <div class="class_members" markdown="1">
 
 ```python
-def run(self, *step_funcs, **kwargs): 
+def run(self):
 def run(step_functions..., until=condition/time):
 def run(step_functions..., until_after_sources=condition/time):
 ```
@@ -2598,7 +2597,7 @@ In particular, a useful value for `until_after_sources` or `until` is often `sto
 <a id="stop_when_fields_decayed"></a>
 
 ```python
-def stop_when_fields_decayed(dt, c, pt, decay_by): 
+def stop_when_fields_decayed(dt, c, pt, decay_by):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2622,7 +2621,7 @@ slow group velocities and are absorbed poorly by [PML](Perfectly_Matched_Layer.m
 <a id="stop_after_walltime"></a>
 
 ```python
-def stop_after_walltime(t): 
+def stop_after_walltime(t):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2635,7 +2634,7 @@ parameter. Stops the simulation after `t` seconds of wall time have passed.
 <a id="stop_on_interrupt"></a>
 
 ```python
-def stop_on_interrupt(): 
+def stop_on_interrupt():
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2656,7 +2655,7 @@ Finally, another run function, useful for computing ω(**k**) band diagrams, is 
 <div class="class_members" markdown="1">
 
 ```python
-def run_k_points(self, t, k_points): 
+def run_k_points(self, t, k_points):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2683,7 +2682,7 @@ Cavity](Python_Tutorials/Resonant_Modes_and_Transmission_in_a_Waveguide_Cavity.m
 <div class="class_members" markdown="1">
 
 ```python
-def run_k_point(self, t, k): 
+def run_k_point(self, t, k):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2714,7 +2713,7 @@ Note that although the various field components are stored at different places i
 <div class="class_members" markdown="1">
 
 ```python
-def output_dft(self, dft_fields, fname): 
+def output_dft(self, dft_fields, fname):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2731,7 +2730,7 @@ suffix).
 <a id="output_epsilon"></a>
 
 ```python
-def output_epsilon(sim, *step_func_args, **kwargs): 
+def output_epsilon(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2747,7 +2746,7 @@ frequency-independent part of ε (the $\omega\to\infty$ limit).
 <a id="output_mu"></a>
 
 ```python
-def output_mu(sim, *step_func_args, **kwargs): 
+def output_mu(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2763,7 +2762,7 @@ frequency-independent part of μ (the $\omega\to\infty$ limit).
 <a id="output_poynting"></a>
 
 ```python
-def output_poynting(sim): 
+def output_poynting(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2778,7 +2777,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_hpwr"></a>
 
 ```python
-def output_hpwr(sim): 
+def output_hpwr(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2790,7 +2789,7 @@ Output the magnetic-field energy density $\mathbf{H}^* \cdot \mathbf{B} / 2$
 <a id="output_dpwr"></a>
 
 ```python
-def output_dpwr(sim): 
+def output_dpwr(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2802,7 +2801,7 @@ Output the electric-field energy density $\mathbf{E}^* \cdot \mathbf{D} / 2$
 <a id="output_tot_pwr"></a>
 
 ```python
-def output_tot_pwr(sim): 
+def output_tot_pwr(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2817,7 +2816,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_png"></a>
 
 ```python
-def output_png(compnt, options, rm_h5=True): 
+def output_png(compnt, options, rm_h5=True):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2847,7 +2846,7 @@ file requires `output_png(component, h5topng_options, rm_h5=False)`.
 <a id="output_hfield"></a>
 
 ```python
-def output_hfield(sim): 
+def output_hfield(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2860,7 +2859,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_hfield_x"></a>
 
 ```python
-def output_hfield_x(sim): 
+def output_hfield_x(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2874,7 +2873,7 @@ imaginary parts, respectively.
 <a id="output_hfield_y"></a>
 
 ```python
-def output_hfield_y(sim): 
+def output_hfield_y(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2888,7 +2887,7 @@ imaginary parts, respectively.
 <a id="output_hfield_z"></a>
 
 ```python
-def output_hfield_z(sim): 
+def output_hfield_z(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2902,7 +2901,7 @@ imaginary parts, respectively.
 <a id="output_hfield_r"></a>
 
 ```python
-def output_hfield_r(sim): 
+def output_hfield_r(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2916,7 +2915,7 @@ imaginary parts, respectively.
 <a id="output_hfield_p"></a>
 
 ```python
-def output_hfield_p(sim): 
+def output_hfield_p(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2931,7 +2930,7 @@ and imaginary parts, respectively.
 <a id="output_bfield"></a>
 
 ```python
-def output_bfield(sim): 
+def output_bfield(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2944,7 +2943,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_bfield_x"></a>
 
 ```python
-def output_bfield_x(sim): 
+def output_bfield_x(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2958,7 +2957,7 @@ imaginary parts, respectively.
 <a id="output_bfield_y"></a>
 
 ```python
-def output_bfield_y(sim): 
+def output_bfield_y(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2972,7 +2971,7 @@ imaginary parts, respectively.
 <a id="output_bfield_z"></a>
 
 ```python
-def output_bfield_z(sim): 
+def output_bfield_z(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2986,7 +2985,7 @@ imaginary parts, respectively.
 <a id="output_bfield_r"></a>
 
 ```python
-def output_bfield_r(sim): 
+def output_bfield_r(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3000,7 +2999,7 @@ imaginary parts, respectively.
 <a id="output_bfield_p"></a>
 
 ```python
-def output_bfield_p(sim): 
+def output_bfield_p(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3018,7 +3017,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_efield"></a>
 
 ```python
-def output_efield(sim): 
+def output_efield(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3031,7 +3030,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_efield_x"></a>
 
 ```python
-def output_efield_x(sim): 
+def output_efield_x(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3045,7 +3044,7 @@ imaginary parts, respectively.
 <a id="output_efield_y"></a>
 
 ```python
-def output_efield_y(sim): 
+def output_efield_y(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3059,7 +3058,7 @@ imaginary parts, respectively.
 <a id="output_efield_z"></a>
 
 ```python
-def output_efield_z(sim): 
+def output_efield_z(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3073,7 +3072,7 @@ imaginary parts, respectively.
 <a id="output_efield_r"></a>
 
 ```python
-def output_efield_r(sim): 
+def output_efield_r(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3087,7 +3086,7 @@ imaginary parts, respectively.
 <a id="output_efield_p"></a>
 
 ```python
-def output_efield_p(sim): 
+def output_efield_p(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3105,7 +3104,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_dfield"></a>
 
 ```python
-def output_dfield(sim): 
+def output_dfield(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3118,7 +3117,7 @@ is, the different components are stored as different datasets within the *same* 
 <a id="output_dfield_x"></a>
 
 ```python
-def output_dfield_x(sim): 
+def output_dfield_x(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3132,7 +3131,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_y"></a>
 
 ```python
-def output_dfield_y(sim): 
+def output_dfield_y(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3146,7 +3145,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_z"></a>
 
 ```python
-def output_dfield_z(sim): 
+def output_dfield_z(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3160,7 +3159,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_r"></a>
 
 ```python
-def output_dfield_r(sim): 
+def output_dfield_r(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3174,7 +3173,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_p"></a>
 
 ```python
-def output_dfield_p(sim): 
+def output_dfield_p(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3192,7 +3191,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_sfield"></a>
 
 ```python
-def output_sfield(sim): 
+def output_sfield(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3208,7 +3207,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_sfield_x"></a>
 
 ```python
-def output_sfield_x(sim): 
+def output_sfield_x(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3222,7 +3221,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_y"></a>
 
 ```python
-def output_sfield_y(sim): 
+def output_sfield_y(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3236,7 +3235,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_z"></a>
 
 ```python
-def output_sfield_z(sim): 
+def output_sfield_z(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3250,7 +3249,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_r"></a>
 
 ```python
-def output_sfield_r(sim): 
+def output_sfield_r(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3264,7 +3263,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_p"></a>
 
 ```python
-def output_sfield_p(sim): 
+def output_sfield_p(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3292,7 +3291,7 @@ def output_field_function(self,
                           cs,
                           func,
                           real_only=False,
-                          h5file=None): 
+                          h5file=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3328,7 +3327,7 @@ def get_array(self,
               cmplx=None,
               arr=None,
               frequency=0,
-              omega=0): 
+              omega=0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3391,7 +3390,7 @@ arrays; rather, you should simply rely on Meep's output.
 <div class="class_members" markdown="1">
 
 ```python
-def get_dft_array(self, dft_obj, component, num_freq): 
+def get_dft_array(self, dft_obj, component, num_freq):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3429,7 +3428,7 @@ def get_array_metadata(self,
                        dft_cell=None,
                        collapse=False,
                        snap=False,
-                       return_pw=False): 
+                       return_pw=False):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3529,7 +3528,7 @@ def get_source(self,
                component,
                vol=None,
                center=None,
-               size=None): 
+               size=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -3561,7 +3560,7 @@ Rather than writing a brand-new step function every time something a bit differe
 <a id="combine_step_funcs"></a>
 
 ```python
-def combine_step_funcs(*step_funcs): 
+def combine_step_funcs():
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3574,7 +3573,7 @@ all of the passed step functions.
 <a id="synchronized_magnetic"></a>
 
 ```python
-def synchronized_magnetic(*step_funcs): 
+def synchronized_magnetic():
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3593,7 +3592,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="when_true"></a>
 
 ```python
-def when_true(cond, *step_funcs): 
+def when_true(cond):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3606,7 +3605,7 @@ no arguments), evaluate the step functions whenever `condition` returns `True`.
 <a id="when_false"></a>
 
 ```python
-def when_false(cond, *step_funcs): 
+def when_false(cond):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3619,7 +3618,7 @@ no arguments), evaluate the step functions whenever `condition` returns `False`.
 <a id="at_every"></a>
 
 ```python
-def at_every(dt, *step_funcs): 
+def at_every(dt):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3632,7 +3631,7 @@ Given zero or more step functions, evaluates them at every time interval of $dT$
 <a id="after_time"></a>
 
 ```python
-def after_time(t, *step_funcs): 
+def after_time(t):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3645,7 +3644,7 @@ units have elapsed from the start of the run.
 <a id="before_time"></a>
 
 ```python
-def before_time(t, *step_funcs): 
+def before_time(t):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3658,7 +3657,7 @@ units have elapsed from the start of the run.
 <a id="at_time"></a>
 
 ```python
-def at_time(t, *step_funcs): 
+def at_time(t):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3671,7 +3670,7 @@ have elapsed from the start of the run.
 <a id="after_sources"></a>
 
 ```python
-def after_sources(*step_funcs): 
+def after_sources():
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3684,7 +3683,7 @@ sources have turned off.
 <a id="after_sources_and_time"></a>
 
 ```python
-def after_sources_and_time(t, *step_funcs): 
+def after_sources_and_time(t):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3697,7 +3696,7 @@ sources have turned off, plus an additional $T$ time units have elapsed.
 <a id="during_sources"></a>
 
 ```python
-def during_sources(*step_funcs): 
+def during_sources():
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3710,7 +3709,7 @@ sources have turned off.
 <a id="at_beginning"></a>
 
 ```python
-def at_beginning(*step_funcs): 
+def at_beginning():
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3723,7 +3722,7 @@ run.
 <a id="at_end"></a>
 
 ```python
-def at_end(*step_funcs): 
+def at_end():
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3739,7 +3738,7 @@ Given zero or more step functions, evaluates them only once, at the end of the r
 <a id="in_volume"></a>
 
 ```python
-def in_volume(v, *step_funcs): 
+def in_volume(v):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3753,7 +3752,7 @@ output a subset (or a superset) of the cell, corresponding to the `meep::volume*
 <a id="in_point"></a>
 
 ```python
-def in_point(pt, *step_funcs): 
+def in_point(pt):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3766,7 +3765,7 @@ output a single *point* of data, at `pt` (a `Vector3`).
 <a id="to_appended"></a>
 
 ```python
-def to_appended(fname, *step_funcs): 
+def to_appended(fname):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3781,7 +3780,7 @@ dimension* to their datasets, corresponding to time.
 <a id="with_prefix"></a>
 
 ```python
-def with_prefix(pre, *step_funcs): 
+def with_prefix(pre):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3964,7 +3963,7 @@ def __init__(self,
              E_chi3=None,
              H_chi2=None,
              H_chi3=None,
-             valid_freq_range=FreqRange(min=-1e+20, max=1e+20)): 
+             valid_freq_range=FreqRange(min=-1e+20, max=1e+20)):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4031,7 +4030,7 @@ Creates a `Medium` object.
 <div class="class_members" markdown="1">
 
 ```python
-def __repr__(self): 
+def __repr__(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4047,7 +4046,7 @@ Return repr(self).
 <div class="class_members" markdown="1">
 
 ```python
-def epsilon(self, freq): 
+def epsilon(self, freq):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4065,7 +4064,7 @@ of a list/array of N frequency points, a Numpy array of size Nx3x3 is returned.
 <div class="class_members" markdown="1">
 
 ```python
-def mu(self, freq): 
+def mu(self, freq):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4083,7 +4082,7 @@ of a list/array of N frequency points, a Numpy array of size Nx3x3 is returned.
 <div class="class_members" markdown="1">
 
 ```python
-def transform(self, m): 
+def transform(self, m):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4129,7 +4128,7 @@ anisotropic amplitude σ. See [Material Dispersion](Materials.md#material-disper
 def __init__(self,
              sigma_diag=Vector3<0.0, 0.0, 0.0>,
              sigma_offdiag=Vector3<0.0, 0.0, 0.0>,
-             sigma=None): 
+             sigma=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4172,7 +4171,7 @@ the parameters (in addition to σ):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, frequency=0.0, gamma=0.0, **kwargs): 
+def __init__(self, frequency=0.0, gamma=0.0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4212,7 +4211,7 @@ Dispersion](Materials.md#material-dispersion), with the parameters (in addition 
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, frequency=0.0, gamma=0.0, **kwargs): 
+def __init__(self, frequency=0.0, gamma=0.0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4253,10 +4252,7 @@ Absorption](Materials.md#saturable-gain-and-absorption).
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self,
-             initial_populations=[],
-             transitions=[],
-             **kwargs): 
+def __init__(self, initial_populations=[], transitions=[]):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4304,7 +4300,7 @@ def __init__(self,
              frequency=0,
              sigma_diag=Vector3<1.0, 1.0, 1.0>,
              gamma=0,
-             pumping_rate=0): 
+             pumping_rate=0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4356,7 +4352,7 @@ space and time, zero mean) added to the **P** damped-oscillator equation.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, noise_amp=0.0, **kwargs): 
+def __init__(self, noise_amp=0.0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4407,7 +4403,7 @@ space and time, zero mean) added to the **P** damped-oscillator equation.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, noise_amp=0.0, **kwargs): 
+def __init__(self, noise_amp=0.0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4458,7 +4454,7 @@ meanings](#susceptibility), and an additional 3-vector `bias`:
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs): 
+def __init__(self, bias=Vector3<0.0, 0.0, 0.0>):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4497,7 +4493,7 @@ meanings](#susceptibility), and an additional 3-vector `bias`:
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs): 
+def __init__(self, bias=Vector3<0.0, 0.0, 0.0>):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4542,8 +4538,7 @@ def __init__(self,
              bias=Vector3<0.0, 0.0, 0.0>,
              frequency=0.0,
              gamma=0.0,
-             alpha=0.0,
-             **kwargs): 
+             alpha=0.0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4600,7 +4595,7 @@ iterable (e.g., a tuple or list) and automatically convert to a `Vector3`.
 <div class="class_members" markdown="1">
 
 ```python
-def __add__(self, other): 
+def __add__(self, other):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4620,7 +4615,7 @@ v3 = v1 + v2
 <div class="class_members" markdown="1">
 
 ```python
-def __eq__(self, other): 
+def __eq__(self, other):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4642,7 +4637,7 @@ v1 == v2
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, x=0.0, y=0.0, z=0.0): 
+def __init__(self, x=0.0, y=0.0, z=0.0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4659,7 +4654,7 @@ zero. This can also be represented simply as `(x,y,z)` or `[x,y,z]`.
 <div class="class_members" markdown="1">
 
 ```python
-def __mul__(self, other): 
+def __mul__(self, other):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4680,7 +4675,7 @@ c = v1 * other
 <div class="class_members" markdown="1">
 
 ```python
-def __ne__(self, other): 
+def __ne__(self, other):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4702,7 +4697,7 @@ v1 != v2
 <div class="class_members" markdown="1">
 
 ```python
-def __repr__(self): 
+def __repr__(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4718,7 +4713,7 @@ Return repr(self).
 <div class="class_members" markdown="1">
 
 ```python
-def __rmul__(self, other): 
+def __rmul__(self, other):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4739,7 +4734,7 @@ c = other * v1
 <div class="class_members" markdown="1">
 
 ```python
-def __sub__(self, other): 
+def __sub__(self, other):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4759,7 +4754,7 @@ v3 = v1 - v2
 <div class="class_members" markdown="1">
 
 ```python
-def cdot(self, v): 
+def cdot(self, v):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4775,7 +4770,7 @@ Returns the conjugated dot product: *self*\* dot *v*.
 <div class="class_members" markdown="1">
 
 ```python
-def close(self, v, tol=1e-07): 
+def close(self, v, tol=1e-07):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4796,7 +4791,7 @@ v1.close(v2, [tol])
 <div class="class_members" markdown="1">
 
 ```python
-def cross(self, v): 
+def cross(self, v):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4816,7 +4811,7 @@ v3 = v1.cross(v2)
 <div class="class_members" markdown="1">
 
 ```python
-def dot(self, v): 
+def dot(self, v):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4836,7 +4831,7 @@ v3 = v1.dot(v2)
 <div class="class_members" markdown="1">
 
 ```python
-def norm(self): 
+def norm(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4856,7 +4851,7 @@ v2 = v1.norm()
 <div class="class_members" markdown="1">
 
 ```python
-def rotate(self, axis, theta): 
+def rotate(self, axis, theta):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4879,7 +4874,7 @@ v2 = v1.rotate(axis, theta)
 <div class="class_members" markdown="1">
 
 ```python
-def unit(self): 
+def unit(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4968,7 +4963,7 @@ geometry = [mp.Prism(vertices, height=1.5, center=mp.Vector3(), material=cSi)]
 def __init__(self,
              material=Medium(),
              center=Vector3<0.0, 0.0, 0.0>,
-             epsilon_func=None): 
+             epsilon_func=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5000,7 +4995,7 @@ constructor via keyword arguments.
 <div class="class_members" markdown="1">
 
 ```python
-def info(self, indent_by=0): 
+def info(self, indent_by=0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5017,7 +5012,7 @@ Displays all properties and current values of a `GeometricObject`, indented by
 <div class="class_members" markdown="1">
 
 ```python
-def shift(self, vec): 
+def shift(self, vec):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5061,7 +5056,7 @@ Represents a sphere.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, radius, **kwargs): 
+def __init__(self, radius):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5106,8 +5101,7 @@ A cylinder, with circular cross-section and finite height.
 def __init__(self,
              radius,
              axis=Vector3<0.0, 0.0, 1.0>,
-             height=1e+20,
-             **kwargs): 
+             height=1e+20):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5143,8 +5137,7 @@ Represents a cylindrical wedge.
 def __init__(self,
              radius,
              wedge_angle=6.283185307179586,
-             wedge_start=Vector3<1.0, 0.0, 0.0>,
-             **kwargs): 
+             wedge_start=Vector3<1.0, 0.0, 0.0>):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5181,7 +5174,7 @@ is halfway between the two circular ends.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, radius, radius2=0, **kwargs): 
+def __init__(self, radius, radius2=0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5222,8 +5215,7 @@ def __init__(self,
              size,
              e1=Vector3<1.0, 0.0, 0.0>,
              e2=Vector3<0.0, 1.0, 0.0>,
-             e3=Vector3<0.0, 0.0, 1.0>,
-             **kwargs): 
+             e3=Vector3<0.0, 0.0, 1.0>):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5265,7 +5257,7 @@ properties, but defines an ellipsoid inscribed inside the block.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, **kwargs): 
+def __init__(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5303,8 +5295,7 @@ def __init__(self,
              height,
              axis=Vector3<0.0, 0.0, 1.0>,
              center=None,
-             sidewall_angle=0,
-             **kwargs): 
+             sidewall_angle=0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5394,7 +5385,7 @@ def __init__(self,
              c2=Vector3<0.0, 0.0, 0.0>,
              c3=Vector3<0.0, 0.0, 0.0>,
              diag=Vector3<0.0, 0.0, 0.0>,
-             offdiag=Vector3<0.0, 0.0, 0.0>): 
+             offdiag=Vector3<0.0, 0.0, 0.0>):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5410,7 +5401,7 @@ Constructs a `Matrix`.
 <div class="class_members" markdown="1">
 
 ```python
-def __repr__(self): 
+def __repr__(self):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5426,7 +5417,7 @@ Return repr(self).
 <a id="get_rotation_matrix"></a>
 
 ```python
-def get_rotation_matrix(axis, theta): 
+def get_rotation_matrix(axis, theta):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -5481,7 +5472,7 @@ the axis of the rotation.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, direction, phase=1): 
+def __init__(self, direction, phase=1):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5606,11 +5597,11 @@ properties.
 ```python
 def __init__(self,
              thickness,
-             direction=-1,
-             side=-1,
+             direction=mp.ALL,
+             side=mp.ALL,
              R_asymptotic=1e-15,
              mean_stretch=1.0,
-             pml_profile=lambda u: u * u):
+             pml_profile=DefaultPMLProfile):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5746,7 +5737,7 @@ def __init__(self,
              amplitude=1.0,
              amp_func=None,
              amp_func_file='',
-             amp_data=None): 
+             amp_data=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5907,15 +5898,14 @@ def __init__(self,
              volume=None,
              eig_lattice_size=None,
              eig_lattice_center=None,
-             component=20,
-             direction=-1,
+             component=mp.ALL_COMPONENTS,
+             direction=mp.AUTOMATIC,
              eig_band=1,
              eig_kpoint=Vector3<0.0, 0.0, 0.0>,
              eig_match_freq=True,
-             eig_parity=0,
+             eig_parity=mp.NO_PARITY,
              eig_resolution=0,
-             eig_tolerance=1e-12,
-             **kwargs): 
+             eig_tolerance=1e-12):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6007,7 +5997,7 @@ Construct an `EigenModeSource`.
 <div class="class_members" markdown="1">
 
 ```python
-def eig_power(self, freq): 
+def eig_power(self, freq):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6048,12 +6038,11 @@ def __init__(self,
              src,
              center=None,
              volume=None,
-             component=20,
+             component=mp.ALL_COMPONENTS,
              beam_x0=Vector3<0.0, 0.0, 0.0>,
              beam_kdir=Vector3<0.0, 0.0, 0.0>,
              beam_w0=None,
-             beam_E0=Vector3<0.0, 0.0, 0.0>,
-             **kwargs):
+             beam_E0=Vector3<0.0, 0.0, 0.0>):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6104,8 +6093,7 @@ def __init__(self,
              width=0,
              fwidth=inf,
              cutoff=3.0,
-             wavelength=None,
-             **kwargs): 
+             wavelength=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6179,8 +6167,7 @@ def __init__(self,
              fwidth=inf,
              start_time=0,
              cutoff=5.0,
-             wavelength=None,
-             **kwargs): 
+             wavelength=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6265,8 +6252,7 @@ def __init__(self,
              src_func,
              start_time=-1e+20,
              end_time=1e+20,
-             center_frequency=0,
-             **kwargs): 
+             center_frequency=0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6335,9 +6321,9 @@ the box add instead of subtract.
 def __init__(self,
              center=None,
              size=Vector3<0.0, 0.0, 0.0>,
-             direction=-1,
+             direction=mp.AUTOMATIC,
              weight=1.0,
-             volume=None): 
+             volume=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6466,7 +6452,7 @@ def __init__(self,
              size=Vector3<0.0, 0.0, 0.0>,
              dims=2,
              is_cylindrical=False,
-             vertices=[]): 
+             vertices=[]):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6482,7 +6468,7 @@ Construct a Volume.
 <a id="get_center_and_size"></a>
 
 ```python
-def get_center_and_size(vol): 
+def get_center_and_size(vol):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -6534,12 +6520,12 @@ swigobj_attr and return the property they requested.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args): 
+def __init__(self, func, args):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Initialize self.  See `help(type(self))` for accurate signature.
+Construct a `DftObj`.
 
 </div>
 
@@ -6567,12 +6553,12 @@ class DftFlux(DftObj):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args): 
+def __init__(self, func, args):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Initialize self.  See `help(type(self))` for accurate signature.
+Construct a `DftFlux`.
 
 </div>
 
@@ -6600,12 +6586,12 @@ class DftForce(DftObj):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args): 
+def __init__(self, func, args):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Initialize self.  See `help(type(self))` for accurate signature.
+Construct a `DftForce`.
 
 </div>
 
@@ -6633,12 +6619,12 @@ class DftNear2Far(DftObj):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args): 
+def __init__(self, func, args):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Initialize self.  See `help(type(self))` for accurate signature.
+Construct a `DftNear2Far`.
 
 </div>
 
@@ -6649,7 +6635,7 @@ Initialize self.  See `help(type(self))` for accurate signature.
 <div class="class_members" markdown="1">
 
 ```python
-def flux(self, direction, where, resolution): 
+def flux(self, direction, where, resolution):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6686,12 +6672,12 @@ class DftEnergy(DftObj):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args): 
+def __init__(self, func, args):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Initialize self.  See `help(type(self))` for accurate signature.
+Construct a `DftEnergy`.
 
 </div>
 
@@ -6719,12 +6705,12 @@ class DftFields(DftObj):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, func, args): 
+def __init__(self, func, args):
 ```
 
 <div class="method_docstring" markdown="1">
 
-Initialize self.  See `help(type(self))` for accurate signature.
+Construct a `DftFields`.
 
 </div>
 
@@ -6779,7 +6765,7 @@ track different volume locations (using `mp.in_volume`) or field components.
 <div class="class_members" markdown="1">
 
 ```python
-def __call__(self, sim, todo): 
+def __call__(self, sim, todo):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6801,8 +6787,7 @@ def __init__(self,
              f=None,
              realtime=False,
              normalize=False,
-             plot_modifiers=None,
-             **customization_args): 
+             plot_modifiers=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6850,7 +6835,7 @@ Construct an `Animate2D` object.
 <div class="class_members" markdown="1">
 
 ```python
-def to_gif(self, fps, filename): 
+def to_gif(self, fps, filename):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6870,7 +6855,7 @@ format only supports 256 colors from a _predefined_ color palette. Requires
 <div class="class_members" markdown="1">
 
 ```python
-def to_jshtml(self, fps): 
+def to_jshtml(self, fps):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6888,7 +6873,7 @@ playback. User must specify a frame rate `fps` in frames per second.
 <div class="class_members" markdown="1">
 
 ```python
-def to_mp4(self, fps, filename): 
+def to_mp4(self, fps, filename):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6966,7 +6951,7 @@ sim.run(mp.after_sources(h))
 <div class="class_members" markdown="1">
 
 ```python
-def __call__(self, sim, todo): 
+def __call__(self, sim, todo):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6982,7 +6967,7 @@ Allows a Haminv instance to be used as a step function.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, c, pt, fcen, df, mxbands=None): 
+def __init__(self, c, pt, fcen, df, mxbands=None):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -7010,7 +6995,7 @@ Miscellaneous Functions Reference
 <a id="quiet"></a>
 
 ```python
-def quiet(quietval=True): 
+def quiet(quietval=True):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7022,26 +7007,13 @@ value will persist across runs within the same script.
 
 </div>
 
-
-<a id="verbosity"></a>
-
-```python
-def verbosity(v=1): 
-```
-
-<div class="function_docstring" markdown="1">
-
-Given a number `v`, specify the degree of Meep's output: `0` is quiet mode, `1` (the
-default) is ordinary output, `2` is extra debugging output, and `3` is all debugging
-output.
-
-</div>
+@@ verbosity @@
 
 
 <a id="interpolate"></a>
 
 ```python
-def interpolate(n, nums): 
+def interpolate(n, nums):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7058,7 +7030,7 @@ original list.
 <a id="get_flux_freqs"></a>
 
 ```python
-def get_flux_freqs(f): 
+def get_flux_freqs(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7072,7 +7044,7 @@ spectrum for.
 <a id="get_fluxes"></a>
 
 ```python
-def get_fluxes(f): 
+def get_fluxes(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7086,7 +7058,7 @@ accumulated.
 <a id="scale_flux_fields"></a>
 
 ```python
-def scale_flux_fields(s, flux): 
+def scale_flux_fields(s, flux):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7101,7 +7073,7 @@ Scale the Fourier-transformed fields in `flux` by the complex number `s`. e.g.
 <a id="get_eigenmode_freqs"></a>
 
 ```python
-def get_eigenmode_freqs(f): 
+def get_eigenmode_freqs(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7118,7 +7090,7 @@ spectrum for.
 <a id="get_energy_freqs"></a>
 
 ```python
-def get_energy_freqs(f): 
+def get_energy_freqs(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7131,7 +7103,7 @@ spectrum for.
 <a id="get_electric_energy"></a>
 
 ```python
-def get_electric_energy(f): 
+def get_electric_energy(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7144,7 +7116,7 @@ electric fields that it has accumulated.
 <a id="get_magnetic_energy"></a>
 
 ```python
-def get_magnetic_energy(f): 
+def get_magnetic_energy(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7157,7 +7129,7 @@ magnetic fields that it has accumulated.
 <a id="get_total_energy"></a>
 
 ```python
-def get_total_energy(f): 
+def get_total_energy(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7174,7 +7146,7 @@ total fields that it has accumulated.
 <a id="get_force_freqs"></a>
 
 ```python
-def get_force_freqs(f): 
+def get_force_freqs(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7187,7 +7159,7 @@ spectrum for.
 <a id="get_forces"></a>
 
 ```python
-def get_forces(f): 
+def get_forces(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7204,7 +7176,7 @@ accumulated.
 <a id="Ldos"></a>
 
 ```python
-def Ldos(*args): 
+def Ldos():
 def Ldos(fcen, df, nfreq, freq):
 ```
 
@@ -7221,7 +7193,7 @@ argument.
 <a id="get_ldos_freqs"></a>
 
 ```python
-def get_ldos_freqs(l): 
+def get_ldos_freqs(l):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7234,7 +7206,7 @@ spectrum for.
 <a id="dft_ldos"></a>
 
 ```python
-def dft_ldos(*args, **kwargs): 
+def dft_ldos():
 def dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None):
 ```
 
@@ -7260,7 +7232,7 @@ is complete.
 <a id="get_near2far_freqs"></a>
 
 ```python
-def get_near2far_freqs(f): 
+def get_near2far_freqs(f):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7273,7 +7245,7 @@ spectrum for.
 <a id="scale_near2far_fields"></a>
 
 ```python
-def scale_near2far_fields(s, near2far): 
+def scale_near2far_fields(s, near2far):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7291,7 +7263,7 @@ Scale the Fourier-transformed fields in `near2far` by the complex number `s`. e.
 <a id="GDSII_layers"></a>
 
 ```python
-def GDSII_layers(fname): 
+def GDSII_layers(fname):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7309,7 +7281,7 @@ Out[2]: [0, 1, 2, 3, 4, 5, 31, 32]
 <a id="GDSII_prisms"></a>
 
 ```python
-def GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0): 
+def GDSII_prisms(material, fname, layer=-1, zmin=0.0, zmax=0.0):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7322,7 +7294,7 @@ Returns a list of `GeometricObject`s with `material` (`mp.Medium`) on layer numb
 <a id="GDSII_vol"></a>
 
 ```python
-def GDSII_vol(fname, layer, zmin, zmax): 
+def GDSII_vol(fname, layer, zmin, zmax):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7344,7 +7316,7 @@ fr = mp.FluxRegion(volume=mp.GDSII_vol(fname, layer, zmin, zmax))
 <a id="stop_when_fields_decayed"></a>
 
 ```python
-def stop_when_fields_decayed(dt, c, pt, decay_by): 
+def stop_when_fields_decayed(dt, c, pt, decay_by):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7368,7 +7340,7 @@ slow group velocities and are absorbed poorly by [PML](Perfectly_Matched_Layer.m
 <a id="stop_after_walltime"></a>
 
 ```python
-def stop_after_walltime(t): 
+def stop_after_walltime(t):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7381,7 +7353,7 @@ parameter. Stops the simulation after `t` seconds of wall time have passed.
 <a id="stop_on_interrupt"></a>
 
 ```python
-def stop_on_interrupt(): 
+def stop_on_interrupt():
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7400,7 +7372,7 @@ follows the `run` function (e.g., outputting fields).
 <a id="output_epsilon"></a>
 
 ```python
-def output_epsilon(sim, *step_func_args, **kwargs): 
+def output_epsilon(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7416,7 +7388,7 @@ frequency-independent part of ε (the $\omega\to\infty$ limit).
 <a id="output_mu"></a>
 
 ```python
-def output_mu(sim, *step_func_args, **kwargs): 
+def output_mu(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7432,7 +7404,7 @@ frequency-independent part of μ (the $\omega\to\infty$ limit).
 <a id="output_poynting"></a>
 
 ```python
-def output_poynting(sim): 
+def output_poynting(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7447,7 +7419,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_hpwr"></a>
 
 ```python
-def output_hpwr(sim): 
+def output_hpwr(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7459,7 +7431,7 @@ Output the magnetic-field energy density $\mathbf{H}^* \cdot \mathbf{B} / 2$
 <a id="output_dpwr"></a>
 
 ```python
-def output_dpwr(sim): 
+def output_dpwr(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7471,7 +7443,7 @@ Output the electric-field energy density $\mathbf{E}^* \cdot \mathbf{D} / 2$
 <a id="output_tot_pwr"></a>
 
 ```python
-def output_tot_pwr(sim): 
+def output_tot_pwr(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7486,7 +7458,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_png"></a>
 
 ```python
-def output_png(compnt, options, rm_h5=True): 
+def output_png(compnt, options, rm_h5=True):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7516,7 +7488,7 @@ file requires `output_png(component, h5topng_options, rm_h5=False)`.
 <a id="output_hfield"></a>
 
 ```python
-def output_hfield(sim): 
+def output_hfield(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7529,7 +7501,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_hfield_x"></a>
 
 ```python
-def output_hfield_x(sim): 
+def output_hfield_x(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7543,7 +7515,7 @@ imaginary parts, respectively.
 <a id="output_hfield_y"></a>
 
 ```python
-def output_hfield_y(sim): 
+def output_hfield_y(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7557,7 +7529,7 @@ imaginary parts, respectively.
 <a id="output_hfield_z"></a>
 
 ```python
-def output_hfield_z(sim): 
+def output_hfield_z(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7571,7 +7543,7 @@ imaginary parts, respectively.
 <a id="output_hfield_r"></a>
 
 ```python
-def output_hfield_r(sim): 
+def output_hfield_r(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7585,7 +7557,7 @@ imaginary parts, respectively.
 <a id="output_hfield_p"></a>
 
 ```python
-def output_hfield_p(sim): 
+def output_hfield_p(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7600,7 +7572,7 @@ and imaginary parts, respectively.
 <a id="output_bfield"></a>
 
 ```python
-def output_bfield(sim): 
+def output_bfield(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7613,7 +7585,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_bfield_x"></a>
 
 ```python
-def output_bfield_x(sim): 
+def output_bfield_x(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7627,7 +7599,7 @@ imaginary parts, respectively.
 <a id="output_bfield_y"></a>
 
 ```python
-def output_bfield_y(sim): 
+def output_bfield_y(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7641,7 +7613,7 @@ imaginary parts, respectively.
 <a id="output_bfield_z"></a>
 
 ```python
-def output_bfield_z(sim): 
+def output_bfield_z(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7655,7 +7627,7 @@ imaginary parts, respectively.
 <a id="output_bfield_r"></a>
 
 ```python
-def output_bfield_r(sim): 
+def output_bfield_r(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7669,7 +7641,7 @@ imaginary parts, respectively.
 <a id="output_bfield_p"></a>
 
 ```python
-def output_bfield_p(sim): 
+def output_bfield_p(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7687,7 +7659,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_efield"></a>
 
 ```python
-def output_efield(sim): 
+def output_efield(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7700,7 +7672,7 @@ the different components are stored as different datasets within the *same* file
 <a id="output_efield_x"></a>
 
 ```python
-def output_efield_x(sim): 
+def output_efield_x(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7714,7 +7686,7 @@ imaginary parts, respectively.
 <a id="output_efield_y"></a>
 
 ```python
-def output_efield_y(sim): 
+def output_efield_y(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7728,7 +7700,7 @@ imaginary parts, respectively.
 <a id="output_efield_z"></a>
 
 ```python
-def output_efield_z(sim): 
+def output_efield_z(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7742,7 +7714,7 @@ imaginary parts, respectively.
 <a id="output_efield_r"></a>
 
 ```python
-def output_efield_r(sim): 
+def output_efield_r(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7756,7 +7728,7 @@ imaginary parts, respectively.
 <a id="output_efield_p"></a>
 
 ```python
-def output_efield_p(sim): 
+def output_efield_p(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7774,7 +7746,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_dfield"></a>
 
 ```python
-def output_dfield(sim): 
+def output_dfield(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7787,7 +7759,7 @@ is, the different components are stored as different datasets within the *same* 
 <a id="output_dfield_x"></a>
 
 ```python
-def output_dfield_x(sim): 
+def output_dfield_x(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7801,7 +7773,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_y"></a>
 
 ```python
-def output_dfield_y(sim): 
+def output_dfield_y(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7815,7 +7787,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_z"></a>
 
 ```python
-def output_dfield_z(sim): 
+def output_dfield_z(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7829,7 +7801,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_r"></a>
 
 ```python
-def output_dfield_r(sim): 
+def output_dfield_r(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7843,7 +7815,7 @@ and imaginary parts, respectively.
 <a id="output_dfield_p"></a>
 
 ```python
-def output_dfield_p(sim): 
+def output_dfield_p(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7861,7 +7833,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_sfield"></a>
 
 ```python
-def output_sfield(sim): 
+def output_sfield(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7877,7 +7849,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="output_sfield_x"></a>
 
 ```python
-def output_sfield_x(sim): 
+def output_sfield_x(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7891,7 +7863,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_y"></a>
 
 ```python
-def output_sfield_y(sim): 
+def output_sfield_y(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7905,7 +7877,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_z"></a>
 
 ```python
-def output_sfield_z(sim): 
+def output_sfield_z(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7919,7 +7891,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_r"></a>
 
 ```python
-def output_sfield_r(sim): 
+def output_sfield_r(sim):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7933,7 +7905,7 @@ and imaginary parts, respectively.
 <a id="output_sfield_p"></a>
 
 ```python
-def output_sfield_p(sim): 
+def output_sfield_p(sim):
 ```
 
 <div class="function_docstring" markdown="1">

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -368,7 +368,7 @@ use. See also [SWIG Wrappers](#swig-wrappers).
 <div class="class_members" markdown="1">
 
 ```python
-def run(self):
+def run(self, *step_funcs, **kwargs):
 def run(step_functions..., until=condition/time):
 def run(step_functions..., until_after_sources=condition/time):
 ```
@@ -675,7 +675,7 @@ of the field at that point.
 <div class="class_members" markdown="1">
 
 ```python
-def add_dft_fields(self):
+def add_dft_fields(self, *args, **kwargs):
 def add_dft_fields(cs, fcen, df, nfreq, freq, where=None, center=None, size=None, yee_grid=False):
 ```
 
@@ -1047,7 +1047,7 @@ Given a bunch of [`FluxRegion`](#fluxregion) objects, you can tell Meep to accum
 <div class="class_members" markdown="1">
 
 ```python
-def add_flux(self):
+def add_flux(self, *args):
 def add_flux(fcen, df, nfreq, freq, FluxRegions...):
 ```
 
@@ -1081,7 +1081,7 @@ Once you have called `add_flux`, the Fourier transforms of the fields are accumu
 <div class="class_members" markdown="1">
 
 ```python
-def display_fluxes(self):
+def display_fluxes(self, *fluxes):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1307,7 +1307,7 @@ Technically, MPB computes `ωₙ(k)` and then inverts it with Newton's method to
 <div class="class_members" markdown="1">
 
 ```python
-def add_mode_monitor(self):
+def add_mode_monitor(self, *args, **kwargs):
 def add_mode_monitor(fcen, df, nfreq, freq, ModeRegions...):
 ```
 
@@ -1437,7 +1437,7 @@ The usage is similar to the flux spectra: you define a set of [`EnergyRegion`](#
 <div class="class_members" markdown="1">
 
 ```python
-def add_energy(self):
+def add_energy(self, *args):
 def add_energy(fcen, df, nfreq, freq, EnergyRegions...):
 ```
 
@@ -1471,7 +1471,7 @@ Once you have called `add_energy`, the Fourier transforms of the fields are accu
 <div class="class_members" markdown="1">
 
 ```python
-def display_electric_energy(self):
+def display_electric_energy(self, *energys):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1491,7 +1491,7 @@ column are the frequencies, and subsequent columns are the energy density spectr
 <div class="class_members" markdown="1">
 
 ```python
-def display_magnetic_energy(self):
+def display_magnetic_energy(self, *energys):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1511,7 +1511,7 @@ column are the frequencies, and subsequent columns are the energy density spectr
 <div class="class_members" markdown="1">
 
 ```python
-def display_total_energy(self):
+def display_total_energy(self, *energys):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1663,7 +1663,7 @@ The usage is similar to the [flux spectra](Python_Tutorials/Basics.md#transmitta
 <div class="class_members" markdown="1">
 
 ```python
-def add_force(self):
+def add_force(self, *args):
 def add_force(fcen, df, nfreq, freq, ForceRegions...):
 ```
 
@@ -1697,7 +1697,7 @@ Once you have called `add_force`, the Fourier transforms of the fields are accum
 <div class="class_members" markdown="1">
 
 ```python
-def display_forces(self):
+def display_forces(self, *forces):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -1870,7 +1870,7 @@ Meep can also calculate the LDOS (local density of states) spectrum, as describe
 <a id="Ldos"></a>
 
 ```python
-def Ldos():
+def Ldos(*args):
 def Ldos(fcen, df, nfreq, freq):
 ```
 
@@ -1900,7 +1900,7 @@ spectrum for.
 <a id="dft_ldos"></a>
 
 ```python
-def dft_ldos():
+def dft_ldos(*args, **kwargs):
 def dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None):
 ```
 
@@ -1942,7 +1942,7 @@ There are three steps to using the near-to-far-field feature: first, define the 
 <div class="class_members" markdown="1">
 
 ```python
-def add_near2far(self):
+def add_near2far(self, *args, **kwargs):
 def add_near2far(fcen, df, nfreq, freq, Near2FarRegions..., nperiods=1):
 ```
 
@@ -2423,7 +2423,8 @@ def plot2D(self,
            plot_eps_flag=True,
            plot_sources_flag=True,
            plot_monitors_flag=True,
-           plot_boundaries_flag=True):
+           plot_boundaries_flag=True,
+           **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -2561,7 +2562,7 @@ A common point of confusion is described in [The Run Function Is Not A Loop](The
 <div class="class_members" markdown="1">
 
 ```python
-def run(self):
+def run(self, *step_funcs, **kwargs):
 def run(step_functions..., until=condition/time):
 def run(step_functions..., until_after_sources=condition/time):
 ```
@@ -2730,7 +2731,7 @@ suffix).
 <a id="output_epsilon"></a>
 
 ```python
-def output_epsilon(sim):
+def output_epsilon(sim, *step_func_args, **kwargs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2746,7 +2747,7 @@ frequency-independent part of ε (the $\omega\to\infty$ limit).
 <a id="output_mu"></a>
 
 ```python
-def output_mu(sim):
+def output_mu(sim, *step_func_args, **kwargs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3560,7 +3561,7 @@ Rather than writing a brand-new step function every time something a bit differe
 <a id="combine_step_funcs"></a>
 
 ```python
-def combine_step_funcs():
+def combine_step_funcs(*step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3573,7 +3574,7 @@ all of the passed step functions.
 <a id="synchronized_magnetic"></a>
 
 ```python
-def synchronized_magnetic():
+def synchronized_magnetic(*step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3592,7 +3593,7 @@ Fields](Synchronizing_the_Magnetic_and_Electric_Fields.md).
 <a id="when_true"></a>
 
 ```python
-def when_true(cond):
+def when_true(cond, *step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3605,7 +3606,7 @@ no arguments), evaluate the step functions whenever `condition` returns `True`.
 <a id="when_false"></a>
 
 ```python
-def when_false(cond):
+def when_false(cond, *step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3618,7 +3619,7 @@ no arguments), evaluate the step functions whenever `condition` returns `False`.
 <a id="at_every"></a>
 
 ```python
-def at_every(dt):
+def at_every(dt, *step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3631,7 +3632,7 @@ Given zero or more step functions, evaluates them at every time interval of $dT$
 <a id="after_time"></a>
 
 ```python
-def after_time(t):
+def after_time(t, *step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3644,7 +3645,7 @@ units have elapsed from the start of the run.
 <a id="before_time"></a>
 
 ```python
-def before_time(t):
+def before_time(t, *step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3657,7 +3658,7 @@ units have elapsed from the start of the run.
 <a id="at_time"></a>
 
 ```python
-def at_time(t):
+def at_time(t, *step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3670,7 +3671,7 @@ have elapsed from the start of the run.
 <a id="after_sources"></a>
 
 ```python
-def after_sources():
+def after_sources(*step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3683,7 +3684,7 @@ sources have turned off.
 <a id="after_sources_and_time"></a>
 
 ```python
-def after_sources_and_time(t):
+def after_sources_and_time(t, *step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3696,7 +3697,7 @@ sources have turned off, plus an additional $T$ time units have elapsed.
 <a id="during_sources"></a>
 
 ```python
-def during_sources():
+def during_sources(*step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3709,7 +3710,7 @@ sources have turned off.
 <a id="at_beginning"></a>
 
 ```python
-def at_beginning():
+def at_beginning(*step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3722,7 +3723,7 @@ run.
 <a id="at_end"></a>
 
 ```python
-def at_end():
+def at_end(*step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3738,7 +3739,7 @@ Given zero or more step functions, evaluates them only once, at the end of the r
 <a id="in_volume"></a>
 
 ```python
-def in_volume(v):
+def in_volume(v, *step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3752,7 +3753,7 @@ output a subset (or a superset) of the cell, corresponding to the `meep::volume*
 <a id="in_point"></a>
 
 ```python
-def in_point(pt):
+def in_point(pt, *step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3765,7 +3766,7 @@ output a single *point* of data, at `pt` (a `Vector3`).
 <a id="to_appended"></a>
 
 ```python
-def to_appended(fname):
+def to_appended(fname, *step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -3780,7 +3781,7 @@ dimension* to their datasets, corresponding to time.
 <a id="with_prefix"></a>
 
 ```python
-def with_prefix(pre):
+def with_prefix(pre, *step_funcs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -4171,7 +4172,7 @@ the parameters (in addition to σ):
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, frequency=0.0, gamma=0.0):
+def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4211,7 +4212,7 @@ Dispersion](Materials.md#material-dispersion), with the parameters (in addition 
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, frequency=0.0, gamma=0.0):
+def __init__(self, frequency=0.0, gamma=0.0, **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4252,7 +4253,10 @@ Absorption](Materials.md#saturable-gain-and-absorption).
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, initial_populations=[], transitions=[]):
+def __init__(self,
+             initial_populations=[],
+             transitions=[],
+             **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4352,7 +4356,7 @@ space and time, zero mean) added to the **P** damped-oscillator equation.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, noise_amp=0.0):
+def __init__(self, noise_amp=0.0, **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4403,7 +4407,7 @@ space and time, zero mean) added to the **P** damped-oscillator equation.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, noise_amp=0.0):
+def __init__(self, noise_amp=0.0, **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4454,7 +4458,7 @@ meanings](#susceptibility), and an additional 3-vector `bias`:
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, bias=Vector3<0.0, 0.0, 0.0>):
+def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4493,7 +4497,7 @@ meanings](#susceptibility), and an additional 3-vector `bias`:
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, bias=Vector3<0.0, 0.0, 0.0>):
+def __init__(self, bias=Vector3<0.0, 0.0, 0.0>, **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4538,7 +4542,8 @@ def __init__(self,
              bias=Vector3<0.0, 0.0, 0.0>,
              frequency=0.0,
              gamma=0.0,
-             alpha=0.0):
+             alpha=0.0,
+             **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5056,7 +5061,7 @@ Represents a sphere.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, radius):
+def __init__(self, radius, **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5101,7 +5106,8 @@ A cylinder, with circular cross-section and finite height.
 def __init__(self,
              radius,
              axis=Vector3<0.0, 0.0, 1.0>,
-             height=1e+20):
+             height=1e+20,
+             **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5137,7 +5143,8 @@ Represents a cylindrical wedge.
 def __init__(self,
              radius,
              wedge_angle=6.283185307179586,
-             wedge_start=Vector3<1.0, 0.0, 0.0>):
+             wedge_start=Vector3<1.0, 0.0, 0.0>,
+             **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5174,7 +5181,7 @@ is halfway between the two circular ends.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self, radius, radius2=0):
+def __init__(self, radius, radius2=0, **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5215,7 +5222,8 @@ def __init__(self,
              size,
              e1=Vector3<1.0, 0.0, 0.0>,
              e2=Vector3<0.0, 1.0, 0.0>,
-             e3=Vector3<0.0, 0.0, 1.0>):
+             e3=Vector3<0.0, 0.0, 1.0>,
+             **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5257,7 +5265,7 @@ properties, but defines an ellipsoid inscribed inside the block.
 <div class="class_members" markdown="1">
 
 ```python
-def __init__(self):
+def __init__(self, **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5295,7 +5303,8 @@ def __init__(self,
              height,
              axis=Vector3<0.0, 0.0, 1.0>,
              center=None,
-             sidewall_angle=0):
+             sidewall_angle=0,
+             **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -5905,7 +5914,8 @@ def __init__(self,
              eig_match_freq=True,
              eig_parity=mp.NO_PARITY,
              eig_resolution=0,
-             eig_tolerance=1e-12):
+             eig_tolerance=1e-12,
+             **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6042,7 +6052,8 @@ def __init__(self,
              beam_x0=Vector3<0.0, 0.0, 0.0>,
              beam_kdir=Vector3<0.0, 0.0, 0.0>,
              beam_w0=None,
-             beam_E0=Vector3<0.0, 0.0, 0.0>):
+             beam_E0=Vector3<0.0, 0.0, 0.0>,
+             **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6093,7 +6104,8 @@ def __init__(self,
              width=0,
              fwidth=inf,
              cutoff=3.0,
-             wavelength=None):
+             wavelength=None,
+             **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6167,7 +6179,8 @@ def __init__(self,
              fwidth=inf,
              start_time=0,
              cutoff=5.0,
-             wavelength=None):
+             wavelength=None,
+             **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6252,7 +6265,8 @@ def __init__(self,
              src_func,
              start_time=-1e+20,
              end_time=1e+20,
-             center_frequency=0):
+             center_frequency=0,
+             **kwargs):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -6787,7 +6801,8 @@ def __init__(self,
              f=None,
              realtime=False,
              normalize=False,
-             plot_modifiers=None):
+             plot_modifiers=None,
+             **customization_args):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -7176,7 +7191,7 @@ accumulated.
 <a id="Ldos"></a>
 
 ```python
-def Ldos():
+def Ldos(*args):
 def Ldos(fcen, df, nfreq, freq):
 ```
 
@@ -7206,7 +7221,7 @@ spectrum for.
 <a id="dft_ldos"></a>
 
 ```python
-def dft_ldos():
+def dft_ldos(*args, **kwargs):
 def dft_ldos(fcen=None, df=None, nfreq=None, freq=None, ldos=None):
 ```
 
@@ -7372,7 +7387,7 @@ follows the `run` function (e.g., outputting fields).
 <a id="output_epsilon"></a>
 
 ```python
-def output_epsilon(sim):
+def output_epsilon(sim, *step_func_args, **kwargs):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7388,7 +7403,7 @@ frequency-independent part of ε (the $\omega\to\infty$ limit).
 <a id="output_mu"></a>
 
 ```python
-def output_mu(sim):
+def output_mu(sim, *step_func_args, **kwargs):
 ```
 
 <div class="function_docstring" markdown="1">

--- a/doc/generate_py_api.py
+++ b/doc/generate_py_api.py
@@ -40,6 +40,9 @@ import sys
 import os
 import inspect
 import io
+import ast
+import itertools
+import textwrap
 
 import meep
 
@@ -100,18 +103,103 @@ class FunctionItem(Item):
         self.signature = inspect.signature(obj)
 
     def get_parameters(self, indent):
-        sig = inspect.signature(self.obj)
-        param_str = str(sig)
+        self.sig = inspect.signature(self.obj)
+        try:
+            # Try using the AST to get the actual text for default values
+            parameters = self.get_parameters_from_ast()
+            param_str = '({})'.format(', '.join(parameters))
+
+            # Wrap and indent the parameters if the line is too long
+            if len(param_str) > 50:
+                params = []
+                for idx, param in enumerate(parameters):
+                    params.append('('+str(param) if idx==0 else ' '*indent+param)
+                param_str = ',\n'.join(params)
+                param_str += ')'
+            return param_str
+
+        except ValueError as ex:
+            print("Warning: falling back to old parameter extraction method for {}\n{}".format(self.name, ex))
+        except OSError:
+            # This happens when there is no source for some function/class (like NamedTuples)
+            pass
+
+        # Fall back to using just the inspect module's info
+        param_str = str(self.sig)
 
         # Wrap and indent the parameters if the line is too long
         if len(param_str) > 50:
-            parameters = list(sig.parameters.values())
+            parameters = list(self.sig.parameters.values())
             params = []
             for idx, param in enumerate(parameters):
                 params.append('('+str(param) if idx==0 else ' '*indent+str(param))
             param_str = ',\n'.join(params)
             param_str += ')'
         return param_str
+
+
+    def get_parameters_from_ast(self):
+        # Use Python's ast module to parse the function's code and pull out parameter names and
+        # the text for default values.
+        def parse_name(node):
+            assert isinstance(node, ast.arg)
+            if node.annotation != None:
+                raise ValueError("Annotations are not currently supported")
+            return node.arg
+
+        source = inspect.getsource(self.obj)
+        source = textwrap.dedent(source)
+        module = ast.parse(source)
+        func = module.body[0]
+
+        if not isinstance(func, ast.FunctionDef):
+            raise ValueError('Unsupported node type: {}'.format(type(func)))
+
+        # Get the param name and defaults together into a list of tuples
+        args = reversed(func.args.args)
+        defaults = reversed(func.args.defaults)
+        iter = itertools.zip_longest(args, defaults, fillvalue=None)
+        parameters = [(parse_name(name), default) for name, default in reversed(list(iter))]
+
+        # Convert each of the parameters (name, ast.node) to valid Python parameter
+        # code, like what would have been in the actual source code.
+        transformed = []
+        for name, node in parameters:
+            if node is None:
+                transformed.append(name)
+            else:
+                default = self.transform_node(name, node)
+                transformed.append("{}={}".format(name, default))
+        return transformed
+
+    def transform_node(self, name, node):
+        if isinstance(node, (ast.Str, ast.Bytes)):
+            default = repr(node.s)
+        elif isinstance(node, ast.Num):
+            default = repr(node.n)
+        elif isinstance(node, (ast.Constant, ast.NameConstant)):
+            default = node.value
+        elif isinstance(node, ast.Name):
+            default = node.id
+        elif isinstance(node, ast.Attribute):
+            a = []
+            n = node
+            while isinstance(n, ast.Attribute):
+                a.append(n.attr)
+                n = n.value
+            assert isinstance(n, ast.Name), "I'm confused..."
+            a.append(n.id)
+            default = ".".join(reversed(a))
+        # elif isinstance(node, ast.Lambda):
+        #     default = 'FIXME_Lambda'
+        # elif isinstance(node, ast.Call):
+        #     default = 'FIXME_Call'
+        else:
+            param = self.sig.parameters[name]
+            default = param.default
+            # print('Using inspect module for {}={} in {}'.format(name, default, self.name))
+        return default
+
 
     def check_other_signatures(self, docstring):
         """ Search for alternate function signatures in the docstring """

--- a/doc/generate_py_api.py
+++ b/doc/generate_py_api.py
@@ -170,6 +170,13 @@ class FunctionItem(Item):
             else:
                 default = self.transform_node(name, node)
                 transformed.append("{}={}".format(name, default))
+
+        # Check for vararg (like *foo) and kwarg (like **bar) parameters
+        if func.args.vararg is not None:
+            transformed.append('*{}'.format(func.args.vararg.arg))
+        if func.args.kwarg is not None:
+            transformed.append('**{}'.format(func.args.kwarg.arg))
+
         return transformed
 
     def transform_node(self, name, node):

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -140,6 +140,8 @@ class DiffractedPlanewave(object):
     def p(self):
         return self._p
 
+DefaultPMLProfile = lambda u: u * u
+
 class PML(object):
     """
     This class is used for specifying the PML absorbing boundary layers around the cell,
@@ -155,7 +157,7 @@ class PML(object):
                  side=mp.ALL,
                  R_asymptotic=1e-15,
                  mean_stretch=1.0,
-                 pml_profile=lambda u: u * u):
+                 pml_profile=DefaultPMLProfile):
         """
         + **`thickness` [`number`]** — The spatial thickness of the PML layer which
           extends from the boundary towards the *inside* of the cell. The thinner it is,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -540,6 +540,7 @@ class DftObj(object):
     swigobj_attr and return the property they requested.
     """
     def __init__(self, func, args):
+        """Construct a `DftObj`."""
         self.func = func
         self.args = args
         self.swigobj = None
@@ -579,6 +580,7 @@ class DftFlux(DftObj):
     """
 
     def __init__(self, func, args):
+        """Construct a `DftFlux`."""
         super(DftFlux, self).__init__(func, args)
         self.nfreqs = len(args[0])
         self.regions = args[1]
@@ -617,6 +619,7 @@ class DftForce(DftObj):
     """
 
     def __init__(self, func, args):
+        """Construct a `DftForce`."""
         super(DftForce, self).__init__(func, args)
         self.nfreqs = len(args[0])
         self.regions = args[1]
@@ -647,6 +650,7 @@ class DftNear2Far(DftObj):
     """
 
     def __init__(self, func, args):
+        """Construct a `DftNear2Far`."""
         super(DftNear2Far, self).__init__(func, args)
         self.nfreqs = len(args[0])
         self.nperiods = args[1]
@@ -692,6 +696,7 @@ class DftEnergy(DftObj):
     """
 
     def __init__(self, func, args):
+        """Construct a `DftEnergy`."""
         super(DftEnergy, self).__init__(func, args)
         self.nfreqs = len(args[0])
         self.regions = args[1]
@@ -718,6 +723,7 @@ class DftFields(DftObj):
     """
 
     def __init__(self, func, args):
+        """Construct a `DftFields`."""
         super(DftFields, self).__init__(func, args)
         self.nfreqs = len(args[4])
         self.regions = [FieldsRegion(where=args[1], center=args[2], size=args[3])]
@@ -734,6 +740,7 @@ Mode = namedtuple('Mode', ['freq', 'decay', 'Q', 'amp', 'err'])
 class EigenmodeData(object):
 
     def __init__(self, band_num, freq, group_velocity, k, swigobj, kdom):
+        """Construct an `EigenmodeData`."""
         self.band_num = band_num
         self.freq = freq
         self.group_velocity = group_velocity


### PR DESCRIPTION
Fixes #1318 (mostly)

* Remove some extra whitespace in the function and method templates

* Add a docstring for some `__init__` methods that don't have one, so they do not inherit default one from `object`

* Use Python's `ast` module (Abstract Syntax Tree) to extract the text for default parameters from the source code instead of using the evaluated value as `inspect` does. This means that the default values in the documentation will be more meaningful, for example: `mp.ALL_COMPONENTS` instead of `20`. 

This extraction via the `ast` works well for simple values and names, but some possible types of default values can result a complex syntax tree, so the code will fall back to using the `inspect` module when it runs into something that is not currently supported, rather than trying to implement something that might end up being fragile and more effort to maintain than it's worth. The most pertinent for our source code are:

* Lambdas. There is currently one example of using a lambda as a default parameter value, in `PML.__init__`. It results in an AST tree with nodes for the lambda's parameters and also a tree for the expression. So rather than trying to support any possible expression there I just changed the source and added a `DefaultPMLProfile` global which could then be used as the default value for the parameter, resulting in just one node in the AST.

* Function calls. This type is what you get when the default parameter is a call to some callable object, like `wedge_start=Vector3()`. I'm letting this one fall back to use `inspect` to get the value of the parameter. As long as the object being created there has a good `__repr__` method then this isn't too bad. But it might make sense in the future to also add something like `DefaultVector3 = Vector3()` and using that everywhere as the default value for the parameters.

* Math expressions. There are some cases where the default value is an expression, like `wedge_angle=2 * math.pi`. WIth some more work at least some of these could be supported, but for now I'm letting them fall back to being evaluated by `inspect`. Of course, adding globals for some of these for use as the default parameter values would also work with things as they are currently in this PR.