### PR TITLE
fix memory leaks in C++ tests

### DIFF
--- a/tests/flux.cpp
+++ b/tests/flux.cpp
@@ -219,8 +219,8 @@ int flux_2d(const double xmax, const double ymax, double eps(const vec &)) {
                   fl1[i] / fl2[i]);
     if (!compare(fl1[i], fl2[i], 0.09, 0, "Flux spectrum")) return 0;
   }
-  delete fl2;
-  delete fl1;
+  delete[] fl2;
+  delete[] fl1;
 
   return 1;
 }
@@ -287,8 +287,8 @@ int flux_cyl(const double rmax, const double zmax, double eps(const vec &), int 
                   fl1[i] / fl2[i]);
     if (!compare(fl1[i], fl2[i], 0.08, 0, "Flux spectrum")) return 0;
   }
-  delete fl2;
-  delete fl1;
+  delete[] fl2;
+  delete[] fl1;
 
   return 1;
 }

--- a/tests/stress_tensor.cpp
+++ b/tests/stress_tensor.cpp
@@ -79,8 +79,8 @@ int main(int argc, char **argv) {
   double *fr = forceR.force();
   master_printf("flux is %0.8g, force is %0.8g, F/P = %0.8g\n", fl[0], fr[0], -0.5 * fr[0] / fl[0]);
   double FoverP = -0.5 * fr[0] / fl[0];
-  delete fl;
-  delete fr;
+  delete[] fl;
+  delete[] fr;
   return fabs(FoverP + 0.33628872) / 0.33628872 > 0.1;
   // MPB: -0.33628872
 }


### PR DESCRIPTION
Fixes a couple of memory leaks in two of the C++ tests related to deleting arrays which are originally defined as pointers.