### PR TITLE
Add surface area function to grid_volume class

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1838,7 +1838,7 @@ meep::structure *create_structure_and_set_materials(vector3 cell_size,
          meep::volume thev = gv.surroundings();
          std::vector<grid_volume> chunk_vols = meep::choose_chunkdivision(gv, thev, num_chunks, sym);
          for (size_t i = 0; i < chunk_vols.size(); ++i)
-              master_printf("CHUNK:, %2zu, %f\n",i,chunk_vols[i].get_cost());
+              master_printf("CHUNK:, %2zu, %f, %zu\n",i,chunk_vols[i].get_cost(),chunk_vols[i].surface_area());
          return NULL;
     }
 

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -948,6 +948,7 @@ public:
   vec loc_at_resolution(ptrdiff_t index, double res) const;
   size_t ntot_at_resolution(double res) const;
   ivec iloc(component, ptrdiff_t index) const;
+  size_t surface_area() const;
 
   ptrdiff_t yee_index(component c) const {
     ptrdiff_t idx = 0;

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -860,6 +860,16 @@ ivec grid_volume::iloc(component c, ptrdiff_t ind) const {
   return out + iyee_shift(c) + io;
 }
 
+size_t grid_volume::surface_area() const {
+  switch(dim) {
+    case Dcyl: return 2*(nr()+nz());
+    case D1: abort("grid_volume::surface_area() does not support 1d\n");
+    case D2: return 2*(nx()+ny());
+    case D3: return 2*(nx()*ny()+nx()*nz()+ny()*nz());
+  }
+  return 0; // This is never reached.
+}
+
 vec grid_volume::dr() const {
   switch (dim) {
     case Dcyl: return veccyl(inva, 0.0);

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -863,7 +863,7 @@ ivec grid_volume::iloc(component c, ptrdiff_t ind) const {
 size_t grid_volume::surface_area() const {
   switch(dim) {
     case Dcyl: return 2*(nr()+nz());
-    case D1: abort("grid_volume::surface_area() does not support 1d\n");
+    case D1: 2;
     case D2: return 2*(nx()+ny());
     case D3: return 2*(nx()*ny()+nx()*nz()+ny()*nz());
   }


### PR DESCRIPTION
This PR adds a new function `size_t grid_volume::surfacearea()` as originally proposed by @stevengj in #1069. The computation of the surface area is based on that of a simple cuboid. No distinction is made between counting only "outer" boundaries in periodic directions (as suggested in this [comment](https://github.com/NanoComp/meep/issues/1069#issuecomment-564351650)) since the boundary information is available from the `structure` or `fields` class. Unfortunately, this means the surface area results may not be accurate for computing the communication cost but at least it provides a rough estimate while keeping the implementation simple.

For offline computations (following #1383), the surface area of each chunk volume (in which PMLs are excluded) is output along with its cost.