### PR TITLE
re-instate undocumented get_array_slice_dimensions in Python interface

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3299,6 +3299,28 @@ class Simulation(object):
             return points,weights
         return tuple(tics) + (weights,)
 
+    def get_array_slice_dimensions(self, component, vol=None, center=None, size=None):
+        """
+        Computes the dimensions of an array slice for a particular `component` (`mp.Ez`, `mp.Ey`, etc.).
+
+        Accepts either a volume object (`vol`), or a `center` and `size` `Vector3` pair.
+
+        Returns a tuple containing the dimensions (`dim_sizes`), a `Vector3` object
+        corresponding to the minimum corner of the volume (`min_corner`),
+        and a `Vector3` object corresponding to the maximum corner (`max_corner`).
+        """
+        if vol is None and center is None and size is None:
+            v = self.fields.total_volume()
+        else:
+            v = self._volume_from_kwargs(vol, center, size)
+        dim_sizes = np.zeros(3, dtype=np.uintp)
+        corners = []
+        _,_ = mp._get_array_slice_dimensions(self.fields, v, dim_sizes, False, False, component, corners)
+        dim_sizes[dim_sizes==0] = 1
+        min_corner = corners[0]
+        max_corner = corners[1]
+        return dim_sizes, min_corner, max_corner
+
     def get_eigenmode_coefficients(self, flux, bands, eig_parity=mp.NO_PARITY, eig_vol=None,
                                    eig_resolution=0, eig_tolerance=1e-12, kpoint_func=None, direction=mp.AUTOMATIC):
         """


### PR DESCRIPTION
#1456 removed `get_array_slice_dimensions` from the Python interface which unfortunately was discovered afterwards to be used by the adjoint solver in a couple of places: 

https://github.com/NanoComp/meep/blob/37117fe527866093bc0713fc21fd34d4aacd448b/python/adjoint/optimization_problem.py#L191-L195

https://github.com/NanoComp/meep/blob/37117fe527866093bc0713fc21fd34d4aacd448b/python/adjoint/optimization_problem.py#L408-L415

Rather than modify the above lines to use the low-level `_get_array_slice_dimensions`, this PR simply re-instates `get_array_slice_dimensions` (in its original form). Note that this is an internal function used only by the adjoint solver that is not documented in the user manual.

We will need to do a version 1.17.1 release after this is merged since 1.17.0 broke the adjoint solver. 

Also, it would be good to add some unit tests for the adjoint solver to prevent these types of fixes in the future.