### PR TITLE
offline computation of cost statistics

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1798,7 +1798,8 @@ meep::structure *create_structure_and_set_materials(vector3 cell_size,
                                                     meep_geom::material_type_list extra_materials,
                                                     bool split_chunks_evenly,
                                                     bool set_materials,
-                                                    meep::structure *existing_s) {
+                                                    meep::structure *existing_s,
+                                                    bool output_chunk_costs) {
     // Initialize fragment_stats static members (used for creating chunks in choose_chunkdivision)
     meep_geom::fragment_stats::geom = gobj_list;
     meep_geom::fragment_stats::dft_data_list = dft_data_list_;
@@ -1813,6 +1814,14 @@ meep::structure *create_structure_and_set_materials(vector3 cell_size,
     meep_geom::fragment_stats::split_chunks_evenly = split_chunks_evenly;
     meep_geom::fragment_stats::init_libctl(_default_material, _ensure_periodicity,
                                            &gv, cell_size, center, &gobj_list);
+
+    if (output_chunk_costs) {
+         std::vector<grid_volume> chunk_vols = choose_chunkdivision(gv, num_chunks, sym);
+         for (size_t i = 0; i < chunk_vols.size(); ++i)
+              master_printf("CHUNK:, %2zu, %f\n",i,chunk_vols[i].get_cost());
+         return NULL;
+    }
+
     meep::structure *s;
     if (existing_s) {
       s = existing_s;

--- a/python/meep.i
+++ b/python/meep.i
@@ -1816,7 +1816,8 @@ meep::structure *create_structure_and_set_materials(vector3 cell_size,
                                            &gv, cell_size, center, &gobj_list);
 
     if (output_chunk_costs) {
-         std::vector<grid_volume> chunk_vols = choose_chunkdivision(gv, num_chunks, sym);
+         meep::volume thev = gv.surroundings();
+         std::vector<grid_volume> chunk_vols = meep::choose_chunkdivision(gv, thev, num_chunks, sym);
          for (size_t i = 0; i < chunk_vols.size(); ++i)
               master_printf("CHUNK:, %2zu, %f\n",i,chunk_vols[i].get_cost());
          return NULL;

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1655,18 +1655,17 @@ class Simulation(object):
 
         if self._output_stats and isinstance(self.default_material, mp.Medium) and verbosity > 0:
             stats = self._compute_fragment_stats(gv)
-            print("STATS: aniso_eps: {}".format(stats.num_anisotropic_eps_pixels))
-            print("STATS: anis_mu: {}".format(stats.num_anisotropic_mu_pixels))
-            print("STATS: nonlinear: {}".format(stats.num_nonlinear_pixels))
-            print("STATS: susceptibility: {}".format(stats.num_susceptibility_pixels))
-            print("STATS: nonzero_cond: {}".format(stats.num_nonzero_conductivity_pixels))
-            print("STATS: pml_1d: {}".format(stats.num_1d_pml_pixels))
-            print("STATS: pml_2d: {}".format(stats.num_2d_pml_pixels))
-            print("STATS: pml_3d: {}".format(stats.num_3d_pml_pixels))
-            print("STATS: dft: {}".format(stats.num_dft_pixels))
-            print("STATS: total_pixels: {}".format(stats.num_pixels_in_box))
-            print("STATS: num_cores: {}".format(mp.count_processors()))
-            sys.exit(0)
+            print("STATS:, aniso_eps:, {}".format(stats.num_anisotropic_eps_pixels))
+            print("STATS:, anis_mu:, {}".format(stats.num_anisotropic_mu_pixels))
+            print("STATS:, nonlinear:, {}".format(stats.num_nonlinear_pixels))
+            print("STATS:, susceptibility:, {}".format(stats.num_susceptibility_pixels))
+            print("STATS:, conductivity:, {}".format(stats.num_nonzero_conductivity_pixels))
+            print("STATS:, pml_1d:, {}".format(stats.num_1d_pml_pixels))
+            print("STATS:, pml_2d:, {}".format(stats.num_2d_pml_pixels))
+            print("STATS:, pml_3d:, {}".format(stats.num_3d_pml_pixels))
+            print("STATS:, dft:, {}".format(stats.num_dft_pixels))
+            print("STATS:, total_pixels:, {}".format(stats.num_pixels_in_box))
+            print("STATS:, num_cores:, {}".format(mp.count_processors()))
 
         fragment_vols = self._make_fragment_lists(gv)
         self.dft_data_list = fragment_vols[0]
@@ -1699,8 +1698,12 @@ class Simulation(object):
             self.extra_materials,
             self.split_chunks_evenly,
             False if self.chunk_layout else True,
-            None
-       )
+            None,
+            True if self._output_stats is not None else False
+        )
+
+        if self._output_stats:
+            sys.exit(0)
 
         if self.chunk_layout:
             self.load_chunk_layout(br, self.chunk_layout)

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1655,17 +1655,17 @@ class Simulation(object):
 
         if self._output_stats and isinstance(self.default_material, mp.Medium) and verbosity > 0:
             stats = self._compute_fragment_stats(gv)
-            print("STATS:, aniso_eps:, {}".format(stats.num_anisotropic_eps_pixels))
-            print("STATS:, anis_mu:, {}".format(stats.num_anisotropic_mu_pixels))
-            print("STATS:, nonlinear:, {}".format(stats.num_nonlinear_pixels))
-            print("STATS:, susceptibility:, {}".format(stats.num_susceptibility_pixels))
-            print("STATS:, conductivity:, {}".format(stats.num_nonzero_conductivity_pixels))
-            print("STATS:, pml_1d:, {}".format(stats.num_1d_pml_pixels))
-            print("STATS:, pml_2d:, {}".format(stats.num_2d_pml_pixels))
-            print("STATS:, pml_3d:, {}".format(stats.num_3d_pml_pixels))
-            print("STATS:, dft:, {}".format(stats.num_dft_pixels))
-            print("STATS:, total_pixels:, {}".format(stats.num_pixels_in_box))
-            print("STATS:, num_cores:, {}".format(mp.count_processors()))
+            print("FRAGMENT:, aniso_eps:, {}".format(stats.num_anisotropic_eps_pixels))
+            print("FRAGMENT:, aniso_mu:, {}".format(stats.num_anisotropic_mu_pixels))
+            print("FRAGMENT:, nonlinear:, {}".format(stats.num_nonlinear_pixels))
+            print("FRAGMENT:, susceptibility:, {}".format(stats.num_susceptibility_pixels))
+            print("FRAGMENT:, conductivity:, {}".format(stats.num_nonzero_conductivity_pixels))
+            print("FRAGMENT:, pml_1d:, {}".format(stats.num_1d_pml_pixels))
+            print("FRAGMENT:, pml_2d:, {}".format(stats.num_2d_pml_pixels))
+            print("FRAGMENT:, pml_3d:, {}".format(stats.num_3d_pml_pixels))
+            print("FRAGMENT:, dft:, {}".format(stats.num_dft_pixels))
+            print("FRAGMENT:, total_pixels:, {}".format(stats.num_pixels_in_box))
+            print("FRAGMENT:, procs:, {}".format(mp.count_processors()))
 
         fragment_vols = self._make_fragment_lists(gv)
         self.dft_data_list = fragment_vols[0]
@@ -1702,7 +1702,7 @@ class Simulation(object):
             True if self._output_stats is not None else False
         )
 
-        if self._output_stats:
+        if self._output_stats is not None:
             sys.exit(0)
 
         if self.chunk_layout:
@@ -1849,7 +1849,8 @@ class Simulation(object):
             self.extra_materials,
             self.split_chunks_evenly,
             True,
-            self.structure
+            self.structure,
+            False
         )
 
     def dump_structure(self, fname):

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -808,7 +808,9 @@ private:
 };
 
 // defined in structure.cpp
-std::vector<grid_volume> choose_chunkdivision(const grid_volume &gv, int num_chunks,
+std::vector<grid_volume> choose_chunkdivision(grid_volume &gv,
+                                              volume &v,
+                                              int num_chunks,
                                               const symmetry &s);
 
 class src_vol;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -807,6 +807,10 @@ private:
   void write_susceptibility_params(h5file *file, const char *dname, int EorH);
 };
 
+// defined in structure.cpp
+std::vector<grid_volume> choose_chunkdivision(const grid_volume &gv, int num_chunks,
+                                              const symmetry &s);
+
 class src_vol;
 class fields;
 class fields_chunk;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2159,16 +2159,16 @@ double fragment_stats::cost() const {
 
 void fragment_stats::print_stats() const {
   master_printf("Fragment stats\n");
-  master_printf("  num_anisotropic_eps_pixels: %zd\n", num_anisotropic_eps_pixels);
-  master_printf("  num_anisotropic_mu_pixels: %zd\n", num_anisotropic_mu_pixels);
-  master_printf("  num_nonlinear_pixels: %zd\n", num_nonlinear_pixels);
-  master_printf("  num_susceptibility_pixels: %zd\n", num_susceptibility_pixels);
-  master_printf("  num_nonzero_conductivity_pixels: %zd\n", num_nonzero_conductivity_pixels);
-  master_printf("  num_1d_pml_pixels: %zd\n", num_1d_pml_pixels);
-  master_printf("  num_2d_pml_pixels: %zd\n", num_2d_pml_pixels);
-  master_printf("  num_3d_pml_pixels: %zd\n", num_3d_pml_pixels);
-  master_printf("  num_dft_pixels: %zd\n", num_dft_pixels);
-  master_printf("  num_pixels_in_box: %zd\n", num_pixels_in_box);
+  master_printf("  anisotropic_eps: %zu\n", num_anisotropic_eps_pixels);
+  master_printf("  anisotropic_mu: %zu\n", num_anisotropic_mu_pixels);
+  master_printf("  nonlinear: %zu\n", num_nonlinear_pixels);
+  master_printf("  susceptibility: %zu\n", num_susceptibility_pixels);
+  master_printf("  conductivity: %zu\n", num_nonzero_conductivity_pixels);
+  master_printf("  pml_1d: %zu\n", num_1d_pml_pixels);
+  master_printf("  pml_2d: %zu\n", num_2d_pml_pixels);
+  master_printf("  pml_3d: %zu\n", num_3d_pml_pixels);
+  master_printf("  dft: %zu\n", num_dft_pixels);
+  master_printf("  pixels_in_box: %zu\n", num_pixels_in_box);
   master_printf("  box.low:  {%f, %f, %f}\n", box.low.x, box.low.y, box.low.z);
   master_printf("  box.high: {%f, %f, %f}\n\n", box.high.x, box.high.y, box.high.z);
 }

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -122,9 +122,10 @@ static void split_by_cost(std::vector<int> factors, grid_volume gvol,
 
 void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_chunks,
                                      const boundary_region &br, const symmetry &s) {
-  user_volume = thegv;
-  if (desired_num_chunks == 0) desired_num_chunks = count_processors();
+
   if (thegv.dim == Dcyl && thegv.get_origin().r() < 0) abort("r < 0 origins are not supported");
+
+  user_volume = thegv;
   gv = thegv;
   v = gv.surroundings();
   S = s;
@@ -173,6 +174,9 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
 
 std::vector<grid_volume> choose_chunkdivision(grid_volume &gv, volume &v, int desired_num_chunks,
                                               const symmetry &S) {
+
+  if (desired_num_chunks == 0) desired_num_chunks = count_processors();
+  if (gv.dim == Dcyl && gv.get_origin().r() < 0) abort("r < 0 origins are not supported");
 
   // First, reduce overall grid_volume gv by symmetries:
   if (S.multiplicity() > 1) {


### PR DESCRIPTION
Closes #1150.

Following @stevengj's outline in #1150, this PR creates a new `choose_chunkdivision` function which does not belong to any class and is based on refactoring `structure::choose_chunkdivision`. All that is required to print the costs of each chunk *without* allocating the  `structure` and `fields` objects is to set the environment variable `MEEP_STATS` to an integer value. Note that the `MEEP_STATS` environment variable is currently used to print the fragment statistics as defined in `python/simulation.py`:

https://github.com/NanoComp/meep/blob/29a92c0ab074259fcfa66b9d09e6c6254032ce46/python/simulation.py#L1247

https://github.com/NanoComp/meep/blob/29a92c0ab074259fcfa66b9d09e6c6254032ce46/python/simulation.py#L1656-L1669

As a demonstration, here is the output for a test script involving 25 and 34 requested chunks:
```
$ MEEP_STATS=1 mpirun -np 25 python3 foo.py
Using MPI version 3.1, 25 processes
-----------
Initializing structure...
Warning: grid volume is not an integer number of pixels; cell size will be rounded to nearest pixel.
STATS:, aniso_eps:, 0
STATS:, anis_mu:, 0
STATS:, nonlinear:, 0
STATS:, susceptibility:, 21688389
STATS:, conductivity:, 20935276
STATS:, pml_1d:, 17031619
STATS:, pml_2d:, 0
STATS:, pml_3d:, 0
STATS:, dft:, 9920976000
STATS:, total_pixels:, 51248959
STATS:, num_cores:, 25
Splitting into 25 chunks by cost
CHUNK:,  0, 58678.791325
CHUNK:,  1, 58466.975063
CHUNK:,  2, 59117.904559
CHUNK:,  3, 58337.339266
CHUNK:,  4, 60545.863842
CHUNK:,  5, 58684.960462
CHUNK:,  6, 58684.960462
CHUNK:,  7, 59497.770752
CHUNK:,  8, 59497.770752
CHUNK:,  9, 60314.116779
CHUNK:, 10, 59175.846869
CHUNK:, 11, 59175.846869
CHUNK:, 12, 58974.471592
CHUNK:, 13, 58974.471592
CHUNK:, 14, 60448.832289
CHUNK:, 15, 58686.790644
CHUNK:, 16, 58686.790644
CHUNK:, 17, 59909.432557
CHUNK:, 18, 59912.967719
CHUNK:, 19, 59912.967719
CHUNK:, 20, 59032.007069
CHUNK:, 21, 59032.007069
CHUNK:, 22, 60261.840424
CHUNK:, 23, 60265.375585
CHUNK:, 24, 60265.375585

Elapsed run time = 1.4928 s
```
```
$ MEEP_STATS=1 mpirun -np 34 python3 foo.py
Using MPI version 3.1, 34 processes
-----------
Initializing structure...
Warning: grid volume is not an integer number of pixels; cell size will be rounded to nearest pixel.
STATS:, aniso_eps:, 0
STATS:, anis_mu:, 0
STATS:, nonlinear:, 0
STATS:, susceptibility:, 28744659
STATS:, conductivity:, 21344328
STATS:, pml_1d:, 18181202
STATS:, pml_2d:, 0
STATS:, pml_3d:, 0
STATS:, dft:, 17125536000
STATS:, total_pixels:, 61673767
STATS:, num_cores:, 34
Splitting into 32 chunks by cost
CHUNK:,  0, 78354.730288
CHUNK:,  1, 79781.841328
CHUNK:,  2, 78535.202868
CHUNK:,  3, 79965.852398
CHUNK:,  4, 78535.202868
CHUNK:,  5, 79965.852398
CHUNK:,  6, 79061.170279
CHUNK:,  7, 80502.512177
CHUNK:,  8, 78719.213937
CHUNK:,  9, 79781.841328
CHUNK:, 10, 78896.152622
CHUNK:, 11, 79965.852398
CHUNK:, 12, 78896.152622
CHUNK:, 13, 79965.852398
CHUNK:, 14, 79425.657557
CHUNK:, 15, 80502.512177
CHUNK:, 16, 78719.213937
CHUNK:, 17, 79781.840982
CHUNK:, 18, 78896.152622
CHUNK:, 19, 79962.317237
CHUNK:, 20, 79781.840982
CHUNK:, 21, 79962.317237
CHUNK:, 22, 79781.841328
CHUNK:, 23, 79965.852398
CHUNK:, 24, 78896.152622
CHUNK:, 25, 79962.317237
CHUNK:, 26, 79425.657557
CHUNK:, 27, 80498.977016
CHUNK:, 28, 79962.317237
CHUNK:, 29, 80498.977016
CHUNK:, 30, 79965.852398
CHUNK:, 31, 80502.512177

Elapsed run time = 5.4122 s
```
Note that the negligible runtime verifies that the `structure` and `fields` object are not allocated.