### PR TITLE
fix variable name in load_minus_near2far

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2638,7 +2638,7 @@ class Simulation(object):
         loaded. This means that they will be *subtracted* from any future field Fourier
         transforms that are accumulated.
         """
-        self.load_near2far(fname, n2f)
+        self.load_near2far(fname, near2far)
         near2far.scale_dfts(-1.0)
 
     def get_near2far_data(self, near2far):


### PR DESCRIPTION
Fixes a typo in `load_minus_near2far` in the simulation.py.