### PR TITLE
improvements to MPI timing statistics

### DIFF
--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -437,6 +437,7 @@ int fields::get_array_slice_dimensions(const volume &where, size_t dims[3], dire
   loop_in_chunks(get_array_slice_dimensions_chunkloop, (void *)data, where, cgrid, use_symmetry,
                  snap_empty_dimensions);
 
+  am_now_working_on(MpiTime);
   data->min_corner = -max_to_all(-data->min_corner); // i.e., min_to_all
   data->max_corner = max_to_all(data->max_corner);
   if (min_max_loc) LOOP_OVER_DIRECTIONS(gv.dim, d) {
@@ -444,6 +445,7 @@ int fields::get_array_slice_dimensions(const volume &where, size_t dims[3], dire
       max_loc->set_direction(d, max_to_all(max_loc->in_direction(d)));
     }
   data->num_chunks = sum_to_all(data->num_chunks);
+  finished_working();
   if (data->num_chunks == 0 || !(data->min_corner <= data->max_corner))
     return 0; // no data to write;
 

--- a/src/cw_fields.cpp
+++ b/src/cw_fields.cpp
@@ -195,7 +195,9 @@ bool fields::solve_cw(double tol, int maxiters, complex<double> frequency, int L
       double babs = abs(b[i]);
       if (babs > bmax) bmax = babs;
     }
+    am_now_working_on(MpiTime);
     if (max_to_all(bmax) == 0.0) abort("zero current amplitudes in solve_cw");
+    finished_working();
   }
 
   fieldop_data data;

--- a/src/fields.cpp
+++ b/src/fields.cpp
@@ -490,7 +490,9 @@ void fields::require_component(component c) {
           chunks[i]->s->has_chi(Hx, Z) || chunks[i]->s->has_chi(Hy, Z) ||
           chunks[i]->s->has_chi(Hz, X) || chunks[i]->s->has_chi(Hz, Y))
         break;
+    am_now_working_on(MpiTime);
     aniso2d = or_to_all(i < num_chunks);
+    finished_working();
   }
   if (aniso2d && beta != 0 && is_real)
     abort("Nonzero beta need complex fields when mu/epsilon couple TE and TM");
@@ -505,7 +507,9 @@ void fields::require_component(component c) {
   }
 
   if (need_to_reconnect) figure_out_step_plan();
+  am_now_working_on(MpiTime);
   if (sum_to_all(need_to_reconnect)) chunk_connections_valid = false;
+  finished_working();
 }
 
 void fields_chunk::remove_sources() {

--- a/src/h5fields.cpp
+++ b/src/h5fields.cpp
@@ -238,9 +238,11 @@ void fields::output_hdf5(h5file *file, const char *dataname, int num_fields,
   loop_in_chunks(h5_findsize_chunkloop, (void *)&data, where, Centered, true, true);
 
   file->prevent_deadlock(); // can't hold a lock since *_to_all is collective
+  am_now_working_on(MpiTime);
   data.max_corner = max_to_all(data.max_corner);
   data.min_corner = -max_to_all(-data.min_corner); // i.e., min_to_all
   data.num_chunks = sum_to_all(data.num_chunks);
+  finished_working();
   if (data.num_chunks == 0 || !(data.min_corner <= data.max_corner)) return; // no data to write;
 
   int rank = 0;

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -440,7 +440,9 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
     // then, synchronize the data
     eps_data.ncache = eps_data.icache; // actual amount of cached data
     double *summed_cache = (double *)malloc(sizeof(double) * 6 * eps_data.ncache);
+    am_now_working_on(MpiTime);
     sum_to_all(eps_data.cache, summed_cache, eps_data.ncache * 6);
+    finished_working();
     free(eps_data.cache);
     eps_data.cache = summed_cache;
 


### PR DESCRIPTION
This PR wraps various untimed instances of `sum_to_all`, `max_to_all`, and `or_to_all` with `am_now_working_on(MpiTime)`/`finished_working()` to improve the accuracy of the MPI timing statistics.

(Note that there are several instances of `sum_to_all` in `src/dft.cpp` from the DFT-related classes (`dft_flux`, `dft_near2far`, etc) which cannot be timed because they are not part of the `fields` class.)