### PR TITLE
refcount safety for Python CustomSource

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -100,7 +100,7 @@ TESTS_ENVIRONMENT = export PYTHONPATH=$(abs_top_builddir)/python:$$PYTHONPATH;
 # the low-level interface between python codes and the libmeep C++ library
 ######################################################################
 BUILT_SOURCES = meep-python.cxx __init__.py meep.py
-EXTRA_DIST = $(BUILT_SOURCES) typemap_utils.cpp materials.py examples tests
+EXTRA_DIST = $(BUILT_SOURCES) meep.i meep-python.hpp typemap_utils.cpp materials.py examples tests
 CLEANFILES = .coverage
 MAINTAINERCLEANFILES = $(BUILT_SOURCES)
 
@@ -158,7 +158,8 @@ HPPFILES=                                    \
  $(top_srcdir)/src/meep/mympi.hpp            \
  $(top_srcdir)/src/meepgeom.hpp              \
  $(top_srcdir)/src/material_data.hpp         \
- $(top_srcdir)/src/adjust_verbosity.hpp
+ $(top_srcdir)/src/adjust_verbosity.hpp      \
+ meep-python.hpp
 
 meep-python.cxx: $(MEEP_SWIG_SRC) $(HPPFILES)
 	$(SWIG) -Wextra $(AM_CPPFLAGS) -outdir $(builddir) -c++ -nofastunpack -python -o $@ $(srcdir)/meep.i

--- a/python/meep-python.hpp
+++ b/python/meep-python.hpp
@@ -1,0 +1,56 @@
+namespace meep {
+
+// like custom_src_time, but using Python function object, with proper reference counting
+class custom_py_src_time : public src_time {
+public:
+  custom_py_src_time(PyObject *fun, double st = -infinity, double et = infinity,
+                     std::complex<double> f = 0)
+      : func(fun), freq(f), start_time(float(st)), end_time(float(et)) {
+    Py_INCREF(func);
+  }
+  virtual ~custom_py_src_time() { Py_DECREF(func); }
+
+  virtual std::complex<double> current(double time, double dt) const {
+    if (is_integrated)
+      return src_time::current(time, dt);
+    else
+      return dipole(time);
+  }
+  virtual std::complex<double> dipole(double time) const {
+    float rtime = float(time);
+    if (rtime >= start_time && rtime <= end_time) {
+      PyObject *py_t = PyFloat_FromDouble(time);
+      PyObject *pyres = PyObject_CallFunctionObjArgs(func, py_t, NULL);
+      double real = PyComplex_RealAsDouble(pyres);
+      double imag = PyComplex_ImagAsDouble(pyres);
+      std::complex<double> ret(real, imag);
+      Py_DECREF(py_t);
+      Py_DECREF(pyres);
+      return ret;
+    }
+    else
+      return 0.0;
+  }
+  virtual double last_time() const { return end_time; };
+  virtual src_time *clone() const {
+    Py_INCREF(func); // default copy constructor doesn't incref
+    return new custom_py_src_time(*this);
+  }
+  virtual bool is_equal(const src_time &t) const {
+    const custom_py_src_time *tp = dynamic_cast<const custom_py_src_time *>(&t);
+    if (tp)
+      return (tp->start_time == start_time && tp->end_time == end_time && tp->func == func &&
+              tp->freq == freq);
+    else
+      return 0;
+  }
+  virtual std::complex<double> frequency() const { return freq; }
+  virtual void set_frequency(std::complex<double> f) { freq = f; }
+
+private:
+  PyObject *func;
+  std::complex<double> freq;
+  double start_time, end_time;
+};
+
+} // namespace meep

--- a/python/source.py
+++ b/python/source.py
@@ -302,7 +302,7 @@ class CustomSource(SourceTime):
         self.start_time = start_time
         self.end_time = end_time
         self.center_frequency = center_frequency
-        self.swigobj = mp.custom_src_time(src_func, start_time, end_time, center_frequency)
+        self.swigobj = mp.custom_py_src_time(src_func, start_time, end_time, center_frequency)
         self.swigobj.is_integrated = self.is_integrated
 
 

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -58,6 +58,13 @@ static char *py2_string_as_utf8(PyObject *po) {
 }
 #endif
 
+static PyObject *get_meep_mod() {
+  // Return value: Borrowed reference
+  static PyObject *meep_mod = NULL;
+  if (meep_mod == NULL) { meep_mod = PyImport_ImportModule("meep"); }
+  return meep_mod;
+}
+
 static PyObject *get_geom_mod() {
   // Return value: Borrowed reference
   static PyObject *geom_mod = NULL;
@@ -99,8 +106,8 @@ static PyObject *py_volume_object() {
   // Return value: Borrowed reference
   static PyObject *volume_object = NULL;
   if (volume_object == NULL) {
-    PyObject *geom_mod = get_geom_mod();
-    volume_object = PyObject_GetAttrString(PyImport_ImportModule("meep"), "Volume");
+    PyObject *meep_mod = get_meep_mod();
+    volume_object = PyObject_GetAttrString(meep_mod, "Volume");
   }
   return volume_object;
 }
@@ -456,7 +463,7 @@ static int pymaterial_grid_to_material_grid(PyObject *po, material_data *md) {
     case 1: md->material_grid_kinds = material_data::U_PROD; break;
     case 2: md->material_grid_kinds = material_data::U_MEAN; break;
     case 3: md->material_grid_kinds = material_data::U_DEFAULT; break;
-    default: meep::abort("Invalid material grid enumeration code: %d.\n", gt_enum);
+    default: meep::abort("Invalid material grid enumeration code: %d.\n", (int) gt_enum);
   }
 
   // initialize grid size
@@ -1058,13 +1065,6 @@ static meep::binary_partition *py_bp_to_bp(PyObject *pybp) {
     Py_XDECREF(left);
     Py_XDECREF(right);
     return bp;
-}
-
-static PyObject *get_meep_mod() {
-  // Return value: Borrowed reference
-  static PyObject *meep_mod = NULL;
-  if (meep_mod == NULL) { meep_mod = PyImport_ImportModule("meep"); }
-  return meep_mod;
 }
 
 static PyObject *py_binary_partition_object() {

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -145,7 +145,7 @@ bool custom_src_time::is_equal(const src_time &t) const {
   const custom_src_time *tp = dynamic_cast<const custom_src_time *>(&t);
   if (tp)
     return (tp->start_time == start_time && tp->end_time == end_time && tp->func == func &&
-            tp->data == data);
+            tp->data == data && tp->freq == freq);
   else
     return 0;
 }

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -31,7 +31,7 @@ namespace meep {
 
 // this function is necessary to make equality commutative ... ugh
 bool src_times_equal(const src_time &t1, const src_time &t2) {
-  return t1.is_equal(t2) && t2.is_equal(t1);
+  return t1.is_equal(t2) && t2.is_equal(t1) && t1.is_integrated == t2.is_integrated;
 }
 
 src_time *src_time::add_to(src_time *others, src_time **added) const {


### PR DESCRIPTION
I noticed that Python `CustomSource` objects were translated to a C++ `custom_src_time` object with a raw `PyObject*` field pointing to the Python function, whose reference count wasn't incremented.  This could potentially lead to crashes if the Python source function was garbage collected, e.g. if it was a `lambda` anonymous function.

This PR implements a Python-specific `custom_py_src_time` that properly updates the Python reference count.

Also cleans up a couple of other spots and makes the `src_time_equal` function more precise.