### PR TITLE
enable single precision floating points for fields arrays

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -828,7 +828,7 @@ void _get_gradient(PyObject *grad, PyObject *fields_a, PyObject *fields_f, PyObj
     if (!PyArray_Check(pao_grad)) meep::abort("grad parameter must be numpy array.");
     if (!PyArray_ISCARRAY(pao_grad)) meep::abort("Numpy grad array must be C-style contiguous.");
     if (PyArray_NDIM(pao_grad) !=2) {meep::abort("Numpy grad array must have 2 dimensions.");}
-    meep::realnum *grad_c = (meep::realnum *)PyArray_DATA(pao_grad);
+    double *grad_c = (double *)PyArray_DATA(pao_grad);
     int ng = PyArray_DIMS(pao_grad)[1]; // number of design parameters
 
     // clean the adjoint fields array
@@ -859,7 +859,7 @@ void _get_gradient(PyObject *grad, PyObject *fields_a, PyObject *fields_f, PyObj
     PyArrayObject *pao_freqs = (PyArrayObject *)frequencies;
     if (!PyArray_Check(pao_freqs)) meep::abort("frequencies parameter must be numpy array.");
     if (!PyArray_ISCARRAY(pao_freqs)) meep::abort("Numpy fields array must be C-style contiguous.");
-    meep::realnum *frequencies_c = (meep::realnum *)PyArray_DATA(pao_freqs);
+    double *frequencies_c = (double *)PyArray_DATA(pao_freqs);
     int nf = PyArray_DIMS(pao_freqs)[0];
     if (PyArray_DIMS(pao_grad)[0] != nf) meep::abort("Numpy grad array is allocated for %d frequencies; it should be allocated for %d.",PyArray_DIMS(pao_grad)[0],nf);
 

--- a/python/meep.i
+++ b/python/meep.i
@@ -310,7 +310,7 @@ PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v) {
     Py_ssize_t len = f->freq.size() * 6;
     PyObject *res = PyList_New(len);
 
-    std::complex<double> *ff_arr = f->farfield(v);
+    std::complex<realnum> *ff_arr = f->farfield(v);
 
     for (Py_ssize_t i = 0; i < len; i++) {
         PyList_SetItem(res, i, PyComplex_FromDoubles(ff_arr[i].real(), ff_arr[i].imag()));
@@ -839,14 +839,14 @@ void _get_gradient(PyObject *grad, PyObject *fields_a, PyObject *fields_f, PyObj
     if (!PyArray_Check(pao_fields_a)) meep::abort("adjoint fields parameter must be numpy array.");
     if (!PyArray_ISCARRAY(pao_fields_a)) meep::abort("Numpy adjoint fields array must be C-style contiguous.");
     if (PyArray_NDIM(pao_fields_a) !=1) {meep::abort("Numpy adjoint fields array must have 1 dimension.");}
-    std::complex<double> * fields_a_c = (std::complex<double> *)PyArray_DATA(pao_fields_a);
+    std::complex<meep::realnum> * fields_a_c = (std::complex<meep::realnum> *)PyArray_DATA(pao_fields_a);
 
     // clean the forward fields array
     PyArrayObject *pao_fields_f = (PyArrayObject *)fields_f;
     if (!PyArray_Check(pao_fields_f)) meep::abort("forward fields parameter must be numpy array.");
     if (!PyArray_ISCARRAY(pao_fields_f)) meep::abort("Numpy forward fields array must be C-style contiguous.");
     if (PyArray_NDIM(pao_fields_f) !=1) {meep::abort("Numpy forward fields array must have 1 dimension.");}
-    std::complex<double> * fields_f_c = (std::complex<double> *)PyArray_DATA(pao_fields_f);
+    std::complex<meep::realnum> * fields_f_c = (std::complex<meep::realnum> *)PyArray_DATA(pao_fields_f);
 
     // scalegrad not currently used
     double scalegrad = 1.0;

--- a/python/meep.i
+++ b/python/meep.i
@@ -322,8 +322,8 @@ PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v) {
 }
 
 // Wrapper around meep::dft_near2far::get_farfields_array
- PyObject *_get_farfields_array(meep::dft_near2far *n2f, const meep::volume &where,
-                                double resolution) {
+PyObject *_get_farfields_array(meep::dft_near2far *n2f, const meep::volume &where,
+                               double resolution) {
     // Return value: New reference
     size_t dims[4] = {1, 1, 1, 1};
     int rank = 0;

--- a/python/tests/chunks.py
+++ b/python/tests/chunks.py
@@ -62,7 +62,7 @@ class TestChunks(unittest.TestCase):
 
         sim.run(until_after_sources=mp.stop_when_fields_decayed(50, mp.Ez, mp.Vector3(), 1e-5))
 
-        self.assertAlmostEqual(86.90826609300862, mp.get_fluxes(tot_flux)[0])
+        self.assertAlmostEqual(86.90826609300862, mp.get_fluxes(tot_flux)[0], places=6)
 
 
 if __name__ == '__main__':

--- a/python/tests/chunks.py
+++ b/python/tests/chunks.py
@@ -62,7 +62,7 @@ class TestChunks(unittest.TestCase):
 
         sim.run(until_after_sources=mp.stop_when_fields_decayed(50, mp.Ez, mp.Vector3(), 1e-5))
 
-        self.assertAlmostEqual(86.90826609300862, mp.get_fluxes(tot_flux)[0], places=6)
+        self.assertAlmostEqual(86.90826609300862, mp.get_fluxes(tot_flux)[0])
 
 
 if __name__ == '__main__':

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -488,8 +488,8 @@ static int pymaterial_grid_to_material_grid(PyObject *po, material_data *md) {
   if (!PyArray_ISCARRAY(pao)) {
     meep::abort("Numpy array weights must be C-style contiguous.");
   }
-  md->weights = new realnum[PyArray_SIZE(pao)];
-  memcpy(md->weights, (realnum *)PyArray_DATA(pao), PyArray_SIZE(pao) * sizeof(realnum));
+  md->weights = new double[PyArray_SIZE(pao)];
+  memcpy(md->weights, (double *)PyArray_DATA(pao), PyArray_SIZE(pao) * sizeof(double));
 
   // if needed, combine sus structs to main object
   PyObject *py_e_sus_m1 = PyObject_GetAttrString(po_medium1, "E_susceptibilities");
@@ -567,8 +567,8 @@ static int pymaterial_to_material(PyObject *po, material_type *mt) {
     md = new material_data();
     md->which_subclass = material_data::MATERIAL_FILE;
     md->epsilon_dims[0] = md->epsilon_dims[1] = md->epsilon_dims[2] = 1;
-    md->epsilon_data = new realnum[PyArray_SIZE(pao)];
-    memcpy(md->epsilon_data, (realnum *)PyArray_DATA(pao), PyArray_SIZE(pao) * sizeof(realnum));
+    md->epsilon_data = new double[PyArray_SIZE(pao)];
+    memcpy(md->epsilon_data, (double *)PyArray_DATA(pao), PyArray_SIZE(pao) * sizeof(double));
 
     for (int i = 0; i < PyArray_NDIM(pao); ++i) {
       md->epsilon_dims[i] = (size_t)PyArray_DIMS(pao)[i];

--- a/scheme/structure.cpp
+++ b/scheme/structure.cpp
@@ -160,7 +160,7 @@ static geom_box gv2box(const meep::volume &v) {
 
 /***********************************************************************/
 
-static meep::realnum *epsilon_data = NULL;
+static double *epsilon_data = NULL;
 static size_t epsilon_dims[3] = {0, 0, 0};
 
 static void read_epsilon_file(const char *eps_input_file) {
@@ -175,7 +175,7 @@ static void read_epsilon_file(const char *eps_input_file) {
     if (dataname) *(dataname++) = 0;
     meep::h5file eps_file(fname, meep::h5file::READONLY, false);
     int rank; // ignored since rank < 3 is equivalent to singleton dims
-    epsilon_data = eps_file.read(dataname, &rank, epsilon_dims, 3);
+    epsilon_data = (double *)eps_file.read(dataname, &rank, epsilon_dims, 3, false);
     master_printf("read in %zdx%zdx%zd epsilon-input-file \"%s\"\n", epsilon_dims[0],
                   epsilon_dims[1], epsilon_dims[2], eps_input_file);
     delete[] fname;

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -682,7 +682,7 @@ complex<double> *fields::get_complex_array_slice(const volume &where, std::vecto
                                                  field_function fun, void *fun_data, complex<double> *slice,
                                                  double frequency, bool snap) {
   return (complex<double> *)do_get_array_slice(where, components, fun, 0, fun_data, (void *)slice,
-                                       frequency, snap);
+                                               frequency, snap);
 }
 
 double *fields::get_array_slice(const volume &where, component c, double *slice, double frequency,

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -568,7 +568,7 @@ double *collapse_array(double *array, int *rank, size_t dims[3], direction dirs[
 }
 
 complex<double> *collapse_array(complex<double> *array, int *rank, size_t dims[3], direction dirs[3],
-                        volume where) {
+                                volume where) {
   return (complex<double> *)collapse_array((double *)array, rank, dims, dirs, where, 2);
 }
 
@@ -679,8 +679,8 @@ double *fields::get_array_slice(const volume &where, std::vector<component> comp
 }
 
 complex<double> *fields::get_complex_array_slice(const volume &where, std::vector<component> components,
-                                         field_function fun, void *fun_data, complex<double> *slice,
-                                         double frequency, bool snap) {
+                                                 field_function fun, void *fun_data, complex<double> *slice,
+                                                 double frequency, bool snap) {
   return (complex<double> *)do_get_array_slice(where, components, fun, 0, fun_data, (void *)slice,
                                        frequency, snap);
 }
@@ -704,7 +704,7 @@ double *fields::get_array_slice(const volume &where, derived_component c, double
 }
 
 complex<double> *fields::get_complex_array_slice(const volume &where, component c, complex<double> *slice,
-                                         double frequency, bool snap) {
+                                                 double frequency, bool snap) {
   std::vector<component> components(1);
   components[0] = c;
   return (complex<double> *)do_get_array_slice(where, components, default_field_func, 0, 0, (void *)slice,
@@ -712,7 +712,7 @@ complex<double> *fields::get_complex_array_slice(const volume &where, component 
 }
 
 complex<double> *fields::get_source_slice(const volume &where, component source_slice_component,
-                                  complex<double> *slice) {
+                                          complex<double> *slice) {
   size_t dims[3];
   direction dirs[3];
   vec min_max_loc[2];

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -95,11 +95,11 @@ dft_chunk::dft_chunk(fields_chunk *fc_, ivec is_, ivec ie_, vec s0_, vec s1_, ve
 
   const int Nomega = data->omega.size();
   omega = data->omega;
-  dft_phase = new complex<realnum>[Nomega];
+  dft_phase = new complex<double>[Nomega];
 
   N = 1;
   LOOP_OVER_DIRECTIONS(is.dim, d) { N *= (ie.in_direction(d) - is.in_direction(d)) / 2 + 1; }
-  dft = new complex<realnum>[N * Nomega];
+  dft = new complex<double>[N * Nomega];
   for (size_t i = 0; i < N * Nomega; ++i)
     dft[i] = 0.0;
   for (int i = 0; i < 5; ++i)
@@ -246,12 +246,12 @@ void dft_chunk::update_dft(double time) {
         f[cmp] = w * fc->f[c][cmp][idx];
 
     if (numcmp == 2) {
-      complex<realnum> fc(f[0], f[1]);
+      complex<double> fc(f[0], f[1]);
       for (int i = 0; i < Nomega; ++i)
         dft[Nomega * idx_dft + i] += dft_phase[i] * fc;
     }
     else {
-      realnum fr = f[0];
+      double fr = f[0];
       for (int i = 0; i < Nomega; ++i)
         dft[Nomega * idx_dft + i] += dft_phase[i] * fr;
     }
@@ -300,7 +300,7 @@ void save_dft_hdf5(dft_chunk *dft_chunks, const char *name, h5file *file, const 
 
   for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_dft) {
     size_t Nchunk = cur->N * cur->omega.size() * 2;
-    file->write_chunk(1, &istart, &Nchunk, (realnum *)cur->dft);
+    file->write_chunk(1, &istart, &Nchunk, (void *)cur->dft, sizeof(realnum) == sizeof(float));
     istart += Nchunk;
   }
   file->done_writing_chunks();
@@ -328,7 +328,7 @@ void load_dft_hdf5(dft_chunk *dft_chunks, const char *name, h5file *file, const 
 
   for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_dft) {
     size_t Nchunk = cur->N * cur->omega.size() * 2;
-    file->read_chunk(1, &istart, &Nchunk, (realnum *)cur->dft);
+    file->read_chunk(1, &istart, &Nchunk, (void *)cur->dft, sizeof(realnum) == sizeof(float));
     istart += Nchunk;
   }
 }
@@ -817,7 +817,7 @@ complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec m
                    ? parent->get_eps(loc)
                    : c_conjugate == Permeability
                          ? parent->get_mu(loc)
-                         : dft[omega.size() * (chunk_idx++) + num_freq] / complex<realnum>(stored_weight));
+                         : dft[omega.size() * (chunk_idx++) + num_freq] / stored_weight);
     if (include_dV_and_interp_weights) dft_val /= (sqrt_dV_and_interp_weights ? sqrt(w) : w);
 
     complex<double> mode1val = 0.0, mode2val = 0.0;

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -988,8 +988,6 @@ complex<double> fields::process_dft_component(dft_chunk **chunklists, int num_ch
   else if (pfield_array)
     *pfield_array = field_array = (array_size ? new complex<double>[array_size] : 0);
 
-  bool append_data = false;
-  bool single_precision = false;
   complex<double> overlap = 0.0;
   for (int reim = 0; reim <= reim_max; reim++) {
     h5file *file = 0;
@@ -998,7 +996,8 @@ complex<double> fields::process_dft_component(dft_chunk **chunklists, int num_ch
       *first_component = false;
       char dataname[100];
       snprintf(dataname, 100, "%s_%i.%c", component_name(c), num_freq, reim ? 'i' : 'r');
-      file->create_or_extend_data(dataname, rank, dims, append_data, single_precision);
+      file->create_or_extend_data(dataname, rank, dims, false /* append_data */,
+                                  false /* single_precision */);
     }
 
     for (int ncl = 0; ncl < num_chunklists; ncl++)
@@ -1153,8 +1152,7 @@ void fields::output_dft_components(dft_chunk **chunklists, int num_chunklists, v
             char dataname[100], filename[100];
             snprintf(dataname, 100, "%s_%i.%c", component_name(c), num_freq, reim ? 'i' : 'r');
             snprintf(filename, 100, "%s%s", HDF5FileName, strstr(".h5", HDF5FileName) ? "" : ".h5");
-            bool single_precision = false;
-            file->write(dataname, rank, dims, real_array, single_precision);
+            file->write(dataname, rank, dims, real_array, false /* single_precision */);
           }
           delete[] real_array;
         }

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -300,7 +300,7 @@ void save_dft_hdf5(dft_chunk *dft_chunks, const char *name, h5file *file, const 
 
   for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_dft) {
     size_t Nchunk = cur->N * cur->omega.size() * 2;
-    file->write_chunk(1, &istart, &Nchunk, (void *)cur->dft, false, /* single_precision */);
+    file->write_chunk(1, &istart, &Nchunk, (void *)cur->dft, false /* single_precision */);
     istart += Nchunk;
   }
   file->done_writing_chunks();

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -739,10 +739,10 @@ dft_fields fields::add_dft_fields(component *components, int num_components, con
 /* chunk-level processing for fields::process_dft_component.   */
 /***************************************************************/
 complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corner, ivec max_corner,
-                                         int num_freq, h5file *file, double *buffer, int reim,
-                                         complex<double> *field_array, void *mode1_data, void *mode2_data,
-                                         int ic_conjugate, bool retain_interp_weights,
-                                         fields *parent) {
+                                                 int num_freq, h5file *file, realnum *buffer, int reim,
+                                                 complex<double> *field_array, void *mode1_data, void *mode2_data,
+                                                 int ic_conjugate, bool retain_interp_weights,
+                                                 fields *parent) {
 
   if ((num_freq < 0) || (num_freq > omega.size()-1))
     abort("process_dft_component: frequency index %d is outside the range of the frequency array of size %lu",num_freq,omega.size());
@@ -817,7 +817,7 @@ complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec m
                    ? parent->get_eps(loc)
                    : c_conjugate == Permeability
                          ? parent->get_mu(loc)
-                         : dft[omega.size() * (chunk_idx++) + num_freq] / stored_weight);
+                         : dft[omega.size() * (chunk_idx++) + num_freq] / complex<realnum>(stored_weight));
     if (include_dV_and_interp_weights) dft_val /= (sqrt_dV_and_interp_weights ? sqrt(w) : w);
 
     complex<double> mode1val = 0.0, mode2val = 0.0;
@@ -1145,7 +1145,7 @@ void fields::output_dft_components(dft_chunk **chunklists, int num_chunklists, v
           array = collapse_array(array, &rank, dims, dirs, dft_volume);
           if (rank == 0) abort("%s:%i: internal error", __FILE__, __LINE__);
           size_t array_size = dims[0] * (rank >= 2 ? dims[1] * (rank == 3 ? dims[2] : 1) : 1);
-          double *real_array = new double[array_size];
+          realnum *real_array = new realnum[array_size];
           if (!real_array) abort("%s:%i:out of memory(%lu)", __FILE__, __LINE__, array_size);
           for (int reim = 0; reim < 2; reim++) {
             for (size_t n = 0; n < array_size; n++)

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -300,7 +300,7 @@ void save_dft_hdf5(dft_chunk *dft_chunks, const char *name, h5file *file, const 
 
   for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_dft) {
     size_t Nchunk = cur->N * cur->omega.size() * 2;
-    file->write_chunk(1, &istart, &Nchunk, (void *)cur->dft, false /* single_precision */);
+    file->write_chunk(1, &istart, &Nchunk, (double *)cur->dft);
     istart += Nchunk;
   }
   file->done_writing_chunks();
@@ -328,7 +328,7 @@ void load_dft_hdf5(dft_chunk *dft_chunks, const char *name, h5file *file, const 
 
   for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_dft) {
     size_t Nchunk = cur->N * cur->omega.size() * 2;
-    file->read_chunk(1, &istart, &Nchunk, (void *)cur->dft, false /* single_precision */);
+    file->read_chunk(1, &istart, &Nchunk, (double *)cur->dft);
     istart += Nchunk;
   }
 }
@@ -859,7 +859,7 @@ complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec m
 
   } // LOOP_OVER_IVECS(fc->gv, is, ie, idx)
 
-  if (file) file->write_chunk(rank, start, file_count, buffer, false /* single_precision */);
+  if (file) file->write_chunk(rank, start, file_count, buffer);
 
   return integral;
 }

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -26,8 +26,6 @@
 
 using namespace std;
 
-typedef complex<double> cdouble;
-
 namespace meep {
 
 std::vector<double> linspace(double freq_min, double freq_max, size_t Nfreq) {
@@ -56,7 +54,7 @@ struct dft_chunk_data { // for passing to field::loop_in_chunks as void*
 
 dft_chunk::dft_chunk(fields_chunk *fc_, ivec is_, ivec ie_, vec s0_, vec s1_, vec e0_, vec e1_,
                      double dV0_, double dV1_, component c_, bool use_centered_grid,
-                     cdouble phase_factor, ivec shift_, const symmetry &S_, int sn_,
+                     complex<double> phase_factor, ivec shift_, const symmetry &S_, int sn_,
                      const void *data_) {
   dft_chunk_data *data = (dft_chunk_data *)data_;
   if (!fc_->f[c_][0]) abort("invalid fields_chunk/component combination in dft_chunk");
@@ -195,7 +193,7 @@ dft_chunk *fields::add_dft(const volume_list *where, const std::vector<double> f
   dft_chunk *chunks = 0;
   while (where) {
     if (is_derived(where->c)) abort("derived_component invalid for dft");
-    cdouble stored_weight = where->weight;
+    complex<double> stored_weight = where->weight;
     chunks = add_dft(component(where->c), where->v, freq, include_dV_and_interp_weights,
                      stored_weight, chunks);
     where = where->next;
@@ -712,7 +710,7 @@ dft_fields::dft_fields(dft_chunk *chunks_, const double *freq_, size_t Nfreq, co
     freq[i] = freq_[i];
 }
 
-void dft_fields::scale_dfts(cdouble scale) { chunks->scale_dft(scale); }
+void dft_fields::scale_dfts(complex<double> scale) { chunks->scale_dft(scale); }
 
 void dft_fields::remove() {
   while (chunks) {
@@ -727,7 +725,7 @@ dft_fields fields::add_dft_fields(component *components, int num_components, con
   bool include_dV_and_interp_weights = false;
   bool sqrt_dV_and_interp_weights = false; // default option from meep.hpp (expose to user?)
   std::complex<double> extra_weight = 1.0; // default option from meep.hpp (expose to user?)
-  cdouble stored_weight = 1.0;
+  complex<double> stored_weight = 1.0;
   dft_chunk *chunks = 0;
   for (int nc = 0; nc < num_components; nc++)
     chunks =
@@ -740,9 +738,9 @@ dft_fields fields::add_dft_fields(component *components, int num_components, con
 /***************************************************************/
 /* chunk-level processing for fields::process_dft_component.   */
 /***************************************************************/
-cdouble dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corner, ivec max_corner,
+complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corner, ivec max_corner,
                                          int num_freq, h5file *file, double *buffer, int reim,
-                                         cdouble *field_array, void *mode1_data, void *mode2_data,
+                                         complex<double> *field_array, void *mode1_data, void *mode2_data,
                                          int ic_conjugate, bool retain_interp_weights,
                                          fields *parent) {
 
@@ -804,7 +802,7 @@ cdouble dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corne
   /***************************************************************/
   vec rshift(shift * (0.5 * fc->gv.inva));
   int chunk_idx = 0;
-  cdouble integral = 0.0;
+  complex<double> integral = 0.0;
   component c_conjugate = (component)(ic_conjugate >= 0 ? ic_conjugate : -ic_conjugate);
   LOOP_OVER_IVECS(fc->gv, is, ie, idx) {
     IVEC_LOOP_LOC(fc->gv, loc);
@@ -812,7 +810,7 @@ cdouble dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corne
     double w = IVEC_LOOP_WEIGHT(s0, s1, e0, e1, dV0 + dV1 * loop_i2);
     double interp_w = retain_interp_weights ? IVEC_LOOP_WEIGHT(s0i, s1i, e0i, e1i, 1.0) : 1.0;
 
-    cdouble dft_val =
+    complex<double> dft_val =
         (c_conjugate == NO_COMPONENT
              ? w
              : c_conjugate == Dielectric
@@ -822,7 +820,7 @@ cdouble dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corne
                          : dft[omega.size() * (chunk_idx++) + num_freq] / stored_weight);
     if (include_dV_and_interp_weights) dft_val /= (sqrt_dV_and_interp_weights ? sqrt(w) : w);
 
-    cdouble mode1val = 0.0, mode2val = 0.0;
+    complex<double> mode1val = 0.0, mode2val = 0.0;
     if (mode1_data) mode1val = eigenmode_amplitude(mode1_data, loc, S.transform(c_conjugate, sn));
     if (mode2_data) mode2val = eigenmode_amplitude(mode2_data, loc, S.transform(c, sn));
 
@@ -833,7 +831,7 @@ cdouble dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corne
 
       dft_val *= interp_w;
 
-      cdouble val = (mode1_data ? mode1val : dft_val);
+      complex<double> val = (mode1_data ? mode1val : dft_val);
       buffer[idx2] = reim ? imag(val) : real(val);
     }
     else if (field_array) {
@@ -906,8 +904,8 @@ cdouble dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corne
 /* if where is non-null, only field components inside *where   */
 /* are processed.                                              */
 /***************************************************************/
-cdouble fields::process_dft_component(dft_chunk **chunklists, int num_chunklists, int num_freq,
-                                      component c, const char *HDF5FileName, cdouble **pfield_array,
+complex<double> fields::process_dft_component(dft_chunk **chunklists, int num_chunklists, int num_freq,
+                                      component c, const char *HDF5FileName, complex<double> **pfield_array,
                                       int *array_rank, size_t *array_dims, direction *array_dirs,
                                       void *mode1_data, void *mode2_data, component c_conjugate,
                                       bool *first_component, bool retain_interp_weights) {
@@ -981,18 +979,18 @@ cdouble fields::process_dft_component(dft_chunk **chunklists, int num_chunklists
   /* like h5_output_data::buf in h5fields.cpp                    */
   /***************************************************************/
   realnum *buffer = 0;
-  cdouble *field_array = 0;
+  complex<double> *field_array = 0;
   int reim_max = 0;
   if (HDF5FileName) {
     buffer = new realnum[bufsz];
     reim_max = 1;
   }
   else if (pfield_array)
-    *pfield_array = field_array = (array_size ? new cdouble[array_size] : 0);
+    *pfield_array = field_array = (array_size ? new complex<double>[array_size] : 0);
 
   bool append_data = false;
   bool single_precision = false;
-  cdouble overlap = 0.0;
+  complex<double> overlap = 0.0;
   for (int reim = 0; reim <= reim_max; reim++) {
     h5file *file = 0;
     if (HDF5FileName) {
@@ -1021,7 +1019,7 @@ cdouble fields::process_dft_component(dft_chunk **chunklists, int num_chunklists
 /* on all cores                                                */
 /***************************************************************/
 #define BUFSIZE 1 << 16 // use 64k buffer
-      cdouble *buf = new cdouble[BUFSIZE];
+      complex<double> *buf = new complex<double>[BUFSIZE];
       ptrdiff_t offset = 0;
       size_t remaining = array_size;
       while (remaining != 0) {
@@ -1029,7 +1027,7 @@ cdouble fields::process_dft_component(dft_chunk **chunklists, int num_chunklists
         am_now_working_on(MpiAllTime);
         sum_to_all(field_array + offset, buf, size);
         finished_working();
-        memcpy(field_array + offset, buf, size * sizeof(cdouble));
+        memcpy(field_array + offset, buf, size * sizeof(complex<double>));
         remaining -= size;
         offset += size;
       }
@@ -1051,46 +1049,46 @@ cdouble fields::process_dft_component(dft_chunk **chunklists, int num_chunklists
 /***************************************************************/
 /* routines for fetching arrays of dft fields                  */
 /***************************************************************/
-cdouble *collapse_array(cdouble *array, int *rank, size_t dims[3], direction dirs[3], volume where);
+complex<double> *collapse_array(complex<double> *array, int *rank, size_t dims[3], direction dirs[3], volume where);
 
-cdouble *fields::get_dft_array(dft_flux flux, component c, int num_freq, int *rank,
+complex<double> *fields::get_dft_array(dft_flux flux, component c, int num_freq, int *rank,
                                size_t dims[3]) {
   dft_chunk *chunklists[2];
   chunklists[0] = flux.E;
   chunklists[1] = flux.H;
-  cdouble *array;
+  complex<double> *array;
   direction dirs[3];
   process_dft_component(chunklists, 2, num_freq, c, 0, &array, rank, dims, dirs);
   return collapse_array(array, rank, dims, dirs, flux.where);
 }
 
-cdouble *fields::get_dft_array(dft_force force, component c, int num_freq, int *rank,
+complex<double> *fields::get_dft_array(dft_force force, component c, int num_freq, int *rank,
                                size_t dims[3]) {
   dft_chunk *chunklists[3];
   chunklists[0] = force.offdiag1;
   chunklists[1] = force.offdiag2;
   chunklists[2] = force.diag;
-  cdouble *array;
+  complex<double> *array;
   direction dirs[3];
   process_dft_component(chunklists, 3, num_freq, c, 0, &array, rank, dims, dirs);
   return collapse_array(array, rank, dims, dirs, force.where);
 }
 
-cdouble *fields::get_dft_array(dft_near2far n2f, component c, int num_freq, int *rank,
+complex<double> *fields::get_dft_array(dft_near2far n2f, component c, int num_freq, int *rank,
                                size_t dims[3]) {
   dft_chunk *chunklists[1];
   chunklists[0] = n2f.F;
-  cdouble *array;
+  complex<double> *array;
   direction dirs[3];
   process_dft_component(chunklists, 1, num_freq, c, 0, &array, rank, dims, dirs);
   return collapse_array(array, rank, dims, dirs, n2f.where);
 }
 
-cdouble *fields::get_dft_array(dft_fields fdft, component c, int num_freq, int *rank,
+complex<double> *fields::get_dft_array(dft_fields fdft, component c, int num_freq, int *rank,
                                size_t dims[3]) {
   dft_chunk *chunklists[1];
   chunklists[0] = fdft.chunks;
-  cdouble *array;
+  complex<double> *array;
   direction dirs[3];
   process_dft_component(chunklists, 1, num_freq, c, 0, &array, rank, dims, dirs);
   return collapse_array(array, rank, dims, dirs, fdft.where);
@@ -1137,7 +1135,7 @@ void fields::output_dft_components(dft_chunk **chunklists, int num_chunklists, v
                               0, Ex, &first_component);
       }
       else {
-        cdouble *array = 0;
+        complex<double> *array = 0;
         int rank;
         size_t dims[3];
         direction dirs[3];
@@ -1197,7 +1195,7 @@ void fields::output_dft(dft_fields fdft, const char *HDF5FileName) {
 /***************************************************************/
 /***************************************************************/
 void fields::get_overlap(void *mode1_data, void *mode2_data, dft_flux flux, int num_freq,
-                         cdouble overlaps[2]) {
+                         complex<double> overlaps[2]) {
   component cE[2], cH[2];
   switch (flux.normal_direction) {
     case X:
@@ -1236,13 +1234,13 @@ void fields::get_overlap(void *mode1_data, void *mode2_data, dft_flux flux, int 
   dft_chunk *chunklists[2];
   chunklists[0] = flux.E;
   chunklists[1] = flux.H;
-  cdouble ExHy = process_dft_component(chunklists, 2, num_freq, cE[0], 0, 0, 0, 0, 0, mode1_data,
+  complex<double> ExHy = process_dft_component(chunklists, 2, num_freq, cE[0], 0, 0, 0, 0, 0, mode1_data,
                                        mode2_data, cH[0]);
-  cdouble EyHx = process_dft_component(chunklists, 2, num_freq, cE[1], 0, 0, 0, 0, 0, mode1_data,
+  complex<double> EyHx = process_dft_component(chunklists, 2, num_freq, cE[1], 0, 0, 0, 0, 0, mode1_data,
                                        mode2_data, cH[1]);
-  cdouble HyEx = process_dft_component(chunklists, 2, num_freq, cH[0], 0, 0, 0, 0, 0, mode1_data,
+  complex<double> HyEx = process_dft_component(chunklists, 2, num_freq, cH[0], 0, 0, 0, 0, 0, mode1_data,
                                        mode2_data, cE[0]);
-  cdouble HxEy = process_dft_component(chunklists, 2, num_freq, cH[1], 0, 0, 0, 0, 0, mode1_data,
+  complex<double> HxEy = process_dft_component(chunklists, 2, num_freq, cH[1], 0, 0, 0, 0, 0, mode1_data,
                                        mode2_data, cE[1]);
   overlaps[0] = ExHy - EyHx;
   overlaps[1] = HyEx - HxEy;

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -300,7 +300,7 @@ void save_dft_hdf5(dft_chunk *dft_chunks, const char *name, h5file *file, const 
 
   for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_dft) {
     size_t Nchunk = cur->N * cur->omega.size() * 2;
-    file->write_chunk(1, &istart, &Nchunk, (void *)cur->dft, sizeof(realnum) == sizeof(float));
+    file->write_chunk(1, &istart, &Nchunk, (void *)cur->dft, false);
     istart += Nchunk;
   }
   file->done_writing_chunks();
@@ -859,7 +859,7 @@ complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec m
 
   } // LOOP_OVER_IVECS(fc->gv, is, ie, idx)
 
-  if (file) file->write_chunk(rank, start, file_count, buffer);
+  if (file) file->write_chunk(rank, start, file_count, buffer, false);
 
   return integral;
 }

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -905,10 +905,10 @@ complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec m
 /* are processed.                                              */
 /***************************************************************/
 complex<double> fields::process_dft_component(dft_chunk **chunklists, int num_chunklists, int num_freq,
-                                      component c, const char *HDF5FileName, complex<double> **pfield_array,
-                                      int *array_rank, size_t *array_dims, direction *array_dirs,
-                                      void *mode1_data, void *mode2_data, component c_conjugate,
-                                      bool *first_component, bool retain_interp_weights) {
+                                              component c, const char *HDF5FileName, complex<double> **pfield_array,
+                                              int *array_rank, size_t *array_dims, direction *array_dirs,
+                                              void *mode1_data, void *mode2_data, component c_conjugate,
+                                              bool *first_component, bool retain_interp_weights) {
 
   /***************************************************************/
   /***************************************************************/
@@ -1052,7 +1052,7 @@ complex<double> fields::process_dft_component(dft_chunk **chunklists, int num_ch
 complex<double> *collapse_array(complex<double> *array, int *rank, size_t dims[3], direction dirs[3], volume where);
 
 complex<double> *fields::get_dft_array(dft_flux flux, component c, int num_freq, int *rank,
-                               size_t dims[3]) {
+                                       size_t dims[3]) {
   dft_chunk *chunklists[2];
   chunklists[0] = flux.E;
   chunklists[1] = flux.H;
@@ -1063,7 +1063,7 @@ complex<double> *fields::get_dft_array(dft_flux flux, component c, int num_freq,
 }
 
 complex<double> *fields::get_dft_array(dft_force force, component c, int num_freq, int *rank,
-                               size_t dims[3]) {
+                                       size_t dims[3]) {
   dft_chunk *chunklists[3];
   chunklists[0] = force.offdiag1;
   chunklists[1] = force.offdiag2;
@@ -1075,7 +1075,7 @@ complex<double> *fields::get_dft_array(dft_force force, component c, int num_fre
 }
 
 complex<double> *fields::get_dft_array(dft_near2far n2f, component c, int num_freq, int *rank,
-                               size_t dims[3]) {
+                                       size_t dims[3]) {
   dft_chunk *chunklists[1];
   chunklists[0] = n2f.F;
   complex<double> *array;
@@ -1085,7 +1085,7 @@ complex<double> *fields::get_dft_array(dft_near2far n2f, component c, int num_fr
 }
 
 complex<double> *fields::get_dft_array(dft_fields fdft, component c, int num_freq, int *rank,
-                               size_t dims[3]) {
+                                       size_t dims[3]) {
   dft_chunk *chunklists[1];
   chunklists[0] = fdft.chunks;
   complex<double> *array;
@@ -1235,13 +1235,13 @@ void fields::get_overlap(void *mode1_data, void *mode2_data, dft_flux flux, int 
   chunklists[0] = flux.E;
   chunklists[1] = flux.H;
   complex<double> ExHy = process_dft_component(chunklists, 2, num_freq, cE[0], 0, 0, 0, 0, 0, mode1_data,
-                                       mode2_data, cH[0]);
+                                               mode2_data, cH[0]);
   complex<double> EyHx = process_dft_component(chunklists, 2, num_freq, cE[1], 0, 0, 0, 0, 0, mode1_data,
-                                       mode2_data, cH[1]);
+                                               mode2_data, cH[1]);
   complex<double> HyEx = process_dft_component(chunklists, 2, num_freq, cH[0], 0, 0, 0, 0, 0, mode1_data,
-                                       mode2_data, cE[0]);
+                                               mode2_data, cE[0]);
   complex<double> HxEy = process_dft_component(chunklists, 2, num_freq, cH[1], 0, 0, 0, 0, 0, mode1_data,
-                                       mode2_data, cE[1]);
+                                               mode2_data, cE[1]);
   overlaps[0] = ExHy - EyHx;
   overlaps[1] = HyEx - HxEy;
 }

--- a/src/dft_ldos.cpp
+++ b/src/dft_ldos.cpp
@@ -24,8 +24,8 @@ namespace meep {
 
 dft_ldos::dft_ldos(double freq_min, double freq_max, int Nfreq) {
   freq = meep::linspace(freq_min, freq_max, Nfreq);
-  Fdft = new complex<realnum>[Nfreq];
-  Jdft = new complex<realnum>[Nfreq];
+  Fdft = new complex<double>[Nfreq];
+  Jdft = new complex<double>[Nfreq];
   for (int i = 0; i < Nfreq; ++i)
     Fdft[i] = Jdft[i] = 0.0;
   Jsum = 1.0;
@@ -34,8 +34,8 @@ dft_ldos::dft_ldos(double freq_min, double freq_max, int Nfreq) {
 dft_ldos::dft_ldos(const std::vector<double> freq_) {
   const size_t Nfreq = freq_.size();
   freq = freq_;
-  Fdft = new complex<realnum>[Nfreq];
-  Jdft = new complex<realnum>[Nfreq];
+  Fdft = new complex<double>[Nfreq];
+  Jdft = new complex<double>[Nfreq];
   for (size_t i = 0; i < Nfreq; ++i)
     Fdft[i] = Jdft[i] = 0.0;
   Jsum = 1.0;
@@ -44,8 +44,8 @@ dft_ldos::dft_ldos(const std::vector<double> freq_) {
 dft_ldos::dft_ldos(const double *freq_, size_t Nfreq) : freq(Nfreq) {
   for (size_t i = 0; i < Nfreq; ++i)
     freq[i] = freq_[i];
-  Fdft = new complex<realnum>[Nfreq];
-  Jdft = new complex<realnum>[Nfreq];
+  Fdft = new complex<double>[Nfreq];
+  Jdft = new complex<double>[Nfreq];
   for (size_t i = 0; i < Nfreq; ++i)
     Fdft[i] = Jdft[i] = 0.0;
   Jsum = 1.0;

--- a/src/fields.cpp
+++ b/src/fields.cpp
@@ -690,11 +690,11 @@ static int mirrorindex(int i, int n) { return i >= n ? 2 * n - 1 - i : (i < 0 ? 
 /* Linearly interpolate a given point in a 3d grid of data.  The point
    coordinates should be in the range [0,1], or at the very least [-1,2]
    ... anything outside [0,1] is *mirror* reflected into [0,1] */
-realnum linear_interpolate(realnum rx, realnum ry, realnum rz, realnum *data, int nx, int ny,
-                           int nz, int stride) {
+double linear_interpolate(double rx, double ry, double rz, double *data,
+                          int nx, int ny, int nz, int stride) {
 
   int x, y, z, x2, y2, z2;
-  realnum dx, dy, dz;
+  double dx, dy, dz;
 
   /* mirror boundary conditions for r just beyond the boundary */
   rx = rx < 0.0 ? -rx : (rx > 1.0 ? 1.0 - rx : rx);

--- a/src/h5fields.cpp
+++ b/src/h5fields.cpp
@@ -36,11 +36,11 @@ typedef struct {
   h5file *file;
   ivec min_corner, max_corner;
   int num_chunks;
-  realnum *buf;
+  double *buf;
   size_t bufsz;
   int rank;
   direction ds[3];
-
+  bool single_precision;
   int reim; // whether to output the real or imaginary part
 
   // the function to output and related info (offsets for averaging, etc.)
@@ -218,7 +218,7 @@ static void h5_output_chunkloop(fields_chunk *fc, int ichnk, component cgrid, iv
 
   //-----------------------------------------------------------------------//
 
-  data->file->write_chunk(data->rank, start, count, data->buf);
+  data->file->write_chunk(data->rank, start, count, data->buf, data->single_precision);
 }
 
 void fields::output_hdf5(h5file *file, const char *dataname, int num_fields,
@@ -261,8 +261,8 @@ void fields::output_hdf5(h5file *file, const char *dataname, int num_fields,
 
   file->create_or_extend_data(dataname, rank, dims, append_data, single_precision);
 
-  data.buf = new realnum[data.bufsz];
-
+  data.buf = new double[data.bufsz];
+  data.single_precision = single_precision;
   data.num_fields = num_fields;
   data.components = components;
   data.cS = new component[num_fields];

--- a/src/h5fields.cpp
+++ b/src/h5fields.cpp
@@ -40,7 +40,7 @@ typedef struct {
   size_t bufsz;
   int rank;
   direction ds[3];
-  bool single_precision;
+
   int reim; // whether to output the real or imaginary part
 
   // the function to output and related info (offsets for averaging, etc.)
@@ -218,7 +218,7 @@ static void h5_output_chunkloop(fields_chunk *fc, int ichnk, component cgrid, iv
 
   //-----------------------------------------------------------------------//
 
-  data->file->write_chunk(data->rank, start, count, data->buf, data->single_precision);
+  data->file->write_chunk(data->rank, start, count, data->buf);
 }
 
 void fields::output_hdf5(h5file *file, const char *dataname, int num_fields,
@@ -262,7 +262,7 @@ void fields::output_hdf5(h5file *file, const char *dataname, int num_fields,
   file->create_or_extend_data(dataname, rank, dims, append_data, single_precision);
 
   data.buf = new double[data.bufsz];
-  data.single_precision = single_precision;
+
   data.num_fields = num_fields;
   data.components = components;
   data.cS = new component[num_fields];

--- a/src/h5file.cpp
+++ b/src/h5file.cpp
@@ -683,9 +683,15 @@ static void _write_chunk(hid_t data_id, h5file::extending_s *cur, int rank,
 }
 
 void h5file::write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,
-                         void *data, bool single_precision) {
+                         float *data) {
   _write_chunk(HID(cur_id), get_extending(cur_dataname), rank, chunk_start, chunk_dims,
-               single_precision ? H5T_NATIVE_FLOAT : H5T_NATIVE_DOUBLE, data);
+               H5T_NATIVE_FLOAT, data);
+}
+
+void h5file::write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,
+                         double *data) {
+  _write_chunk(HID(cur_id), get_extending(cur_dataname), rank, chunk_start, chunk_dims,
+               H5T_NATIVE_DOUBLE, data);
 }
 
 void h5file::write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,
@@ -712,7 +718,12 @@ void h5file::write(const char *dataname, int rank, const size_t *dims, void *dat
     for (int i = 0; i < rank; i++)
       start[i] = 0;
     create_data(dataname, rank, dims, false, single_precision);
-    if (am_master()) write_chunk(rank, start, dims, data, single_precision);
+    if (am_master()) {
+      if (single_precision)
+        write_chunk(rank, start, dims, (float *)data);
+      else
+        write_chunk(rank, start, dims, (double *)data);
+    }
     done_writing_chunks();
     unset_cur();
     delete[] start;
@@ -813,9 +824,15 @@ static void _read_chunk(hid_t data_id, int rank, const size_t *chunk_start,
 }
 
 void h5file::read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,
-                        void *data, bool single_precision) {
+                        float *data) {
   _read_chunk(HID(cur_id), rank, chunk_start, chunk_dims,
-              single_precision ? H5T_NATIVE_FLOAT : H5T_NATIVE_DOUBLE, data);
+              H5T_NATIVE_FLOAT, data);
+}
+
+void h5file::read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,
+                        double *data) {
+  _read_chunk(HID(cur_id), rank, chunk_start, chunk_dims,
+              H5T_NATIVE_DOUBLE, data);
 }
 
 void h5file::read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,

--- a/src/h5file.cpp
+++ b/src/h5file.cpp
@@ -282,10 +282,8 @@ static herr_t find_dataset(hid_t group_id, const char *name, void *d) {
 #endif
 
 #ifdef HAVE_HDF5
-#define REALNUM_H5T (sizeof(realnum) == sizeof(double) ? H5T_NATIVE_DOUBLE : H5T_NATIVE_FLOAT)
 #define SIZE_T_H5T (sizeof(size_t) == 4 ? H5T_NATIVE_UINT32 : H5T_NATIVE_UINT64)
 #else
-#define REALNUM_H5T 0
 #define SIZE_T_H5T 0
 #endif
 

--- a/src/h5file.cpp
+++ b/src/h5file.cpp
@@ -500,7 +500,7 @@ void h5file::create_data(const char *dataname, int rank, const size_t *dims, boo
 
     delete[] dims_copy;
 
-    hid_t type_id = single_precision ? H5T_NATIVE_FLOAT : REALNUM_H5T;
+    hid_t type_id = single_precision ? H5T_NATIVE_FLOAT : H5T_NATIVE_DOUBLE;
 
     data_id = H5Dcreate(file_id, dataname, type_id, space_id, prop_id);
     if (data_id < 0) abort("Error creating dataset");
@@ -614,8 +614,8 @@ void h5file::create_or_extend_data(const char *dataname, int rank, const size_t 
    that have no data can be skipped).
 */
 static void _write_chunk(hid_t data_id, h5file::extending_s *cur, int rank,
-                         const size_t *chunk_start, const size_t *chunk_dims, hid_t datatype,
-                         void *data) {
+                         const size_t *chunk_start, const size_t *chunk_dims,
+                         hid_t datatype, void *data) {
 #ifdef HAVE_HDF5
   int i;
   bool do_write = true;
@@ -686,8 +686,8 @@ static void _write_chunk(hid_t data_id, h5file::extending_s *cur, int rank,
 
 void h5file::write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,
                          void *data, bool single_precision) {
-  _write_chunk(HID(cur_id), get_extending(cur_dataname), rank, chunk_start, chunk_dims, REALNUM_H5T,
-               data);
+  _write_chunk(HID(cur_id), get_extending(cur_dataname), rank, chunk_start, chunk_dims,
+               single_precision ? H5T_NATIVE_FLOAT : H5T_NATIVE_DOUBLE, data);
 }
 
 void h5file::write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,
@@ -731,7 +731,6 @@ void h5file::write(const char *dataname, const char *data) {
     remove_data(dataname); // HDF5 gives error if we H5Dcreate existing dataset
 
     type_id = H5Tcopy(H5T_C_S1);
-    ;
     H5Tset_size(type_id, strlen(data) + 1);
     space_id = H5Screate(H5S_SCALAR);
 
@@ -817,7 +816,8 @@ static void _read_chunk(hid_t data_id, int rank, const size_t *chunk_start,
 
 void h5file::read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,
                         void *data, bool single_precision) {
-  _read_chunk(HID(cur_id), rank, chunk_start, chunk_dims, REALNUM_H5T, data);
+  _read_chunk(HID(cur_id), rank, chunk_start, chunk_dims,
+              single_precision ? H5T_NATIVE_FLOAT : H5T_NATIVE_DOUBLE, data);
 }
 
 void h5file::read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,

--- a/src/h5file.cpp
+++ b/src/h5file.cpp
@@ -672,9 +672,9 @@ static void _write_chunk(hid_t data_id, h5file::extending_s *cur, int rank,
 }
 
 void h5file::write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,
-                         realnum *data) {
+                         void *data, bool single_precision) {
   _write_chunk(HID(cur_id), get_extending(cur_dataname), rank, chunk_start, chunk_dims, REALNUM_H5T,
-               (void *)data);
+               data);
 }
 
 void h5file::write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,
@@ -694,14 +694,14 @@ void h5file::done_writing_chunks() {
   if (parallel && cur_dataname && get_extending(cur_dataname)) prevent_deadlock(); // closes id
 }
 
-void h5file::write(const char *dataname, int rank, const size_t *dims, realnum *data,
+void h5file::write(const char *dataname, int rank, const size_t *dims, void *data,
                    bool single_precision) {
   if (parallel || am_master()) {
     size_t *start = new size_t[rank + 1];
     for (int i = 0; i < rank; i++)
       start[i] = 0;
     create_data(dataname, rank, dims, false, single_precision);
-    if (am_master()) write_chunk(rank, start, dims, data);
+    if (am_master()) write_chunk(rank, start, dims, data, single_precision);
     done_writing_chunks();
     unset_cur();
     delete[] start;
@@ -803,8 +803,8 @@ static void _read_chunk(hid_t data_id, int rank, const size_t *chunk_start,
 }
 
 void h5file::read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,
-                        realnum *data) {
-  _read_chunk(HID(cur_id), rank, chunk_start, chunk_dims, REALNUM_H5T, (void *)data);
+                        void *data, bool single_precision) {
+  _read_chunk(HID(cur_id), rank, chunk_start, chunk_dims, REALNUM_H5T, data);
 }
 
 void h5file::read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims,

--- a/src/loop_in_chunks.cpp
+++ b/src/loop_in_chunks.cpp
@@ -213,7 +213,7 @@ void chunkloop_field_components::update_values(ptrdiff_t idx) {
     ptrdiff_t ofs1 = offsets[2 * nc], ofs2 = offsets[2 * nc + 1];
     double favg[2] = {0.0, 0.0}; // real, imag parts
     for (int reim = 0; reim < 2; reim++) {
-      const double *fgrid = fc->f[cparent][reim];
+      const realnum *fgrid = fc->f[cparent][reim];
       if (!fgrid) continue;
       favg[reim] =
           0.25 * (fgrid[idx] + fgrid[idx + ofs1] + fgrid[idx + ofs2] + fgrid[idx + ofs1 + ofs2]);

--- a/src/material_data.hpp
+++ b/src/material_data.hpp
@@ -182,16 +182,16 @@ struct material_data {
   bool do_averaging;
 
   // these fields used only if which_subclass==MATERIAL_FILE
-  meep::realnum *epsilon_data;
+  double *epsilon_data;
   size_t epsilon_dims[3];
 
   // these fields used only if which_subclass==MATERIAL_GRID
   vector3 grid_size;
-  meep::realnum *weights;
+  double *weights;
   medium_struct medium_1;
   medium_struct medium_2;
-  meep::realnum beta;
-  meep::realnum eta;
+  double beta;
+  double eta;
   /*
   There are several possible scenarios when material grids overlap -- these
   different scenarios enable different applications.

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -387,7 +387,7 @@ public:
   bool ok();
 
   realnum *read(const char *dataname, int *rank, size_t *dims, int maxrank);
-  void write(const char *dataname, int rank, const size_t *dims, realnum *data,
+  void write(const char *dataname, int rank, const size_t *dims, void *data,
              bool single_precision = true);
   char *read(const char *dataname);
   void write(const char *dataname, const char *data);
@@ -397,12 +397,14 @@ public:
   void extend_data(const char *dataname, int rank, const size_t *dims);
   void create_or_extend_data(const char *dataname, int rank, const size_t *dims, bool append_data,
                              bool single_precision);
-  void write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, realnum *data);
+  void write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, void *data,
+                   bool single_precision = true);
   void write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, size_t *data);
   void done_writing_chunks();
 
   void read_size(const char *dataname, int *rank, size_t *dims, int maxrank);
-  void read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, realnum *data);
+  void read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, void *data,
+                  bool single_precision = true);
   void read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, size_t *data);
 
   void remove();
@@ -1029,7 +1031,7 @@ public:
   component c; // component to DFT (possibly transformed by symmetry)
 
   size_t N;                   // number of spatial points (on epsilon grid)
-  std::complex<realnum> *dft; // N x Nomega array of DFT values.
+  std::complex<double> *dft; // N x Nomega array of DFT values.
 
   class dft_chunk *next_in_chunk; // per-fields_chunk list of DFT chunks
   class dft_chunk *next_in_dft;   // next for this particular DFT vol./component
@@ -1080,7 +1082,7 @@ public:
   int sn;
 
   // cache of exp(iwt) * scale, of length Nomega
-  std::complex<realnum> *dft_phase;
+  std::complex<double> *dft_phase;
 
   ptrdiff_t avg1, avg2; // index offsets for average to get epsilon grid
 
@@ -1224,17 +1226,17 @@ public:
   dft_near2far(const dft_near2far &f);
 
   /* return an array (Ex,Ey,Ez,Hx,Hy,Hz) x Nfreq of the far fields at x */
-  std::complex<realnum> *farfield(const vec &x);
+  std::complex<double> *farfield(const vec &x);
 
   /* like farfield, but requires F to be Nfreq*6 preallocated array, and
      does *not* perform the reduction over processes...an MPI allreduce
      summation by the caller is required to get the final result ... used
      by other output routine to efficiently get far field on a grid of pts */
-  void farfield_lowlevel(std::complex<realnum> *F, const vec &x);
+  void farfield_lowlevel(std::complex<double> *F, const vec &x);
 
   /* Return a newly allocated array with all far fields */
-  realnum *get_farfields_array(const volume &where, int &rank, size_t *dims, size_t &N,
-                               double resolution);
+  double *get_farfields_array(const volume &where, int &rank, size_t *dims, size_t &N,
+                              double resolution);
 
   /* output far fields on a grid to an HDF5 file */
   void save_farfields(const char *fname, const char *prefix, const volume &where,
@@ -2139,9 +2141,9 @@ double BesselJ(int m, double kr);
 // analytical Green's functions (in near2far.cpp); upon return,
 // EH[0..5] are set to the Ex,Ey,Ez,Hx,Hy,Hz field components at x
 // from a c0 source of amplitude f0 at x0.
-void green2d(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
+void green2d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
              const vec &x0, component c0, std::complex<double> f0);
-void green3d(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
+void green3d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
              const vec &x0, component c0, std::complex<double> f0);
 
 // non-class methods for working with mpb eigenmode data

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -568,14 +568,14 @@ class structure;
 
 class structure_chunk {
 public:
-  double a, Courant, dt; // res. a, Courant num., and timestep dt=Courant/a
+  double a, Courant, dt; // resolution a, Courant num., and timestep dt=Courant/a
   realnum *chi3[NUM_FIELD_COMPONENTS], *chi2[NUM_FIELD_COMPONENTS];
   realnum *chi1inv[NUM_FIELD_COMPONENTS][5];
   bool trivial_chi1inv[NUM_FIELD_COMPONENTS][5];
   realnum *conductivity[NUM_FIELD_COMPONENTS][5];
   realnum *condinv[NUM_FIELD_COMPONENTS][5]; // cache of 1/(1+conduct*dt/2)
   bool condinv_stale;                        // true if condinv needs to be recomputed
-  double *sig[6], *kap[6], *siginv[6];       // conductivity array for uPML
+  realnum *sig[6], *kap[6], *siginv[6];      // conductivity array for uPML
   int sigsize[6];                            // conductivity array size
   grid_volume gv; // integer grid_volume that could be bigger than non-overlapping v below
   volume v;
@@ -717,7 +717,7 @@ public:
   int num_chunks;
   bool shared_chunks; // whether modifications to chunks will be visible to fields objects
   grid_volume gv, user_volume;
-  double a, Courant, dt; // res. a, Courant num., and timestep dt=Courant/a
+  double a, Courant, dt; // resolution a, Courant num., and timestep dt=Courant/a
   volume v;
   symmetry S;
   const char *outdir;
@@ -1359,7 +1359,7 @@ public:
   int npol[NUM_FIELD_TYPES];                // only E_stuff and H_stuff are used
   polarization_state *pol[NUM_FIELD_TYPES]; // array of npol[i] polarization_state structures
 
-  double a, Courant, dt; // res. a, Courant num., and timestep dt=Courant/a
+  double a, Courant, dt; // resolution a, Courant num., and timestep dt=Courant/a
   grid_volume gv;
   volume v;
   double m;                        // angular dependence in cyl. coords

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -99,12 +99,12 @@ public:
   bool operator==(const susceptibility &s) const { return id == s.id; };
 
   // Returns the 1st order nonlinear susceptibility (generic)
-  virtual std::complex<double> chi1(double freq, double sigma = 1);
+  virtual std::complex<realnum> chi1(realnum freq, realnum sigma = 1);
 
   // update all of the internal polarization state given the W field
   // at the current time step, possibly the previous field W_prev, etc.
   virtual void update_P(realnum *W[NUM_FIELD_COMPONENTS][2],
-                        realnum *W_prev[NUM_FIELD_COMPONENTS][2], double dt, const grid_volume &gv,
+                        realnum *W_prev[NUM_FIELD_COMPONENTS][2], realnum dt, const grid_volume &gv,
                         void *P_internal_data) const {
     (void)P;
     (void)W;
@@ -147,7 +147,7 @@ public:
     return 0;
   }
   virtual void delete_internal_data(void *data) const;
-  virtual void init_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], double dt,
+  virtual void init_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], realnum dt,
                                   const grid_volume &gv, void *data) const {
     (void)W;
     (void)dt;
@@ -236,23 +236,23 @@ private:
   denominator to obtain a Drude model. */
 class lorentzian_susceptibility : public susceptibility {
 public:
-  lorentzian_susceptibility(double omega_0, double gamma, bool no_omega_0_denominator = false)
+  lorentzian_susceptibility(realnum omega_0, realnum gamma, bool no_omega_0_denominator = false)
       : omega_0(omega_0), gamma(gamma), no_omega_0_denominator(no_omega_0_denominator) {}
   virtual susceptibility *clone() const { return new lorentzian_susceptibility(*this); }
   virtual ~lorentzian_susceptibility() {}
 
   // Returns the 1st order nonlinear susceptibility
-  virtual std::complex<double> chi1(double freq, double sigma = 1);
+  virtual std::complex<realnum> chi1(realnum freq, realnum sigma = 1);
 
   virtual void update_P(realnum *W[NUM_FIELD_COMPONENTS][2],
-                        realnum *W_prev[NUM_FIELD_COMPONENTS][2], double dt, const grid_volume &gv,
+                        realnum *W_prev[NUM_FIELD_COMPONENTS][2], realnum dt, const grid_volume &gv,
                         void *P_internal_data) const;
 
   virtual void subtract_P(field_type ft, realnum *f_minus_p[NUM_FIELD_COMPONENTS][2],
                           void *P_internal_data) const;
 
   virtual void *new_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], const grid_volume &gv) const;
-  virtual void init_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], double dt,
+  virtual void init_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], realnum dt,
                                   const grid_volume &gv, void *data) const;
   virtual void *copy_internal_data(void *data) const;
 
@@ -264,7 +264,7 @@ public:
   virtual int get_num_params() { return 4; }
 
 protected:
-  double omega_0, gamma;
+  realnum omega_0, gamma;
   bool no_omega_0_denominator;
 };
 
@@ -272,21 +272,21 @@ protected:
    includes white noise with a specified amplitude */
 class noisy_lorentzian_susceptibility : public lorentzian_susceptibility {
 public:
-  noisy_lorentzian_susceptibility(double noise_amp, double omega_0, double gamma,
+  noisy_lorentzian_susceptibility(realnum noise_amp, realnum omega_0, realnum gamma,
                                   bool no_omega_0_denominator = false)
       : lorentzian_susceptibility(omega_0, gamma, no_omega_0_denominator), noise_amp(noise_amp) {}
 
   virtual susceptibility *clone() const { return new noisy_lorentzian_susceptibility(*this); }
 
   virtual void update_P(realnum *W[NUM_FIELD_COMPONENTS][2],
-                        realnum *W_prev[NUM_FIELD_COMPONENTS][2], double dt, const grid_volume &gv,
+                        realnum *W_prev[NUM_FIELD_COMPONENTS][2], realnum dt, const grid_volume &gv,
                         void *P_internal_data) const;
 
   virtual void dump_params(h5file *h5f, size_t *start);
   virtual int get_num_params() { return 5; }
 
 protected:
-  double noise_amp;
+  realnum noise_amp;
 };
 
 typedef enum { GYROTROPIC_LORENTZIAN, GYROTROPIC_DRUDE, GYROTROPIC_SATURATED } gyrotropy_model;
@@ -339,14 +339,14 @@ public:
   virtual ~multilevel_susceptibility();
 
   virtual void update_P(realnum *W[NUM_FIELD_COMPONENTS][2],
-                        realnum *W_prev[NUM_FIELD_COMPONENTS][2], double dt, const grid_volume &gv,
+                        realnum *W_prev[NUM_FIELD_COMPONENTS][2], realnum dt, const grid_volume &gv,
                         void *P_internal_data) const;
 
   virtual void subtract_P(field_type ft, realnum *f_minus_p[NUM_FIELD_COMPONENTS][2],
                           void *P_internal_data) const;
 
   virtual void *new_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], const grid_volume &gv) const;
-  virtual void init_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], double dt,
+  virtual void init_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], realnum dt,
                                   const grid_volume &gv, void *data) const;
   virtual void *copy_internal_data(void *data) const;
   virtual void delete_internal_data(void *data) const;
@@ -387,25 +387,25 @@ public:
   bool ok();
 
   void *read(const char *dataname, int *rank, size_t *dims, int maxrank,
-             bool single_precision = false);
+             bool single_precision = true);
   void write(const char *dataname, int rank, const size_t *dims, void *data,
-             bool single_precision = false);
+             bool single_precision = true);
   char *read(const char *dataname);
   void write(const char *dataname, const char *data);
 
   void create_data(const char *dataname, int rank, const size_t *dims, bool append_data = false,
-                   bool single_precision = false);
+                   bool single_precision = true);
   void extend_data(const char *dataname, int rank, const size_t *dims);
   void create_or_extend_data(const char *dataname, int rank, const size_t *dims, bool append_data,
-                             bool single_precision = false);
+                             bool single_precision = true);
   void write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, void *data,
-                   bool single_precision = false);
+                   bool single_precision = true);
   void write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, size_t *data);
   void done_writing_chunks();
 
   void read_size(const char *dataname, int *rank, size_t *dims, int maxrank);
   void read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, void *data,
-                  bool single_precision = false);
+                  bool single_precision = true);
   void read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, size_t *data);
 
   void remove();
@@ -500,7 +500,7 @@ public:
   /* Return c'th row of effective 1/(1+chi1) tensor in the given grid_volume v
      ... virtual so that e.g. libctl can override with more-efficient
      libctlgeom-based routines.  maxeval == 0 if no averaging desired. */
-  virtual void eff_chi1inv_row(component c, double chi1inv_row[3], const volume &v,
+  virtual void eff_chi1inv_row(component c, realnum chi1inv_row[3], const volume &v,
                                double tol = DEFAULT_SUBPIXEL_TOL,
                                int maxeval = DEFAULT_SUBPIXEL_MAXEVAL);
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -294,18 +294,18 @@ typedef enum { GYROTROPIC_LORENTZIAN, GYROTROPIC_DRUDE, GYROTROPIC_SATURATED } g
 /* gyrotropic susceptibility */
 class gyrotropic_susceptibility : public susceptibility {
 public:
-  gyrotropic_susceptibility(const vec &bias, double omega_0, double gamma, double alpha = 0.0,
+  gyrotropic_susceptibility(const vec &bias, realnum omega_0, realnum gamma, realnum alpha = 0.0,
                             gyrotropy_model model = GYROTROPIC_LORENTZIAN);
   virtual susceptibility *clone() const { return new gyrotropic_susceptibility(*this); }
 
   virtual void *new_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], const grid_volume &gv) const;
-  virtual void init_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], double dt,
+  virtual void init_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], realnum dt,
                                   const grid_volume &gv, void *data) const;
   virtual void *copy_internal_data(void *data) const;
 
   virtual bool needs_P(component c, int cmp, realnum *W[NUM_FIELD_COMPONENTS][2]) const;
   virtual void update_P(realnum *W[NUM_FIELD_COMPONENTS][2],
-                        realnum *W_prev[NUM_FIELD_COMPONENTS][2], double dt, const grid_volume &gv,
+                        realnum *W_prev[NUM_FIELD_COMPONENTS][2], realnum dt, const grid_volume &gv,
                         void *P_internal_data) const;
   virtual void subtract_P(field_type ft, realnum *f_minus_p[NUM_FIELD_COMPONENTS][2],
                           void *P_internal_data) const;
@@ -323,8 +323,8 @@ public:
   }
 
 protected:
-  double gyro_tensor[3][3];
-  double omega_0, gamma, alpha;
+  realnum gyro_tensor[3][3];
+  realnum omega_0, gamma, alpha;
   gyrotropy_model model;
 };
 
@@ -500,7 +500,7 @@ public:
   /* Return c'th row of effective 1/(1+chi1) tensor in the given grid_volume v
      ... virtual so that e.g. libctl can override with more-efficient
      libctlgeom-based routines.  maxeval == 0 if no averaging desired. */
-  virtual void eff_chi1inv_row(component c, realnum chi1inv_row[3], const volume &v,
+  virtual void eff_chi1inv_row(component c, double chi1inv_row[3], const volume &v,
                                double tol = DEFAULT_SUBPIXEL_TOL,
                                int maxeval = DEFAULT_SUBPIXEL_MAXEVAL);
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -35,7 +35,7 @@ namespace meep {
    However, we will default to using double-precision for large
    arrays, as the factor of two in memory and the moderate increase
    in speed currently don't seem worth the loss of precision. */
-#define MEEP_SINGLE 1 // 1 for single precision, 0 for double
+#define MEEP_SINGLE 0 // 1 for single precision, 0 for double
 #if MEEP_SINGLE
 typedef float realnum;
 #else
@@ -2123,9 +2123,6 @@ make_casimir_gfunc(double T, double dt, double sigma, field_type ft,
                    double Tfft = 0);
 
 std::complex<double> *make_casimir_gfunc_kz(double T, double dt, double sigma, field_type ft);
-
-void broadcast(int from, float *data, int size);
-void broadcast(int from, double *data, int size);
 
 // random number generation: random.cpp
 void set_random_seed(unsigned long seed);

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -398,14 +398,14 @@ public:
   void extend_data(const char *dataname, int rank, const size_t *dims);
   void create_or_extend_data(const char *dataname, int rank, const size_t *dims, bool append_data,
                              bool single_precision = true);
-  void write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, void *data,
-                   bool single_precision = true);
+  void write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, float *data);
+  void write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, double *data);
   void write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, size_t *data);
   void done_writing_chunks();
 
   void read_size(const char *dataname, int *rank, size_t *dims, int maxrank);
-  void read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, void *data,
-                  bool single_precision = true);
+  void read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, float *data);
+  void read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, double *data);
   void read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, size_t *data);
 
   void remove();

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -35,7 +35,7 @@ namespace meep {
    However, we will default to using double-precision for large
    arrays, as the factor of two in memory and the moderate increase
    in speed currently don't seem worth the loss of precision. */
-#define MEEP_SINGLE 0 // 1 for single precision, 0 for double
+#define MEEP_SINGLE 1 // 1 for single precision, 0 for double
 #if MEEP_SINGLE
 typedef float realnum;
 #else
@@ -386,7 +386,8 @@ public:
 
   bool ok();
 
-  realnum *read(const char *dataname, int *rank, size_t *dims, int maxrank);
+  void *read(const char *dataname, int *rank, size_t *dims, int maxrank,
+             bool single_precision = true);
   void write(const char *dataname, int rank, const size_t *dims, void *data,
              bool single_precision = true);
   char *read(const char *dataname);
@@ -2123,10 +2124,9 @@ make_casimir_gfunc(double T, double dt, double sigma, field_type ft,
 
 std::complex<double> *make_casimir_gfunc_kz(double T, double dt, double sigma, field_type ft);
 
-#if MEEP_SINGLE
 // in mympi.cpp ... must be here in order to use realnum type
-void broadcast(int from, realnum *data, int size);
-#endif
+void broadcast(int from, float *data, int size);
+void broadcast(int from, double *data, int size);
 
 // random number generation: random.cpp
 void set_random_seed(unsigned long seed);
@@ -2153,8 +2153,8 @@ std::complex<double> eigenmode_amplitude(void *vedata, const vec &p, component c
 double get_group_velocity(void *vedata);
 vec get_k(void *vedata);
 
-realnum linear_interpolate(realnum rx, realnum ry, realnum rz, realnum *data, int nx, int ny,
-                           int nz, int stride);
+double linear_interpolate(double rx, double ry, double rz, double *data,
+                          int nx, int ny, int nz, int stride);
 
 // binary tree class for importing layout of chunk partition
 class binary_partition {

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -28,13 +28,12 @@
 
 namespace meep {
 
-/* We use the type realnum for large arrays, e.g. the fields.
-   For local variables and small arrays, we use double precision,
-   but for things like the fields we can often get away with
-   single precision (since the errors are not dominated by roundoff).
-   However, we will default to using double-precision for large
-   arrays, as the factor of two in memory and the moderate increase
-   in speed currently don't seem worth the loss of precision. */
+/* The (time-domain) fields arrays of the fields_chunk class as well
+   as the material arrays of the structure_chunk class chi1inv,
+   chi3, sigma, etc. can be stored using single-precision floating
+   point rather than double precision (the default). The reduced
+   precision can provide for up to a factor of 2X improvement in the
+   time-stepping rate with generally negligible loss in accuracy. */
 #define MEEP_SINGLE 0 // 1 for single precision, 0 for double
 #if MEEP_SINGLE
 typedef float realnum;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -387,25 +387,25 @@ public:
   bool ok();
 
   void *read(const char *dataname, int *rank, size_t *dims, int maxrank,
-             bool single_precision = true);
+             bool single_precision = false);
   void write(const char *dataname, int rank, const size_t *dims, void *data,
-             bool single_precision = true);
+             bool single_precision = false);
   char *read(const char *dataname);
   void write(const char *dataname, const char *data);
 
   void create_data(const char *dataname, int rank, const size_t *dims, bool append_data = false,
-                   bool single_precision = true);
+                   bool single_precision = false);
   void extend_data(const char *dataname, int rank, const size_t *dims);
   void create_or_extend_data(const char *dataname, int rank, const size_t *dims, bool append_data,
-                             bool single_precision);
+                             bool single_precision = false);
   void write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, void *data,
-                   bool single_precision = true);
+                   bool single_precision = false);
   void write_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, size_t *data);
   void done_writing_chunks();
 
   void read_size(const char *dataname, int *rank, size_t *dims, int maxrank);
   void read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, void *data,
-                  bool single_precision = true);
+                  bool single_precision = false);
   void read_chunk(int rank, const size_t *chunk_start, const size_t *chunk_dims, size_t *data);
 
   void remove();
@@ -1019,7 +1019,7 @@ public:
   // fields::process_dft_component
   std::complex<double> process_dft_component(int rank, direction *ds, ivec min_corner,
                                              ivec max_corner, int num_freq, h5file *file,
-                                             realnum *buffer, int reim,
+                                             double *buffer, int reim,
                                              std::complex<double> *field_array, void *mode1_data,
                                              void *mode2_data, int ic_conjugate,
                                              bool retain_interp_weights, fields *parent);
@@ -2124,7 +2124,6 @@ make_casimir_gfunc(double T, double dt, double sigma, field_type ft,
 
 std::complex<double> *make_casimir_gfunc_kz(double T, double dt, double sigma, field_type ft);
 
-// in mympi.cpp ... must be here in order to use realnum type
 void broadcast(int from, float *data, int size);
 void broadcast(int from, double *data, int size);
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -568,7 +568,7 @@ class structure;
 
 class structure_chunk {
 public:
-  double a, Courant, dt; // resolution a, Courant num., and timestep dt=Courant/a
+  double a, Courant, dt; // resolution a, Courant number, and timestep dt=Courant/a
   realnum *chi3[NUM_FIELD_COMPONENTS], *chi2[NUM_FIELD_COMPONENTS];
   realnum *chi1inv[NUM_FIELD_COMPONENTS][5];
   bool trivial_chi1inv[NUM_FIELD_COMPONENTS][5];
@@ -717,7 +717,7 @@ public:
   int num_chunks;
   bool shared_chunks; // whether modifications to chunks will be visible to fields objects
   grid_volume gv, user_volume;
-  double a, Courant, dt; // resolution a, Courant num., and timestep dt=Courant/a
+  double a, Courant, dt; // resolution a, Courant number, and timestep dt=Courant/a
   volume v;
   symmetry S;
   const char *outdir;
@@ -1359,7 +1359,7 @@ public:
   int npol[NUM_FIELD_TYPES];                // only E_stuff and H_stuff are used
   polarization_state *pol[NUM_FIELD_TYPES]; // array of npol[i] polarization_state structures
 
-  double a, Courant, dt; // resolution a, Courant num., and timestep dt=Courant/a
+  double a, Courant, dt; // resolution a, Courant number, and timestep dt=Courant/a
   grid_volume gv;
   volume v;
   double m;                        // angular dependence in cyl. coords

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -389,7 +389,6 @@ public:
   realnum *read(const char *dataname, int *rank, size_t *dims, int maxrank);
   void write(const char *dataname, int rank, const size_t *dims, realnum *data,
              bool single_precision = true);
-
   char *read(const char *dataname);
   void write(const char *dataname, const char *data);
 
@@ -1017,7 +1016,7 @@ public:
   // fields::process_dft_component
   std::complex<double> process_dft_component(int rank, direction *ds, ivec min_corner,
                                              ivec max_corner, int num_freq, h5file *file,
-                                             double *buffer, int reim,
+                                             realnum *buffer, int reim,
                                              std::complex<double> *field_array, void *mode1_data,
                                              void *mode2_data, int ic_conjugate,
                                              bool retain_interp_weights, fields *parent);
@@ -1200,7 +1199,7 @@ public:
 };
 
 
-struct sourcedata{
+struct sourcedata {
   component near_fd_comp;
   std::vector<ptrdiff_t> idx_arr;
   int fc_idx;
@@ -1225,13 +1224,13 @@ public:
   dft_near2far(const dft_near2far &f);
 
   /* return an array (Ex,Ey,Ez,Hx,Hy,Hz) x Nfreq of the far fields at x */
-  std::complex<double> *farfield(const vec &x);
+  std::complex<realnum> *farfield(const vec &x);
 
   /* like farfield, but requires F to be Nfreq*6 preallocated array, and
      does *not* perform the reduction over processes...an MPI allreduce
      summation by the caller is required to get the final result ... used
      by other output routine to efficiently get far field on a grid of pts */
-  void farfield_lowlevel(std::complex<double> *F, const vec &x);
+  void farfield_lowlevel(std::complex<realnum> *F, const vec &x);
 
   /* Return a newly allocated array with all far fields */
   realnum *get_farfields_array(const volume &where, int &rank, size_t *dims, size_t &N,
@@ -2140,9 +2139,9 @@ double BesselJ(int m, double kr);
 // analytical Green's functions (in near2far.cpp); upon return,
 // EH[0..5] are set to the Ex,Ey,Ez,Hx,Hy,Hz field components at x
 // from a c0 source of amplitude f0 at x0.
-void green2d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
+void green2d(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
              const vec &x0, component c0, std::complex<double> f0);
-void green3d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
+void green3d(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
              const vec &x0, component c0, std::complex<double> f0);
 
 // non-class methods for working with mpb eigenmode data

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1292,8 +1292,8 @@ public:
   std::vector<double> freq;
 
 private:
-  std::complex<realnum> *Fdft; // Nomega array of field * J*(x) DFT values
-  std::complex<realnum> *Jdft; // Nomega array of J(t) DFT values
+  std::complex<double> *Fdft;  // Nomega array of field * J*(x) DFT values
+  std::complex<double> *Jdft;  // Nomega array of J(t) DFT values
   double Jsum;                 // sum of |J| over all points
 };
 

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -72,12 +72,10 @@ float sum_to_master(float);   // Only returns the correct value to proc 0.
 double sum_to_master(double); // Only returns the correct value to proc 0.
 double sum_to_all(double);
 void sum_to_all(const double *in, double *out, int size);
-void sum_to_all(const float *in, float *out, int size);
 void sum_to_master(const float *in, float *out, int size);
 void sum_to_master(const double *in, double *out, int size);
 void sum_to_all(const float *in, double *out, int size);
 void sum_to_all(const std::complex<float> *in, std::complex<double> *out, int size);
-void sum_to_all(const std::complex<float> *in, std::complex<float> *out, int size);
 void sum_to_all(const std::complex<double> *in, std::complex<double> *out, int size);
 void sum_to_master(const std::complex<float> *in, std::complex<float> *out, int size);
 void sum_to_master(const std::complex<double> *in, std::complex<double> *out, int size);

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -71,10 +71,12 @@ float sum_to_master(float);   // Only returns the correct value to proc 0.
 double sum_to_master(double); // Only returns the correct value to proc 0.
 double sum_to_all(double);
 void sum_to_all(const double *in, double *out, int size);
+void sum_to_all(const float *in, float *out, int size);
 void sum_to_master(const float *in, float *out, int size);
 void sum_to_master(const double *in, double *out, int size);
 void sum_to_all(const float *in, double *out, int size);
 void sum_to_all(const std::complex<float> *in, std::complex<double> *out, int size);
+void sum_to_all(const std::complex<float> *in, std::complex<float> *out, int size);
 void sum_to_all(const std::complex<double> *in, std::complex<double> *out, int size);
 void sum_to_master(const std::complex<float> *in, std::complex<float> *out, int size);
 void sum_to_master(const std::complex<double> *in, std::complex<double> *out, int size);

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -55,6 +55,7 @@ inline int am_master() { return my_rank() == 0; }
 bool with_mpi();
 
 void send(int from, int to, double *data, int size = 1);
+void broadcast(int from, float *data, int size);
 void broadcast(int from, double *data, int size);
 void broadcast(int from, char *data, int size);
 void broadcast(int from, int *data, int size);

--- a/src/meep_internals.hpp
+++ b/src/meep_internals.hpp
@@ -152,11 +152,11 @@ void step_beta_stride1(realnum *f, component c, const realnum *g, const grid_vol
   } while (0)
 
 // analytical Green's functions from near2far.cpp, which we might want to expose someday
-void green3d(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
+void green3d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
              const vec &x0, component c0, std::complex<double> f0);
-void green2d(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
+void green2d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
              const vec &x0, component c0, std::complex<double> f0);
-void greencyl(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
+void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
               const vec &x0, component c0, std::complex<double> f0, double m, double tol);
 
 } // namespace meep

--- a/src/meep_internals.hpp
+++ b/src/meep_internals.hpp
@@ -152,11 +152,11 @@ void step_beta_stride1(realnum *f, component c, const realnum *g, const grid_vol
   } while (0)
 
 // analytical Green's functions from near2far.cpp, which we might want to expose someday
-void green3d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
+void green3d(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
              const vec &x0, component c0, std::complex<double> f0);
-void green2d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
+void green2d(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
              const vec &x0, component c0, std::complex<double> f0);
-void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
+void greencyl(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
               const vec &x0, component c0, std::complex<double> f0, double m, double tol);
 
 } // namespace meep

--- a/src/meep_internals.hpp
+++ b/src/meep_internals.hpp
@@ -79,41 +79,41 @@ symmetry r_to_minus_r_symmetry(int m);
 
 // functions in step_generic.cpp:
 
-void step_curl(realnum *f, component c, const realnum *g1, const realnum *g2, ptrdiff_t s1,
-               ptrdiff_t s2, // strides for g1/g2 shift
-               const grid_volume &gv, double dtdx, direction dsig, const double *sig,
-               const double *kap, const double *siginv, realnum *fu, direction dsigu,
-               const double *sigu, const double *kapu, const double *siginvu, double dt,
+void step_curl(realnum *f, component c, const realnum *g1, const realnum *g2,
+               ptrdiff_t s1, ptrdiff_t s2, // strides for g1/g2 shift
+               const grid_volume &gv, realnum dtdx, direction dsig, const realnum *sig,
+               const realnum *kap, const realnum *siginv, realnum *fu, direction dsigu,
+               const realnum *sigu, const realnum *kapu, const realnum *siginvu, realnum dt,
                const realnum *cnd, const realnum *cndinv, realnum *fcnd);
 
 void step_update_EDHB(realnum *f, component fc, const grid_volume &gv, const realnum *g,
                       const realnum *g1, const realnum *g2, const realnum *u, const realnum *u1,
                       const realnum *u2, ptrdiff_t s, ptrdiff_t s1, ptrdiff_t s2,
                       const realnum *chi2, const realnum *chi3, realnum *fw, direction dsigw,
-                      const double *sigw, const double *kapw);
+                      const realnum *sigw, const realnum *kapw);
 
-void step_beta(realnum *f, component c, const realnum *g, const grid_volume &gv, double betadt,
-               direction dsig, const double *siginv, realnum *fu, direction dsigu,
-               const double *siginvu, const realnum *cndinv, realnum *fcnd);
+void step_beta(realnum *f, component c, const realnum *g, const grid_volume &gv, realnum betadt,
+               direction dsig, const realnum *siginv, realnum *fu, direction dsigu,
+               const realnum *siginvu, const realnum *cndinv, realnum *fcnd);
 
 // functions in step_generic_stride1.cpp, generated from step_generic.cpp:
 
-void step_curl_stride1(realnum *f, component c, const realnum *g1, const realnum *g2, ptrdiff_t s1,
-                       ptrdiff_t s2, // strides for g1/g2 shift
-                       const grid_volume &gv, double dtdx, direction dsig, const double *sig,
-                       const double *kap, const double *siginv, realnum *fu, direction dsigu,
-                       const double *sigu, const double *kapu, const double *siginvu, double dt,
+void step_curl_stride1(realnum *f, component c, const realnum *g1, const realnum *g2,
+                       ptrdiff_t s1, ptrdiff_t s2, // strides for g1/g2 shift
+                       const grid_volume &gv, realnum dtdx, direction dsig, const realnum *sig,
+                       const realnum *kap, const realnum *siginv, realnum *fu, direction dsigu,
+                       const realnum *sigu, const realnum *kapu, const realnum *siginvu, realnum dt,
                        const realnum *cnd, const realnum *cndinv, realnum *fcnd);
 
 void step_update_EDHB_stride1(realnum *f, component fc, const grid_volume &gv, const realnum *g,
                               const realnum *g1, const realnum *g2, const realnum *u,
                               const realnum *u1, const realnum *u2, ptrdiff_t s, ptrdiff_t s1,
                               ptrdiff_t s2, const realnum *chi2, const realnum *chi3, realnum *fw,
-                              direction dsigw, const double *sigw, const double *kapw);
+                              direction dsigw, const realnum *sigw, const realnum *kapw);
 
 void step_beta_stride1(realnum *f, component c, const realnum *g, const grid_volume &gv,
-                       double betadt, direction dsig, const double *siginv, realnum *fu,
-                       direction dsigu, const double *siginvu, const realnum *cndinv,
+                       realnum betadt, direction dsig, const realnum *siginv, realnum *fu,
+                       direction dsigu, const realnum *siginvu, const realnum *cndinv,
                        realnum *fcnd);
 
 /* macro wrappers around time-stepping functions: for performance reasons,

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2285,19 +2285,19 @@ double vec_to_value(vector3 diag, vector3 offdiag, int idx) {
 }
 
 void get_material_tensor(const medium_struct *mm, meep::realnum freq,
-                         std::complex<meep::realnum> *tensor) {
+                         std::complex<double> *tensor) {
   /*
   Note that the current implementation assumes that any dispersion
   is either a lorentzian or drude profile.
   */
   for (int i = 0; i < 9; i++) {
-    std::complex<meep::realnum> a = std::complex<meep::realnum>(1, 0);
-    std::complex<meep::realnum> b = std::complex<meep::realnum>(0, 0);
+    std::complex<double> a = std::complex<double>(1, 0);
+    std::complex<double> b = std::complex<double>(0, 0);
     // compute first part containing conductivity
     vector3 dummy;
     dummy.x = dummy.y = dummy.z = 0.0;
     double conductivityCur = vec_to_value(mm->D_conductivity_diag, dummy, i);
-    a += std::complex<meep::realnum>(0.0, conductivityCur / freq);
+    a += std::complex<double>(0.0, conductivityCur / freq);
 
     // compute lorentzian component
     b = cvec_to_value(mm->epsilon_diag, mm->epsilon_offdiag, i);
@@ -2316,13 +2316,13 @@ void get_material_tensor(const medium_struct *mm, meep::realnum freq,
 }
 
 meep::realnum get_material_gradient(
-    meep::realnum u,                // material parameter at current point
-    std::complex<meep::realnum> fields_a,  // adjoint field at current point
-    std::complex<meep::realnum> fields_f,  // forward field at current point
-    meep::realnum freq,             // frequency
+    double u,                       // material parameter at current point
+    std::complex<double> fields_a,  // adjoint field at current point
+    std::complex<double> fields_f,  // forward field at current point
+    double freq,                    // frequency
     material_data *md,              // material
     meep::component field_dir,      // current field component
-    meep::realnum du                // step size
+    double du                       // step size
 ) {
   /* Note that the current implementation assumes that
   no materials have off-diag components and that if a material
@@ -2347,15 +2347,15 @@ meep::realnum get_material_gradient(
   /* For now we do a finite difference approach to estimate the
   gradient of the system matrix `A` since it's fairly accurate,
   cheap, and easy to generalize. */
-  std::complex<meep::realnum> dA_du_0[9] = {std::complex<meep::realnum>(0, 0)};
+  std::complex<double> dA_du_0[9] = {std::complex<double>(0, 0)};
   epsilon_material_grid(md, u - du);
   get_material_tensor(mm, freq, dA_du_0);
 
-  std::complex<meep::realnum> dA_du_1[9] = {std::complex<meep::realnum>(0, 0)};
+  std::complex<double> dA_du_1[9] = {std::complex<double>(0, 0)};
   epsilon_material_grid(md, u + du);
   get_material_tensor(mm, freq, dA_du_1);
 
-  std::complex<meep::realnum> dA_du[9] = {std::complex<meep::realnum>(0, 0)};
+  std::complex<double> dA_du[9] = {std::complex<double>(0, 0)};
   for (int i = 0; i < 9; i++)
     dA_du[i] = (dA_du_1[i] - dA_du_0[i]) / (2 * du);
 
@@ -2369,7 +2369,7 @@ meep::realnum get_material_gradient(
   else
     meep::abort("Invalid adjoint field component");
 
-  std::complex<meep::realnum> result = fields_a * dA_du[3 * dir_idx + dir_idx] * fields_f;
+  std::complex<double> result = fields_a * dA_du[3 * dir_idx + dir_idx] * fields_f;
   return 2 * result.real();
 }
 
@@ -2440,8 +2440,8 @@ in row-major order (the order used by HDF5): */
 #undef U
 }
 
-void material_grids_addgradient_point(meep::realnum *v, std::complex<meep::realnum> fields_a,
-                                      std::complex<meep::realnum> fields_f, meep::component field_dir,
+void material_grids_addgradient_point(meep::realnum *v, std::complex<double> fields_a,
+                                      std::complex<double> fields_f, meep::component field_dir,
                                       vector3 p, meep::realnum scalegrad, meep::realnum freq,
                                       geom_box_tree geometry_tree) {
   geom_box_tree tp;
@@ -2515,8 +2515,8 @@ void material_grids_addgradient_point(meep::realnum *v, std::complex<meep::realn
   }
 }
 
-void material_grids_addgradient(meep::realnum *v, size_t ng, std::complex<meep::realnum> *fields_a,
-                                std::complex<meep::realnum> *fields_f, meep::realnum *frequencies,
+void material_grids_addgradient(meep::realnum *v, size_t ng, std::complex<double> *fields_a,
+                                std::complex<double> *fields_f, meep::realnum *frequencies,
                                 size_t nf, meep::realnum scalegrad, const meep::volume &where,
                                 geom_box_tree geometry_tree, meep::fields *f) {
   int n2, n3, n4;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2285,19 +2285,19 @@ double vec_to_value(vector3 diag, vector3 offdiag, int idx) {
 }
 
 void get_material_tensor(const medium_struct *mm, meep::realnum freq,
-                         std::complex<double> *tensor) {
+                         std::complex<meep::realnum> *tensor) {
   /*
   Note that the current implementation assumes that any dispersion
   is either a lorentzian or drude profile.
   */
   for (int i = 0; i < 9; i++) {
-    std::complex<double> a = std::complex<double>(1, 0);
-    std::complex<double> b = std::complex<double>(0, 0);
+    std::complex<meep::realnum> a = std::complex<meep::realnum>(1, 0);
+    std::complex<meep::realnum> b = std::complex<meep::realnum>(0, 0);
     // compute first part containing conductivity
     vector3 dummy;
     dummy.x = dummy.y = dummy.z = 0.0;
     double conductivityCur = vec_to_value(mm->D_conductivity_diag, dummy, i);
-    a += std::complex<double>(0.0, conductivityCur / freq);
+    a += std::complex<meep::realnum>(0.0, conductivityCur / freq);
 
     // compute lorentzian component
     b = cvec_to_value(mm->epsilon_diag, mm->epsilon_offdiag, i);
@@ -2317,8 +2317,8 @@ void get_material_tensor(const medium_struct *mm, meep::realnum freq,
 
 meep::realnum get_material_gradient(
     meep::realnum u,                // material parameter at current point
-    std::complex<double> fields_a,  // adjoint field at current point
-    std::complex<double> fields_f,  // forward field at current point
+    std::complex<meep::realnum> fields_a,  // adjoint field at current point
+    std::complex<meep::realnum> fields_f,  // forward field at current point
     meep::realnum freq,             // frequency
     material_data *md,              // material
     meep::component field_dir,      // current field component
@@ -2347,15 +2347,15 @@ meep::realnum get_material_gradient(
   /* For now we do a finite difference approach to estimate the
   gradient of the system matrix `A` since it's fairly accurate,
   cheap, and easy to generalize. */
-  std::complex<double> dA_du_0[9] = {std::complex<double>(0, 0)};
+  std::complex<meep::realnum> dA_du_0[9] = {std::complex<meep::realnum>(0, 0)};
   epsilon_material_grid(md, u - du);
   get_material_tensor(mm, freq, dA_du_0);
 
-  std::complex<double> dA_du_1[9] = {std::complex<double>(0, 0)};
+  std::complex<meep::realnum> dA_du_1[9] = {std::complex<meep::realnum>(0, 0)};
   epsilon_material_grid(md, u + du);
   get_material_tensor(mm, freq, dA_du_1);
 
-  std::complex<double> dA_du[9] = {std::complex<double>(0, 0)};
+  std::complex<meep::realnum> dA_du[9] = {std::complex<meep::realnum>(0, 0)};
   for (int i = 0; i < 9; i++)
     dA_du[i] = (dA_du_1[i] - dA_du_0[i]) / (2 * du);
 
@@ -2369,7 +2369,7 @@ meep::realnum get_material_gradient(
   else
     meep::abort("Invalid adjoint field component");
 
-  std::complex<double> result = fields_a * dA_du[3 * dir_idx + dir_idx] * fields_f;
+  std::complex<meep::realnum> result = fields_a * dA_du[3 * dir_idx + dir_idx] * fields_f;
   return 2 * result.real();
 }
 
@@ -2440,8 +2440,8 @@ in row-major order (the order used by HDF5): */
 #undef U
 }
 
-void material_grids_addgradient_point(meep::realnum *v, std::complex<double> fields_a,
-                                      std::complex<double> fields_f, meep::component field_dir,
+void material_grids_addgradient_point(meep::realnum *v, std::complex<meep::realnum> fields_a,
+                                      std::complex<meep::realnum> fields_f, meep::component field_dir,
                                       vector3 p, meep::realnum scalegrad, meep::realnum freq,
                                       geom_box_tree geometry_tree) {
   geom_box_tree tp;
@@ -2515,8 +2515,8 @@ void material_grids_addgradient_point(meep::realnum *v, std::complex<double> fie
   }
 }
 
-void material_grids_addgradient(meep::realnum *v, size_t ng, std::complex<double> *fields_a,
-                                std::complex<double> *fields_f, meep::realnum *frequencies,
+void material_grids_addgradient(meep::realnum *v, size_t ng, std::complex<meep::realnum> *fields_a,
+                                std::complex<meep::realnum> *fields_f, meep::realnum *frequencies,
                                 size_t nf, meep::realnum scalegrad, const meep::volume &where,
                                 geom_box_tree geometry_tree, meep::fields *f) {
   int n2, n3, n4;

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -172,7 +172,7 @@ material_type make_material_grid(bool do_averaging, double beta, double eta);
 vector3 vec_to_vector3(const meep::vec &pt);
 meep::vec vector3_to_vec(const vector3 v3);
 
-void epsilon_material_grid(material_data *md, meep::realnum u);
+void epsilon_material_grid(material_data *md, double u);
 void epsilon_file_material(material_data *md, vector3 p);
 bool susceptibility_equal(const susceptibility &s1, const susceptibility &s2);
 bool susceptibility_list_equal(const susceptibility_list &s1, const susceptibility_list &s2);
@@ -209,24 +209,24 @@ void init_libctl(material_type default_mat, bool ensure_per,
 // material grid functions
 /***************************************************************/
 void update_weights(material_type matgrid, double *weights);
-meep::realnum matgrid_val(vector3 p, geom_box_tree tp, int oi, material_data *md);
-meep::realnum material_grid_val(vector3 p, material_data *md);
+double matgrid_val(vector3 p, geom_box_tree tp, int oi, material_data *md);
+double material_grid_val(vector3 p, material_data *md);
 geom_box_tree calculate_tree(const meep::volume &v, geometric_object_list g);
-void get_material_tensor(const medium_struct *mm, meep::realnum freq, std::complex<double> *tensor);
-meep::realnum get_material_gradient(double u, std::complex<double> fields_a,
-                                    std::complex<double> fields_f, double freq,
-                                    material_data *md, meep::component field_dir,
-                                    double du = 1.0e-3);
-void add_interpolate_weights(meep::realnum rx, meep::realnum ry, meep::realnum rz,
-                             meep::realnum *data, int nx, int ny, int nz, int stride,
-                             double scaleby, const meep::realnum *udata, int ukind, double uval);
-void material_grids_addgradient_point(meep::realnum *v, std::complex<double> fields_a,
+void get_material_tensor(const medium_struct *mm, double freq, std::complex<double> *tensor);
+double get_material_gradient(double u, std::complex<double> fields_a,
+                             std::complex<double> fields_f, double freq,
+                             material_data *md, meep::component field_dir,
+                             double du = 1.0e-3);
+void add_interpolate_weights(double rx, double ry, double rz,
+                             double *data, int nx, int ny, int nz, int stride,
+                             double scaleby, const double *udata, int ukind, double uval);
+void material_grids_addgradient_point(double *v, std::complex<double> fields_a,
                                       std::complex<double> fields_f, meep::component field_dir,
-                                      vector3 p, meep::realnum scalegrad, meep::realnum freq,
+                                      vector3 p, double scalegrad, double freq,
                                       geom_box_tree geometry_tree);
-void material_grids_addgradient(meep::realnum *v, size_t ng, std::complex<double> *fields_a,
-                                std::complex<double> *fields_f, meep::realnum *frequencies,
-                                size_t nf, meep::realnum scalegrad, const meep::volume &where,
+void material_grids_addgradient(double *v, size_t ng, std::complex<double> *fields_a,
+                                std::complex<double> *fields_f, double *frequencies,
+                                size_t nf, double scalegrad, const meep::volume &where,
                                 geom_box_tree geometry_tree, meep::fields *f);
 
 /***************************************************************/

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -212,20 +212,20 @@ void update_weights(material_type matgrid, double *weights);
 meep::realnum matgrid_val(vector3 p, geom_box_tree tp, int oi, material_data *md);
 meep::realnum material_grid_val(vector3 p, material_data *md);
 geom_box_tree calculate_tree(const meep::volume &v, geometric_object_list g);
-void get_material_tensor(const medium_struct *mm, meep::realnum freq, std::complex<double> *tensor);
-meep::realnum get_material_gradient(meep::realnum u, std::complex<double> fields_a,
-                                    std::complex<double> fields_f, meep::realnum freq,
+void get_material_tensor(const medium_struct *mm, meep::realnum freq, std::complex<meep::realnum> *tensor);
+meep::realnum get_material_gradient(meep::realnum u, std::complex<meep::realnum> fields_a,
+                                    std::complex<meep::realnum> fields_f, meep::realnum freq,
                                     material_data *md, meep::component field_dir,
                                     meep::realnum du = 1.0e-3);
 void add_interpolate_weights(meep::realnum rx, meep::realnum ry, meep::realnum rz,
                              meep::realnum *data, int nx, int ny, int nz, int stride,
                              double scaleby, const meep::realnum *udata, int ukind, double uval);
-void material_grids_addgradient_point(meep::realnum *v, std::complex<double> fields_a,
-                                      std::complex<double> fields_f, meep::component field_dir,
+void material_grids_addgradient_point(meep::realnum *v, std::complex<meep::realnum> fields_a,
+                                      std::complex<meep::realnum> fields_f, meep::component field_dir,
                                       vector3 p, meep::realnum scalegrad, meep::realnum freq,
                                       geom_box_tree geometry_tree);
-void material_grids_addgradient(meep::realnum *v, size_t ng, std::complex<double> *fields_a,
-                                std::complex<double> *fields_f, meep::realnum *frequencies,
+void material_grids_addgradient(meep::realnum *v, size_t ng, std::complex<meep::realnum> *fields_a,
+                                std::complex<meep::realnum> *fields_f, meep::realnum *frequencies,
                                 size_t nf, meep::realnum scalegrad, const meep::volume &where,
                                 geom_box_tree geometry_tree, meep::fields *f);
 

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -28,10 +28,6 @@
 
 namespace meep_geom {
 
-#ifndef cdouble
-typedef std::complex<double> cdouble;
-#endif
-
 // constants from meep-ctl-const.hpp
 #define CYLINDRICAL -2
 

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -212,20 +212,20 @@ void update_weights(material_type matgrid, double *weights);
 meep::realnum matgrid_val(vector3 p, geom_box_tree tp, int oi, material_data *md);
 meep::realnum material_grid_val(vector3 p, material_data *md);
 geom_box_tree calculate_tree(const meep::volume &v, geometric_object_list g);
-void get_material_tensor(const medium_struct *mm, meep::realnum freq, std::complex<meep::realnum> *tensor);
-meep::realnum get_material_gradient(meep::realnum u, std::complex<meep::realnum> fields_a,
-                                    std::complex<meep::realnum> fields_f, meep::realnum freq,
+void get_material_tensor(const medium_struct *mm, meep::realnum freq, std::complex<double> *tensor);
+meep::realnum get_material_gradient(double u, std::complex<double> fields_a,
+                                    std::complex<double> fields_f, double freq,
                                     material_data *md, meep::component field_dir,
-                                    meep::realnum du = 1.0e-3);
+                                    double du = 1.0e-3);
 void add_interpolate_weights(meep::realnum rx, meep::realnum ry, meep::realnum rz,
                              meep::realnum *data, int nx, int ny, int nz, int stride,
                              double scaleby, const meep::realnum *udata, int ukind, double uval);
-void material_grids_addgradient_point(meep::realnum *v, std::complex<meep::realnum> fields_a,
-                                      std::complex<meep::realnum> fields_f, meep::component field_dir,
+void material_grids_addgradient_point(meep::realnum *v, std::complex<double> fields_a,
+                                      std::complex<double> fields_f, meep::component field_dir,
                                       vector3 p, meep::realnum scalegrad, meep::realnum freq,
                                       geom_box_tree geometry_tree);
-void material_grids_addgradient(meep::realnum *v, size_t ng, std::complex<meep::realnum> *fields_a,
-                                std::complex<meep::realnum> *fields_f, meep::realnum *frequencies,
+void material_grids_addgradient(meep::realnum *v, size_t ng, std::complex<double> *fields_a,
+                                std::complex<double> *fields_f, meep::realnum *frequencies,
                                 size_t nf, meep::realnum scalegrad, const meep::volume &where,
                                 geom_box_tree geometry_tree, meep::fields *f);
 

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -32,8 +32,6 @@
 
 using namespace std;
 
-typedef complex<double> cdouble;
-
 namespace meep {
 
 #ifdef HAVE_MPB
@@ -722,7 +720,7 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
   // so we need to divide the E-field amplitudes by -frequency; we also take this
   // opportunity to rescale the overall E and H amplitudes to yield unit power flux.
   double scale = -1.0 / frequency, factor = 2.0 / sqrt(fabs(vgrp));
-  cdouble *efield = (cdouble *)fft_data_E, *hfield = (cdouble *)(mdata->fft_data);
+  complex<double> *efield = (complex<double> *)fft_data_E, *hfield = (complex<double> *)(mdata->fft_data);
   for (int n = 0; n < NFFT; ++n) {
     efield[n] *= factor * scale;
     hfield[n] *= factor;
@@ -938,15 +936,15 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
       /*--------------------------------------------------------------*/
       /*--------------------------------------------------------------*/
       /*--------------------------------------------------------------*/
-      cdouble mode_flux[2], mode_mode[2];
+      complex<double> mode_flux[2], mode_mode[2];
       get_mode_flux_overlap(mode_data, flux, nf, mode_flux);
       get_mode_mode_overlap(mode_data, mode_data, flux, mode_mode);
-      cdouble cplus = 0.5 * (mode_flux[0] + mode_flux[1]);
-      cdouble cminus = 0.5 * (mode_flux[0] - mode_flux[1]);
+      complex<double> cplus = 0.5 * (mode_flux[0] + mode_flux[1]);
+      complex<double> cminus = 0.5 * (mode_flux[0] - mode_flux[1]);
       /* MPB modes are normalized to unit power above, but we need to re-normalize here to have
          unit power as integrated on Meep's Yee grid and not on MPB's grid.  Thus, normfac differs
          from a constant factor only because of discretization effects. */
-      cdouble normfac = 0.5 * (mode_mode[0] + mode_mode[1]);
+      complex<double> normfac = 0.5 * (mode_mode[0] + mode_mode[1]);
       if (normfac == 0.0) normfac = 1.0;
       double csc = sqrt((flux.use_symmetry ? S.multiplicity() : 1.0) / abs(normfac));
       if (cscale)

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -318,6 +318,14 @@ void sum_to_all(const double *in, double *out, int size) {
 #endif
 }
 
+void sum_to_all(const float *in, float *out, int size) {
+#ifdef HAVE_MPI
+  MPI_Allreduce((void *)in, out, size, MPI_FLOAT, MPI_SUM, mycomm);
+#else
+  memcpy(out, in, sizeof(float) * size);
+#endif
+}
+
 void sum_to_master(const float *in, float *out, int size) {
 #ifdef HAVE_MPI
   MPI_Reduce((void *)in, out, size, MPI_FLOAT, MPI_SUM, 0, mycomm);
@@ -344,6 +352,10 @@ void sum_to_all(const float *in, double *out, int size) {
 
 void sum_to_all(const complex<double> *in, complex<double> *out, int size) {
   sum_to_all((const double *)in, (double *)out, 2 * size);
+}
+
+void sum_to_all(const complex<float> *in, complex<float> *out, int size) {
+  sum_to_all((const float *)in, (float *)out, 2 * size);
 }
 
 void sum_to_all(const complex<float> *in, complex<double> *out, int size) {

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -152,8 +152,7 @@ void send(int from, int to, double *data, int size) {
 #endif
 }
 
-#if MEEP_SINGLE
-void broadcast(int from, realnum *data, int size) {
+void broadcast(int from, float *data, int size) {
 #ifdef HAVE_MPI
   if (size == 0) return;
   MPI_Bcast(data, size, MPI_FLOAT, from, mycomm);
@@ -163,7 +162,6 @@ void broadcast(int from, realnum *data, int size) {
   UNUSED(size);
 #endif
 }
-#endif
 
 void broadcast(int from, double *data, int size) {
 #ifdef HAVE_MPI

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -316,14 +316,6 @@ void sum_to_all(const double *in, double *out, int size) {
 #endif
 }
 
-void sum_to_all(const float *in, float *out, int size) {
-#ifdef HAVE_MPI
-  MPI_Allreduce((void *)in, out, size, MPI_FLOAT, MPI_SUM, mycomm);
-#else
-  memcpy(out, in, sizeof(float) * size);
-#endif
-}
-
 void sum_to_master(const float *in, float *out, int size) {
 #ifdef HAVE_MPI
   MPI_Reduce((void *)in, out, size, MPI_FLOAT, MPI_SUM, 0, mycomm);
@@ -350,10 +342,6 @@ void sum_to_all(const float *in, double *out, int size) {
 
 void sum_to_all(const complex<double> *in, complex<double> *out, int size) {
   sum_to_all((const double *)in, (double *)out, 2 * size);
-}
-
-void sum_to_all(const complex<float> *in, complex<float> *out, int size) {
-  sum_to_all((const float *)in, (float *)out, 2 * size);
 }
 
 void sum_to_all(const complex<float> *in, complex<double> *out, int size) {

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -399,7 +399,7 @@ std::complex<double> *dft_near2far::farfield(const vec &x) {
 }
 
 double *dft_near2far::get_farfields_array(const volume &where, int &rank, size_t *dims, size_t &N,
-                                           double resolution) {
+                                          double resolution) {
   /* compute output grid size etc. */
   double dx[3] = {0, 0, 0};
   direction dirs[3] = {X, Y, Z};

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -687,7 +687,7 @@ std::vector<struct sourcedata> dft_near2far::near_sourcedata(const vec &x_0, dou
                 else
                   green(EH6, x, freq[i], eps, mu, xs, c0, w);
                 for (int j = 0; j < 6; ++j)
-                  EH0 += EH6[j] * complex<double>(cphase * (f->stored_weight) * dJ[6*Nfreq*ipt + 6*i + j]);
+                  EH0 += EH6[j] * cphase * (f->stored_weight) * dJ[6*Nfreq*ipt + 6*i + j];
               }
           }
         }

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -121,7 +121,7 @@ void dft_near2far::scale_dfts(complex<double> scale) {
   if (F) F->scale_dft(scale);
 }
 
-typedef void (*greenfunc)(std::complex<realnum> *EH, const vec &x, double freq, double eps,
+typedef void (*greenfunc)(std::complex<double> *EH, const vec &x, double freq, double eps,
                           double mu, const vec &x0, component c0, std::complex<double> f0);
 
 /* Given the field f0 correponding to current-source component c0 at
@@ -130,7 +130,7 @@ typedef void (*greenfunc)(std::complex<realnum> *EH, const vec &x, double freq, 
 
    Adapted from code by M. T. Homer Reid in his SCUFF-EM package
    (file scuff-em/src/libs/libIncField/PointSource.cc), which is GPL v2+. */
-void green3d(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
+void green3d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
              const vec &x0, component c0, std::complex<double> f0) {
   vec rhat = x - x0;
   double r = abs(rhat);
@@ -206,7 +206,7 @@ static std::complex<double> hankel(int n, double x) {
 #endif /* !HAVE_LIBGSL */
 
 /* like green3d, but 2d Green's functions */
-void green2d(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
+void green2d(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
              const vec &x0, component c0, std::complex<double> f0) {
   vec rhat = x - x0;
   double r = abs(rhat);
@@ -277,7 +277,7 @@ void green2d(std::complex<realnum> *EH, const vec &x, double freq, double eps, d
 // term rotates around the z axis with exp(im*phi) dependence, integrated to a tolerance tol.
 // (note: this is the Green's function divided by 2pi*x0.r(), to compensate for a 2piR factor
 //  in the near2far add_dft weight.)
-void greencyl(std::complex<realnum> *EH, const vec &x, double freq, double eps, double mu,
+void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
               const vec &x0, component c0, std::complex<double> f0, double m, double tol) {
   if (x0.dim != Dcyl) abort("wrong dimensionality in greencyl");
   vec x_3d(x.dim == Dcyl ? x.r() : x.x(), x.y(), x.z());
@@ -292,18 +292,17 @@ void greencyl(std::complex<realnum> *EH, const vec &x, double freq, double eps, 
   const int N0 = 4;
   double dphi = 2.0 / N0; // factor of 2*pi*r is already included in add_dft weight
   for (int N = N0; N <= 65536; N *= 2) {
-    std::complex<realnum> EH_sum[6];
+    std::complex<double> EH_sum[6];
     dphi *= 0.5; // delta phi is halved because N doubles
     double dphi2pi = dphi * 2 * pi;
     for (int j = 0; j < 6; ++j)
-      EH_sum[j] = EH[j] * realnum(0.5); // re-use previous quadrature points (with halved dphi)
+      EH_sum[j] = EH[j] * 0.5; // re-use previous quadrature points (with halved dphi)
     /* N-point quadrature points i = 0..N-1.  After the first iteration (N==N0), we
        only need to sum over odd i, since the even i were summed for the previous N. */
     for (int i = (N > N0); i < N; i += 1 + (N > N0)) {
       double phi = i * dphi2pi, c = cos(phi), s = sin(phi);
       vec x0_phi(x0.r() * c, x0.r() * s, x0.z()); // source point rotated by phi
-      std::complex<realnum> EH_phi[6];
-      std::complex<double> f0_exp_imphi = f0 * std::polar(1.0, m * phi) * dphi;
+      std::complex<double> EH_phi[6], f0_exp_imphi = f0 * std::polar(1.0, m * phi) * dphi;
       /* if the source direction is in the r or phi directions, then we must rotate
         the direction of the source current in the xy plane as well */
       if (d == Z) { // source currents in z direction don't rotate
@@ -339,7 +338,7 @@ void greencyl(std::complex<realnum> *EH, const vec &x, double freq, double eps, 
   }
 }
 
-void dft_near2far::farfield_lowlevel(std::complex<realnum> *EH, const vec &x) {
+void dft_near2far::farfield_lowlevel(std::complex<double> *EH, const vec &x) {
   if (x.dim != D3 && x.dim != D2 && x.dim != Dcyl)
     abort("only 2d or 3d or cylindrical far-field computation is supported");
   greenfunc green = x.dim == D2 ? green2d : green3d;
@@ -358,7 +357,7 @@ void dft_near2far::farfield_lowlevel(std::complex<realnum> *EH, const vec &x) {
 #pragma omp parallel for
 #endif
     for (size_t i = 0; i < Nfreq; ++i) {
-      std::complex<realnum> EH6[6];
+      std::complex<double> EH6[6];
       size_t idx_dft = 0;
       LOOP_OVER_IVECS(f->fc->gv, f->is, f->ie, idx) {
         IVEC_LOOP_LOC(f->fc->gv, x0);
@@ -379,7 +378,7 @@ void dft_near2far::farfield_lowlevel(std::complex<realnum> *EH, const vec &x) {
             else
               green(EH6, x, freq[i], eps, mu, xs, c0, f->dft[Nfreq * idx_dft + i]);
             for (int j = 0; j < 6; ++j)
-              EH[i * 6 + j] += EH6[j] * complex<realnum>(cphase);
+              EH[i * 6 + j] += EH6[j] * complex<double>(cphase);
           }
         }
         idx_dft++;
@@ -388,18 +387,18 @@ void dft_near2far::farfield_lowlevel(std::complex<realnum> *EH, const vec &x) {
   }
 }
 
-std::complex<realnum> *dft_near2far::farfield(const vec &x) {
-  std::complex<realnum> *EH, *EH_local;
+std::complex<double> *dft_near2far::farfield(const vec &x) {
+  std::complex<double> *EH, *EH_local;
   const size_t Nfreq = freq.size();
-  EH_local = new std::complex<realnum>[6 * Nfreq];
+  EH_local = new std::complex<double>[6 * Nfreq];
   farfield_lowlevel(EH_local, x);
-  EH = new std::complex<realnum>[6 * Nfreq];
+  EH = new std::complex<double>[6 * Nfreq];
   sum_to_all(EH_local, EH, 6 * Nfreq);
   delete[] EH_local;
   return EH;
 }
 
-realnum *dft_near2far::get_farfields_array(const volume &where, int &rank, size_t *dims, size_t &N,
+double *dft_near2far::get_farfields_array(const volume &where, int &rank, size_t *dims, size_t &N,
                                            double resolution) {
   /* compute output grid size etc. */
   double dx[3] = {0, 0, 0};
@@ -423,11 +422,11 @@ realnum *dft_near2far::get_farfields_array(const volume &where, int &rank, size_
   if (N * Nfreq < 1) return NULL; /* nothing to output */
 
   /* 6 x 2 x N x Nfreq array of fields in row-major order */
-  realnum *EH = new realnum[6 * 2 * N * Nfreq];
-  realnum *EH_ = new realnum[6 * 2 * N * Nfreq]; // temp array for sum_to_all
+  double *EH = new double[6 * 2 * N * Nfreq];
+  double *EH_ = new double[6 * 2 * N * Nfreq]; // temp array for sum_to_all
 
   /* fields for farfield_lowlevel for a single output point x */
-  std::complex<realnum> *EH1 = new std::complex<realnum>[6 * Nfreq];
+  std::complex<double> *EH1 = new std::complex<double>[6 * Nfreq];
 
   double start = wall_time();
   size_t last_point = 0;
@@ -479,7 +478,7 @@ void dft_near2far::save_farfields(const char *fname, const char *prefix, const v
   int rank = 0;
   size_t N = 1;
 
-  realnum *EH = get_farfields_array(where, rank, dims, N, resolution);
+  double *EH = get_farfields_array(where, rank, dims, N, resolution);
   if (!EH) return; /* nothing to output */
 
   const size_t Nfreq = freq.size();
@@ -513,12 +512,12 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
   int rank = 0;
   size_t N = 1;
 
-  realnum *EH = get_farfields_array(where, rank, dims, N, resolution);
+  double *EH = get_farfields_array(where, rank, dims, N, resolution);
 
   const size_t Nfreq = freq.size();
   double *F = new double[Nfreq];
-  std::complex<realnum> ff_EH[6];
-  std::complex<realnum> cE[2], cH[2];
+  std::complex<double> ff_EH[6];
+  std::complex<double> cE[2], cH[2];
 
   for (size_t i = 0; i < Nfreq; ++i)
     F[i] = 0;
@@ -526,7 +525,7 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
   for (size_t idx = 0; idx < N; ++idx) {
     for (size_t i = 0; i < Nfreq; ++i) {
       for (int k = 0; k < 6; ++k)
-        ff_EH[k] = std::complex<realnum>(*(EH + ((k * 2 + 0) * N + idx) * Nfreq + i),
+        ff_EH[k] = std::complex<double>(*(EH + ((k * 2 + 0) * N + idx) * Nfreq + i),
                                          *(EH + ((k * 2 + 1) * N + idx) * Nfreq + i));
       switch (df) {
         case X: cE[0] = ff_EH[1], cE[1] = ff_EH[2], cH[0] = ff_EH[5], cH[1] = ff_EH[4]; break;
@@ -657,7 +656,7 @@ std::vector<struct sourcedata> dft_near2far::near_sourcedata(const vec &x_0, dou
     component c0 = component(f->vc); /* equivalent source component */
 
     vec rshift(f->shift * (0.5 * f->fc->gv.inva));
-      std::complex<realnum> EH6[6];
+      std::complex<double> EH6[6];
       size_t idx_dft = 0;
       sourcedata temp_struct = {component(f->c), idx_arr, f->fc->chunk_idx, amp_arr};
 
@@ -671,7 +670,7 @@ std::vector<struct sourcedata> dft_near2far::near_sourcedata(const vec &x_0, dou
 
         temp_struct.idx_arr.push_back(idx);
         for (size_t i = 0; i < Nfreq; ++i) {
-          std::complex<realnum> EH0 = std::complex<realnum>(0,0);
+          std::complex<double> EH0 = std::complex<double>(0,0);
           for (int i0 = -periodic_n[0]; i0 <= periodic_n[0]; ++i0) {
             if (periodic_d[0] != NO_DIRECTION)
               xs.set_direction(periodic_d[0], x0.in_direction(periodic_d[0]) + i0 * period[0]);
@@ -688,7 +687,7 @@ std::vector<struct sourcedata> dft_near2far::near_sourcedata(const vec &x_0, dou
                 else
                   green(EH6, x, freq[i], eps, mu, xs, c0, w);
                 for (int j = 0; j < 6; ++j)
-                  EH0 += EH6[j] * complex<realnum>(cphase * (f->stored_weight) * dJ[6*Nfreq*ipt + 6*i + j]);
+                  EH0 += EH6[j] * complex<double>(cphase * (f->stored_weight) * dJ[6*Nfreq*ipt + 6*i + j]);
               }
           }
         }

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -378,7 +378,7 @@ void dft_near2far::farfield_lowlevel(std::complex<double> *EH, const vec &x) {
             else
               green(EH6, x, freq[i], eps, mu, xs, c0, f->dft[Nfreq * idx_dft + i]);
             for (int j = 0; j < 6; ++j)
-              EH[i * 6 + j] += EH6[j] * complex<double>(cphase);
+              EH[i * 6 + j] += EH6[j] * cphase;
           }
         }
         idx_dft++;
@@ -526,7 +526,7 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
     for (size_t i = 0; i < Nfreq; ++i) {
       for (int k = 0; k < 6; ++k)
         ff_EH[k] = std::complex<double>(*(EH + ((k * 2 + 0) * N + idx) * Nfreq + i),
-                                         *(EH + ((k * 2 + 1) * N + idx) * Nfreq + i));
+                                        *(EH + ((k * 2 + 1) * N + idx) * Nfreq + i));
       switch (df) {
         case X: cE[0] = ff_EH[1], cE[1] = ff_EH[2], cH[0] = ff_EH[5], cH[1] = ff_EH[4]; break;
         case Y: cE[0] = ff_EH[2], cE[1] = ff_EH[0], cH[0] = ff_EH[3], cH[1] = ff_EH[5]; break;

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -373,8 +373,8 @@ void fields::add_volume_source(component c, const src_time &src, const volume &w
   amp_file_dims[2] = dim3;
 
   size_t total_size = dim1 * dim2 * dim3;
-  amp_func_data_re = new double[total_size];
-  amp_func_data_im = new double[total_size];
+  amp_func_data_re = new realnum[total_size];
+  amp_func_data_im = new realnum[total_size];
 
   for (size_t i = 0; i < total_size; ++i) {
     amp_func_data_re[i] = real(arr[i]);
@@ -398,13 +398,13 @@ void fields::add_volume_source(component c, const src_time &src, const volume &w
   std::string dataset_im = std::string(dataset) + ".im";
 
   size_t re_dims[] = {1, 1, 1};
-  double *real_data = eps_file.read(dataset_re.c_str(), &rank, re_dims, 3);
+  realnum *real_data = eps_file.read(dataset_re.c_str(), &rank, re_dims, 3);
   if (verbosity > 0)
     master_printf("read in %zdx%zdx%zd amplitude function file \"%s:%s\"\n", re_dims[0], re_dims[1],
                   re_dims[2], filename, dataset_re.c_str());
 
   size_t im_dims[] = {1, 1, 1};
-  double *imag_data = eps_file.read(dataset_im.c_str(), &rank, im_dims, 3);
+  realnum *imag_data = eps_file.read(dataset_im.c_str(), &rank, im_dims, 3);
   if (verbosity > 0)
     master_printf("read in %zdx%zdx%zd amplitude function file \"%s:%s\"\n", im_dims[0], im_dims[1],
                   im_dims[2], filename, dataset_im.c_str());

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -325,8 +325,8 @@ void fields::add_srcdata(struct sourcedata cur_data, src_time *src, size_t n, st
   //     after all add_srcdata calls are complete.
 }
 
-static realnum *amp_func_data_re = NULL;
-static realnum *amp_func_data_im = NULL;
+static double *amp_func_data_re = NULL;
+static double *amp_func_data_im = NULL;
 static const volume *amp_func_vol = NULL;
 static size_t amp_file_dims[3];
 
@@ -373,8 +373,8 @@ void fields::add_volume_source(component c, const src_time &src, const volume &w
   amp_file_dims[2] = dim3;
 
   size_t total_size = dim1 * dim2 * dim3;
-  amp_func_data_re = new realnum[total_size];
-  amp_func_data_im = new realnum[total_size];
+  amp_func_data_re = new double[total_size];
+  amp_func_data_im = new double[total_size];
 
   for (size_t i = 0; i < total_size; ++i) {
     amp_func_data_re[i] = real(arr[i]);
@@ -398,13 +398,13 @@ void fields::add_volume_source(component c, const src_time &src, const volume &w
   std::string dataset_im = std::string(dataset) + ".im";
 
   size_t re_dims[] = {1, 1, 1};
-  realnum *real_data = eps_file.read(dataset_re.c_str(), &rank, re_dims, 3);
+  realnum *real_data = (realnum *)eps_file.read(dataset_re.c_str(), &rank, re_dims, 3, sizeof(realnum) == sizeof(float));
   if (verbosity > 0)
     master_printf("read in %zdx%zdx%zd amplitude function file \"%s:%s\"\n", re_dims[0], re_dims[1],
                   re_dims[2], filename, dataset_re.c_str());
 
   size_t im_dims[] = {1, 1, 1};
-  realnum *imag_data = eps_file.read(dataset_im.c_str(), &rank, im_dims, 3);
+  realnum *imag_data = (realnum *)eps_file.read(dataset_im.c_str(), &rank, im_dims, 3, sizeof(realnum) == sizeof(float));
   if (verbosity > 0)
     master_printf("read in %zdx%zdx%zd amplitude function file \"%s:%s\"\n", im_dims[0], im_dims[1],
                   im_dims[2], filename, dataset_im.c_str());

--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -92,12 +92,12 @@ bool fields_chunk::step_db(field_type ft) {
                the derivative and integral are replaced by differences
                and sums, but you get the idea). */
             if (!f_rderiv_int) f_rderiv_int = new realnum[gv.ntot()];
-            double ir0 = gv.origin_r() * gv.a + 0.5 * gv.iyee_shift(c_p).in_direction(R);
+            realnum ir0 = gv.origin_r() * gv.a + 0.5 * gv.iyee_shift(c_p).in_direction(R);
             for (int iz = 0; iz <= gv.nz(); ++iz)
               f_rderiv_int[iz] = 0;
             int sr = gv.nz() + 1;
             for (int ir = 1; ir <= gv.nr(); ++ir) {
-              double rinv = 1.0 / ((ir + ir0) - 0.5);
+              realnum rinv = 1.0 / ((ir + ir0) - 0.5);
               for (int iz = 0; iz <= gv.nz(); ++iz) {
                 ptrdiff_t idx = ir * sr + iz;
                 f_rderiv_int[idx] =
@@ -140,7 +140,7 @@ bool fields_chunk::step_db(field_type ft) {
       const direction dsig = s->sigsize[dsig0] > 1 ? dsig0 : NO_DIRECTION;
       const direction dsigu0 = cycle_direction(gv.dim, d_c, 2);
       const direction dsigu = s->sigsize[dsigu0] > 1 ? dsigu0 : NO_DIRECTION;
-      const double betadt = 2 * pi * beta * dt * (d_c == X ? +1 : -1) *
+      const realnum betadt = 2 * pi * beta * dt * (d_c == X ? +1 : -1) *
                             (f[c_g][1 - cmp] ? (ft == D_stuff ? -1 : +1) * (2 * cmp - 1) : 1);
       STEP_BETA(the_f, cc, g, gv, betadt, dsig, s->siginv[dsig], f_u[cc][cmp], dsigu,
                 s->siginv[dsigu], s->condinv[cc][d_c], f_cond[cc][cmp]);
@@ -157,14 +157,14 @@ bool fields_chunk::step_db(field_type ft) {
         realnum *fcnd = f_cond[cc][cmp];
         realnum *fu = f_u[cc][cmp];
         const direction dsig = cycle_direction(gv.dim, d_c, 1);
-        const double *siginv = s->sigsize[dsig] > 1 ? s->siginv[dsig] : 0;
+        const realnum *siginv = s->sigsize[dsig] > 1 ? s->siginv[dsig] : 0;
         const int dk = gv.iyee_shift(cc).in_direction(dsig);
         const direction dsigu = cycle_direction(gv.dim, d_c, 2);
-        const double *siginvu = s->sigsize[dsigu] > 1 ? s->siginv[dsigu] : 0;
+        const realnum *siginvu = s->sigsize[dsigu] > 1 ? s->siginv[dsigu] : 0;
         const int dku = gv.iyee_shift(cc).in_direction(dsigu);
-        const double the_m =
+        const realnum the_m =
             m * (1 - 2 * cmp) * (1 - 2 * (ft == B_stuff)) * (1 - 2 * (d_c == R)) * Courant;
-        const double ir0 = gv.origin_r() * gv.a + 0.5 * gv.iyee_shift(cc).in_direction(R);
+        const realnum ir0 = gv.origin_r() * gv.a + 0.5 * gv.iyee_shift(cc).in_direction(R);
         int sr = gv.nz() + 1;
 
         // 8 special cases of the same loop (sigh):
@@ -173,12 +173,12 @@ bool fields_chunk::step_db(field_type ft) {
             if (cndinv)  // PML + fu + conductivity
               //////////////////// MOST GENERAL CASE //////////////////////
               for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                double rinv = the_m / (ir + ir0);
+                realnum rinv = the_m / (ir + ir0);
                 for (int iz = 0; iz <= gv.nz(); ++iz) {
                   ptrdiff_t idx = ir * sr + iz;
                   int k = dk + 2 * (dsig == Z ? iz : ir);
                   int ku = dku + 2 * (dsigu == Z ? iz : ir);
-                  double df, dfcnd = rinv * g[idx] * cndinv[idx];
+                  realnum df, dfcnd = rinv * g[idx] * cndinv[idx];
                   fcnd[idx] += dfcnd;
                   fu[idx] += (df = dfcnd * siginv[k]);
                   the_f[idx] += siginvu[ku] * df;
@@ -187,12 +187,12 @@ bool fields_chunk::step_db(field_type ft) {
             /////////////////////////////////////////////////////////////
             else // PML + fu - conductivity
               for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                double rinv = the_m / (ir + ir0);
+                realnum rinv = the_m / (ir + ir0);
                 for (int iz = 0; iz <= gv.nz(); ++iz) {
                   ptrdiff_t idx = ir * sr + iz;
                   int k = dk + 2 * (dsig == Z ? iz : ir);
                   int ku = dku + 2 * (dsigu == Z ? iz : ir);
-                  double df, dfcnd = rinv * g[idx];
+                  realnum df, dfcnd = rinv * g[idx];
                   fu[idx] += (df = dfcnd * siginv[k]);
                   the_f[idx] += siginvu[ku] * df;
                 }
@@ -201,22 +201,22 @@ bool fields_chunk::step_db(field_type ft) {
           else {        // PML - fu
             if (cndinv) // PML - fu + conductivity
               for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                double rinv = the_m / (ir + ir0);
+                realnum rinv = the_m / (ir + ir0);
                 for (int iz = 0; iz <= gv.nz(); ++iz) {
                   ptrdiff_t idx = ir * sr + iz;
                   int k = dk + 2 * (dsig == Z ? iz : ir);
-                  double dfcnd = rinv * g[idx] * cndinv[idx];
+                  realnum dfcnd = rinv * g[idx] * cndinv[idx];
                   fcnd[idx] += dfcnd;
                   the_f[idx] += dfcnd * siginv[k];
                 }
               }
             else // PML - fu - conductivity
               for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                double rinv = the_m / (ir + ir0);
+                realnum rinv = the_m / (ir + ir0);
                 for (int iz = 0; iz <= gv.nz(); ++iz) {
                   ptrdiff_t idx = ir * sr + iz;
                   int k = dk + 2 * (dsig == Z ? iz : ir);
-                  double dfcnd = rinv * g[idx];
+                  realnum dfcnd = rinv * g[idx];
                   the_f[idx] += dfcnd * siginv[k];
                 }
               }
@@ -226,22 +226,22 @@ bool fields_chunk::step_db(field_type ft) {
           if (siginvu) { // no PML + fu
             if (cndinv)  // no PML + fu + conductivity
               for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                double rinv = the_m / (ir + ir0);
+                realnum rinv = the_m / (ir + ir0);
                 for (int iz = 0; iz <= gv.nz(); ++iz) {
                   ptrdiff_t idx = ir * sr + iz;
                   int ku = dku + 2 * (dsigu == Z ? iz : ir);
-                  double df = rinv * g[idx] * cndinv[idx];
+                  realnum df = rinv * g[idx] * cndinv[idx];
                   fu[idx] += df;
                   the_f[idx] += siginvu[ku] * df;
                 }
               }
             else // no PML + fu - conductivity
               for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                double rinv = the_m / (ir + ir0);
+                realnum rinv = the_m / (ir + ir0);
                 for (int iz = 0; iz <= gv.nz(); ++iz) {
                   ptrdiff_t idx = ir * sr + iz;
                   int ku = dku + 2 * (dsigu == Z ? iz : ir);
-                  double df = rinv * g[idx];
+                  realnum df = rinv * g[idx];
                   fu[idx] += df;
                   the_f[idx] += siginvu[ku] * df;
                 }
@@ -250,7 +250,7 @@ bool fields_chunk::step_db(field_type ft) {
           else {        // no PML - fu
             if (cndinv) // no PML - fu + conductivity
               for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                double rinv = the_m / (ir + ir0);
+                realnum rinv = the_m / (ir + ir0);
                 for (int iz = 0; iz <= gv.nz(); ++iz) {
                   ptrdiff_t idx = ir * sr + iz;
                   the_f[idx] += rinv * g[idx] * cndinv[idx];
@@ -258,7 +258,7 @@ bool fields_chunk::step_db(field_type ft) {
               }
             else // no PML - fu - conductivity
               for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                double rinv = the_m / (ir + ir0);
+                realnum rinv = the_m / (ir + ir0);
                 for (int iz = 0; iz <= gv.nz(); ++iz) {
                   ptrdiff_t idx = ir * sr + iz;
                   the_f[idx] += rinv * g[idx];
@@ -280,16 +280,16 @@ bool fields_chunk::step_db(field_type ft) {
         const realnum *cndinv = s->condinv[Dz][Z];
         realnum *fcnd = f_cond[Dz][cmp];
         const direction dsig = cycle_direction(gv.dim, Z, 1);
-        const double *siginv = s->sigsize[dsig] > 1 ? s->siginv[dsig] : 0;
+        const realnum *siginv = s->sigsize[dsig] > 1 ? s->siginv[dsig] : 0;
         const int dk = gv.iyee_shift(Dz).in_direction(dsig);
         const direction dsigu = cycle_direction(gv.dim, Z, 2);
-        const double *siginvu = s->sigsize[dsigu] > 1 ? s->siginv[dsigu] : 0;
+        const realnum *siginvu = s->sigsize[dsigu] > 1 ? s->siginv[dsigu] : 0;
         const int dku = gv.iyee_shift(Dz).in_direction(dsigu);
         realnum *fu = siginvu && f_u[Dz][cmp] ? f[Dz][cmp] : 0;
         realnum *the_f = fu ? f_u[Dz][cmp] : f[Dz][cmp];
         for (int iz = 0; iz < nz; ++iz) {
           // Note: old code (prior to Meep 0.2) was missing factor of 4??
-          double df, dfcnd = g[iz] * (Courant * 4) * (cndinv ? cndinv[iz] : 1);
+          realnum df, dfcnd = g[iz] * (Courant * 4) * (cndinv ? cndinv[iz] : 1);
           if (fcnd) fcnd[iz] += dfcnd;
           the_f[iz] += (df = dfcnd * (siginv ? siginv[dk + 2 * (dsig == Z) * iz] : 1));
           if (fu) fu[iz] += siginvu[dku + 2 * (dsigu == Z) * iz] * df;
@@ -314,19 +314,19 @@ bool fields_chunk::step_db(field_type ft) {
         const realnum *cndinv = s->condinv[cc][d_c];
         realnum *fcnd = f_cond[cc][cmp];
         const direction dsig = cycle_direction(gv.dim, d_c, 1);
-        const double *siginv = s->sigsize[dsig] > 1 ? s->siginv[dsig] : 0;
+        const realnum *siginv = s->sigsize[dsig] > 1 ? s->siginv[dsig] : 0;
         const int dk = gv.iyee_shift(cc).in_direction(dsig);
         const direction dsigu = cycle_direction(gv.dim, d_c, 2);
-        const double *siginvu = s->sigsize[dsigu] > 1 ? s->siginv[dsigu] : 0;
+        const realnum *siginvu = s->sigsize[dsigu] > 1 ? s->siginv[dsigu] : 0;
         const int dku = gv.iyee_shift(cc).in_direction(dsigu);
         realnum *fu = siginvu && f_u[cc][cmp] ? f[cc][cmp] : 0;
         realnum *the_f = fu ? f_u[cc][cmp] : f[cc][cmp];
         int sd = ft == D_stuff ? +1 : -1;
-        double f_m_mult = ft == D_stuff ? 2 : (1 - 2 * cmp);
+        realnum f_m_mult = ft == D_stuff ? 2 : (1 - 2 * cmp);
 
         for (int iz = (ft == D_stuff); iz < nz + (ft == D_stuff); ++iz) {
-          double df;
-          double dfcnd = (sd * Courant) * (f_p[iz] - f_p[iz - sd] - f_m_mult * f_m[iz]) *
+          realnum df;
+          realnum dfcnd = (sd * Courant) * (f_p[iz] - f_p[iz - sd] - f_m_mult * f_m[iz]) *
                          (cndinv ? cndinv[iz] : 1);
           if (fcnd) fcnd[iz] += dfcnd;
           the_f[iz] += (df = dfcnd * (siginv ? siginv[dk + 2 * (dsig == Z) * iz] : 1));

--- a/src/stress.cpp
+++ b/src/stress.cpp
@@ -90,7 +90,7 @@ void dft_force::operator-=(const dft_force &st) {
 static void stress_sum(size_t Nfreq, double *F, const dft_chunk *F1, const dft_chunk *F2) {
   for (const dft_chunk *curF1 = F1, *curF2 = F2; curF1 && curF2;
        curF1 = curF1->next_in_dft, curF2 = curF2->next_in_dft) {
-    complex<realnum> extra_weight(real(curF1->extra_weight), imag(curF1->extra_weight));
+    complex<double> extra_weight(real(curF1->extra_weight), imag(curF1->extra_weight));
     for (size_t k = 0; k < curF1->N; ++k)
       for (size_t i = 0; i < Nfreq; ++i)
         F[i] += real(extra_weight * curF1->dft[k * Nfreq + i] * conj(curF2->dft[k * Nfreq + i]));

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -685,9 +685,9 @@ void structure_chunk::use_pml(direction d, double dx, double bloc, double Rasymp
       if (!sig[dd]) {
         int spml = (dd == d) ? (2 * gv.num_direction(d) + 2) : 1;
         sigsize[dd] = spml;
-        sig[dd] = new double[spml];
-        kap[dd] = new double[spml];
-        siginv[dd] = new double[spml];
+        sig[dd] = new realnum[spml];
+        kap[dd] = new realnum[spml];
+        siginv[dd] = new realnum[spml];
         for (int i = 0; i < spml; ++i) {
           sig[dd][i] = 0.0;
           kap[dd][i] = 1.0;
@@ -806,9 +806,9 @@ structure_chunk::structure_chunk(const structure_chunk *o) : v(o->v) {
   // Copy over the PML conductivity arrays:
   if (is_mine()) FOR_DIRECTIONS(d) {
       if (o->sig[d]) {
-        sig[d] = new double[2 * gv.num_direction(d) + 1];
-        kap[d] = new double[2 * gv.num_direction(d) + 1];
-        siginv[d] = new double[2 * gv.num_direction(d) + 1];
+        sig[d] = new realnum[2 * gv.num_direction(d) + 1];
+        kap[d] = new realnum[2 * gv.num_direction(d) + 1];
+        siginv[d] = new realnum[2 * gv.num_direction(d) + 1];
         sigsize[d] = o->sigsize[d];
         for (int i = 0; i < 2 * gv.num_direction(d) + 1; i++) {
           sig[d][i] = o->sig[d][i];

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -73,7 +73,7 @@ void structure::dump_chunk_layout(const char *filename) {
   file.create_data("gv_origins", 1, &sz, false /* append_data */, false /* single_precision */);
   if (am_master()) {
     size_t gv_origins_start = 0;
-    file.write_chunk(1, &gv_origins_start, &sz, origins, false /* single_precision */);
+    file.write_chunk(1, &gv_origins_start, &sz, origins);
   }
   file.create_data("gv_nums", 1, &sz);
   if (am_master()) {
@@ -123,8 +123,7 @@ void structure::dump(const char *filename) {
       for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c)
         for (int d = 0; d < 5; ++d)
           if (chunks[i]->chi1inv[c][d]) {
-            file.write_chunk(1, &my_start, &ntot, chunks[i]->chi1inv[c][d],
-                             sizeof(realnum) == sizeof(float) /* single_precision */);
+            file.write_chunk(1, &my_start, &ntot, chunks[i]->chi1inv[c][d]);
             my_start += ntot;
           }
     }
@@ -282,8 +281,7 @@ void structure::dump(const char *filename) {
             size_t start = 0;
             while (sus) {
               size_t count = chunks[i]->gv.ntot();
-              file.write_chunk(1, &start, &count, sus->sigma[c][d],
-                               sizeof(realnum) == sizeof(float) /* single_precision */);
+              file.write_chunk(1, &start, &count, sus->sigma[c][d]);
               sus = sus->next;
               start += count;
             }
@@ -313,16 +311,14 @@ susceptibility *make_sus_list_from_params(h5file *file, int rank, size_t dims[3]
   while (start < dims[0]) {
     size_t num_params_dims[3] = {1, 0, 0};
     realnum num_params;
-    file->read_chunk(rank, &start, num_params_dims, &num_params,
-                     sizeof(realnum) == sizeof(float) /* single_precision */);
+    file->read_chunk(rank, &start, num_params_dims, &num_params);
     start += num_params_dims[0];
     if (num_params == 4) {
       // This is a lorentzian_susceptibility and the next 4 values in the dataset
       // are id, omega_0, gamma, and no_omega_0_denominator.
       size_t lorentzian_dims[3] = {4, 0, 0};
       realnum lorentzian_params[4];
-      file->read_chunk(rank, &start, lorentzian_dims, lorentzian_params,
-                       sizeof(realnum) == sizeof(float) /* single_precision */);
+      file->read_chunk(rank, &start, lorentzian_dims, lorentzian_params);
       start += lorentzian_dims[0];
 
       int id = (int)lorentzian_params[0];
@@ -347,8 +343,7 @@ susceptibility *make_sus_list_from_params(h5file *file, int rank, size_t dims[3]
       // are id, noise_amp, omega_0, gamma, and no_omega_0_denominator.
       size_t noisy_lorentzian_dims[3] = {5, 0, 0};
       realnum noisy_lorentzian_params[5];
-      file->read_chunk(rank, &start, noisy_lorentzian_dims, noisy_lorentzian_params,
-                       sizeof(realnum) == sizeof(float) /* single_precision */);
+      file->read_chunk(rank, &start, noisy_lorentzian_dims, noisy_lorentzian_params);
       start += noisy_lorentzian_dims[0];
 
       int id = (int)noisy_lorentzian_params[0];
@@ -376,8 +371,7 @@ susceptibility *make_sus_list_from_params(h5file *file, int rank, size_t dims[3]
       // are id, bias.x, bias.y, bias.z, omega_0, gamma, alpha, and model.
       size_t gyro_susc_dims[3] = {8, 0, 0};
       realnum gyro_susc_params[8];
-      file->read_chunk(rank, &start, gyro_susc_dims, gyro_susc_params,
-                       sizeof(realnum) == sizeof(float) /* single_precision */);
+      file->read_chunk(rank, &start, gyro_susc_dims, gyro_susc_params);
       start += gyro_susc_dims[0];
 
       int id = (int)gyro_susc_params[0];
@@ -484,8 +478,7 @@ void structure::load_chunk_layout(const char *filename, boundary_region &br) {
   if (origins_rank != 1 || origins_dims != sz) { abort("chunk mismatch in structure::load"); }
   if (am_master()) {
     size_t gv_origins_start = 0;
-    file.read_chunk(1, &gv_origins_start, &origins_dims, origins,
-                    false /* single_precision */);
+    file.read_chunk(1, &gv_origins_start, &origins_dims, origins);
   }
   file.prevent_deadlock();
   broadcast(0, origins, sz);
@@ -590,8 +583,7 @@ void structure::load(const char *filename) {
       for (int c = 0; c < NUM_FIELD_COMPONENTS; ++c)
         for (int d = 0; d < 5; ++d)
           if (chunks[i]->chi1inv[c][d]) {
-            file.read_chunk(1, &my_start, &ntot, chunks[i]->chi1inv[c][d],
-                            sizeof(realnum) == sizeof(float) /* single_precision */);
+            file.read_chunk(1, &my_start, &ntot, chunks[i]->chi1inv[c][d]);
             my_start += ntot;
           }
     }
@@ -715,8 +707,7 @@ void structure::load(const char *filename) {
                 if (sus->sigma[c][d]) { delete[] sus->sigma[c][d]; }
                 sus->sigma[c][d] = new realnum[count];
                 sus->trivial_sigma[c][d] = false;
-                file.read_chunk(rank, &start, &count, sus->sigma[c][d],
-                                sizeof(realnum) == sizeof(float) /* single_precision */);
+                file.read_chunk(rank, &start, &count, sus->sigma[c][d]);
                 sus = sus->next;
                 start += count;
               }

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -44,7 +44,8 @@ void structure::write_susceptibility_params(h5file *file, const char *dname, int
 
   // Write params
   size_t params_start = 0;
-  file->create_data(dname, 1, &params_ntotal);
+  file->create_data(dname, 1, &params_ntotal, false /* append_data */,
+                    sizeof(realnum) == sizeof(float) /* single_precision */);
   if (am_master()) {
     susceptibility *sus = chunks[0]->chiP[EorH];
     while (sus) {
@@ -69,7 +70,7 @@ void structure::dump_chunk_layout(const char *filename) {
     }
   }
   h5file file(filename, h5file::WRITE, true);
-  file.create_data("gv_origins", 1, &sz);
+  file.create_data("gv_origins", 1, &sz, false /* append_data */, false /* single_precision */);
   if (am_master()) {
     size_t gv_origins_start = 0;
     file.write_chunk(1, &gv_origins_start, &sz, origins, false /* single_precision */);
@@ -115,7 +116,7 @@ void structure::dump(const char *filename) {
   delete[] num_chi1inv;
 
   // write the data
-  file.create_data("chi1inv", 1, &ntotal);
+  file.create_data("chi1inv", 1, &ntotal, false /* append_data */, false /* single_precision */);
   for (int i = 0; i < num_chunks; i++)
     if (chunks[i]->is_mine()) {
       size_t ntot = chunks[i]->gv.ntot();

--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -55,10 +55,10 @@ susceptibility *susceptibility::clone() const {
 }
 
 // generic base class definition.
-std::complex<double> susceptibility::chi1(double freq, double sigma) {
+std::complex<realnum> susceptibility::chi1(realnum freq, realnum sigma) {
   (void)freq;
   (void)sigma;
-  return std::complex<double>(0, 0);
+  return std::complex<realnum>(0, 0);
 }
 
 void susceptibility::delete_internal_data(void *data) const { free(data); }
@@ -118,7 +118,7 @@ void *lorentzian_susceptibility::new_internal_data(realnum *W[NUM_FIELD_COMPONEN
   return (void *)d;
 }
 
-void lorentzian_susceptibility::init_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], double dt,
+void lorentzian_susceptibility::init_internal_data(realnum *W[NUM_FIELD_COMPONENTS][2], realnum dt,
                                                    const grid_volume &gv, void *data) const {
   (void)dt; // unused
   lorentzian_data *d = (lorentzian_data *)data;
@@ -166,10 +166,10 @@ void *lorentzian_susceptibility::copy_internal_data(void *data) const {
    algebra from this to get the condition for a root with |z| > 1.
 
    FIXME: this test seems to be too conservative (issue #12) */
-static bool lorentzian_unstable(double omega_0, double gamma, double dt) {
-  double w = 2 * pi * omega_0, g = 2 * pi * gamma;
-  double g2 = g * dt / 2, w2 = (w * dt) * (w * dt);
-  double b = (1 - w2 / 2) / (1 + g2), c = (1 - g2) / (1 + g2);
+static bool lorentzian_unstable(realnum omega_0, realnum gamma, realnum dt) {
+  realnum w = 2 * pi * omega_0, g = 2 * pi * gamma;
+  realnum g2 = g * dt / 2, w2 = (w * dt) * (w * dt);
+  realnum b = (1 - w2 / 2) / (1 + g2), c = (1 - g2) / (1 + g2);
   return b * b > c && 2 * b * b - c + 2 * fabs(b) * sqrt(b * b - c) > 1;
 }
 #endif
@@ -186,13 +186,13 @@ static bool lorentzian_unstable(double omega_0, double gamma, double dt) {
   (0.25 * ((g[i] + g[i - sx]) * u[i] + (g[i + s] + g[(i + s) - sx]) * u[i + s]))
 
 void lorentzian_susceptibility::update_P(realnum *W[NUM_FIELD_COMPONENTS][2],
-                                         realnum *W_prev[NUM_FIELD_COMPONENTS][2], double dt,
+                                         realnum *W_prev[NUM_FIELD_COMPONENTS][2], realnum dt,
                                          const grid_volume &gv, void *P_internal_data) const {
   lorentzian_data *d = (lorentzian_data *)P_internal_data;
-  const double omega2pi = 2 * pi * omega_0, g2pi = gamma * 2 * pi;
-  const double omega0dtsqr = omega2pi * omega2pi * dt * dt;
-  const double gamma1inv = 1 / (1 + g2pi * dt / 2), gamma1 = (1 - g2pi * dt / 2);
-  const double omega0dtsqr_denom = no_omega_0_denominator ? 0 : omega0dtsqr;
+  const realnum omega2pi = 2 * pi * omega_0, g2pi = gamma * 2 * pi;
+  const realnum omega0dtsqr = omega2pi * omega2pi * dt * dt;
+  const realnum gamma1inv = 1 / (1 + g2pi * dt / 2), gamma1 = (1 - g2pi * dt / 2);
+  const realnum omega0dtsqr_denom = no_omega_0_denominator ? 0 : omega0dtsqr;
   (void)W_prev; // unused;
 
   // TODO: add back lorentzian_unstable(omega_0, gamma, dt) if we can improve the stability test
@@ -294,15 +294,15 @@ realnum *lorentzian_susceptibility::cinternal_notowned_ptr(int inotowned, compon
   return d->P[c][cmp] + n;
 }
 
-std::complex<double> lorentzian_susceptibility::chi1(double freq, double sigma) {
+std::complex<realnum> lorentzian_susceptibility::chi1(realnum freq, realnum sigma) {
   if (no_omega_0_denominator) {
     // Drude model
-    return sigma * omega_0 * omega_0 / std::complex<double>(-freq * freq, -gamma * freq);
+    return sigma * omega_0 * omega_0 / std::complex<realnum>(-freq * freq, -gamma * freq);
   }
   else {
     // Standard Lorentzian model
     return sigma * omega_0 * omega_0 /
-           std::complex<double>(omega_0 * omega_0 - freq * freq, -gamma * freq);
+           std::complex<realnum>(omega_0 * omega_0 - freq * freq, -gamma * freq);
   }
 }
 
@@ -315,14 +315,14 @@ void lorentzian_susceptibility::dump_params(h5file *h5f, size_t *start) {
 }
 
 void noisy_lorentzian_susceptibility::update_P(realnum *W[NUM_FIELD_COMPONENTS][2],
-                                               realnum *W_prev[NUM_FIELD_COMPONENTS][2], double dt,
+                                               realnum *W_prev[NUM_FIELD_COMPONENTS][2], realnum dt,
                                                const grid_volume &gv, void *P_internal_data) const {
   lorentzian_susceptibility::update_P(W, W_prev, dt, gv, P_internal_data);
   lorentzian_data *d = (lorentzian_data *)P_internal_data;
 
-  const double g2pi = gamma * 2 * pi;
-  const double w2pi = omega_0 * 2 * pi;
-  const double amp = w2pi * noise_amp * sqrt(g2pi) * dt * dt / (1 + g2pi * dt / 2);
+  const realnum g2pi = gamma * 2 * pi;
+  const realnum w2pi = omega_0 * 2 * pi;
+  const realnum amp = w2pi * noise_amp * sqrt(g2pi) * dt * dt / (1 + g2pi * dt / 2);
   /* for uniform random numbers in [-amp,amp] below, multiply amp by sqrt(3) */
 
   FOR_COMPONENTS(c) DOCMP2 {

--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -309,7 +309,7 @@ std::complex<double> lorentzian_susceptibility::chi1(double freq, double sigma) 
 void lorentzian_susceptibility::dump_params(h5file *h5f, size_t *start) {
   size_t num_params = 5;
   size_t params_dims[1] = {num_params};
-  double params_data[] = {4, (double)get_id(), omega_0, gamma, (double)no_omega_0_denominator};
+  realnum params_data[] = {4, (realnum)get_id(), omega_0, gamma, (realnum)no_omega_0_denominator};
   h5f->write_chunk(1, start, params_dims, params_data);
   *start += num_params;
 }
@@ -341,8 +341,8 @@ void noisy_lorentzian_susceptibility::update_P(realnum *W[NUM_FIELD_COMPONENTS][
 void noisy_lorentzian_susceptibility::dump_params(h5file *h5f, size_t *start) {
   size_t num_params = 6;
   size_t params_dims[1] = {num_params};
-  double params_data[] = {
-      5, (double)get_id(), noise_amp, omega_0, gamma, (double)no_omega_0_denominator};
+  realnum params_data[] = {
+      5, (realnum)get_id(), noise_amp, omega_0, gamma, (realnum)no_omega_0_denominator};
   h5f->write_chunk(1, start, params_dims, params_data);
   *start += num_params;
 }
@@ -618,9 +618,9 @@ realnum *gyrotropic_susceptibility::cinternal_notowned_ptr(int inotowned, compon
 void gyrotropic_susceptibility::dump_params(h5file *h5f, size_t *start) {
   size_t num_params = 9;
   size_t params_dims[1] = {num_params};
-  double bias[] = {gyro_tensor[Y][Z], gyro_tensor[Z][X], gyro_tensor[X][Y]};
-  double params_data[] = {8,     (double)get_id(), bias[X], bias[Y], bias[Z], omega_0, gamma,
-                          alpha, (double)model};
+  realnum bias[] = {gyro_tensor[Y][Z], gyro_tensor[Z][X], gyro_tensor[X][Y]};
+  realnum params_data[] = {8, (realnum)get_id(), bias[X], bias[Y], bias[Z], omega_0, gamma,
+                          alpha, (realnum)model};
   h5f->write_chunk(1, start, params_dims, params_data);
   *start += num_params;
 }

--- a/tests/array-slice-ll.cpp
+++ b/tests/array-slice-ll.cpp
@@ -223,19 +223,29 @@ int main(int argc, char *argv[]) {
     rank = f.get_array_slice_dimensions(v1d, dims1D, dirs1D, true, false);
     if (rank != 1 || dims1D[0] != NX) abort("incorrect dimensions for 1D slice");
     std::complex<double> *slice1d = f.get_complex_array_slice(v1d, Hz, 0, 0, true);
-    std::complex<realnum> *slice1d_realnum = new std::complex<realnum>[NX];
-    for (int i = 0; i < NX; ++i)
-      slice1d_realnum[i] = std::complex<realnum>(slice1d[i]);
-    double RelErr1D = Compare(slice1d_realnum, file_slice1d, NX, "Hz_1d");
+    double RelErr1D = 0;
+    if (sizeof(realnum) == sizeof(double)) {
+      RelErr1D = Compare(slice1d, file_slice1d, NX, "Hz_1d");
+    } else {
+      std::complex<realnum> *slice1d_realnum = new std::complex<realnum>[NX];
+      for (int i = 0; i < NX; ++i)
+        slice1d_realnum[i] = std::complex<realnum>(slice1d[i]);
+      RelErr1D = Compare(slice1d_realnum, file_slice1d, NX, "Hz_1d");
+    }
     master_printf("1D: rel error %e\n", RelErr1D);
 
     rank = f.get_array_slice_dimensions(v2d, dims2D, dirs2D, true, false);
     if (rank != 2 || dims2D[0] != NX || dims2D[1] != NY) abort("incorrect dimensions for 2D slice");
     double *slice2d = f.get_array_slice(v2d, Sy, 0, 0, true);
-    realnum *slice2d_realnum = new realnum[NX*NY];
-    for (int i = 0; i < NX*NY; ++i)
-      slice2d_realnum[i] = realnum(slice2d[i]);
-    double RelErr2D = Compare(slice2d_realnum, file_slice2d, NX * NY, "Sy_2d");
+    double RelErr2D = 0;
+    if (sizeof(realnum) == sizeof(double)) {
+      RelErr2D = Compare(slice2d, file_slice2d, NX * NY, "Sy_2d");
+    } else {
+      realnum *slice2d_realnum = new realnum[NX*NY];
+      for (int i = 0; i < NX*NY; ++i)
+        slice2d_realnum[i] = realnum(slice2d[i]);
+      RelErr2D = Compare(slice2d_realnum, file_slice2d, NX * NY, "Sy_2d");
+    }
     master_printf("2D: rel error %e\n", RelErr2D);
 
   }; // if (write_files) ... else ...

--- a/tests/array-slice-ll.cpp
+++ b/tests/array-slice-ll.cpp
@@ -223,29 +223,19 @@ int main(int argc, char *argv[]) {
     rank = f.get_array_slice_dimensions(v1d, dims1D, dirs1D, true, false);
     if (rank != 1 || dims1D[0] != NX) abort("incorrect dimensions for 1D slice");
     std::complex<double> *slice1d = f.get_complex_array_slice(v1d, Hz, 0, 0, true);
-    double RelErr1D = 0;
-    if (sizeof(realnum) == sizeof(double)) {
-      RelErr1D = Compare(slice1d, file_slice1d, NX, "Hz_1d");
-    } else {
-      std::complex<realnum> *slice1d_realnum = new std::complex<realnum>[NX];
-      for (int i = 0; i < NX; ++i)
-        slice1d_realnum[i] = std::complex<realnum>(slice1d[i]);
-      RelErr1D = Compare(slice1d_realnum, file_slice1d, NX, "Hz_1d");
-    }
+    std::complex<realnum> *slice1d_realnum = new std::complex<realnum>[NX];
+    for (int i = 0; i < NX; ++i)
+      slice1d_realnum[i] = std::complex<realnum>(slice1d[i]);
+    double RelErr1D = Compare(slice1d_realnum, file_slice1d, NX, "Hz_1d");
     master_printf("1D: rel error %e\n", RelErr1D);
 
     rank = f.get_array_slice_dimensions(v2d, dims2D, dirs2D, true, false);
     if (rank != 2 || dims2D[0] != NX || dims2D[1] != NY) abort("incorrect dimensions for 2D slice");
     double *slice2d = f.get_array_slice(v2d, Sy, 0, 0, true);
-    double RelErr2D = 0;
-    if (sizeof(realnum) == sizeof(double)) {
-      RelErr2D = Compare(slice2d, file_slice2d, NX * NY, "Sy_2d");
-    } else {
-      realnum *slice2d_realnum = new realnum[NX*NY];
-      for (int i = 0; i < NX*NY; ++i)
-        slice2d_realnum[i] = realnum(slice2d[i]);
-      RelErr2D = Compare(slice2d_realnum, file_slice2d, NX * NY, "Sy_2d");
-    }
+    realnum *slice2d_realnum = new realnum[NX*NY];
+    for (int i = 0; i < NX*NY; ++i)
+      slice2d_realnum[i] = realnum(slice2d[i]);
+    double RelErr2D = Compare(slice2d_realnum, file_slice2d, NX * NY, "Sy_2d");
     master_printf("2D: rel error %e\n", RelErr2D);
 
   }; // if (write_files) ... else ...

--- a/tests/array-slice-ll.cpp
+++ b/tests/array-slice-ll.cpp
@@ -199,10 +199,10 @@ int main(int argc, char *argv[]) {
     // read 1D and 2D array-slice data from HDF5 file
     //
     h5file *file = f.open_h5file(H5FILENAME, h5file::READONLY);
-    realnum *rdata = file->read("hz.r", &rank, dims1D, 1);
+    realnum *rdata = (realnum *)file->read("hz.r", &rank, dims1D, 1, sizeof(realnum) == sizeof(float));
     if (rank != 1 || dims1D[0] != NX)
       abort("failed to read 1D data(hz.r) from file %s.h5", H5FILENAME);
-    realnum *idata = file->read("hz.i", &rank, dims1D, 1);
+    realnum *idata = (realnum *)file->read("hz.i", &rank, dims1D, 1, sizeof(realnum) == sizeof(float));
     if (rank != 1 || dims1D[0] != NX)
       abort("failed to read 1D data(hz.i) from file %s.h5", H5FILENAME);
     file_slice1d = new std::complex<realnum>[dims1D[0]];
@@ -211,7 +211,7 @@ int main(int argc, char *argv[]) {
     delete[] rdata;
     delete[] idata;
 
-    file_slice2d = file->read("sy", &rank, dims2D, 2);
+    file_slice2d = (realnum *)file->read("sy", &rank, dims2D, 2, sizeof(realnum) == sizeof(float));
     if (rank != 2 || dims2D[0] != NX || dims2D[1] != NY)
       abort("failed to read 2D reference data from file %s.h5", H5FILENAME);
     delete file;

--- a/tests/array-slice-ll.cpp
+++ b/tests/array-slice-ll.cpp
@@ -19,8 +19,6 @@
 
 using namespace meep;
 
-typedef std::complex<double> cdouble;
-
 vector3 v3(double x, double y = 0.0, double z = 0.0) {
   vector3 v;
   v.x = x;
@@ -30,7 +28,7 @@ vector3 v3(double x, double y = 0.0, double z = 0.0) {
 }
 
 // passthrough field function
-cdouble default_field_function(const cdouble *fields, const vec &loc, void *data_) {
+std::complex<double> default_field_function(const std::complex<double> *fields, const vec &loc, void *data_) {
   (void)loc;   // unused
   (void)data_; // unused
   return fields[0];
@@ -40,7 +38,7 @@ cdouble default_field_function(const cdouble *fields, const vec &loc, void *data
 /***************************************************************/
 /***************************************************************/
 #define RELTOL 1.0e-6
-double Compare(double *d1, double *d2, int N, const char *Name) {
+double Compare(realnum *d1, realnum *d2, int N, const char *Name) {
   double Norm1 = 0.0, Norm2 = 0.0, NormDelta = 0.0;
   for (int n = 0; n < N; n++) {
     Norm1 += d1[n] * d1[n];
@@ -55,7 +53,7 @@ double Compare(double *d1, double *d2, int N, const char *Name) {
   return RelErr;
 }
 
-double Compare(cdouble *d1, cdouble *d2, int N, const char *Name) {
+double Compare(std::complex<realnum> *d1, std::complex<realnum> *d2, int N, const char *Name) {
   double Norm1 = 0.0, Norm2 = 0.0, NormDelta = 0.0;
   for (int n = 0; n < N; n++) {
     Norm1 += norm(d1[n]);
@@ -182,8 +180,8 @@ int main(int argc, char *argv[]) {
   int rank;
   size_t dims1D[1], dims2D[2];
   direction dirs1D[1], dirs2D[2];
-  cdouble *file_slice1d = 0;
-  double *file_slice2d = 0;
+  std::complex<realnum> *file_slice1d = 0;
+  realnum *file_slice2d = 0;
 
 #define H5FILENAME DATADIR "array-slice-ll-ref"
 #define NX 126
@@ -201,15 +199,15 @@ int main(int argc, char *argv[]) {
     // read 1D and 2D array-slice data from HDF5 file
     //
     h5file *file = f.open_h5file(H5FILENAME, h5file::READONLY);
-    double *rdata = file->read("hz.r", &rank, dims1D, 1);
+    realnum *rdata = file->read("hz.r", &rank, dims1D, 1);
     if (rank != 1 || dims1D[0] != NX)
       abort("failed to read 1D data(hz.r) from file %s.h5", H5FILENAME);
-    double *idata = file->read("hz.i", &rank, dims1D, 1);
+    realnum *idata = file->read("hz.i", &rank, dims1D, 1);
     if (rank != 1 || dims1D[0] != NX)
       abort("failed to read 1D data(hz.i) from file %s.h5", H5FILENAME);
-    file_slice1d = new cdouble[dims1D[0]];
+    file_slice1d = new std::complex<realnum>[dims1D[0]];
     for (size_t n = 0; n < dims1D[0]; n++)
-      file_slice1d[n] = cdouble(rdata[n], idata[n]);
+      file_slice1d[n] = std::complex<realnum>(rdata[n], idata[n]);
     delete[] rdata;
     delete[] idata;
 
@@ -224,14 +222,20 @@ int main(int argc, char *argv[]) {
     //
     rank = f.get_array_slice_dimensions(v1d, dims1D, dirs1D, true, false);
     if (rank != 1 || dims1D[0] != NX) abort("incorrect dimensions for 1D slice");
-    cdouble *slice1d = f.get_complex_array_slice(v1d, Hz, 0, 0, true);
-    double RelErr1D = Compare(slice1d, file_slice1d, NX, "Hz_1d");
+    std::complex<double> *slice1d = f.get_complex_array_slice(v1d, Hz, 0, 0, true);
+    std::complex<realnum> *slice1d_realnum = new std::complex<realnum>[NX];
+    for (int i = 0; i < NX; ++i)
+      slice1d_realnum[i] = std::complex<realnum>(slice1d[i]);
+    double RelErr1D = Compare(slice1d_realnum, file_slice1d, NX, "Hz_1d");
     master_printf("1D: rel error %e\n", RelErr1D);
 
     rank = f.get_array_slice_dimensions(v2d, dims2D, dirs2D, true, false);
     if (rank != 2 || dims2D[0] != NX || dims2D[1] != NY) abort("incorrect dimensions for 2D slice");
     double *slice2d = f.get_array_slice(v2d, Sy, 0, 0, true);
-    double RelErr2D = Compare(slice2d, file_slice2d, NX * NY, "Sy_2d");
+    realnum *slice2d_realnum = new realnum[NX*NY];
+    for (int i = 0; i < NX*NY; ++i)
+      slice2d_realnum[i] = realnum(slice2d[i]);
+    double RelErr2D = Compare(slice2d_realnum, file_slice2d, NX * NY, "Sy_2d");
     master_printf("2D: rel error %e\n", RelErr2D);
 
   }; // if (write_files) ... else ...

--- a/tests/cyl-ellipsoid-ll.cpp
+++ b/tests/cyl-ellipsoid-ll.cpp
@@ -30,13 +30,13 @@ bool compare_hdf5_datasets(const char *file1, const char *name1, const char *fil
   h5file f1(file1, h5file::READONLY, false);
   int rank1;
   size_t *dims1 = new size_t[expected_rank];
-  double *data1 = f1.read(name1, &rank1, dims1, expected_rank);
+  realnum *data1 = f1.read(name1, &rank1, dims1, expected_rank);
   if (!data1) return false;
 
   h5file f2(file2, h5file::READONLY, false);
   int rank2;
   size_t *dims2 = new size_t[expected_rank];
-  double *data2 = f2.read(name2, &rank2, dims2, expected_rank);
+  realnum *data2 = f2.read(name2, &rank2, dims2, expected_rank);
   if (!data2) return false;
 
   if (rank1 != expected_rank || rank2 != expected_rank) return false;

--- a/tests/cyl-ellipsoid-ll.cpp
+++ b/tests/cyl-ellipsoid-ll.cpp
@@ -30,13 +30,13 @@ bool compare_hdf5_datasets(const char *file1, const char *name1, const char *fil
   h5file f1(file1, h5file::READONLY, false);
   int rank1;
   size_t *dims1 = new size_t[expected_rank];
-  realnum *data1 = f1.read(name1, &rank1, dims1, expected_rank);
+  realnum *data1 = (realnum *)f1.read(name1, &rank1, dims1, expected_rank, sizeof(realnum) == sizeof(float));
   if (!data1) return false;
 
   h5file f2(file2, h5file::READONLY, false);
   int rank2;
   size_t *dims2 = new size_t[expected_rank];
-  realnum *data2 = f2.read(name2, &rank2, dims2, expected_rank);
+  realnum *data2 = (realnum *)f2.read(name2, &rank2, dims2, expected_rank, sizeof(realnum) == sizeof(float));
   if (!data2) return false;
 
   if (rank1 != expected_rank || rank2 != expected_rank) return false;

--- a/tests/dft-fields.cpp
+++ b/tests/dft-fields.cpp
@@ -111,9 +111,9 @@ double compare_array_to_dataset(cdouble *field_array, int array_rank, size_t *ar
   h5file f(file, h5file::READONLY, false);
   char dataname[100];
   snprintf(dataname, 100, "%s.r", name);
-  realnum *rdata = f.read(dataname, &file_rank, file_dims, 2);
+  realnum *rdata = (realnum *)f.read(dataname, &file_rank, file_dims, 2, sizeof(realnum) == sizeof(float));
   snprintf(dataname, 100, "%s.i", name);
-  realnum *idata = f.read(dataname, &file_rank, file_dims, 2);
+  realnum *idata = (realnum *)f.read(dataname, &file_rank, file_dims, 2, sizeof(realnum) == sizeof(float));
   if (!rdata || !idata) return -1.0;
   if (file_rank != array_rank) return -1.0;
   for (int n = 0; n < file_rank; n++)
@@ -150,9 +150,9 @@ double compare_complex_hdf5_datasets(const char *file1, const char *name1, const
   int rank1;
   size_t *dims1 = new size_t[expected_rank];
   snprintf(dataname, 100, "%s.r", name1);
-  realnum *rdata1 = f1.read(dataname, &rank1, dims1, expected_rank);
+  realnum *rdata1 = (realnum *)f1.read(dataname, &rank1, dims1, expected_rank, sizeof(realnum) == sizeof(float));
   snprintf(dataname, 100, "%s.i", name1);
-  realnum *idata1 = f1.read(dataname, &rank1, dims1, expected_rank);
+  realnum *idata1 = (realnum *)f1.read(dataname, &rank1, dims1, expected_rank, sizeof(realnum) == sizeof(float));
   if (!rdata1 || !idata1) return -1.0;
 
   // read dataset 2
@@ -160,9 +160,9 @@ double compare_complex_hdf5_datasets(const char *file1, const char *name1, const
   int rank2;
   size_t *dims2 = new size_t[expected_rank];
   snprintf(dataname, 100, "%s.r", name2);
-  realnum *rdata2 = f2.read(dataname, &rank2, dims2, expected_rank);
+  realnum *rdata2 = (realnum *)f2.read(dataname, &rank2, dims2, expected_rank, sizeof(realnum) == sizeof(float));
   snprintf(dataname, 100, "%s.i", name2);
-  realnum *idata2 = f2.read(dataname, &rank2, dims2, expected_rank);
+  realnum *idata2 = (realnum *)f2.read(dataname, &rank2, dims2, expected_rank, sizeof(realnum) == sizeof(float));
   if (!rdata2 || !idata2) return -1.0;
 
   // check same size

--- a/tests/dft-fields.cpp
+++ b/tests/dft-fields.cpp
@@ -111,9 +111,9 @@ double compare_array_to_dataset(cdouble *field_array, int array_rank, size_t *ar
   h5file f(file, h5file::READONLY, false);
   char dataname[100];
   snprintf(dataname, 100, "%s.r", name);
-  double *rdata = f.read(dataname, &file_rank, file_dims, 2);
+  realnum *rdata = f.read(dataname, &file_rank, file_dims, 2);
   snprintf(dataname, 100, "%s.i", name);
-  double *idata = f.read(dataname, &file_rank, file_dims, 2);
+  realnum *idata = f.read(dataname, &file_rank, file_dims, 2);
   if (!rdata || !idata) return -1.0;
   if (file_rank != array_rank) return -1.0;
   for (int n = 0; n < file_rank; n++)
@@ -150,9 +150,9 @@ double compare_complex_hdf5_datasets(const char *file1, const char *name1, const
   int rank1;
   size_t *dims1 = new size_t[expected_rank];
   snprintf(dataname, 100, "%s.r", name1);
-  double *rdata1 = f1.read(dataname, &rank1, dims1, expected_rank);
+  realnum *rdata1 = f1.read(dataname, &rank1, dims1, expected_rank);
   snprintf(dataname, 100, "%s.i", name1);
-  double *idata1 = f1.read(dataname, &rank1, dims1, expected_rank);
+  realnum *idata1 = f1.read(dataname, &rank1, dims1, expected_rank);
   if (!rdata1 || !idata1) return -1.0;
 
   // read dataset 2
@@ -160,9 +160,9 @@ double compare_complex_hdf5_datasets(const char *file1, const char *name1, const
   int rank2;
   size_t *dims2 = new size_t[expected_rank];
   snprintf(dataname, 100, "%s.r", name2);
-  double *rdata2 = f2.read(dataname, &rank2, dims2, expected_rank);
+  realnum *rdata2 = f2.read(dataname, &rank2, dims2, expected_rank);
   snprintf(dataname, 100, "%s.i", name2);
-  double *idata2 = f2.read(dataname, &rank2, dims2, expected_rank);
+  realnum *idata2 = f2.read(dataname, &rank2, dims2, expected_rank);
   if (!rdata2 || !idata2) return -1.0;
 
   // check same size

--- a/tests/dft-fields.cpp
+++ b/tests/dft-fields.cpp
@@ -111,9 +111,9 @@ double compare_array_to_dataset(cdouble *field_array, int array_rank, size_t *ar
   h5file f(file, h5file::READONLY, false);
   char dataname[100];
   snprintf(dataname, 100, "%s.r", name);
-  realnum *rdata = (realnum *)f.read(dataname, &file_rank, file_dims, 2, sizeof(realnum) == sizeof(float));
+  double *rdata = (double *)f.read(dataname, &file_rank, file_dims, 2, false /* single_precision */);
   snprintf(dataname, 100, "%s.i", name);
-  realnum *idata = (realnum *)f.read(dataname, &file_rank, file_dims, 2, sizeof(realnum) == sizeof(float));
+  double *idata = (double *)f.read(dataname, &file_rank, file_dims, 2, false /* single_precision */);
   if (!rdata || !idata) return -1.0;
   if (file_rank != array_rank) return -1.0;
   for (int n = 0; n < file_rank; n++)
@@ -150,9 +150,9 @@ double compare_complex_hdf5_datasets(const char *file1, const char *name1, const
   int rank1;
   size_t *dims1 = new size_t[expected_rank];
   snprintf(dataname, 100, "%s.r", name1);
-  realnum *rdata1 = (realnum *)f1.read(dataname, &rank1, dims1, expected_rank, sizeof(realnum) == sizeof(float));
+  double *rdata1 = (double *)f1.read(dataname, &rank1, dims1, expected_rank, false /* single_precision */);
   snprintf(dataname, 100, "%s.i", name1);
-  realnum *idata1 = (realnum *)f1.read(dataname, &rank1, dims1, expected_rank, sizeof(realnum) == sizeof(float));
+  double *idata1 = (double *)f1.read(dataname, &rank1, dims1, expected_rank, false /* single_precision */);
   if (!rdata1 || !idata1) return -1.0;
 
   // read dataset 2
@@ -160,9 +160,9 @@ double compare_complex_hdf5_datasets(const char *file1, const char *name1, const
   int rank2;
   size_t *dims2 = new size_t[expected_rank];
   snprintf(dataname, 100, "%s.r", name2);
-  realnum *rdata2 = (realnum *)f2.read(dataname, &rank2, dims2, expected_rank, sizeof(realnum) == sizeof(float));
+  double *rdata2 = (double *)f2.read(dataname, &rank2, dims2, expected_rank, false /* single_precision */);
   snprintf(dataname, 100, "%s.i", name2);
-  realnum *idata2 = (realnum *)f2.read(dataname, &rank2, dims2, expected_rank, sizeof(realnum) == sizeof(float));
+  double *idata2 = (double *)f2.read(dataname, &rank2, dims2, expected_rank, false /* single_precision */);
   if (!rdata2 || !idata2) return -1.0;
 
   // check same size

--- a/tests/h5test.cpp
+++ b/tests/h5test.cpp
@@ -114,7 +114,7 @@ bool check_2d(double eps(const vec &), double a, int splitting, symfunc Sf, doub
     snprintf(dataname, 256, "%s%s", component_name(file_c),
              reim ? ".i" : (real_fields ? "" : ".r"));
 
-    realnum *h5data = file->read(dataname, &rank, dims, 2);
+    realnum *h5data = (realnum *)file->read(dataname, &rank, dims, 2, sizeof(realnum) == sizeof(float));
     file->prevent_deadlock(); // hackery
     if (!h5data) abort("failed to read dataset %s:%s\n", name, dataname);
     if (rank != expected_rank)
@@ -223,7 +223,7 @@ bool check_3d(double eps(const vec &), double a, int splitting, symfunc Sf, comp
     snprintf(dataname, 256, "%s%s", component_name(file_c),
              reim ? ".i" : (real_fields ? "" : ".r"));
 
-    realnum *h5data = file->read(dataname, &rank, dims, 3);
+    realnum *h5data = (realnum *)file->read(dataname, &rank, dims, 3, sizeof(realnum) == sizeof(float));
     file->prevent_deadlock(); // hackery
     if (!h5data) abort("failed to read dataset %s:%s\n", name, dataname);
     if (rank != expected_rank)
@@ -330,7 +330,7 @@ bool check_2d_monitor(double eps(const vec &), double a, int splitting, symfunc 
     snprintf(dataname, 256, "%s%s", component_name(file_c),
              reim ? ".i" : (real_fields ? "" : ".r"));
 
-    realnum *h5data = file->read(dataname, &rank, dims, 2);
+    realnum *h5data = (realnum *)file->read(dataname, &rank, dims, 2, sizeof(realnum) == sizeof(float));
     file->prevent_deadlock(); // hackery
     if (!h5data) abort("failed to read dataset %s:%s\n", file->file_name(), dataname);
     if (rank != 1) abort("monitor-point data is not one-dimensional");

--- a/tests/near2far.cpp
+++ b/tests/near2far.cpp
@@ -49,7 +49,7 @@ int check_cyl(double sr, double sz, double a) {
   component c = Ep;
   const int N = 20;
   double dr = sr / N;
-  complex<realnum> F[N], F0[N], EH[6];
+  complex<double> F[N], F0[N], EH[6];
   double diff = 0.0, dot0 = 0.0;
   complex<double> phase = polar(1.0, (4 * w * f.dt) * pi);
   for (int i = 0; i < N; ++i) {
@@ -57,7 +57,7 @@ int check_cyl(double sr, double sz, double a) {
     vec x = veccyl(rr, 0.5 * sz);
     F[i] = f.get_field(c, x) * phase;
     greencyl(EH, x, w, 2.0, 1.0, x0, c0, 1.0, m, 1e-6);
-    F0[i] = EH[EHcomp[c]] * realnum(2.0 * pi * x0.r()); // Ey = Ep for \phi = 0 (rz = xz) plane
+    F0[i] = EH[EHcomp[c]] * 2.0 * pi * x0.r(); // Ey = Ep for \phi = 0 (rz = xz) plane
     double d = abs(F0[i] - F[i]);
     double f0 = abs(F0[i]);
     diff += d * d;
@@ -84,16 +84,16 @@ int check_cyl(double sr, double sz, double a) {
   f.update_dfts();
   n2f.scale_dfts(sqrt(2 * pi) / f.dt); // cancel time-integration factor
 
-  complex<realnum> EH_[6];
+  complex<double> EH_[6];
   diff = 0.0, dot0 = 0.0;
   for (int i = 0; i < N; ++i) {
     double rr = dr * i;
     vec x = veccyl(rr, 10.0 / w);
     n2f.farfield_lowlevel(EH_, x);
     sum_to_all(EH_, EH, 6);
-    F[i] = EH[EHcomp[c]] * complex<realnum>(phase);
+    F[i] = EH[EHcomp[c]] * phase;
     greencyl(EH, x, w, 2.0, 1.0, x0, c0, 1.0, m, 1e-6);
-    F0[i] = EH[EHcomp[c]] * complex<realnum>(2.0 * pi * x0.r());
+    F0[i] = EH[EHcomp[c]] * 2.0 * pi * x0.r();
     double d = abs(F0[i] - F[i]);
     double f0 = abs(F0[i]);
     diff += d * d;
@@ -143,7 +143,7 @@ int check_2d_3d(ndim dim, const double xmax, double a, component c0, component c
     if (gv.has_field(c)) {
       const int N = 20;
       double dx = 0.75 * (xmax / 4) / N;
-      complex<realnum> F[N], F0[N], EH[6];
+      complex<double> F[N], F0[N], EH[6];
       double diff = 0.0, dot0 = 0.0, dot = 0.0;
       complex<double> phase = polar(1.0, (4 * w * f.dt) * pi);
       vec x0 = zero_vec(dim);
@@ -208,7 +208,7 @@ int check_2d_3d(ndim dim, const double xmax, double a, component c0, component c
     if (gv.has_field(c)) {
       const int N = 20;
       double dx = 0.75 * (xmax / 4) / N;
-      complex<realnum> F[N], F0[N], EH_[6], EH[6];
+      complex<double> F[N], F0[N], EH_[6], EH[6];
       double diff = 0.0, dot = 0.0;
       complex<double> phase = polar(1.0, (4 * w * f.dt) * pi);
       vec x0 = zero_vec(dim);
@@ -217,7 +217,7 @@ int check_2d_3d(ndim dim, const double xmax, double a, component c0, component c
         vec x = dim == D2 ? vec(s, 0.5 * s) : vec(s, 0.5 * s, 0.3 * s);
         n2f.farfield_lowlevel(EH_, x);
         sum_to_all(EH_, EH, 6);
-        F[i] = EH[EHcomp[c]] * complex<realnum>(phase);
+        F[i] = EH[EHcomp[c]] * phase;
         (dim == D2 ? green2d : green3d)(EH, x, w, 2.0, 1.0, x0, c0, 1.0);
         F0[i] = EH[EHcomp[c]];
         if (c1 != NO_COMPONENT) {

--- a/tests/near2far.cpp
+++ b/tests/near2far.cpp
@@ -49,7 +49,7 @@ int check_cyl(double sr, double sz, double a) {
   component c = Ep;
   const int N = 20;
   double dr = sr / N;
-  complex<double> F[N], F0[N], EH[6];
+  complex<realnum> F[N], F0[N], EH[6];
   double diff = 0.0, dot0 = 0.0;
   complex<double> phase = polar(1.0, (4 * w * f.dt) * pi);
   for (int i = 0; i < N; ++i) {
@@ -57,7 +57,7 @@ int check_cyl(double sr, double sz, double a) {
     vec x = veccyl(rr, 0.5 * sz);
     F[i] = f.get_field(c, x) * phase;
     greencyl(EH, x, w, 2.0, 1.0, x0, c0, 1.0, m, 1e-6);
-    F0[i] = EH[EHcomp[c]] * 2.0 * pi * x0.r(); // Ey = Ep for \phi = 0 (rz = xz) plane
+    F0[i] = EH[EHcomp[c]] * realnum(2.0 * pi * x0.r()); // Ey = Ep for \phi = 0 (rz = xz) plane
     double d = abs(F0[i] - F[i]);
     double f0 = abs(F0[i]);
     diff += d * d;
@@ -84,16 +84,16 @@ int check_cyl(double sr, double sz, double a) {
   f.update_dfts();
   n2f.scale_dfts(sqrt(2 * pi) / f.dt); // cancel time-integration factor
 
-  complex<double> EH_[6];
+  complex<realnum> EH_[6];
   diff = 0.0, dot0 = 0.0;
   for (int i = 0; i < N; ++i) {
     double rr = dr * i;
     vec x = veccyl(rr, 10.0 / w);
     n2f.farfield_lowlevel(EH_, x);
     sum_to_all(EH_, EH, 6);
-    F[i] = EH[EHcomp[c]] * phase;
+    F[i] = EH[EHcomp[c]] * complex<realnum>(phase);
     greencyl(EH, x, w, 2.0, 1.0, x0, c0, 1.0, m, 1e-6);
-    F0[i] = EH[EHcomp[c]] * 2.0 * pi * x0.r();
+    F0[i] = EH[EHcomp[c]] * complex<realnum>(2.0 * pi * x0.r());
     double d = abs(F0[i] - F[i]);
     double f0 = abs(F0[i]);
     diff += d * d;
@@ -143,7 +143,7 @@ int check_2d_3d(ndim dim, const double xmax, double a, component c0, component c
     if (gv.has_field(c)) {
       const int N = 20;
       double dx = 0.75 * (xmax / 4) / N;
-      complex<double> F[N], F0[N], EH[6];
+      complex<realnum> F[N], F0[N], EH[6];
       double diff = 0.0, dot0 = 0.0, dot = 0.0;
       complex<double> phase = polar(1.0, (4 * w * f.dt) * pi);
       vec x0 = zero_vec(dim);
@@ -208,7 +208,7 @@ int check_2d_3d(ndim dim, const double xmax, double a, component c0, component c
     if (gv.has_field(c)) {
       const int N = 20;
       double dx = 0.75 * (xmax / 4) / N;
-      complex<double> F[N], F0[N], EH_[6], EH[6];
+      complex<realnum> F[N], F0[N], EH_[6], EH[6];
       double diff = 0.0, dot = 0.0;
       complex<double> phase = polar(1.0, (4 * w * f.dt) * pi);
       vec x0 = zero_vec(dim);
@@ -217,7 +217,7 @@ int check_2d_3d(ndim dim, const double xmax, double a, component c0, component c
         vec x = dim == D2 ? vec(s, 0.5 * s) : vec(s, 0.5 * s, 0.3 * s);
         n2f.farfield_lowlevel(EH_, x);
         sum_to_all(EH_, EH, 6);
-        F[i] = EH[EHcomp[c]] * phase;
+        F[i] = EH[EHcomp[c]] * complex<realnum>(phase);
         (dim == D2 ? green2d : green3d)(EH, x, w, 2.0, 1.0, x0, c0, 1.0);
         F0[i] = EH[EHcomp[c]];
         if (c1 != NO_COMPONENT) {

--- a/tests/user-defined-material.cpp
+++ b/tests/user-defined-material.cpp
@@ -54,13 +54,13 @@ bool compare_hdf5_datasets(const char *file1, const char *name1, const char *fil
   h5file f1(file1, h5file::READONLY, false);
   int rank1;
   size_t *dims1 = new size_t[expected_rank];
-  double *data1 = f1.read(name1, &rank1, dims1, expected_rank);
+  realnum *data1 = f1.read(name1, &rank1, dims1, expected_rank);
   if (!data1) return false;
 
   h5file f2(file2, h5file::READONLY, false);
   int rank2;
   size_t *dims2 = new size_t[expected_rank];
-  double *data2 = f2.read(name2, &rank2, dims2, expected_rank);
+  realnum *data2 = f2.read(name2, &rank2, dims2, expected_rank);
   if (!data2) return false;
 
   if (rank1 != expected_rank || rank2 != expected_rank) return false;

--- a/tests/user-defined-material.cpp
+++ b/tests/user-defined-material.cpp
@@ -54,13 +54,13 @@ bool compare_hdf5_datasets(const char *file1, const char *name1, const char *fil
   h5file f1(file1, h5file::READONLY, false);
   int rank1;
   size_t *dims1 = new size_t[expected_rank];
-  realnum *data1 = f1.read(name1, &rank1, dims1, expected_rank);
+  realnum *data1 = (realnum *)f1.read(name1, &rank1, dims1, expected_rank, sizeof(realnum) == sizeof(float));
   if (!data1) return false;
 
   h5file f2(file2, h5file::READONLY, false);
   int rank2;
   size_t *dims2 = new size_t[expected_rank];
-  realnum *data2 = f2.read(name2, &rank2, dims2, expected_rank);
+  realnum *data2 = (realnum *)f2.read(name2, &rank2, dims2, expected_rank, sizeof(realnum) == sizeof(float));
   if (!data2) return false;
 
   if (rank1 != expected_rank || rank2 != expected_rank) return false;


### PR DESCRIPTION
Currently, all fields arrays (time domain and DFT) are double precision floating point. However, in the past Meep used to support [single precision floating point](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) for the fields arrays for reducing memory storage and improving runtime performance (due to the reduced [memory bandwidth](https://en.wikipedia.org/wiki/Memory_bandwidth) consumption). Unfortunately, this feature had bit rotted although its artifact still exists in `src/meep.hpp`:

https://github.com/NanoComp/meep/blob/0b460cdd24f28b5c9576e9fc2d3854056c4545c5/src/meep.hpp#L31-L43

This PR restores this feature by replacing numerous instances of `double`, `complex<double>` with `realnum`, `complex<realnum>`. Both the time-domain and the DFT fields arrays are set to the `realnum` type. 

The PR compiles and all tests pass with `MEEP_SINGLE` set to `0` in `src/meep.hpp` (the default). This just means that this PR does not break anything.

When this feature is enabled, all but two of the nineteen C++ tests are passing (which is expected since some tests are comparing results against hard-coded values obtained using double precision):
```
PASS: aniso_disp
PASS: bench
PASS: bragg_transmission
PASS: convergence_cyl_waveguide
PASS: cylindrical
PASS: flux
PASS: harmonics
PASS: integrate
PASS: known_results
FAIL: near2far
PASS: one_dimensional
PASS: physical
PASS: stress_tensor
FAIL: symmetry
PASS: three_d
PASS: two_dimensional
PASS: 2D_convergence
PASS: h5test
PASS: pml
============================================================================
# TOTAL: 19
# PASS:  17
# SKIP:  0
# XFAIL: 0
# FAIL:  2
# XPASS: 0
# ERROR: 0
```
This PR also causes several of the Python tests to fail:
```
FAIL: tests/3rd_harm_1d.py
PASS: tests/absorber_1d.py
FAIL: tests/adjoint_solver.py
PASS: tests/antenna_radiation.py
PASS: tests/array_metadata.py
PASS: tests/bend_flux.py
PASS: tests/binary_grating.py
FAIL: tests/cavity_arrayslice.py
FAIL: tests/cavity_farfield.py
PASS: tests/chunk_layout.py
FAIL: tests/chunks.py
PASS: tests/cyl_ellipsoid.py
PASS: tests/dft_energy.py
PASS: tests/dft_fields.py
PASS: tests/diffracted_planewave.py
FAIL: tests/dispersive_eigenmode.py
FAIL: tests/divide_mpi_processes.py
```
I haven't yet performed any benchmarking to verify that this PR actually speeds up the time stepping. 

Importantly, we'll need to investigate what effect reducing the floating point precision has on the adjoint solver since its unit test is failing.