### PR TITLE
 remove deprecated features and minor tweaks to docs

### DIFF
--- a/doc/docs/Python_Tutorials/GDSII_Import.md
+++ b/doc/docs/Python_Tutorials/GDSII_Import.md
@@ -217,6 +217,9 @@ In the limit of infinite resolution, the discretization error is removed and the
 In the directional coupler example above, individual layers of the GDS file were imported by specifying a single number in the `get_GDSII_prisms` routine (i.e., 1, 2, 31, 32, etc.). However, there are certain GDS files in which the layers are referenced using a 2-tuple (e.g., (37,4)). Since `get_GDSII_prisms` which is based on [`libGDSII`](https://github.com/HomerReid/libGDSII) does not support this feature, you will need to use [`gdspy`](https://gdspy.readthedocs.io/) as demonstrated in the following example.
 
 ```py
+import meep as mp
+import gdspy
+
 ## load the GDS file
 gds = gdspy.GdsLibrary(infile=gds_file)
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -431,12 +431,12 @@ def use_output_directory(self, dname=''):
 
 <div class="method_docstring" markdown="1">
 
-Put output in a subdirectory, which is created if necessary. If the optional
-argument `dname` is specified, that is the name of the directory. If the `dname`
-is omitted, the directory name is the current Python file name (if `filename_prefix`
-is `None`) with `".py"` replaced by `"-out"`: e.g. `test.py` implies a directory of
-`"test-out"`. Also resets `filename_prefix` to `None`. Otherwise the directory name
-is set to `filename_prefix`.
+Output all files into a subdirectory, which is created if necessary. If the optional
+argument `dname` is specified, that is the name of the directory. If `dname`
+is omitted and `filename_prefix` is `None`, the directory name is the current Python
+filename with `".py"` replaced by `"-out"`: e.g. `test.py` implies a directory of
+`"test-out"`. If `dname` is omitted and `filename_prefix` has been set, the directory
+name is set to `filename_prefix` + "-out" and `filename_prefix` is then reset to `None`.
 
 </div>
 
@@ -633,7 +633,7 @@ returns the value of that component at that point.
 <div class="class_members" markdown="1">
 
 ```python
-def get_epsilon_point(self, pt, frequency=0, omega=0):
+def get_epsilon_point(self, pt, frequency=0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -652,7 +652,7 @@ frequency-independent part of $\varepsilon$ (the $\omega\to\infty$ limit).
 <div class="class_members" markdown="1">
 
 ```python
-def get_mu_point(self, pt, frequency=0, omega=0):
+def get_mu_point(self, pt, frequency=0):
 ```
 
 <div class="method_docstring" markdown="1">
@@ -4195,18 +4195,18 @@ def __init__(self,
 
 Creates a `MaterialGrid` object.
 
-The input are two materials `medium1` and `medium2` along with a weight function $u(x)$ which is defined on the Cartesian grid points
+The input are two materials `medium1` and `medium2` along with a weight function $u(x)$ which is defined on a Cartesian grid
 by the NumPy array `weights` of size `grid_size` (a 3-tuple or `Vector3` of integers). Elements of the `weights` array must be in the
-range [0,1] where 0 is `medium1` and 1 is `medium2`. Currently, only two material types are supported: (1) frequency-independent
+range [0,1] where 0 is `medium1` and 1 is `medium2`. Two material types are supported: (1) frequency-independent
 isotropic $\varepsilon$ or $\mu$ and (2) `LorentzianSusceptibility`. `medium1` and `medium2` must both be the same type. The
-materials are bilinearly interpolated from the Cartesian grid points to Meep's [Yee grid](Yee_Lattice.md).
+materials are bilinearly interpolated from the Cartesian grid to Meep's [Yee grid](Yee_Lattice.md).
 
 For improving accuracy, [subpixel smoothing](Subpixel_Smoothing.md) can be enabled by specifying `do_averaging=True`.
 If you want to use a material grid to define a (nearly) discontinuous, piecewise-constant material that is *either* `medium1`
 or `medium2` almost everywhere, you can optionally enable a (smoothed) *projection* feature by setting the parameter `beta`
 to a positive value. When the projection feature is enabled, the weights $u(x)$ can be thought of as a [level-set
 function](https://en.wikipedia.org/wiki/Level-set_method) defining an interface at $u(x)=\eta$ with a smoothing factor
-$\beta$ where $\beta=\infty$ gives an unsmoothed, discontinuous interface. The projection operator is $(\tanh(\beta\times\eta)
+$\beta$ where $\beta=+\infty$ gives an unsmoothed, discontinuous interface. The projection operator is $(\tanh(\beta\times\eta)
 +\tanh(\beta\times(u-\eta)))/(\tanh(\beta\times\eta)+\tanh(\beta\times(1-\eta)))$ involving the parameters `beta`
 ($\beta$: "smoothness" of the turn on) and `eta` ($\eta$: erosion/dilation). The level set provides a general approach for
 defining a *discontinuous* function from otherwise continuously varying (via the bilinear interpolation) grid values.
@@ -7293,24 +7293,6 @@ Miscellaneous Functions Reference
 ---------------------------------
 
 
-<a id="quiet"></a>
-
-```python
-def quiet(quietval=True):
-```
-
-<div class="function_docstring" markdown="1">
-
-Meep ordinarily prints various diagnostic and progress information to standard output.
-This output can be suppressed by calling this function with `True` (the default). The
-output can be enabled again by passing `False`. This sets a global variable, so the
-value will persist across runs within the same script.
-
-This function is deprecated, please use the [Verbosity](#verbosity) class instead.
-
-</div>
-
-
 <a id="interpolate"></a>
 
 ```python
@@ -7319,7 +7301,7 @@ def interpolate(n, nums):
 
 <div class="function_docstring" markdown="1">
 
-Given a list of numbers or `Vector3`s `nums`, linearly interpolates between them to
+Given a list of numbers or `Vector3`s as `nums`, linearly interpolates between them to
 add `n` new evenly-spaced values between each pair of consecutive values in the
 original list.
 

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -826,8 +826,6 @@ The following classes are available directly via the `meep` package.
 Miscellaneous Functions Reference
 ---------------------------------
 
-@@ quiet @@
-
 @@ interpolate @@
 
 #### Flux functions

--- a/python/geom.py
+++ b/python/geom.py
@@ -532,18 +532,18 @@ class MaterialGrid(object):
         """
         Creates a `MaterialGrid` object.
 
-        The input are two materials `medium1` and `medium2` along with a weight function $u(x)$ which is defined on the Cartesian grid points
+        The input are two materials `medium1` and `medium2` along with a weight function $u(x)$ which is defined on a Cartesian grid
         by the NumPy array `weights` of size `grid_size` (a 3-tuple or `Vector3` of integers). Elements of the `weights` array must be in the
-        range [0,1] where 0 is `medium1` and 1 is `medium2`. Currently, only two material types are supported: (1) frequency-independent
+        range [0,1] where 0 is `medium1` and 1 is `medium2`. Two material types are supported: (1) frequency-independent
         isotropic $\\varepsilon$ or $\\mu$ and (2) `LorentzianSusceptibility`. `medium1` and `medium2` must both be the same type. The
-        materials are bilinearly interpolated from the Cartesian grid points to Meep's [Yee grid](Yee_Lattice.md).
+        materials are bilinearly interpolated from the Cartesian grid to Meep's [Yee grid](Yee_Lattice.md).
 
         For improving accuracy, [subpixel smoothing](Subpixel_Smoothing.md) can be enabled by specifying `do_averaging=True`.
         If you want to use a material grid to define a (nearly) discontinuous, piecewise-constant material that is *either* `medium1`
         or `medium2` almost everywhere, you can optionally enable a (smoothed) *projection* feature by setting the parameter `beta`
         to a positive value. When the projection feature is enabled, the weights $u(x)$ can be thought of as a [level-set
         function](https://en.wikipedia.org/wiki/Level-set_method) defining an interface at $u(x)=\\eta$ with a smoothing factor
-        $\\beta$ where $\\beta=\\infty$ gives an unsmoothed, discontinuous interface. The projection operator is $(\\tanh(\\beta\\times\\eta)
+        $\\beta$ where $\\beta=+\\infty$ gives an unsmoothed, discontinuous interface. The projection operator is $(\\tanh(\\beta\\times\\eta)
         +\\tanh(\\beta\\times(u-\\eta)))/(\\tanh(\\beta\\times\\eta)+\\tanh(\\beta\\times(1-\\eta)))$ involving the parameters `beta`
         ($\\beta$: "smoothness" of the turn on) and `eta` ($\\eta$: erosion/dilation). The level set provides a general approach for
         defining a *discontinuous* function from otherwise continuously varying (via the bilinear interpolation) grid values.

--- a/python/meep.i
+++ b/python/meep.i
@@ -1758,7 +1758,6 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         output_sfield_r,
         output_sfield_p,
         py_v3_to_vec,
-        quiet,
         scale_energy_fields,
         scale_flux_fields,
         scale_force_fields,

--- a/python/meep.i
+++ b/python/meep.i
@@ -1758,6 +1758,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         output_sfield_r,
         output_sfield_p,
         py_v3_to_vec,
+        quiet,
         scale_energy_fields,
         scale_flux_fields,
         scale_force_fields,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1937,10 +1937,6 @@ class Simulation(object):
 
         self._is_initialized = True
 
-    def init_fields(self):
-        warnings.warn('init_fields is deprecated. Please use init_sim instead', DeprecationWarning)
-        self.init_sim()
-
     def initialize_field(self, cmpnt, amp_func):
         """
         Initialize the component `c` fields using the function `func` which has a single
@@ -2064,7 +2060,7 @@ class Simulation(object):
         v3 = py_v3_to_vec(self.dimensions, pt, self.is_cylindrical)
         return self.fields.get_field_from_comp(c, v3)
 
-    def get_epsilon_point(self, pt, frequency=0, omega=0):
+    def get_epsilon_point(self, pt, frequency=0):
         """
         Given a frequency `frequency` and a `Vector3` `pt`, returns the average eigenvalue
         of the permittivity tensor at that location and frequency. If `frequency` is
@@ -2072,12 +2068,9 @@ class Simulation(object):
         frequency-independent part of $\\varepsilon$ (the $\\omega\\to\\infty$ limit).
         """
         v3 = py_v3_to_vec(self.dimensions, pt, self.is_cylindrical)
-        if omega != 0:
-            frequency = omega
-            warnings.warn("get_epsilon_point: omega has been deprecated; use frequency instead", RuntimeWarning)
         return self.fields.get_eps(v3,frequency)
 
-    def get_mu_point(self, pt, frequency=0, omega=0):
+    def get_mu_point(self, pt, frequency=0):
         """
         Given a frequency `frequency` and a `Vector3` `pt`, returns the average eigenvalue
         of the permeability tensor at that location and frequency. If `frequency` is
@@ -2085,9 +2078,6 @@ class Simulation(object):
         frequency-independent part of $\\mu$ (the $\\omega\\to\\infty$ limit).
         """
         v3 = py_v3_to_vec(self.dimensions, pt, self.is_cylindrical)
-        if omega != 0:
-            frequency = omega
-            warnings.warn("get_mu_point: omega has been deprecated; use frequency instead", RuntimeWarning)
         return self.fields.get_mu(v3,frequency)
 
     def get_filename_prefix(self):
@@ -2115,12 +2105,12 @@ class Simulation(object):
 
     def use_output_directory(self, dname=''):
         """
-        Put output in a subdirectory, which is created if necessary. If the optional
-        argument `dname` is specified, that is the name of the directory. If the `dname`
-        is omitted, the directory name is the current Python file name (if `filename_prefix`
-        is `None`) with `".py"` replaced by `"-out"`: e.g. `test.py` implies a directory of
-        `"test-out"`. Also resets `filename_prefix` to `None`. Otherwise the directory name
-        is set to `filename_prefix`.
+        Output all files into a subdirectory, which is created if necessary. If the optional
+        argument `dname` is specified, that is the name of the directory. If `dname`
+        is omitted and `filename_prefix` is `None`, the directory name is the current Python
+        filename with `".py"` replaced by `"-out"`: e.g. `test.py` implies a directory of
+        `"test-out"`. If `dname` is omitted and `filename_prefix` has been set, the directory
+        name is set to `filename_prefix` + "-out" and `filename_prefix` is then reset to `None`.
         """
         if not dname:
             dname = self.get_filename_prefix() + '-out'
@@ -2825,10 +2815,6 @@ class Simulation(object):
 
         return self.fields.add_mode_monitor(d, v.swigobj, freq, centered_grid)
 
-    def add_eigenmode(self, *args):
-        warnings.warn('add_eigenmode is deprecated. Please use add_mode_monitor instead.', DeprecationWarning)
-        return self.add_mode_monitor(args)
-
     def display_fluxes(self, *fluxes):
         """
         Given a number of flux objects, this displays a comma-separated table of
@@ -3059,17 +3045,13 @@ class Simulation(object):
 
         return stuff
 
-    def output_component(self, c, h5file=None, frequency=0, omega=0):
+    def output_component(self, c, h5file=None, frequency=0):
         if self.fields is None:
             raise RuntimeError("Fields must be initialized before calling output_component")
 
         vol = self.fields.total_volume() if self.output_volume is None else self.output_volume
         h5 = self.output_append_h5 if h5file is None else h5file
         append = h5file is None and self.output_append_h5 is not None
-
-        if omega != 0:
-            frequency = omega
-            warnings.warn("output_component: omega has been deprecated; use frequency instead", RuntimeWarning)
 
         self.fields.output_hdf5(c, vol, h5, append, self.output_single_precision,self.get_filename_prefix(), frequency)
 
@@ -4465,10 +4447,6 @@ def output_epsilon(sim=None,*step_func_args,**kwargs):
         return lambda sim: mp.output_epsilon(sim, *step_func_args, **kwargs)
 
     frequency = kwargs.pop('frequency', 0.0)
-    omega = kwargs.pop('omega', 0.0)
-    if omega != 0:
-        frequency = omega
-        warnings.warn("output_epsilon: omega has been deprecated; use frequency instead", RuntimeWarning)
     sim.output_component(mp.Dielectric,frequency=frequency)
 
 
@@ -4487,10 +4465,6 @@ def output_mu(sim=None,*step_func_args,**kwargs):
         return lambda sim: mp.output_mu(sim, *step_func_args, **kwargs)
 
     frequency = kwargs.pop('frequency', 0.0)
-    omega = kwargs.pop('omega', 0.0)
-    if omega != 0:
-        frequency = omega
-        warnings.warn("output_mu: omega has been deprecated; use frequency instead", RuntimeWarning)
     sim.output_component(mp.Permeability,frequency=frequency)
 
 
@@ -5086,18 +5060,6 @@ def complexarray(re, im):
     z = im * 1j
     z += re
     return z
-
-
-def quiet(quietval=True):
-    """
-    Meep ordinarily prints various diagnostic and progress information to standard output.
-    This output can be suppressed by calling this function with `True` (the default). The
-    output can be enabled again by passing `False`. This sets a global variable, so the
-    value will persist across runs within the same script.
-
-    This function is deprecated, please use the [Verbosity](#verbosity) class instead.
-    """
-    verbosity(int(not quietval))
 
 
 def get_num_groups():

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -5061,6 +5061,18 @@ def complexarray(re, im):
     z += re
     return z
 
+def quiet(quietval=True):
+    """
+    Meep ordinarily prints various diagnostic and progress information to standard output.
+    This output can be suppressed by calling this function with `True` (the default). The
+    output can be enabled again by passing `False`. This sets a global variable, so the
+    value will persist across runs within the same script.
+
+    This function is deprecated, please use the [Verbosity](#verbosity) class instead.
+    """
+    verbosity(int(not quietval))
+    warnings.warn("quiet has been deprecated; use the Verbosity class instead", RuntimeWarning)
+
 
 def get_num_groups():
     # Lazy import

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4968,7 +4968,7 @@ def get_total_energy(f):
 
 def interpolate(n, nums):
     """
-    Given a list of numbers or `Vector3`s `nums`, linearly interpolates between them to
+    Given a list of numbers or `Vector3`s as `nums`, linearly interpolates between them to
     add `n` new evenly-spaced values between each pair of consecutive values in the
     original list.
     """

--- a/python/tests/adjoint_solver.py
+++ b/python/tests/adjoint_solver.py
@@ -8,7 +8,6 @@ from autograd import numpy as npa
 from autograd import tensor_jacobian_product
 import unittest
 from enum import Enum
-mp.quiet(True)
 
 MonitorObject = Enum('MonitorObject', 'EIGENMODE DFT')
 

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -670,6 +670,7 @@ def visualize_chunks(sim):
 
         ax.set_xlabel('x')
         ax.set_ylabel('y')
+        ax.set_aspect('equal')
 
         cell_box = mp.gv2box(sim.structure.gv.surroundings())
         if sim.structure.gv.dim == 2:
@@ -680,7 +681,6 @@ def visualize_chunks(sim):
         else:
             ax.set_xlim(left=cell_box.low.x,right=cell_box.high.x)
             ax.set_ylim(bottom=cell_box.low.y,top=cell_box.high.y)
-            ax.set_aspect('equal')
 
         plt.tight_layout()
         plt.show()


### PR DESCRIPTION
Removes the deprecated `quiet` variable from the docs as well as the `omega` argument of several output functions including warnings that they are deprecated.

Also includes some minor tweaks to the docs.