### PR TITLE
unit test for adjoint solver

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -211,11 +211,11 @@ HL_IFACE =                  \
 pkgpython_PYTHON = __init__.py $(HL_IFACE)
 
 adjointdir = $(pkgpythondir)/adjoint
-adjoint_PYTHON  = $(srcdir)/adjoint/__init__.py			\
-                  $(srcdir)/adjoint/basis.py  			\
-                  $(srcdir)/adjoint/objective.py        	\
-                  $(srcdir)/adjoint/optimization_problem.py	\
-                  $(srcdir)/adjoint/filters.py	                \
+adjoint_PYTHON  = $(srcdir)/adjoint/__init__.py              \
+                  $(srcdir)/adjoint/basis.py                 \
+                  $(srcdir)/adjoint/objective.py             \
+                  $(srcdir)/adjoint/optimization_problem.py  \
+                  $(srcdir)/adjoint/filters.py               \
                   $(srcdir)/adjoint/filter_source.py
 
 ######################################################################

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -37,6 +37,7 @@ endif
 TESTS =                                   \
     $(TEST_DIR)/3rd_harm_1d.py            \
     $(TEST_DIR)/absorber_1d.py            \
+    $(TEST_DIR)/adjoint_solver.py         \
     $(TEST_DIR)/antenna_radiation.py      \
     $(TEST_DIR)/array_metadata.py         \
     $(TEST_DIR)/bend_flux.py              \
@@ -214,7 +215,7 @@ adjoint_PYTHON  = $(srcdir)/adjoint/__init__.py			\
                   $(srcdir)/adjoint/basis.py  			\
                   $(srcdir)/adjoint/objective.py        	\
                   $(srcdir)/adjoint/optimization_problem.py	\
-                  $(srcdir)/adjoint/filters.py	\
+                  $(srcdir)/adjoint/filters.py	                \
                   $(srcdir)/adjoint/filter_source.py
 
 ######################################################################

--- a/python/tests/adjoint_solver.py
+++ b/python/tests/adjoint_solver.py
@@ -1,0 +1,150 @@
+import meep as mp
+import meep.adjoint as mpa
+import numpy as np
+from autograd import numpy as npa
+from copy import deepcopy
+import unittest
+
+class TestAdjointSolver(unittest.TestCase):
+
+    def test_adjoint_solver(self):
+        np.random.seed(9861548)
+        mp.verbosity(1)
+
+        resolution = 25
+
+        silicon = mp.Medium(epsilon=12)
+
+        sxy = 5.0
+        cell_size = mp.Vector3(sxy,sxy,0)
+
+        dpml = 1.0
+        boundary_layers = [mp.PML(thickness=dpml)]
+
+        eig_parity = mp.EVEN_Y+mp.ODD_Z
+
+        design_shape = mp.Vector3(1.5,1.5)
+        design_region_resolution = int(2*resolution)
+        Nx = int(design_region_resolution*design_shape.x)
+        Ny = int(design_region_resolution*design_shape.y)
+
+        w = 1.0 # waveguide width
+        waveguide_geometry = [mp.Block(material=silicon,
+                                       center=mp.Vector3(),
+                                       size=mp.Vector3(mp.inf,w,mp.inf))]
+
+        fcen = 1/1.55
+        df = 0.2*fcen
+        sources = [mp.EigenModeSource(src=mp.GaussianSource(fcen,fwidth=df),
+                                      center=mp.Vector3(-0.5*sxy+dpml,0),
+                                      size=mp.Vector3(0,sxy,0),
+                                      eig_band=1,
+                                      eig_parity=eig_parity,
+                                      eig_match_freq=True)]
+
+        def forward_simulation(design_params):
+            matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
+                                      mp.air,
+                                      silicon,
+                                      design_parameters=design_params.reshape(Nx,Ny),
+                                      grid_type='U_SUM')
+            
+            matgrid_geometry = [mp.Block(center=mp.Vector3(),
+                                         size=mp.Vector3(design_shape.x,design_shape.y,0),
+                                         material=matgrid)]
+
+            geometry = waveguide_geometry + matgrid_geometry
+
+            sim = mp.Simulation(resolution=resolution,
+                                cell_size=cell_size,
+                                boundary_layers=boundary_layers,
+                                sources=sources,
+                                geometry=geometry)
+
+            mode = sim.add_mode_monitor(fcen, 0, 1,
+                                        mp.ModeRegion(center=mp.Vector3(0.5*sxy-dpml),size=mp.Vector3(0,sxy,0)),
+                                        yee_grid=True)
+
+            sim.run(until_after_sources=20)
+
+            # mode coefficients
+            coeff = sim.get_eigenmode_coefficients(mode,[1],eig_parity).alpha[0,0,0]
+
+            # S parameters
+            S12 = abs(coeff)**2
+
+            sim.reset_meep()
+
+            return S12
+
+        def adjoint_solver(design_params):
+            matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
+                                      mp.air,
+                                      silicon,
+                                      design_parameters=np.ones((Nx,Ny)))
+
+            matgrid_region = mpa.DesignRegion(matgrid,
+                                              volume=mp.Volume(center=mp.Vector3(),
+                                                               size=mp.Vector3(design_shape.x,design_shape.y,0)))
+
+            matgrid_geometry = [mp.Block(center=matgrid_region.center,
+                                         size=matgrid_region.size,
+                                         material=matgrid)]
+
+            geometry = waveguide_geometry + matgrid_geometry
+
+            sim = mp.Simulation(resolution=resolution,
+                                cell_size=cell_size,
+                                boundary_layers=boundary_layers,
+                                sources=sources,
+                                geometry=geometry)
+
+            obj_list = [mpa.EigenmodeCoefficient(sim,mp.Volume(center=mp.Vector3(0.5*sxy-dpml),size=mp.Vector3(0,sxy,0)),1)]
+
+            def J(mode_mon):
+                return npa.abs(mode_mon)**2
+
+            opt = mpa.OptimizationProblem(
+                simulation = sim,
+                objective_functions = J,
+                objective_arguments = obj_list,
+                design_regions = [matgrid_region],
+                frequencies=[fcen],
+                decay_by = 1e-4,
+                decay_fields=[mp.Ez])
+
+            f, dJ_du = opt([design_params])
+
+            sim.reset_meep()
+
+            return dJ_du
+
+        design_params_orig = np.random.rand(Nx*Ny)
+
+        ## compute gradient using adjoint solver
+        adjsol_grad = adjoint_solver(design_params_orig)
+
+        ## compute gradient using finite differences
+        S12_unperturbed = forward_simulation(design_params_orig)
+
+        ## epsilon perturbation
+        deps = 1e-7
+
+        design_params = deepcopy(design_params_orig)
+        design_params[2984] = design_params[2984] + deps
+        S12_perturbed = forward_simulation(design_params)
+        fd_grad1 = (S12_perturbed - S12_unperturbed) / deps
+
+        print("gradient #1:, {:.10f}, {:.10f}".format(fd_grad1,adjsol_grad[2984]))
+        self.assertAlmostEqual(fd_grad1,adjsol_grad[2984],places=3)
+
+        design_params = deepcopy(design_params_orig)
+        design_params[5044] = design_params[5044] + deps
+        S12_perturbed = forward_simulation(design_params)
+        fd_grad2 = (S12_perturbed - S12_unperturbed) / deps
+
+        print("gradient #2:, {:.10f}, {:.10f}".format(fd_grad2,adjsol_grad[5044]))
+        self.assertAlmostEqual(fd_grad2,adjsol_grad[5044],places=3)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/adjoint_solver.py
+++ b/python/tests/adjoint_solver.py
@@ -1,5 +1,8 @@
 import meep as mp
-import adjoint as mpa
+try:
+    import meep.adjoint as mpa
+except:
+    import adjoint as mpa
 import numpy as np
 from autograd import numpy as npa
 from copy import deepcopy


### PR DESCRIPTION
Adds a new unit test for the adjoint solver which is based on computing the gradient of the scattering matrix element S<sub>12</sub> of a straight waveguide with respect to a square region of random ε (shown below) and comparing to the brute-force result based on a finite difference. The test verifies that the gradient at two randomly chosen positions in the design region computed using the adjoint solver and finite differences are equivalent to within three decimal places. The total runtime is ~20 seconds using a single Intel Xeon 4.20 GHz core.

![test_matgrid](https://user-images.githubusercontent.com/7152530/104662938-b8227280-5680-11eb-9a10-552f3989f7f2.png)

Note that `yee_grid=True` is used in the `add_mode_monitor` definition of the brute-force simulations in order to be consistent with its use in the adjoint solver:

https://github.com/NanoComp/meep/blob/36942d3356c37f630e60b4970da3420dd3ec2026/python/adjoint/objective.py#L43

Before this PR can be merged, [`python/Makefile.am`](https://github.com/NanoComp/meep/blob/master/python/Makefile.am) needs to be modified so that the `meep.adjoint` module can be loaded from the `python/adjoint` subdirectory otherwise `make check` will fail for this test. Note that `autograd` is a dependency for this test.