### PR TITLE
output timing statistics to CSV file

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -547,6 +547,23 @@ other.
 
 </div>
 
+<a id="Simulation.output_times"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def output_times(self, fname=''):
+```
+
+<div class="method_docstring" markdown="1">
+
+Call after running a simulation to output to a file with filename `fname` the
+times spent on various types of work as CSV (comma separated values) with headers
+for each column.
+
+</div>
+
+</div>
 
 ### Field Computations
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -559,7 +559,7 @@ def output_times(self, fname):
 
 Call after running a simulation to output to a file with filename `fname` the
 times spent on various types of work as CSV (comma separated values) with headers
-for each column.
+for each column and one row per process.
 
 </div>
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -552,7 +552,7 @@ other.
 <div class="class_members" markdown="1">
 
 ```python
-def output_times(self, fname=''):
+def output_times(self, fname):
 ```
 
 <div class="method_docstring" markdown="1">

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -88,7 +88,7 @@ The `Simulation` class provides the following time-related methods:
 @@ Simulation.print_times @@
 @@ Simulation.time_spent_on @@
 @@ Simulation.mean_time_spent_on @@
-
+@@ Simulation.output_times @@
 
 ### Field Computations
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3673,7 +3673,7 @@ class Simulation(object):
         """
         return self.fields.time_spent_on(time_sink)
 
-    def output_times(self, fname=''):
+    def output_times(self, fname):
         """
         Call after running a simulation to output to a file with filename `fname` the
         times spent on various types of work as CSV (comma separated values) with headers

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3677,7 +3677,7 @@ class Simulation(object):
         """
         Call after running a simulation to output to a file with filename `fname` the
         times spent on various types of work as CSV (comma separated values) with headers
-        for each column.
+        for each column and one row per process.
         """
         if self.fields:
             if not fname.endswith('.csv'):

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3673,6 +3673,17 @@ class Simulation(object):
         """
         return self.fields.time_spent_on(time_sink)
 
+    def output_times(self, fname=''):
+        """
+        Call after running a simulation to output to a file with filename `fname` the
+        times spent on various types of work as CSV (comma separated values) with headers
+        for each column.
+        """
+        if self.fields:
+            if not fname.endswith('.csv'):
+                fname += '.csv'
+            self.fields.output_times(fname)
+
     def get_epsilon(self,frequency=0,omega=0):
         if omega != 0:
             frequency = omega

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1628,6 +1628,8 @@ public:
                       const char *prefix = NULL, bool timestamp = false);
   const char *h5file_name(const char *name, const char *prefix = NULL, bool timestamp = false);
 
+  void output_times(const char *fname);
+
   // array_slice.cpp methods
 
   // given a subvolume, compute the dimensions of the array slice

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -133,8 +133,10 @@ void fields::print_times() {
 
 void fields::output_times(const char *fname) {
   if (verbosity > 0) master_printf("creating timings output file \"%s\"...\n", fname);
-  h5file file(fname, h5file::WRITE, true);
-  size_t n = count_processors();
+  FILE *tf = master_fopen(fname, "w");
+  if (!tf) abort("Unable to create file %s!\n", fname);
+
+  int n = count_processors();
   double *alltimes_tmp = new double[n * (Other + 1)];
   double *alltimes = new double[n * (Other + 1)];
   for (int i = 0; i <= Other; ++i) {
@@ -143,10 +145,17 @@ void fields::output_times(const char *fname) {
   }
   sum_to_master(alltimes_tmp, alltimes, n * (Other + 1));
   delete[] alltimes_tmp;
-  for (size_t i = 0; i <= Other; i++) {
-    file.create_data(ts2n((time_sink)i), 1, n);
-    if (am_master()) file.write_chunk(1, i*n, n, alltimes);
+
+  for (int i = 0; i <= Other-1; ++i)
+    master_fprintf(tf, "%s, ", ts2n((time_sink)i));
+  master_fprintf(tf, "%s\n", ts2n(Other));
+
+  for (int j = 0; j < n; ++j) {
+    for (int i = 0; i <= Other-1; ++i)
+      master_fprintf(tf, "%g, ", alltimes[i * n + j]);
+    master_fprintf(tf, "%g\n", alltimes[Other * n + j]);
   }
+  master_fclose(tf);
   delete[] alltimes;
 }
 

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -132,7 +132,7 @@ void fields::print_times() {
 }
 
 void fields::output_times(const char *fname) {
-  if (verbosity > 0) master_printf("creating timings output file \"%s\"...\n", fname);
+  if (verbosity > 0) master_printf("outputting timing statistics to file \"%s\"...\n", fname);
   FILE *tf = master_fopen(fname, "w");
   if (!tf) abort("Unable to create file %s!\n", fname);
 


### PR DESCRIPTION
This PR adds a new function `fields::output_times` which outputs the timing statistics to an ~~HDF5~~ 
CSV file as an alternative to `fields::print_times` and `fields::time_spent_on` which either print to standard output or return the values.