### PR TITLE
clean up grid_volume::split_at_fraction

### DIFF
--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -989,7 +989,7 @@ public:
   friend grid_volume vol2d(double xsize, double ysize, double a);
   friend grid_volume vol3d(double xsize, double ysize, double zsize, double a);
 
-  grid_volume split_at_fraction(bool want_high, int numer, int bestd = -1, int bestlen = 1) const;
+  grid_volume split_at_fraction(bool side_high, int split_pt, int split_dir) const;
   double get_cost() const;
   grid_volume halve(direction d) const;
   void pad_self(direction d);

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -87,11 +87,10 @@ static void split_by_cost(int n, grid_volume gvol,
     direction best_split_direction;
     double left_effort_fraction;
     gvol.find_best_split(n, fragment_cost, best_split_point, best_split_direction, left_effort_fraction);
-    int num_in_split_dir = gvol.num_direction(best_split_direction);
-    grid_volume left_gvol = gvol.split_at_fraction(false, best_split_point, best_split_direction, num_in_split_dir);
+    grid_volume left_gvol = gvol.split_at_fraction(false, best_split_point, best_split_direction);
     const int num_left = (size_t)(left_effort_fraction * n + 0.5);
     split_by_cost(num_left, left_gvol, result, fragment_cost);
-    grid_volume right_gvol = gvol.split_at_fraction(true, best_split_point, best_split_direction, num_in_split_dir);
+    grid_volume right_gvol = gvol.split_at_fraction(true, best_split_point, best_split_direction);
     split_by_cost(n - num_left, right_gvol, result, fragment_cost);
     return;
   }

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1035,38 +1035,21 @@ void grid_volume::find_best_split(int desired_chunks, bool fragment_cost,
   }
 }
 
-grid_volume grid_volume::split_at_fraction(bool want_high, int numer, int bestd,
-                                           int bestlen) const {
-
-  if (bestd == -1) {
-    for (int i = 0; i < 3; i++)
-      if (num[i] > bestlen) {
-        bestd = i;
-        bestlen = num[i];
-      }
-  }
-  else {
-    bestd %= 3;
-  }
-
-  if (bestd == -1) {
-    for (int i = 0; i < 3; i++)
-      master_printf("num[%d] = %d\n", i, num[i]);
-    abort("Crazy weird splitting error.\n");
-  }
+grid_volume grid_volume::split_at_fraction(bool side_high, int split_pt, int split_dir) const {
+  if (dim == Dcyl) split_dir %= 3;
   grid_volume retval(dim, a, 1, 1, 1);
   for (int i = 0; i < 3; i++)
     retval.num[i] = num[i];
-  if (numer >= num[bestd]) abort("Aaack bad bug in split_at_fraction.\n");
-  direction d = (direction)bestd;
+  if (split_pt >= num[split_dir]) abort("Aaack bad bug in split_at_fraction.\n");
+  direction d = (direction)split_dir;
   if (dim == Dcyl && d == X) d = R;
   retval.set_origin(io);
-  if (want_high) retval.shift_origin(d, numer * 2);
+  if (side_high) retval.shift_origin(d, split_pt * 2);
 
-  if (want_high)
-    retval.num[bestd] -= numer;
+  if (side_high)
+    retval.num[split_dir] -= split_pt;
   else
-    retval.num[bestd] = numer;
+    retval.num[split_dir] = split_pt;
   retval.num_changed();
   return retval;
 }


### PR DESCRIPTION
This PR cleans up `grid_volume::split_at_fraction` by removing an unused argument (`bestlen`) and a portion of this function which is never actually used in practice (`bestd == -1`). These items were added by #681 and also b11d5ad45507 (bit rotted; Oct. 2003). The remaining three arguments to `split_at_fraction` have been renamed to improve code readability.

This PR is meant to precede a forthcoming PR which will add a new `split_by_binarytree` function (#1510).