### PR TITLE
enable support for subpixel smoothing of MaterialGrid

### DIFF
--- a/python/geom.py
+++ b/python/geom.py
@@ -523,7 +523,7 @@ class Medium(object):
         return np.squeeze(epsmu)
 
 class MaterialGrid(object):
-    def __init__(self,grid_size,medium1,medium2,design_parameters=None,grid_type="U_DEFAULT",do_averaging=False):
+    def __init__(self,grid_size,medium1,medium2,design_parameters=None,grid_type="U_DEFAULT",do_averaging=False,beta=0,eta=0):
         self.grid_size = mp.Vector3(*grid_size)
         self.medium1 = medium1
         self.medium2 = medium2
@@ -537,6 +537,8 @@ class MaterialGrid(object):
             self.grid_size.z = 1
         self.num_params=int(self.grid_size.x*self.grid_size.y*self.grid_size.z)
         self.do_averaging = do_averaging
+        self.beta = beta
+        self.eta = eta
         if design_parameters is None:
             self.design_parameters = np.zeros((self.num_params,))
         elif design_parameters.size != self.num_params:

--- a/python/geom.py
+++ b/python/geom.py
@@ -523,7 +523,7 @@ class Medium(object):
         return np.squeeze(epsmu)
 
 class MaterialGrid(object):
-    def __init__(self,grid_size,medium1,medium2,design_parameters=None,grid_type="U_DEFAULT",do_averaging=False,beta=0,eta=0):
+    def __init__(self,grid_size,medium1,medium2,design_parameters=None,grid_type="U_DEFAULT",do_averaging=False,beta=0,eta=0.5):
         self.grid_size = mp.Vector3(*grid_size)
         self.medium1 = medium1
         self.medium2 = medium2

--- a/python/geom.py
+++ b/python/geom.py
@@ -523,7 +523,7 @@ class Medium(object):
         return np.squeeze(epsmu)
 
 class MaterialGrid(object):
-    def __init__(self,grid_size,medium1,medium2,design_parameters=None,grid_type="U_DEFAULT"):
+    def __init__(self,grid_size,medium1,medium2,design_parameters=None,grid_type="U_DEFAULT",do_averaging=False):
         self.grid_size = mp.Vector3(*grid_size)
         self.medium1 = medium1
         self.medium2 = medium2
@@ -536,7 +536,7 @@ class MaterialGrid(object):
         if isclose(self.grid_size.z,0):
             self.grid_size.z = 1
         self.num_params=int(self.grid_size.x*self.grid_size.y*self.grid_size.z)
-
+        self.do_averaging = do_averaging
         if design_parameters is None:
             self.design_parameters = np.zeros((self.num_params,))
         elif design_parameters.size != self.num_params:

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -525,7 +525,13 @@ static int pymaterial_to_material(PyObject *po, material_type *mt) {
     PyObject *py_do_averaging = PyObject_GetAttrString(po, "do_averaging");
     bool do_averaging = false;
     if (py_do_averaging) { do_averaging = PyObject_IsTrue(py_do_averaging); }
-    md = make_material_grid(do_averaging);
+    PyObject *py_beta = PyObject_GetAttrString(po, "beta");
+    double beta = 0;
+    if (py_beta) { beta = PyFloat_AsDouble(py_beta); }
+    PyObject *py_eta = PyObject_GetAttrString(po, "eta");
+    double eta = 0;
+    if (py_eta) { eta = PyFloat_AsDouble(py_eta); }
+    md = make_material_grid(do_averaging,beta,eta);
     if (!pymaterial_grid_to_material_grid(po, md)) { return 0; }
     Py_XDECREF(py_do_averaging);
   }

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -522,8 +522,12 @@ static int pymaterial_to_material(PyObject *po, material_type *mt) {
     if (!pymedium_to_medium(po, &md->medium)) { return 0; }
   }
   else if (PyObject_IsInstance(po, py_material_grid_object())) { // Material grid subclass
-    md = make_material_grid();
+    PyObject *py_do_averaging = PyObject_GetAttrString(po, "do_averaging");
+    bool do_averaging = false;
+    if (py_do_averaging) { do_averaging = PyObject_IsTrue(py_do_averaging); }
+    md = make_material_grid(do_averaging);
     if (!pymaterial_grid_to_material_grid(po, md)) { return 0; }
+    Py_XDECREF(py_do_averaging);
   }
   else if (PyFunction_Check(po)) {
     PyObject *eps = PyObject_GetAttrString(po, "eps");

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -534,6 +534,8 @@ static int pymaterial_to_material(PyObject *po, material_type *mt) {
     md = make_material_grid(do_averaging,beta,eta);
     if (!pymaterial_grid_to_material_grid(po, md)) { return 0; }
     Py_XDECREF(py_do_averaging);
+    Py_XDECREF(py_beta);
+    Py_XDECREF(py_eta);
   }
   else if (PyFunction_Check(po)) {
     PyObject *eps = PyObject_GetAttrString(po, "eps");

--- a/src/material_data.hpp
+++ b/src/material_data.hpp
@@ -190,6 +190,8 @@ struct material_data {
   meep::realnum *design_parameters;
   medium_struct medium_1;
   medium_struct medium_2;
+  meep::realnum beta;
+  meep::realnum eta;
   /*
   There are several possible scenarios when material grids overlap -- these
   different scenarios enable different applications.
@@ -243,7 +245,7 @@ extern material_type vacuum;
 material_type make_dielectric(double epsilon);
 material_type make_user_material(user_material_func user_func, void *user_data);
 material_type make_file_material(char *epsilon_input_file);
-material_type make_material_grid();
+material_type make_material_grid(bool do_averaging, double beta, double eta);
 void read_epsilon_file(const char *eps_input_file);
 void update_design_parameters(material_type matgrid, double *design_parameters);
 

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -359,9 +359,11 @@ meep::realnum matgrid_val(vector3 p, geom_box_tree tp, int oi, material_data *md
 
   // project interpolated grid point
   meep::realnum u_proj;
-  if (md->beta)
-    u_proj = (tanh(md->beta*md->eta) + tanh(md->beta*(u_interp-md->eta))) /
-      (tanh(md->beta*md->eta) + tanh(md->beta*(1-md->eta)));
+  if (md->beta != 0) {
+    double tanh_beta_eta = tanh(md->beta*md->eta);
+    u_proj = (tanh_beta_eta + tanh(md->beta*(u_interp-md->eta))) /
+      (tanh_beta_eta + tanh(md->beta*(1-md->eta)));
+  }
 
   return md->beta ? u_proj : u_interp;
 }
@@ -1808,7 +1810,7 @@ material_type make_file_material(const char *eps_input_file) {
 /******************************************************************************/
 /* Material grid functions                                                    */
 /******************************************************************************/
-  material_type make_material_grid(bool do_averaging, double beta, double eta) {
+material_type make_material_grid(bool do_averaging, double beta, double eta) {
   material_data *md = new material_data();
   md->which_subclass = material_data::MATERIAL_GRID;
   md->do_averaging = do_averaging;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -869,7 +869,6 @@ void geom_epsilon::eff_chi1inv_row(meep::component c, double chi1inv_row[3], con
   symmetric_matrix meps_inv;
   bool fallback;
   eff_chi1inv_matrix(c, &meps_inv, v, tol, maxeval, fallback);
-  ;
 
   if (fallback) { fallback_chi1inv_row(c, chi1inv_row, v, tol, maxeval); }
   else {
@@ -916,7 +915,9 @@ void geom_epsilon::eff_chi1inv_matrix(meep::component c, symmetric_matrix *chi1i
 
   if (!get_front_object(v, geometry_tree, p, &o, shiftby, mat, mat_behind)) {
     get_material_pt(mat, v.center());
-    if (mat && mat->which_subclass == material_data::MATERIAL_USER && mat->do_averaging) {
+    if (mat && (mat->which_subclass == material_data::MATERIAL_USER ||
+                mat->which_subclass == material_data::MATERIAL_GRID)
+        && mat->do_averaging) {
       fallback = true;
       return;
     }
@@ -1797,10 +1798,10 @@ material_type make_file_material(const char *eps_input_file) {
 /******************************************************************************/
 /* Material grid functions                                                    */
 /******************************************************************************/
-material_type make_material_grid() {
+material_type make_material_grid(bool do_averaging) {
   material_data *md = new material_data();
   md->which_subclass = material_data::MATERIAL_GRID;
-  md->do_averaging = false;
+  md->do_averaging = do_averaging;
   return md;
 }
 

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -365,7 +365,7 @@ meep::realnum matgrid_val(vector3 p, geom_box_tree tp, int oi, material_data *md
       (tanh_beta_eta + tanh(md->beta*(1-md->eta)));
   }
 
-  return md->beta ? u_proj : u_interp;
+  return (md->beta != 0) ? u_proj : u_interp;
 }
 static void cinterp_tensors(vector3 diag_in_1, cvector3 offdiag_in_1, vector3 diag_in_2,
                             cvector3 offdiag_in_2, vector3 *diag_out, cvector3 *offdiag_out,

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -174,7 +174,7 @@ void set_materials_from_geometry(meep::structure *s, geometric_object_list g,
 material_type make_dielectric(double epsilon);
 material_type make_user_material(user_material_func user_func, void *user_data, bool do_averaging);
 material_type make_file_material(const char *eps_input_file);
-material_type make_material_grid();
+material_type make_material_grid(bool do_averaging);
 
 vector3 vec_to_vector3(const meep::vec &pt);
 meep::vec vector3_to_vec(const vector3 v3);

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -174,7 +174,7 @@ void set_materials_from_geometry(meep::structure *s, geometric_object_list g,
 material_type make_dielectric(double epsilon);
 material_type make_user_material(user_material_func user_func, void *user_data, bool do_averaging);
 material_type make_file_material(const char *eps_input_file);
-material_type make_material_grid(bool do_averaging);
+material_type make_material_grid(bool do_averaging, double beta, double eta);
 
 vector3 vec_to_vector3(const meep::vec &pt);
 meep::vec vector3_to_vec(const vector3 v3);


### PR DESCRIPTION
Closes #1500.

After some recent consultation with @smartalecH, it turns out enabling subpixel smoothing for the `MaterialGrid` is actually much easier than expected. All that is required is to make sure that the parameter `fallback` is set to `true` inside `geom_epsilon::eff_chi1inv_matrix` in order to use the *existing* adaptive quadrature routine from libctl:

https://github.com/NanoComp/meep/blob/7067536d9db2d229f7717b49f8bdb5abab0c3e10/src/meepgeom.cpp#L874

Because the routine `geom_epsilon::fallback_chi1inv_row` invokes `geom_epsilon::get_material_pt(material_type &material, const meep::vec &r)` to obtain ε at a given point `r` for which the use case of `material` as a material grid is *already* supported, no additional functions need to be added. In fact, setting it up this way means that subpixel smoothing also automatically supports symmetries for the material grid.

This PR simply adds a new `do_averaging` boolean property to the `MaterialGrid` object (default is `False`) which is passed from the Python interface into `geom_epsilon::eff_chi1inv_matrix` in C/C++. This means that the existing parameters `subpixel_maxeval` and `subpixel_tol` for the `Simulation` constructor which are used to specify the properties of the quadrature scheme can be used as-is.

The convergence test described in #1500 (shown below) verifies that the quadrature scheme for the `MaterialGrid` is second-order accurate (green line). This requires making sure that the resolution of the `MaterialGrid` is suffficiently higher than Meep's Yee grid (in this example, the ratio is `100`). If the resolution of the `MaterialGrid` is small relative to the Meep resolution (e.g., 2X), the convergence is closer to first-order accurate.

The next feature to add is the gradient of the subpixel smoothing for back propagation.

![relerr_vs_resolution](https://user-images.githubusercontent.com/7152530/107998590-4fd5f200-6f9a-11eb-9e4f-32f70c230244.png)

```py
import numpy as np
import argparse
import meep as mp

parser = argparse.ArgumentParser()
parser.add_argument('-res',
                    type=int,
                    default=20,
                    help='resolution (default: 20 pixels/um)')
parser.add_argument('-geom_type',
                    type=int,
                    choices=[1,2],
                    default=1,
                    help='type of geometry: 1: Cylinder (default), 2: material grid')
args = parser.parse_args()

cell_size = mp.Vector3(1,1,0)

rad = 0.301943

if args.geom_type == 1:
    geometry = [mp.Cylinder(radius=rad,
                            center=mp.Vector3(),
                            height=mp.inf,
                            material=mp.Medium(index=3.5))]
else:
    design_shape = mp.Vector3(1,1,0)
    design_region_resolution = int(100*args.res)
    Nx = int(design_region_resolution*design_shape.x)
    Ny = int(design_region_resolution*design_shape.y)
    x = np.linspace(-0.5*cell_size.x,0.5*cell_size.x,Nx)
    y = np.linspace(-0.5*cell_size.y,0.5*cell_size.y,Ny)
    xv, yv = np.meshgrid(x,y)
    design_params = np.sqrt(np.square(xv) + np.square(yv)) < rad

    matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                              mp.air,
                              mp.Medium(index=3.5),
                              design_parameters=design_params,
                              grid_type='U_SUM',
                              do_averaging=True)

    geometry = [mp.Block(center=mp.Vector3(),
                         size=mp.Vector3(design_shape.x,design_shape.y,0),
                         material=matgrid)]

fcen = 0.3
df = 0.2*fcen
sources = [mp.Source(mp.GaussianSource(fcen,fwidth=df),
                     component=mp.Hz,
                     center=mp.Vector3(-0.1057,0.2094,0))]

k_point = mp.Vector3(0.3892,0.1597,0)

sim = mp.Simulation(resolution=args.res,
                    cell_size=cell_size,
                    geometry=geometry,
                    sources=sources,
                    k_point=k_point)

h = mp.Harminv(mp.Hz, mp.Vector3(0.3718,-0.2076), fcen, df)
sim.run(mp.after_sources(h),
        until_after_sources=200)

for m in h.modes:
    print("harminv:, {}, {}, {}".format(args.res,m.freq,m.Q))
```