### PR TITLE
replace Numpy matrix with array in test geom.py

### DIFF
--- a/python/tests/geom.py
+++ b/python/tests/geom.py
@@ -601,8 +601,8 @@ class TestMatrix(unittest.TestCase):
     def test_to_numpy_array(self):
         m = mp.Matrix(mp.Vector3(1+1j), mp.Vector3(1+1j), mp.Vector3(1+1j))
         adjoint = m.H
-        m_arr = np.matrix(m)
-        np_adjoint = m_arr.H
+        m_arr = np.array(m)
+        np_adjoint = m_arr.conj().transpose()
         np.testing.assert_allclose(adjoint, np_adjoint)
 
 


### PR DESCRIPTION
Closes #1376. 

Since Numpy's `ndarray` class does not have a built-in Hermitian adjoint function (unlike `matrix`), it is replaced with the two separate operations of conjugate and transpose following https://numpy.org/doc/stable/user/numpy-for-matlab-users.html.