### PR TITLE
Ignore some C++ str() methods to avoid SWIG warnings

### DIFF
--- a/python/vec.i
+++ b/python/vec.i
@@ -70,6 +70,12 @@
 %rename(vec_dim_val) meep::vec::vec(ndim, double);
 %rename(vec_dim) meep::vec::vec(ndim);
 
+// ignore methods that conflict with python built-ins
+%ignore meep::vec::str;
+%ignore meep::ivec::str;
+%ignore meep::volume::str;
+%ignore meep::grid_volume::str;
+
 
 // Include the C++ class declarations
 %include "meep/vec.hpp"


### PR DESCRIPTION
Fixes #1391 