### PR TITLE
distinguish between subpixel averaging and grid initialization during progress update for set_epsilon

### DIFF
--- a/src/anisotropic_averaging.cpp
+++ b/src/anisotropic_averaging.cpp
@@ -252,7 +252,9 @@ breakout:
 
     if (verbosity > 0 && (ipixel + 1) % 1000 == 0 &&
         wall_time() > last_output_time + MEEP_MIN_OUTPUT_TIME) {
-      master_printf("subpixel-averaging is %g%% done, %g s remaining\n", ipixel * 100.0 / npixels,
+      master_printf("%s is %g%% done, %g s remaining\n",
+                    use_anisotropic_averaging ? "subpixel-averaging" : "grid initialization",
+                    ipixel * 100.0 / npixels,
                     (npixels - ipixel) * (wall_time() - last_output_time) / ipixel);
       last_output_time = wall_time();
     }


### PR DESCRIPTION
Currently, when the `verbosity` flag is set to any non-zero value, the `set_epsilon` routine which is called prior to time-stepping to initialize the grid always displays e.g. `subpixel-averaging is 11.7598% done, 30.0265 s remaining` as part of its progress update which is inaccurate when subpixel averaging is disabled. This PR modifies this output to display `grid initialization` rather than `subpixel-averaging` whenever subpixel averaging is turned off.