### PR TITLE
only remove swig-generated files on maintainer-clean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,8 +178,8 @@ script:
     fi
   - >
     if [[ "${BUILD_WITHOUT_MPB}" = "1" ]] && [[ "${MAKE_DISTCHECK_EXIT_CODE}" = "0" ]]; then
+      make maintainer-clean &&
       ../configure --enable-maintainer-mode --prefix=$HOME/local --with-libctl=$HOME/local/share/libctl ${MPICONF} ac_cv_header_mpb_h=no &&
-      make clean &&
       make;
     fi
   # Kill background sleep loop

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -99,7 +99,8 @@ TESTS_ENVIRONMENT = export PYTHONPATH=$(abs_top_builddir)/python:$$PYTHONPATH;
 ######################################################################
 BUILT_SOURCES = meep-python.cxx __init__.py
 EXTRA_DIST = $(BUILT_SOURCES) typemap_utils.cpp materials.py examples tests
-CLEANFILES = $(BUILT_SOURCES) meep.py .coverage
+CLEANFILES = meep.py .coverage
+MAINTAINERCLEANFILES = $(BUILT_SOURCES)
 
 AM_CPPFLAGS = -I$(top_srcdir)/src               \
               -I$(top_srcdir)/libpympb		\

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -97,10 +97,8 @@ TESTS_ENVIRONMENT = export PYTHONPATH=$(abs_top_builddir)/python:$$PYTHONPATH;
 # instructions for building the _meep binary library that implements
 # the low-level interface between python codes and the libmeep C++ library
 ######################################################################
-BUILT_SOURCES = meep-python.cxx __init__.py
+BUILT_SOURCES = meep-python.cxx __init__.py meep.py
 EXTRA_DIST = $(BUILT_SOURCES) typemap_utils.cpp materials.py examples tests
-CLEANFILES = meep.py .coverage
-MAINTAINERCLEANFILES = $(BUILT_SOURCES)
 
 AM_CPPFLAGS = -I$(top_srcdir)/src               \
               -I$(top_srcdir)/libpympb		\
@@ -138,6 +136,9 @@ uninstall-hook:
 	rm -f $(DESTDIR)$(pkgpythondir)/mpb/__init__.py
 
 endif
+
+CLEANFILES = .coverage
+MAINTAINERCLEANFILES = $(BUILT_SOURCES)
 
 ##################################################
 # instructions for running SWIG to generate the

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -99,6 +99,8 @@ TESTS_ENVIRONMENT = export PYTHONPATH=$(abs_top_builddir)/python:$$PYTHONPATH;
 ######################################################################
 BUILT_SOURCES = meep-python.cxx __init__.py meep.py
 EXTRA_DIST = $(BUILT_SOURCES) typemap_utils.cpp materials.py examples tests
+CLEANFILES = .coverage
+MAINTAINERCLEANFILES = $(BUILT_SOURCES)
 
 AM_CPPFLAGS = -I$(top_srcdir)/src               \
               -I$(top_srcdir)/libpympb		\
@@ -136,9 +138,6 @@ uninstall-hook:
 	rm -f $(DESTDIR)$(pkgpythondir)/mpb/__init__.py
 
 endif
-
-CLEANFILES = .coverage
-MAINTAINERCLEANFILES = $(BUILT_SOURCES)
 
 ##################################################
 # instructions for running SWIG to generate the


### PR DESCRIPTION
Otherwise `make clean` will break the build (since re-generating these files requires `swig`, which should only be needed in maintainer mode).