### PR TITLE
add option to plot2D to plot contour of geometry rather than its image

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -2484,8 +2484,8 @@ plt.savefig('sim_domain.png')
     - `interpolation='spline36'`: interpolation algorithm used to upsample the pixels.
     - `cmap='binary'`: the color map of the geometry
     - `alpha=1.0`: transparency of geometry
-    - `contour=False`: if True, plot a contour of the geometry rather than its image
-    - `contour_linewidth=0.5`: width of the contour lines if `contour=True`
+    - `contour=False`: if `True`, plot a contour of the geometry rather than its image
+    - `contour_linewidth=1`: line width of the contour lines if `contour=True`
 * `boundary_parameters`: a `dict` of optional plotting parameters that override
   the default parameters for the boundary layers.
     - `alpha=1.0`: transparency of boundary layers

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -2484,6 +2484,8 @@ plt.savefig('sim_domain.png')
     - `interpolation='spline36'`: interpolation algorithm used to upsample the pixels.
     - `cmap='binary'`: the color map of the geometry
     - `alpha=1.0`: transparency of geometry
+    - `contour=False`: if True, plot a contour of the geometry rather than its image
+    - `contour_linewidth=0.5`: width of the contour lines if `contour=True`
 * `boundary_parameters`: a `dict` of optional plotting parameters that override
   the default parameters for the boundary layers.
     - `alpha=1.0`: transparency of boundary layers

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3876,6 +3876,8 @@ class Simulation(object):
             - `interpolation='spline36'`: interpolation algorithm used to upsample the pixels.
             - `cmap='binary'`: the color map of the geometry
             - `alpha=1.0`: transparency of geometry
+            - `contour=False`: if True, plot a contour of the geometry rather than its image
+            - `contour_linewidth=0.5`: width of the contour lines if `contour=True`
         * `boundary_parameters`: a `dict` of optional plotting parameters that override
           the default parameters for the boundary layers.
             - `alpha=1.0`: transparency of boundary layers

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3876,8 +3876,8 @@ class Simulation(object):
             - `interpolation='spline36'`: interpolation algorithm used to upsample the pixels.
             - `cmap='binary'`: the color map of the geometry
             - `alpha=1.0`: transparency of geometry
-            - `contour=False`: if True, plot a contour of the geometry rather than its image
-            - `contour_linewidth=0.5`: width of the contour lines if `contour=True`
+            - `contour=False`: if `True`, plot a contour of the geometry rather than its image
+            - `contour_linewidth=1`: line width of the contour lines if `contour=True`
         * `boundary_parameters`: a `dict` of optional plotting parameters that override
           the default parameters for the boundary layers.
             - `alpha=1.0`: transparency of boundary layers

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -45,7 +45,9 @@ default_field_parameters = {
 default_eps_parameters = {
         'interpolation':'spline36',
         'cmap':'binary',
-        'alpha':1.0
+        'alpha':1.0,
+        'contour':False,
+        'contour_linewidth':0.5
     }
 
 default_boundary_parameters = {
@@ -343,7 +345,10 @@ def plot_eps(sim,ax,output_plane=None,eps_parameters=None,frequency=0):
 
     eps_data = np.rot90(np.real(sim.get_array(center=center, size=cell_size, component=mp.Dielectric, frequency=frequency)))
     if mp.am_master():
-        ax.imshow(eps_data, extent=extent, **eps_parameters)
+        if eps_parameters['contour']:
+            ax.contour(eps_data, extent=extent, linewidths=eps_parameters['contour_linewidth'], **filter_dict(eps_parameters, ax.contour))
+        else:
+            ax.imshow(eps_data, extent=extent, **filter_dict(eps_parameters, ax.imshow))
         ax.set_xlabel(xlabel)
         ax.set_ylabel(ylabel)
 

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -346,7 +346,7 @@ def plot_eps(sim,ax,output_plane=None,eps_parameters=None,frequency=0):
     eps_data = np.rot90(np.real(sim.get_array(center=center, size=cell_size, component=mp.Dielectric, frequency=frequency)))
     if mp.am_master():
         if eps_parameters['contour']:
-            ax.contour(eps_data, extent=extent, linewidths=eps_parameters['contour_linewidth'], **filter_dict(eps_parameters, ax.contour))
+            ax.contour(eps_data, 0, colors='black', extent=extent, linewidths=eps_parameters['contour_linewidth'])
         else:
             ax.imshow(eps_data, extent=extent, **filter_dict(eps_parameters, ax.imshow))
         ax.set_xlabel(xlabel)

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -47,7 +47,7 @@ default_eps_parameters = {
         'cmap':'binary',
         'alpha':1.0,
         'contour':False,
-        'contour_linewidth':0.5
+        'contour_linewidth':1
     }
 
 default_boundary_parameters = {
@@ -346,7 +346,7 @@ def plot_eps(sim,ax,output_plane=None,eps_parameters=None,frequency=0):
     eps_data = np.rot90(np.real(sim.get_array(center=center, size=cell_size, component=mp.Dielectric, frequency=frequency)))
     if mp.am_master():
         if eps_parameters['contour']:
-            ax.contour(eps_data, 0, colors='black', extent=extent, linewidths=eps_parameters['contour_linewidth'])
+            ax.contour(eps_data, 0, colors='black', origin='upper', extent=extent, linewidths=eps_parameters['contour_linewidth'])
         else:
             ax.imshow(eps_data, extent=extent, **filter_dict(eps_parameters, ax.imshow))
         ax.set_xlabel(xlabel)


### PR DESCRIPTION
Fixes #1435.

Adds new options `contour` and  `contour_linewidth` (for Matplotlib's [`contour`](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.pyplot.contour.html)) to `eps_parameters` of `plot2D`.

Documentation is also provided.

Example usage:
```
sim.plot2D(fields=mp.Hz,
           field_parameters={'alpha':1.0},
           eps_parameters={'contour':True},
           plot_sources_flag=True,
           plot_monitors_flag=True,
           plot_boundaries_flag=True)
```

![demux_cw_fields_1 31um](https://user-images.githubusercontent.com/7152530/100528729-aea67f00-3194-11eb-8d94-c069f8c0265d.png)

For comparison, the default `imshow` rendering:

```
sim.plot2D(fields=mp.Hz,
           field_parameters={'alpha':0.7},
           plot_sources_flag=True,
	   plot_monitors_flag=True,
           plot_boundaries_flag=True)
```

![demux_cw_fields_1 31um_imshow](https://user-images.githubusercontent.com/7152530/100529040-efec5e00-3197-11eb-8bf1-3da1bebc23fc.png)