### PR TITLE
minor fixes/tweaks to docs

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -2743,7 +2743,7 @@ Given a frequency `frequency`, (provided as a keyword argument) output $\varepsi
 permittivity); for an anisotropic $\varepsilon$ tensor the output is the [harmonic
 mean](https://en.wikipedia.org/wiki/Harmonic_mean) of the $\varepsilon$ eigenvalues. If
 `frequency` is non-zero, the output is complex; otherwise it is the real,
-frequency-independent part of $arepsilon$ (the $\omega\to\infty$ limit).
+frequency-independent part of $\varepsilon$ (the $\omega\to\infty$ limit).
 When called as part of a [step function](Python_User_Interface.md#controlling-when-a-step-function-executes),
 the `sim` argument specifying the `Simulation` object can be omitted, e.g.,
 `sim.run(mp.at_beginning(mp.output_epsilon(frequency=1/0.7)),until=10)`.

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4439,7 +4439,7 @@ def output_epsilon(sim=None,*step_func_args,**kwargs):
     permittivity); for an anisotropic $\\varepsilon$ tensor the output is the [harmonic
     mean](https://en.wikipedia.org/wiki/Harmonic_mean) of the $\\varepsilon$ eigenvalues. If
     `frequency` is non-zero, the output is complex; otherwise it is the real,
-    frequency-independent part of $\varepsilon$ (the $\\omega\\to\\infty$ limit).
+    frequency-independent part of $\\varepsilon$ (the $\\omega\\to\\infty$ limit).
     When called as part of a [step function](Python_User_Interface.md#controlling-when-a-step-function-executes),
     the `sim` argument specifying the `Simulation` object can be omitted, e.g.,
     `sim.run(mp.at_beginning(mp.output_epsilon(frequency=1/0.7)),until=10)`.
@@ -4461,7 +4461,7 @@ def output_mu(sim=None,*step_func_args,**kwargs):
     permeability); for an anisotropic $\mu$ tensor the output is the [harmonic
     mean](https://en.wikipedia.org/wiki/Harmonic_mean) of the $\mu$ eigenvalues. If
     `frequency` is non-zero, the output is complex; otherwise it is the real,
-    frequency-independent part of $\mu$ (the $\\omega\\to\\infty$ limit).
+    frequency-independent part of $\\mu$ (the $\\omega\\to\\infty$ limit).
     When called as part of a [step function](Python_User_Interface.md#controlling-when-a-step-function-executes),
     the `sim` argument specifying the `Simulation` object can be omitted, e.g.,
     `sim.run(mp.at_beginning(mp.output_mu(frequency=1/0.7)),until=10)`.


### PR DESCRIPTION
Updates the (outdated) definitions for `get_eigenmode_coefficients` and `get_eigenmodes` in [Mode Decomposition](https://meep.readthedocs.io/en/latest/Mode_Decomposition/) as well as other minor fixes.