### PR TITLE
unit test for adjoint solver involving DFT fields objective function

### DIFF
--- a/python/tests/adjoint_solver.py
+++ b/python/tests/adjoint_solver.py
@@ -9,9 +9,7 @@ from autograd import tensor_jacobian_product
 import unittest
 from enum import Enum
 
-class MonitorObject(Enum):
-    eigenmode = 1
-    DFT_fields = 2
+MonitorObject = Enum('MonitorObject', 'EIGENMODE DFT')
 
 resolution = 25
 
@@ -173,16 +171,16 @@ class TestAdjointSolver(unittest.TestCase):
 
     def test_adjoint_solver_DFT_fields(self):
         ## compute gradient using adjoint solver
-        adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.DFT_fields)
+        adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.DFT)
 
         ## compute unperturbed Ez2
-        Ez2_unperturbed = forward_simulation(p, MonitorObject.DFT_fields)
+        Ez2_unperturbed = forward_simulation(p, MonitorObject.DFT)
 
         print("Ez2:, {:.6f}, {:.6f}".format(adjsol_obj,Ez2_unperturbed))
         self.assertAlmostEqual(adjsol_obj,Ez2_unperturbed,places=3)
 
         ## compute perturbed Ez2
-        Ez2_perturbed = forward_simulation(p+dp, MonitorObject.DFT_fields)
+        Ez2_perturbed = forward_simulation(p+dp, MonitorObject.DFT)
 
         print("directional_derivative:, {:.6f}, {:.6f}".format(np.dot(dp,adjsol_grad),Ez2_perturbed-Ez2_unperturbed))
         self.assertAlmostEqual(np.dot(dp,adjsol_grad),Ez2_perturbed-Ez2_unperturbed,places=5)
@@ -190,16 +188,16 @@ class TestAdjointSolver(unittest.TestCase):
 
     def test_adjoint_solver_eigenmode(self):
         ## compute gradient using adjoint solver
-        adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.eigenmode)
+        adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.EIGENMODE)
 
         ## compute unperturbed S12
-        S12_unperturbed = forward_simulation(p, MonitorObject.eigenmode)
+        S12_unperturbed = forward_simulation(p, MonitorObject.EIGENMODE)
 
         print("S12:, {:.6f}, {:.6f}".format(adjsol_obj,S12_unperturbed))
         self.assertAlmostEqual(adjsol_obj,S12_unperturbed,places=3)
 
         ## compute perturbed S12
-        S12_perturbed = forward_simulation(p+dp, MonitorObject.eigenmode)
+        S12_perturbed = forward_simulation(p+dp, MonitorObject.EIGENMODE)
 
         print("directional_derivative:, {:.6f}, {:.6f}".format(np.dot(dp,adjsol_grad),S12_perturbed-S12_unperturbed))
         self.assertAlmostEqual(np.dot(dp,adjsol_grad),S12_perturbed-S12_unperturbed,places=5)
@@ -214,19 +212,19 @@ class TestAdjointSolver(unittest.TestCase):
         mapped_p = mapping(p,filter_radius,eta,beta)
 
         ## compute gradient using adjoint solver
-        adjsol_obj, adjsol_grad = adjoint_solver(mapped_p, MonitorObject.eigenmode)
+        adjsol_obj, adjsol_grad = adjoint_solver(mapped_p, MonitorObject.EIGENMODE)
 
         ## backpropagate the gradient
         bp_adjsol_grad = tensor_jacobian_product(mapping,0)(p,filter_radius,eta,beta,adjsol_grad)
 
         ## compute unperturbed S12
-        S12_unperturbed = forward_simulation(mapped_p, MonitorObject.eigenmode)
+        S12_unperturbed = forward_simulation(mapped_p, MonitorObject.EIGENMODE)
 
         print("S12:, {:.6f}, {:.6f}".format(adjsol_obj,S12_unperturbed))
         self.assertAlmostEqual(adjsol_obj,S12_unperturbed,places=3)
 
         ## compute perturbed S12
-        S12_perturbed = forward_simulation(mapping(p+dp,filter_radius,eta,beta), MonitorObject.eigenmode)
+        S12_perturbed = forward_simulation(mapping(p+dp,filter_radius,eta,beta), MonitorObject.EIGENMODE)
 
         print("directional_derivative:, {:.6f}, {:.6f}".format(np.dot(dp,bp_adjsol_grad),S12_perturbed-S12_unperturbed))
         self.assertAlmostEqual(np.dot(dp,bp_adjsol_grad),S12_perturbed-S12_unperturbed,places=5)

--- a/python/tests/adjoint_solver.py
+++ b/python/tests/adjoint_solver.py
@@ -7,8 +7,12 @@ import numpy as np
 from autograd import numpy as npa
 from autograd import tensor_jacobian_product
 import unittest
+from enum import Enum
 
-np.random.seed(9861548)
+class MonitorObject(Enum):
+    eigenmode = 1
+    DFT_fields = 2
+
 resolution = 25
 
 silicon = mp.Medium(epsilon=12)
@@ -26,7 +30,17 @@ design_region_resolution = int(2*resolution)
 Nx = int(design_region_resolution*design_shape.x)
 Ny = int(design_region_resolution*design_shape.y)
 
-w = 1.0 # waveguide width
+## ensure reproducible results
+np.random.seed(9861548)
+
+## random design region
+p = np.random.rand(Nx*Ny)
+
+## random epsilon perturbation for design region
+deps = 1e-5
+dp = deps*np.random.rand(Nx*Ny)
+
+w = 1.0
 waveguide_geometry = [mp.Block(material=silicon,
                                center=mp.Vector3(),
                                size=mp.Vector3(mp.inf,w,mp.inf))]
@@ -35,12 +49,12 @@ fcen = 1/1.55
 df = 0.2*fcen
 sources = [mp.EigenModeSource(src=mp.GaussianSource(fcen,fwidth=df),
                               center=mp.Vector3(-0.5*sxy+dpml,0),
-                              size=mp.Vector3(0,sxy,0),
+                              size=mp.Vector3(0,sxy),
                               eig_band=1,
-                              eig_parity=eig_parity,
-                              eig_match_freq=True)]
+                              eig_parity=eig_parity)]
 
-def forward_simulation(design_params):
+
+def forward_simulation(design_params,mon_type):
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
@@ -59,23 +73,41 @@ def forward_simulation(design_params):
                         sources=sources,
                         geometry=geometry)
 
-    mode = sim.add_mode_monitor(fcen, 0, 1,
-                                mp.ModeRegion(center=mp.Vector3(0.5*sxy-dpml),size=mp.Vector3(0,sxy,0)),
-                                yee_grid=True)
+    if mon_type.name == 'eigenmode':
+        mode = sim.add_mode_monitor(fcen,
+                                    0,
+                                    1,
+                                    mp.ModeRegion(center=mp.Vector3(0.5*sxy-dpml),size=mp.Vector3(0,sxy,0)),
+                                    yee_grid=True)
+
+    elif mon_type.name == 'DFT_fields':
+        mode = sim.add_dft_fields([mp.Ez],
+                                  fcen,
+                                  0,
+                                  1,
+                                  center=mp.Vector3(0.5*sxy-dpml),
+                                  size=mp.Vector3(0,sxy),
+                                  yee_grid=False)
 
     sim.run(until_after_sources=20)
 
-    # mode coefficients
-    coeff = sim.get_eigenmode_coefficients(mode,[1],eig_parity).alpha[0,0,0]
+    if mon_type.name == 'eigenmode':
+        coeff = sim.get_eigenmode_coefficients(mode,[1],eig_parity).alpha[0,0,0]
+        S12 = abs(coeff)**2
 
-    # S parameters
-    S12 = abs(coeff)**2
+    elif mon_type.name == 'DFT_fields':
+        Ez_dft = sim.get_dft_array(mode, mp.Ez, 0)
+        Ez2 = abs(Ez_dft[47])**2
 
     sim.reset_meep()
 
-    return S12
+    if mon_type.name == 'eigenmode':
+        return S12
+    elif mon_type.name == 'DFT_fields':
+        return Ez2
 
-def adjoint_solver(design_params):
+
+def adjoint_solver(design_params, mon_type):
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
@@ -97,12 +129,22 @@ def adjoint_solver(design_params):
                         sources=sources,
                         geometry=geometry)
 
-    obj_list = [mpa.EigenmodeCoefficient(sim,
-                                         mp.Volume(center=mp.Vector3(0.5*sxy-dpml),
-                                                   size=mp.Vector3(0,sxy,0)),1)]
+    if mon_type.name == 'eigenmode':
+        obj_list = [mpa.EigenmodeCoefficient(sim,
+                                             mp.Volume(center=mp.Vector3(0.5*sxy-dpml),
+                                                       size=mp.Vector3(0,sxy,0)),1)]
 
-    def J(mode_mon):
-        return npa.abs(mode_mon)**2
+        def J(mode_mon):
+            return npa.abs(mode_mon)**2
+
+    elif mon_type.name == 'DFT_fields':
+        obj_list = [mpa.FourierFields(sim,
+                                      mp.Volume(center=mp.Vector3(0.5*sxy-dpml),
+                                                size=mp.Vector3(0,sxy,0)),
+                                      mp.Ez)]
+
+        def J(mode_mon):
+            return npa.abs(mode_mon[0,47])**2
 
     opt = mpa.OptimizationProblem(
         simulation = sim,
@@ -118,6 +160,7 @@ def adjoint_solver(design_params):
 
     return f, dJ_du
 
+
 def mapping(x,filter_radius,eta,beta):
     filtered_field = mpa.conic_filter(x,filter_radius,design_shape.x,design_shape.y,design_region_resolution)
 
@@ -125,34 +168,44 @@ def mapping(x,filter_radius,eta,beta):
 
     return projected_field.flatten()
 
+
 class TestAdjointSolver(unittest.TestCase):
 
-    def test_adjoint_solver(self):
-        p = np.random.rand(Nx*Ny)
-
+    def test_adjoint_solver_DFT_fields(self):
         ## compute gradient using adjoint solver
-        adjsol_obj, adjsol_grad = adjoint_solver(p)
+        adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.DFT_fields)
+
+        ## compute unperturbed Ez2
+        Ez2_unperturbed = forward_simulation(p, MonitorObject.DFT_fields)
+
+        print("Ez2:, {:.6f}, {:.6f}".format(adjsol_obj,Ez2_unperturbed))
+        self.assertAlmostEqual(adjsol_obj,Ez2_unperturbed,places=3)
+
+        ## compute perturbed Ez2
+        Ez2_perturbed = forward_simulation(p+dp, MonitorObject.DFT_fields)
+
+        print("directional_derivative:, {:.6f}, {:.6f}".format(np.dot(dp,adjsol_grad),Ez2_perturbed-Ez2_unperturbed))
+        self.assertAlmostEqual(np.dot(dp,adjsol_grad),Ez2_perturbed-Ez2_unperturbed,places=5)
+
+
+    def test_adjoint_solver_eigenmode(self):
+        ## compute gradient using adjoint solver
+        adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.eigenmode)
 
         ## compute unperturbed S12
-        S12_unperturbed = forward_simulation(p)
+        S12_unperturbed = forward_simulation(p, MonitorObject.eigenmode)
 
         print("S12:, {:.6f}, {:.6f}".format(adjsol_obj,S12_unperturbed))
         self.assertAlmostEqual(adjsol_obj,S12_unperturbed,places=3)
 
-        ## random epsilon perturbation for computing gradient via finite difference
-        deps = 1e-5
-        dp = deps*np.random.rand(Nx*Ny)
-
         ## compute perturbed S12
-        S12_perturbed = forward_simulation(p+dp)
+        S12_perturbed = forward_simulation(p+dp, MonitorObject.eigenmode)
 
-        print("directional_derivative:, {:.10f}, {:.10f}".format(np.dot(dp,adjsol_grad),S12_perturbed-S12_unperturbed))
-        self.assertAlmostEqual(np.dot(dp,adjsol_grad),S12_perturbed-S12_unperturbed,places=6)
+        print("directional_derivative:, {:.6f}, {:.6f}".format(np.dot(dp,adjsol_grad),S12_perturbed-S12_unperturbed))
+        self.assertAlmostEqual(np.dot(dp,adjsol_grad),S12_perturbed-S12_unperturbed,places=5)
 
 
     def test_gradient_backpropagation(self):
-        p = np.random.rand(Nx*Ny)
-
         ## filter/thresholding parameters
         filter_radius = 0.21985
         eta = 0.49093
@@ -161,26 +214,23 @@ class TestAdjointSolver(unittest.TestCase):
         mapped_p = mapping(p,filter_radius,eta,beta)
 
         ## compute gradient using adjoint solver
-        adjsol_obj, adjsol_grad = adjoint_solver(mapped_p)
+        adjsol_obj, adjsol_grad = adjoint_solver(mapped_p, MonitorObject.eigenmode)
 
         ## backpropagate the gradient
         bp_adjsol_grad = tensor_jacobian_product(mapping,0)(p,filter_radius,eta,beta,adjsol_grad)
 
         ## compute unperturbed S12
-        S12_unperturbed = forward_simulation(mapped_p)
+        S12_unperturbed = forward_simulation(mapped_p, MonitorObject.eigenmode)
 
         print("S12:, {:.6f}, {:.6f}".format(adjsol_obj,S12_unperturbed))
         self.assertAlmostEqual(adjsol_obj,S12_unperturbed,places=3)
 
-        ## random epsilon perturbation for computing gradient via finite difference
-        deps = 1e-5
-        dp = deps*np.random.rand(Nx*Ny)
-
         ## compute perturbed S12
-        S12_perturbed = forward_simulation(mapping(p+dp,filter_radius,eta,beta))
+        S12_perturbed = forward_simulation(mapping(p+dp,filter_radius,eta,beta), MonitorObject.eigenmode)
 
-        print("directional_derivative:, {:.10f}, {:.10f}".format(np.dot(dp,bp_adjsol_grad),S12_perturbed-S12_unperturbed))
-        self.assertAlmostEqual(np.dot(dp,bp_adjsol_grad),S12_perturbed-S12_unperturbed,places=6)
+        print("directional_derivative:, {:.6f}, {:.6f}".format(np.dot(dp,bp_adjsol_grad),S12_perturbed-S12_unperturbed))
+        self.assertAlmostEqual(np.dot(dp,bp_adjsol_grad),S12_perturbed-S12_unperturbed,places=5)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds a unit test for the `FourierFields` class of the adjoint solver. This involved reorganizing `python/tests/adjoint_solver.py` in order to support separate unit tests for different objective functions within a single file.

Should be merged after #1487.

cc @mochen4 

