### PR TITLE
add missing test case in meepgeom::geom_boxes_intersect

### DIFF
--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1842,11 +1842,11 @@ static int geom_boxes_intersect(const geom_box *b1, const geom_box *b2) {
   /* true if the x, y, and z ranges all intersect. */
   return (
       (BETWEEN(b1->low.x, b2->low.x, b2->high.x) || BETWEEN(b1->high.x, b2->low.x, b2->high.x) ||
-       BETWEEN(b2->low.x, b1->low.x, b1->high.x)) &&
+       BETWEEN(b2->low.x, b1->low.x, b1->high.x) || BETWEEN(b2->high.x, b1->low.x, b1->high.x)) &&
       (BETWEEN(b1->low.y, b2->low.y, b2->high.y) || BETWEEN(b1->high.y, b2->low.y, b2->high.y) ||
-       BETWEEN(b2->low.y, b1->low.y, b1->high.y)) &&
+       BETWEEN(b2->low.y, b1->low.y, b1->high.y) || BETWEEN(b2->high.y, b1->low.y, b1->high.y)) &&
       (BETWEEN(b1->low.z, b2->low.z, b2->high.z) || BETWEEN(b1->high.z, b2->low.z, b2->high.z) ||
-       BETWEEN(b2->low.z, b1->low.z, b1->high.z)));
+       BETWEEN(b2->low.z, b1->low.z, b1->high.z) || BETWEEN(b2->high.z, b1->low.z, b1->high.z)));
 }
 
 /******************************************************************************/


### PR DESCRIPTION
While investigating ways to speed up [`grid_volume::get_cost()`](https://github.com/NanoComp/meep/blob/2dcfa9fcc226e07bf3d177ba8318c867a79567a9/src/vec.cpp#L952-L957) which in turn calls [`fragment_stats::compute()`](https://github.com/NanoComp/meep/blob/2dcfa9fcc226e07bf3d177ba8318c867a79567a9/src/meepgeom.cpp#L2155-L2160), I found a bug in the function `geom_boxes_intersect` (originally added in #340) involving a missing check. This means that the computation of the fragment statistics used by the cell partitioning algorithm via [`grid_volume::find_best_split`](https://github.com/NanoComp/meep/blob/2dcfa9fcc226e07bf3d177ba8318c867a79567a9/src/vec.cpp#L984-L1036)has thus far been inaccurate. Pending further testing, this could partly explain why this feature has not been able to consistently and reliably improve load balancing of large parallel simulations.