### PR TITLE
computing the normal vector to an interface for a MaterialGrid using analytic gradient

### DIFF
--- a/python/tests/material_grid.py
+++ b/python/tests/material_grid.py
@@ -64,7 +64,7 @@ class TestMaterialGrid(unittest.TestCase):
 
     def test_material_grid(self):
         ## reference frequency computed using MaterialGrid at resolution = 300
-        freq_ref = 0.3068839373003908
+        freq_ref = 0.306877757638932
 
         res = [25, 50]
         freq_matgrid = []
@@ -76,7 +76,8 @@ class TestMaterialGrid(unittest.TestCase):
 
         ## verify that the relative error is decreasing with increasing resolution
         ## and is better than linear convergence because of subpixel smoothing
-        self.assertLess(abs(freq_matgrid[1]-freq_ref)*(res[1]**2)/2,abs(freq_matgrid[0]-freq_ref)*(res[0]**2))
+        self.assertLess(abs(freq_matgrid[1]-freq_ref)*(res[1]/res[0]),
+                        abs(freq_matgrid[0]-freq_ref))
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/material_grid.py
+++ b/python/tests/material_grid.py
@@ -3,7 +3,7 @@ import numpy as np
 from scipy.ndimage import gaussian_filter
 import unittest
 
-def compute_resonant_mode(res):
+def compute_resonant_mode(res,default_mat=False):
         cell_size = mp.Vector3(1,1,0)
 
         rad = 0.301943
@@ -42,7 +42,8 @@ def compute_resonant_mode(res):
 
         sim = mp.Simulation(resolution=res,
                             cell_size=cell_size,
-                            geometry=geometry,
+                            default_material=matgrid if default_mat else mp.Medium(),
+                            geometry=geometry if not default_mat else [],
                             sources=sources,
                             k_point=k_point)
 
@@ -78,6 +79,9 @@ class TestMaterialGrid(unittest.TestCase):
         ## and is better than linear convergence because of subpixel smoothing
         self.assertLess(abs(freq_matgrid[1]-freq_ref)*(res[1]/res[0]),
                         abs(freq_matgrid[0]-freq_ref))
+
+        freq_matgrid_default_mat = compute_resonant_mode(res[0], True)
+        self.assertAlmostEqual(freq_matgrid[0], freq_matgrid_default_mat)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/fields.cpp
+++ b/src/fields.cpp
@@ -685,7 +685,7 @@ void fields::unset_solve_cw_omega() {
 }
 
 /* implement mirror boundary conditions for i outside 0..n-1: */
-static int mirrorindex(int i, int n) { return i >= n ? 2 * n - 1 - i : (i < 0 ? -1 - i : i); }
+int mirrorindex(int i, int n) { return i >= n ? 2 * n - 1 - i : (i < 0 ? -1 - i : i); }
 
 /* Linearly interpolate a given point in a 3d grid of data.  The point
    coordinates should be in the range [0,1], or at the very least [-1,2]

--- a/src/fields.cpp
+++ b/src/fields.cpp
@@ -693,7 +693,7 @@ static int mirrorindex(int i, int n) { return i >= n ? 2 * n - 1 - i : (i < 0 ? 
 double linear_interpolate(double rx, double ry, double rz, double *data,
                           int nx, int ny, int nz, int stride) {
 
-  int x, y, z, x2, y2, z2;
+  int x1, y1, z1, x2, y2, z2;
   double dx, dy, dz;
 
   /* mirror boundary conditions for r just beyond the boundary */
@@ -702,19 +702,19 @@ double linear_interpolate(double rx, double ry, double rz, double *data,
   rz = rz < 0.0 ? -rz : (rz > 1.0 ? 1.0 - rz : rz);
 
   /* get the point corresponding to r in the epsilon array grid: */
-  x = mirrorindex(int(rx * nx), nx);
-  y = mirrorindex(int(ry * ny), ny);
-  z = mirrorindex(int(rz * nz), nz);
+  x1 = mirrorindex(int(rx * nx), nx);
+  y1 = mirrorindex(int(ry * ny), ny);
+  z1 = mirrorindex(int(rz * nz), nz);
 
   /* get the difference between (x,y,z) and the actual point */
-  dx = rx * nx - x - 0.5;
-  dy = ry * ny - y - 0.5;
-  dz = rz * nz - z - 0.5;
+  dx = rx * nx - x1 - 0.5;
+  dy = ry * ny - y1 - 0.5;
+  dz = rz * nz - z1 - 0.5;
 
   /* get the other closest point in the grid, with mirror boundaries: */
-  x2 = mirrorindex(dx >= 0.0 ? x + 1 : x - 1, nx);
-  y2 = mirrorindex(dy >= 0.0 ? y + 1 : y - 1, ny);
-  z2 = mirrorindex(dz >= 0.0 ? z + 1 : z - 1, nz);
+  x2 = mirrorindex(dx >= 0.0 ? x1 + 1 : x1 - 1, nx);
+  y2 = mirrorindex(dy >= 0.0 ? y1 + 1 : y1 - 1, ny);
+  z2 = mirrorindex(dz >= 0.0 ? z1 + 1 : z1 - 1, nz);
 
   /* take abs(d{xyz}) to get weights for {xyz} and {xyz}2: */
   dx = fabs(dx);
@@ -725,11 +725,11 @@ double linear_interpolate(double rx, double ry, double rz, double *data,
      in row-major order (the order used by HDF5): */
 #define D(x, y, z) (data[(((x)*ny + (y)) * nz + (z)) * stride])
 
-  return (((D(x, y, z) * (1.0 - dx) + D(x2, y, z) * dx) * (1.0 - dy) +
-           (D(x, y2, z) * (1.0 - dx) + D(x2, y2, z) * dx) * dy) *
+  return (((D(x1, y1, z1) * (1.0 - dx) + D(x2, y1, z1) * dx) * (1.0 - dy) +
+           (D(x1, y2, z1) * (1.0 - dx) + D(x2, y2, z1) * dx) * dy) *
               (1.0 - dz) +
-          ((D(x, y, z2) * (1.0 - dx) + D(x2, y, z2) * dx) * (1.0 - dy) +
-           (D(x, y2, z2) * (1.0 - dx) + D(x2, y2, z2) * dx) * dy) *
+          ((D(x1, y1, z2) * (1.0 - dx) + D(x2, y1, z2) * dx) * (1.0 - dy) +
+           (D(x1, y2, z2) * (1.0 - dx) + D(x2, y2, z2) * dx) * dy) *
               dz);
 
 #undef D

--- a/src/meep_internals.hpp
+++ b/src/meep_internals.hpp
@@ -34,6 +34,9 @@ static inline double abs(double a) { return fabs(a); }
 // note that C99 has a round() function, but I don't want to rely on it
 static inline int my_round(double x) { return int(floor(fabs(x) + 0.5) * (x < 0 ? -1 : 1)); }
 
+/* implement mirror boundary conditions for i outside 0..n-1: */
+int mirrorindex(int i, int n);
+
 inline int small_r_metal(int m) { return m - 1; }
 
 inline int rmin_bulk(int m) {

--- a/src/meep_internals.hpp
+++ b/src/meep_internals.hpp
@@ -37,6 +37,14 @@ static inline int my_round(double x) { return int(floor(fabs(x) + 0.5) * (x < 0 
 /* implement mirror boundary conditions for i outside 0..n-1: */
 int mirrorindex(int i, int n);
 
+/* map the cell coordinates into the range [0,1] */
+void map_coordinates(double rx, double ry, double rz,
+                     int nx, int ny, int nz,
+                     int &x1, int &y1, int &z1,
+                     int &x2, int &y2, int &z2,
+                     double &dx, double &dy, double &dz,
+                     bool do_fabs = true);
+
 inline int small_r_metal(int m) { return m - 1; }
 
 inline int rmin_bulk(int m) {

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -16,6 +16,7 @@
 
 #include <vector>
 #include "meepgeom.hpp"
+#include "meep_internals.hpp"
 
 namespace meep_geom {
 
@@ -307,9 +308,6 @@ bool is_metal(meep::field_type ft, const material_type *material) {
     }
 }
 
-/* implement mirror boundary conditions for i outside 0..n-1: */
-static int mirrorindex(int i, int n) { return i >= n ? 2 * n - 1 - i : (i < 0 ? -1 - i : i); }
-
 meep::vec matgrid_grad(meep::field_type ft, const meep::volume &v, geom_box_tree tp, int oi) {
   meep::vec gradient(zero_vec(v.dim));
   vector3 pc = vec_to_vector3(v.center());
@@ -338,9 +336,9 @@ meep::vec matgrid_grad(meep::field_type ft, const meep::volume &v, geom_box_tree
     rz = rz < 0.0 ? -rz : (rz > 1.0 ? 1.0 - rz : rz);
 
     /* get the point corresponding to r in the epsilon array grid: */
-    x1 = mirrorindex(int(rx * nx), nx);
-    y1 = mirrorindex(int(ry * ny), ny);
-    z1 = mirrorindex(int(rz * nz), nz);
+    x1 = meep::mirrorindex(int(rx * nx), nx);
+    y1 = meep::mirrorindex(int(ry * ny), ny);
+    z1 = meep::mirrorindex(int(rz * nz), nz);
 
     /* get the difference between (x1,y1,z1) and the actual point */
     dx = rx * nx - x1 - 0.5;
@@ -348,9 +346,9 @@ meep::vec matgrid_grad(meep::field_type ft, const meep::volume &v, geom_box_tree
     dz = rz * nz - z1 - 0.5;
 
     /* get the other closest point in the grid, with mirror boundaries: */
-    x2 = mirrorindex(dx >= 0.0 ? x1 + 1 : x1 - 1, nx);
-    y2 = mirrorindex(dy >= 0.0 ? y1 + 1 : y1 - 1, ny);
-    z2 = mirrorindex(dz >= 0.0 ? z1 + 1 : z1 - 1, nz);
+    x2 = meep::mirrorindex(dx >= 0.0 ? x1 + 1 : x1 - 1, nx);
+    y2 = meep::mirrorindex(dy >= 0.0 ? y1 + 1 : y1 - 1, ny);
+    z2 = meep::mirrorindex(dz >= 0.0 ? z1 + 1 : z1 - 1, nz);
 
     /* take abs(d{xyz}) to get weights for {xyz} and {xyz}2: */
     bool signflip_dx = false, signflip_dy = false, signflip_dz = false;
@@ -2489,9 +2487,9 @@ void add_interpolate_weights(double rx, double ry, double rz,
   rz = rz < 0.0 ? -rz : (rz > 1.0 ? 1.0 - rz : rz);
 
   /* get the point corresponding to r in the epsilon array grid: */
-  x = mirrorindex(int(rx * nx), nx);
-  y = mirrorindex(int(ry * ny), ny);
-  z = mirrorindex(int(rz * nz), nz);
+  x = meep::mirrorindex(int(rx * nx), nx);
+  y = meep::mirrorindex(int(ry * ny), ny);
+  z = meep::mirrorindex(int(rz * nz), nz);
 
   /* get the difference between (x,y,z) and the actual point */
   dx = rx * nx - x - 0.5;
@@ -2499,9 +2497,9 @@ void add_interpolate_weights(double rx, double ry, double rz,
   dz = rz * nz - z - 0.5;
 
   /* get the other closest point in the grid, with mirror boundaries: */
-  x2 = mirrorindex(dx >= 0.0 ? x + 1 : x - 1, nx);
-  y2 = mirrorindex(dy >= 0.0 ? y + 1 : y - 1, ny);
-  z2 = mirrorindex(dz >= 0.0 ? z + 1 : z - 1, nz);
+  x2 = meep::mirrorindex(dx >= 0.0 ? x + 1 : x - 1, nx);
+  y2 = meep::mirrorindex(dy >= 0.0 ? y + 1 : y - 1, ny);
+  z2 = meep::mirrorindex(dz >= 0.0 ? z + 1 : z - 1, nz);
 
   /* take abs(d{xyz}) to get weights for {xyz} and {xyz}2: */
   dx = fabs(dx);

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -399,7 +399,7 @@ meep::vec matgrid_grad(vector3 p, geom_box_tree tp, int oi, material_data *md) {
     } while (tp && is_material_grid((material_data *)tp->objects[oi].o->material));
   }
   // perhaps there is no object tree and the default material is a material grid
-  if (!tp && is_material_grid(&default_material)) {
+  if (!tp && is_material_grid(default_material)) {
     map_lattice_coordinates(p.x,p.y,p.z);
     gradient = material_grid_grad(p, (material_data *)default_material);
     ++matgrid_val_count;
@@ -441,7 +441,7 @@ double matgrid_val(vector3 p, geom_box_tree tp, int oi, material_data *md) {
     } while (tp && is_material_grid((material_data *)tp->objects[oi].o->material));
   }
   // perhaps there is no object tree and the default material is a material grid
-  if (!tp && is_material_grid(&default_material)) {
+  if (!tp && is_material_grid(default_material)) {
     map_lattice_coordinates(p.x,p.y,p.z);
     u = material_grid_val(p, (material_data *)default_material);
     if (matgrid_val_count == 0) udefault = u;
@@ -2598,7 +2598,7 @@ void material_grids_addgradient_point(double *v, std::complex<double> fields_a,
     } while (tp && is_material_grid((material_data *)tp->objects[oi].o->material));
   }
   // no object tree -- the whole domain is the material grid
-  if (!tp && is_material_grid(&default_material)) {
+  if (!tp && is_material_grid(default_material)) {
     vector3 pb = to_geom_box_coords(p, &tp->objects[oi]);
     vector3 sz = mg->grid_size;
     double *vcur = v, *ucur;

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -209,6 +209,7 @@ void init_libctl(material_type default_mat, bool ensure_per,
 // material grid functions
 /***************************************************************/
 void update_weights(material_type matgrid, double *weights);
+meep::vec matgrid_grad(meep::field_type ft, const meep::volume &v, geom_box_tree tp, int oi);
 double matgrid_val(vector3 p, geom_box_tree tp, int oi, material_data *md);
 double material_grid_val(vector3 p, material_data *md);
 geom_box_tree calculate_tree(const meep::volume &v, geometric_object_list g);

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -209,7 +209,8 @@ void init_libctl(material_type default_mat, bool ensure_per,
 // material grid functions
 /***************************************************************/
 void update_weights(material_type matgrid, double *weights);
-meep::vec matgrid_grad(meep::field_type ft, const meep::volume &v, geom_box_tree tp, int oi);
+meep::vec matgrid_grad(vector3 p, geom_box_tree tp, int oi, material_data *md);
+meep::vec material_grid_grad(vector3 p, material_data *md);
 double matgrid_val(vector3 p, geom_box_tree tp, int oi, material_data *md);
 double material_grid_val(vector3 p, material_data *md);
 geom_box_tree calculate_tree(const meep::volume &v, geometric_object_list g);


### PR DESCRIPTION
Closes #1537.

Initial attempt to add a new function `matgrid_grad` for computing the normal vector to an interface for a `MaterialGrid` using the analytic gradient via the formulas for bilinear interpolation shown in #1537. For now, it is assumed there is only one `MaterialGrid` object in 2d. The generalization to multiple overlapping `MaterialGrid`s in 3d will be added later once this base case is working.

This PR compiles and the normal vector for a test case involving a circle in 2d seems reasonably correct but for some reason the fields are diverging:

```py
import numpy as np
from scipy.ndimage import gaussian_filter
import meep as mp

res = 20 ## pixels/um    

design_region_res = 50  ## MaterialGrid resolution   

sigma = 3.0; ## standard deviation for Gaussian filter kernel    

cell_size = mp.Vector3(1,1,0)

rad = 0.301943

design_shape = mp.Vector3(1,1,0)
design_region_resolution = design_region_res
Nx = int(design_region_resolution*design_shape.x)
Ny = int(design_region_resolution*design_shape.y)
x = np.linspace(-0.5*cell_size.x,0.5*cell_size.x,Nx)
y = np.linspace(-0.5*cell_size.y,0.5*cell_size.y,Ny)
xv, yv = np.meshgrid(x,y)
design_params = np.sqrt(np.square(xv) + np.square(yv)) < rad
filtered_design_params = gaussian_filter(design_params, sigma=sigma, output=np.double)

matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                          mp.air,
                          mp.Medium(index=3.5),
                          weights=filtered_design_params,
                          do_averaging=True,
                          beta=0,
                          eta=0.5)

geometry = [mp.Block(center=mp.Vector3(),
                     size=mp.Vector3(design_shape.x,design_shape.y,0),
                     material=matgrid)]

fcen = 0.3
df = 0.2*fcen
sources = [mp.Source(mp.GaussianSource(fcen,fwidth=df),
                     component=mp.Hz,
                     center=mp.Vector3(-0.1057,0.2094,0))]

k_point = mp.Vector3(0.3892,0.1597,0)

sim = mp.Simulation(resolution=res,
                    cell_size=cell_size,
                    geometry=geometry,
                    sources=sources,
                    k_point=k_point)

h = mp.Harminv(mp.Hz, mp.Vector3(0.3718,-0.2076), fcen, df)
sim.run(mp.after_sources(h),
        until_after_sources=200)

for m in h.modes:
    print("harminv:, {}, {}, {}".format(res,m.freq,m.Q))
```

*output from running script*
```
-----------
Initializing structure...
time for choose_chunkdivision = 7.2417e-05 s
Working in 2D dimensions.
Computational cell is 1 x 1 x 0 with resolution 20
     block, center = (0,0,0)
          size (1,1,0)
          axes (1,0,0), (0,1,0), (0,0,1)
time for set_epsilon = 0.202574 s
-----------
Meep: using complex fields.
Traceback (most recent call last):
  File "circle2d_matgrid_test.py", line 56, in <module>
    until_after_sources=200)
  File "simulation.py", line 3645, in run
    self._run_sources_until(until_after_sources, step_funcs)
  File "simulation.py", line 2232, in _run_sources_until
    self._run_until(new_conds, step_funcs)
  File "simulation.py", line 2196, in _run_until
    self.fields.step()
  File "__init__.py", line 3948, in step
    return _meep.fields_step(self)
RuntimeError: meep: simulation fields are NaN or Inf
```
