### PR TITLE
compute material volume averages of a MaterialGrid using analytic formulation

### DIFF
--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -311,6 +311,8 @@ bool is_metal(meep::field_type ft, const material_type *material) {
 // computes the vector-Jacobian product of the gradient of the matgrid_val function v
 // with the Jacobian of the to_geom_box_coords function for geometric_object o
 vector3 to_geom_object_coords_VJP(vector3 v, const geometric_object *o) {
+  if (!o) { meep::abort("must pass a geometric_object to to_geom_object_coords_VJP.\n"); }
+
   switch (o->which_subclass) {
     default: {
       vector3 po = {0, 0, 0};
@@ -392,9 +394,9 @@ meep::vec material_grid_grad(vector3 p, material_data *md, const geometric_objec
 
   // [du_dx,du_dy,du_dz] is the gradient ∇u with respect to the transformed coordinate
   // r1 of the matgrid_val function but what we want is the gradient of u(g(r2)) with 
-  // respect to r2 where g(r2) is the to_geom_object_coords function. computing this
-  // quantity involves using the chain rule and the vector-Jacobian product ∇u J
-  // where J is the Jacobian matrix of g.
+  // respect to r2 where g(r2) is the to_geom_object_coords function (in libctl/utils/geom.c).
+  // computing this quantity involves using the chain rule and thus the vector-Jacobian product
+  // ∇u J where J is the Jacobian matrix of g.
   vector3 grad_u;
   grad_u.x = du_dx * nx;
   grad_u.y = du_dy * ny;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1185,7 +1185,7 @@ static number matgrid_eps_func(int n, number *x, void *mgva_) {
   vector3 med2_eps_diag = mgva->med2_eps_diag;
   double eps1 = (med1_eps_diag.x + med1_eps_diag.y + med1_eps_diag.z)/3;
   double eps2 = (med2_eps_diag.x + med2_eps_diag.y + med2_eps_diag.z)/3;
-  double eps_interp = u_proj*eps1 + (1-u_proj)*eps2;
+  double eps_interp = (1-u_proj)*eps1 + u_proj*eps2;
   double w = 0;
   if (mgva->dim == meep::D1)
     w = 1/(2*mgva->rad);
@@ -1203,7 +1203,7 @@ static number matgrid_inveps_func(int n, number *x, void *mgva_) {
   vector3 med2_eps_diag = mgva->med2_eps_diag;
   double eps1 = (med1_eps_diag.x + med1_eps_diag.y + med1_eps_diag.z)/3;
   double eps2 = (med2_eps_diag.x + med2_eps_diag.y + med2_eps_diag.z)/3;
-  double epsinv_interp = u_proj/eps1 + (1-u_proj)/eps2;
+  double epsinv_interp = (1-u_proj)/eps1 + u_proj/eps2;
   double w = 0;
   if (mgva->dim == meep::D1)
     w = 1/(2*mgva->rad);
@@ -1322,7 +1322,6 @@ void geom_epsilon::fallback_chi1inv_row(meep::component c, double chi1inv_row[3]
     }
     return;
   }
-
   number esterr;
   integer errflag;
   number xmin[3], xmax[3];
@@ -1399,7 +1398,6 @@ void geom_epsilon::fallback_chi1inv_row(meep::component c, double chi1inv_row[3]
     if (eps_ever_negative) // averaging negative eps causes instability
       minveps = 1.0 / (meps = eps(v.center()));
   }
-
   {
     double n[3] = {0, 0, 0};
     double nabsinv = 1.0 / meep::abs(gradient);

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1215,6 +1215,7 @@ static void get_uproj_w(const void *mgva_, double x0, double &uproj_, double &w_
 static cnumber matgrid_ceps_func(int n, number *x, void *mgva_) {
   double u_proj = 0, w = 0;
   get_uproj_w(mgva_, x[0], u_proj, w);
+  matgrid_volavg *mgva = (matgrid_volavg *)mgva_;
   double eps1 = mgva->eps1;
   double eps2 = mgva->eps2;
   cnumber ret;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -408,9 +408,9 @@ meep::vec material_grid_grad(vector3 p, material_data *md, const geometric_objec
     gradient.set_direction(meep::Z, grad_u_J.z);
   }
   else {
-    gradient.set_direction(meep::X, grad_u.x);
-    gradient.set_direction(meep::Y, grad_u.y);
-    gradient.set_direction(meep::Z, grad_u.z);
+    gradient.set_direction(meep::X, geometry_lattice.size.x == 0 ? 0 : grad_u.x / geometry_lattice.size.x);
+    gradient.set_direction(meep::Y, geometry_lattice.size.y == 0 ? 0 : grad_u.y / geometry_lattice.size.y);
+    gradient.set_direction(meep::Z, geometry_lattice.size.z == 0 ? 0 : grad_u.z / geometry_lattice.size.z);
   }
 
   return gradient;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1163,13 +1163,12 @@ static cnumber matgrid_ceps_func(int n, number *x, void *geomeps_) {
   }
   cnumber ret;
   double r2 = voxel_rad*voxel_rad;
-  double z2 = sqr(p.x-voxel_cen.x) + sqr(p.y-voxel_cen.y);
+  double z2 = (p.x-voxel_cen.x)*(p.x-voxel_cen.x) + (p.y-voxel_cen.y)*(p.y-voxel_cen.y);
   double w = 2*sqrt(r2 - z2)/(meep::pi*r2);
   double ep = geomeps->chi1p1(func_ft, vector3_to_vec(p));
   if (ep < 0) eps_ever_negative = 1;
   ret.re = ep * s;
   ret.im = s / ep;
-  master_printf("matgrid_ceps_func:, (%0.5f,%0.5f), %0.5f, %0.5f\n",p.x,p.y,ret.re,ret.im);
   return ret * w;
 }
 #else
@@ -1191,7 +1190,6 @@ static number matgrid_eps_func(int n, number *x, void *geomeps_) {
   double w = 2*sqrt(r2 - z2)/(meep::pi*r2);
   double ep = geomeps->chi1p1(func_ft, vector3_to_vec(p));
   if (ep < 0) eps_ever_negative = 1;
-  master_printf("matgrid_eps_func:, (%0.5f,%0.5f), (%0.5f,%0.5f), %0.6f, %0.6f, %d\n",p.x,p.y,voxel_cen.x,voxel_cen.y,r2,z2,r2 < z2 ? 1 : 0);
   return (ep * s) * w;
 }
 static number matgrid_inveps_func(int n, number *x, void *geomeps_) {
@@ -1212,7 +1210,6 @@ static number matgrid_inveps_func(int n, number *x, void *geomeps_) {
   double w = 2*sqrt(r2 - z2)/(meep::pi*r2);
   double ep = geomeps->chi1p1(func_ft, vector3_to_vec(p));
   if (ep < 0) eps_ever_negative = 1;
-  master_printf("matgrid_inveps_func:, (%0.5f,%0.5f), (%0.5f,%0.5f), %0.6f, %0.6f, %d\n",p.x,p.y,voxel_cen.x,voxel_cen.y,r2,z2,r2 < z2 ? 1 : 0);
   return (s / ep) * w;
 }
 #endif
@@ -1333,30 +1330,12 @@ void geom_epsilon::fallback_chi1inv_row(meep::component c, double chi1inv_row[3]
     double theta = atan(gradient.y()/gradient.x());
     voxel_rad = v.diameter()/2;
     voxel_cen = p;
-    if (theta == 0) {
-      xmin[0] = -voxel_rad;
-      xmin[1] = 0;
-      xmin[2] = 0;
-      xmax[0] = voxel_rad;
-      xmax[1] = 0;
-      xmax[2] = 0;
-    }
-    else if (fabs(theta) == meep::pi/2) {
-      xmin[0] = 0;
-      xmin[1] = -voxel_rad;
-      xmin[2] = 0;
-      xmax[0] = 0;
-      xmax[1] = voxel_rad;
-      xmax[2] = 0;
-    }
-    else {
-      xmin[0] = -cos(theta)*voxel_rad + p.x;
-      xmin[1] = -sin(theta)*voxel_rad + p.y;
-      xmin[2] = 0;
-      xmax[0] = cos(theta)*voxel_rad + p.x;
-      xmax[1] = sin(theta)*voxel_rad + p.y;
-      xmax[2] = 0;
-    }
+    xmin[0] = -cos(theta)*voxel_rad + p.x;
+    xmin[1] = -sin(theta)*voxel_rad + p.y;
+    xmin[2] = 0;
+    xmax[0] = cos(theta)*voxel_rad + p.x;
+    xmax[1] = sin(theta)*voxel_rad + p.y;
+    xmax[2] = 0;
     n = 2;
     vol = 2*voxel_rad;
   }

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -370,7 +370,7 @@ meep::vec material_grid_grad(vector3 p, material_data *md) {
   // component by nx,ny,nz respectively (see map_coordinates)
   gradient.set_direction(meep::X, du_dx * nx);
   gradient.set_direction(meep::Y, du_dy * ny);
-  gradient.set_direction(meep::Z, du_dz * ny);
+  gradient.set_direction(meep::Z, du_dz * nz);
 
   return gradient;
 }
@@ -1395,9 +1395,9 @@ void geom_epsilon::fallback_chi1inv_row(meep::component c, double chi1inv_row[3]
     minveps = adaptive_integration(inveps_func, xmin, xmax, n, (void *)this, 0, tol, maxeval, &esterr,
                                    &errflag) / vol;
 #endif
-    if (eps_ever_negative) // averaging negative eps causes instability
-      minveps = 1.0 / (meps = eps(v.center()));
   }
+  if (eps_ever_negative) // averaging negative eps causes instability
+    minveps = 1.0 / (meps = eps(v.center()));
   {
     double n[3] = {0, 0, 0};
     double nabsinv = 1.0 / meep::abs(gradient);

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -210,7 +210,7 @@ void init_libctl(material_type default_mat, bool ensure_per,
 /***************************************************************/
 void update_weights(material_type matgrid, double *weights);
 meep::vec matgrid_grad(vector3 p, geom_box_tree tp, int oi, material_data *md);
-meep::vec material_grid_grad(vector3 p, material_data *md);
+meep::vec material_grid_grad(vector3 p, material_data *md, const geometric_object *o);
 double matgrid_val(vector3 p, geom_box_tree tp, int oi, material_data *md);
 double material_grid_val(vector3 p, material_data *md);
 geom_box_tree calculate_tree(const meep::volume &v, geometric_object_list g);


### PR DESCRIPTION
Initial attempt to compute the volume averages for ε and ε<sup>-1</sup> as part of subpixel smoothing using an analytic formulation based on a 1d line integral through a spherical voxel. This is intended to replace the existing approach involving an adaptive quadrature scheme over a cubic voxel.

Currently only supports 2d. It compiles but for a test case involving a 2d photonic crystal (same as the one used in #1539) the fields blow up.