### PR TITLE
compiling for specific architecture using --disable-portable-binary

### DIFF
--- a/doc/docs/Build_From_Source.md
+++ b/doc/docs/Build_From_Source.md
@@ -238,7 +238,7 @@ By default, Meep's `configure` script picks compiler flags to optimize Meep as m
 
 **`--with-gcc-arch=arch`, `--without-gcc-arch`**
 —
-By default, Meep's configure script tries to guess the gcc `-march` flag for the system you are compiling on using `-mtune` instead when `--enable-portable-binary` is specified. If it guesses wrong, or if you want to specify a different architecture, you can pass it here. (Alternatively, you may not even need to specify the `arch` explicitly using `--with-gcc-arch` if you *only* use `--disable-portable-binary` which will then leave it up to the compiler to determine the native architecture.) If you want to omit `-march`/`-mtune` flags entirely, pass `--without-gcc-arch`.
+By default, Meep's configure script tries to guess the gcc `-march` flag for the system you are compiling on using `-mtune` instead when `--enable-portable-binary` is specified. If it guesses wrong, or if you want to specify a different architecture, you can pass it here. Alternatively, if you want to compile using your native architecture, you can just use `--disable-portable-binary` and omit `--with-gcc-arch` entirely. This approach will leave it up to your compiler to automatically determine the architecture. If you want to omit `-march`/`-mtune` flags entirely, pass `--without-gcc-arch`.
 
 **`--with-openmp`**
 —

--- a/doc/docs/Build_From_Source.md
+++ b/doc/docs/Build_From_Source.md
@@ -238,7 +238,7 @@ By default, Meep's `configure` script picks compiler flags to optimize Meep as m
 
 **`--with-gcc-arch=arch`, `--without-gcc-arch`**
 —
-By default, Meep's configure script tries to guess the gcc `-march` flag for the system you are compiling on using `-mtune` instead when `--enable-portable-binary` is specified. If it guesses wrong, or if you want to specify a different architecture, you can pass it here. If you want to omit `-march`/`-mtune` flags entirely, pass `--without-gcc-arch`.
+By default, Meep's configure script tries to guess the gcc `-march` flag for the system you are compiling on using `-mtune` instead when `--enable-portable-binary` is specified. If it guesses wrong, or if you want to specify a different architecture, you can pass it here. (Alternatively, you may not even need to specify the `arch` explicitly using `--with-gcc-arch` if you *only* use `--disable-portable-binary` which will then leave it up to the compiler to determine the native architecture.) If you want to omit `-march`/`-mtune` flags entirely, pass `--without-gcc-arch`.
 
 **`--with-openmp`**
 —


### PR DESCRIPTION
This updates the documentation for the compiler flag `--with-gcc-arch=arch` in [Build From Source](https://meep.readthedocs.io/en/latest/Build_From_Source/#meep) to point out that when compiling for a specific hardware architecture, simply using `--disable-portable-binary` (and omitting `--with-gcc-arch` entirely) will leave it up to the compiler to determine the native architecture.

As a demonstration that this approach actually works, here is the relevant output from `config.log` as well as the timing results for serial Meep for the Python test suite (`meep/python/tests`) for two different builds: (1) portable vs. (2) hardware specific (Intel Xeon Kaby Lake processor at 4.2 GHz). The `config.log` output verifies that the builds are indeed different. However, there are no significant differences in the timing results although (2) is slightly faster than (1) which is expected.

**1. --enable-portable-binary**
```
$ grep march config.log
/usr/lib/gcc/x86_64-linux-gnu/7/f951 ... -mtune=generic -march=x86-64 ...
```

```
$ time make check
real	10m2.053s
user	18m23.464s
sys	10m13.218s
```

**2. --disable-portable-binary**
```
$ grep march config.log
g++ -c -O3 -fstrict-aliasing -march=native ...
```

```
$ time make check
real	9m52.264s
user	18m14.748s
sys	10m12.129s
```

