### PR TITLE
Clean runtime warnings

### DIFF
--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2198,32 +2198,76 @@ static void print_tensor(std::complex<double> *in) {
 
 /* convenience routine to get element of material tensors */
 static std::complex<double> cvec_to_value(vector3 diag, cvector3 offdiag, int idx) {
+  std::complex<double> val = std::complex<double>(0, 0);
   switch (idx) {
-    case 0: return std::complex<double>(diag.x, 0);
-    case 1: return std::complex<double>(offdiag.x.re, offdiag.x.im);
-    case 2: return std::complex<double>(offdiag.y.re, offdiag.y.im);
-    case 3: return std::complex<double>(offdiag.x.re, -offdiag.x.im);
-    case 4: return std::complex<double>(diag.y, 0);
-    case 5: return std::complex<double>(offdiag.z.re, offdiag.z.im);
-    case 6: return std::complex<double>(offdiag.y.re, -offdiag.y.im);
-    case 7: return std::complex<double>(offdiag.z.re, -offdiag.z.im);
-    case 8: return std::complex<double>(diag.z, 0);
+    case 0:
+      val = std::complex<double>(diag.x, 0);
+      break;
+    case 1:
+      val = std::complex<double>(offdiag.x.re, offdiag.x.im);
+      break;
+    case 2:
+      val = std::complex<double>(offdiag.y.re, offdiag.y.im);
+      break;
+    case 3:
+      val = std::complex<double>(offdiag.x.re, -offdiag.x.im);
+      break;
+    case 4:
+      val = std::complex<double>(diag.y, 0);
+      break;
+    case 5:
+      val = std::complex<double>(offdiag.z.re, offdiag.z.im);
+      break;
+    case 6:
+      val = std::complex<double>(offdiag.y.re, -offdiag.y.im);
+      break;
+    case 7:
+      val = std::complex<double>(offdiag.z.re, -offdiag.z.im);
+      break;
+    case 8:
+      val = std::complex<double>(diag.z, 0);
+      break;
+    default:
+      meep::abort("Invalid value in switch statement.");
   }
+  return val;
 }
 
 /* convenience routine to get element of material tensors */
 double vec_to_value(vector3 diag, vector3 offdiag, int idx) {
+  double val = 0.0;
   switch (idx) {
-    case 0: return diag.x;
-    case 1: return offdiag.x;
-    case 2: return offdiag.y;
-    case 3: return offdiag.x;
-    case 4: return diag.y;
-    case 5: return offdiag.z;
-    case 6: return offdiag.y;
-    case 7: return offdiag.z;
-    case 8: return diag.z;
+    case 0:
+      val = diag.x;
+      break;
+    case 1:
+      val = offdiag.x;
+      break;
+    case 2:
+      val = offdiag.y;
+      break;
+    case 3:
+      val = offdiag.x;
+      break;
+    case 4:
+      val = diag.y;
+      break;
+    case 5:
+      val = offdiag.z;
+      break;
+    case 6:
+      val = offdiag.y;
+      break;
+    case 7:
+      val = offdiag.z;
+      break;
+    case 8:
+      val = diag.z;
+      break;
+    default:
+      meep::abort("Invalid value in switch statement.");
   }
+  return val;
 }
 
 void get_material_tensor(const medium_struct *mm, meep::realnum freq,

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2345,7 +2345,7 @@ meep::realnum get_material_gradient(
   for (int i = 0; i < 9; i++)
     dA_du[i] = (dA_du_1[i] - dA_du_0[i]) / (2 * du);
 
-  int dir_idx;
+  int dir_idx = 0;
   if (field_dir == meep::Ex)
     dir_idx = 0;
   else if (field_dir == meep::Ey)
@@ -2516,8 +2516,8 @@ void material_grids_addgradient(meep::realnum *v, size_t ng, std::complex<double
   size_t dims[9] = {1, 1, 1, 1, 1, 1, 1, 1, 1};
   for (int c = 0; c < 3; c++) {
 
-    int rank = f->get_array_slice_dimensions(where, &dims[3 * c], dirs, true, false, min_max_loc,
-                                             0, field_dir[c]);
+    f->get_array_slice_dimensions(where, &dims[3 * c], dirs, true, false, min_max_loc,
+                                  0, field_dir[c]);
 
     vector3 max_corner = vec_to_vector3(min_max_loc[1]);
     meep::realnum max_c_array[3] = {max_corner.x, max_corner.y, max_corner.z};
@@ -2538,7 +2538,6 @@ void material_grids_addgradient(meep::realnum *v, size_t ng, std::complex<double
     s1 = s[c][0]; s2 = s[c][1]; s3 = s[c][2];
 
     for (int i1 = 0; i1 < nf; ++i1) {       // freq
-      meep::realnum *v_cur = &v[ng * i1];
       for (int i2 = 0; i2 < n2; ++i2) {     // x
         for (int i3 = 0; i3 < n3; ++i3) {   // y
           for (int i4 = 0; i4 < n4; ++i4) { // z

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1978,8 +1978,8 @@ void fragment_stats::update_stats_from_material(material_type mat, size_t pixels
           nonzero_conductivity_pixels_extmat_already_added =
               count_nonzero_conductivity_pixels(med, pixels);
         }
-        break;
       }
+      break;
     }
     default:
       // Only Medium and Material Function are supported

--- a/src/multilevel-atom.cpp
+++ b/src/multilevel-atom.cpp
@@ -88,7 +88,7 @@ extern "C" void DGETRI(const int *n, realnum *A, const int *lda, int *ipiv, real
 /* S -> inv(S), where S is a p x p matrix in row-major order */
 static bool invert(realnum *S, int p) {
 #ifdef HAVE_LAPACK
-  int info;
+  int info = 0;
   int *ipiv = new int[p];
   DGETRF(&p, &p, S, &p, ipiv, &info);
   if (info < 0) abort("invalid argument %d in DGETRF", -info);
@@ -98,11 +98,11 @@ static bool invert(realnum *S, int p) {
   } // singular
 
   int lwork = -1;
-  realnum work1;
+  realnum work1 = 0.0;
   DGETRI(&p, S, &p, ipiv, &work1, &lwork, &info);
   if (info != 0) abort("error %d in DGETRI workspace query", info);
   lwork = int(work1);
-  realnum *work = new realnum[lwork];
+  realnum *work = new realnum[lwork]();
   DGETRI(&p, S, &p, ipiv, work, &lwork, &info);
   if (info < 0) abort("invalid argument %d in DGETRI", -info);
 

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -524,7 +524,7 @@ void fields::add_volume_source(const src_time &src, const volume &where, gaussia
 
 gaussianbeam::gaussianbeam(const vec &x0_, const vec &kdir_, double w0_, double freq_,
                            double eps_, double mu_, std::complex<double> E0_[3]) {
-  if (x0.dim == Dcyl) abort("wrong dimensionality in gaussianbeam");
+  if (x0_.dim == Dcyl) abort("wrong dimensionality in gaussianbeam");
 
   x0 = x0_;
   kdir = kdir_;


### PR DESCRIPTION
CONTEXT: We observe some warnings related to meep c++ source code when unit tests are performed with MSan and ASan. We would like to clean the runtime warnings.

SCOPE:
1. Fixed a logic bug in `update_stats_from_material()`
2. Removed the fall-through warnings in switch statements and if statements.
3. Deleted unused variables.
4. Initialized variables and an array created by `new`.
5. Fixed a bug in the constructor function of `gaussianbeam` class.