### PR TITLE
remove unused function output_mode_fields

### DIFF
--- a/doc/docs/Mode_Decomposition.md
+++ b/doc/docs/Mode_Decomposition.md
@@ -153,14 +153,11 @@ These functions are implemented in [src/mpb.cpp](https://github.com/NanoComp/mee
 ````
   void output_dft(dft_flux flux, const char *HDF5FileName);
 
-  void output_mode_fields(void *mode_data, dft_flux flux, const char *HDF5FileName);
 ````
 
 `output_dft` exports the components of the frequency-domain fields stored in `flux` to an HDF5 file with the given filename In general, `flux` will store data for fields at multiple frequencies.
 
-`output_mode_fields` is similar, but instead exports the components of the eigenmode described by `mode_data` which should be the return value of a call to `get_eigenmode`.
-
-These functions are implemented in [src/dft.cpp](https://github.com/NanoComp/meep/blob/master/src/dft.cpp#L982-L1021).
+This function is implemented in [src/dft.cpp](https://github.com/NanoComp/meep/blob/master/src/dft.cpp#L1184-L1196).
 
 ### Computing Overlap Integrals
 ````

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -1182,20 +1182,6 @@ void fields::output_dft(dft_fields fdft, const char *HDF5FileName) {
 }
 
 /***************************************************************/
-/* does the same thing as output_dft(flux ...), but using      */
-/* eigenmode fields instead of dft_flux fields.                */
-/***************************************************************/
-void fields::output_mode_fields(void *mode_data, dft_flux flux, const char *HDF5FileName) {
-  h5file *file = open_h5file(HDF5FileName, h5file::WRITE);
-  delete file;
-
-  dft_chunk *chunklists[2];
-  chunklists[0] = flux.E;
-  chunklists[1] = flux.H;
-  FOR_E_AND_H(c) { process_dft_component(chunklists, 2, 0, c, 0, 0, 0, 0, 0, mode_data, 0, c); }
-}
-
-/***************************************************************/
 /***************************************************************/
 /***************************************************************/
 void fields::get_overlap(void *mode1_data, void *mode2_data, dft_flux flux, int num_freq,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1897,7 +1897,6 @@ public:
   void output_dft(dft_force force, const char *HDF5FileName);
   void output_dft(dft_near2far n2f, const char *HDF5FileName);
   void output_dft(dft_fields fdft, const char *HDF5FileName);
-  void output_mode_fields(void *mode_data, dft_flux flux, const char *HDF5FileName);
 
   // get array of DFT field values
   std::complex<double> *get_dft_array(dft_flux flux, component c, int num_freq, int *rank,


### PR DESCRIPTION
This PR removes the function `fields::output_mode_fields` which was added in #192 but seems to no longer be used. This function is intended to output to an HDF5 file the eigenmode fields obtained from calling `get_eigenmode` but does not seem to be implemented correctly since it never writes anything to a file and requires a `dft_flux` argument which is unnecessary. It's also missing a (high-level) Python interface.

(If we do want such a function then we will need to fix these bugs and provide a Python interface.)