### PR TITLE
abort get_dft_array if user-supplied frequency index is invalid

### DIFF
--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -746,6 +746,9 @@ cdouble dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corne
                                          int ic_conjugate, bool retain_interp_weights,
                                          fields *parent) {
 
+  if ((num_freq < 0) || (num_freq > omega.size()-1))
+    abort("process_dft_component: frequency index %d is outside the range of the frequency array of size %lu",num_freq,omega.size());
+
   /*****************************************************************/
   /* compute the size of the chunk we own and its strides etc.     */
   /*****************************************************************/


### PR DESCRIPTION
Currently, if the frequency index parameter `num_freq` of [`get_dft_array`](https://meep.readthedocs.io/en/latest/Python_User_Interface/#array-slices) is outside the valid range (e.g., if `num_freq` is larger than the size of the array), the function returns an array of zero values which is incorrect. This PR adds a check in `dft_chunk::process_dft_component` to verify that `num_freq` is valid, otherwise it aborts with an error.