### PR TITLE
WIP: Initial version of JAX-Meep wrapper

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -38,6 +38,7 @@ TESTS =                                   \
     $(TEST_DIR)/3rd_harm_1d.py            \
     $(TEST_DIR)/absorber_1d.py            \
     $(TEST_DIR)/adjoint_solver.py         \
+    $(TEST_DIR)/adjoint_jax.py            \
     $(TEST_DIR)/antenna_radiation.py      \
     $(TEST_DIR)/array_metadata.py         \
     $(TEST_DIR)/bend_flux.py              \
@@ -218,7 +219,10 @@ adjoint_PYTHON  = $(srcdir)/adjoint/__init__.py              \
                   $(srcdir)/adjoint/objective.py             \
                   $(srcdir)/adjoint/optimization_problem.py  \
                   $(srcdir)/adjoint/filters.py               \
-                  $(srcdir)/adjoint/filter_source.py
+                  $(srcdir)/adjoint/filter_source.py         \
+                  $(srcdir)/adjoint/jax/__init__.py          \
+                  $(srcdir)/adjoint/jax/wrapper.py           \
+                  $(srcdir)/adjoint/jax/utils.py             \
 
 ######################################################################
 # finally, specification of what gets installed in the meep python

--- a/python/adjoint/__init__.py
+++ b/python/adjoint/__init__.py
@@ -15,3 +15,5 @@ from .optimization_problem import (OptimizationProblem, Grid, DesignRegion)
 from .filter_source import FilteredSource
 
 from .filters import *
+
+from . import jax

--- a/python/adjoint/__init__.py
+++ b/python/adjoint/__init__.py
@@ -19,4 +19,4 @@ from .filters import *
 try:
   from . import jax
 except ImportError as error:
-  print('Unable to import JAX.')
+  pass

--- a/python/adjoint/__init__.py
+++ b/python/adjoint/__init__.py
@@ -16,4 +16,7 @@ from .filter_source import FilteredSource
 
 from .filters import *
 
-from . import jax
+try:
+  from . import jax
+except ImportError as error:
+  print('Unable to import JAX.')

--- a/python/adjoint/jax/__init__.py
+++ b/python/adjoint/jax/__init__.py
@@ -1,0 +1,7 @@
+"""Interface for composing Meep with JAX.
+
+"""
+
+from .wrapper import MeepJaxWrapper
+
+from . import utils

--- a/python/adjoint/jax/utils.py
+++ b/python/adjoint/jax/utils.py
@@ -1,0 +1,126 @@
+from typing import List, Iterable
+
+import meep as mp
+import meep.adjoint as mpa
+import numpy as onp
+
+# Meep field components used to compute adjoint sensitivities
+_ADJOINT_FIELD_COMPONENTS = [mp.Ex, mp.Ey, mp.Ez]
+
+
+def _make_at_least_nd(x: onp.ndarray, dims: int = 3) -> onp.ndarray:
+  """Makes an array have at least the specified number of dimensions."""
+  return onp.reshape(x, x.shape + onp.maximum(dims - x.ndim, 0) * (1,))
+
+
+def register_monitors(
+  monitors: List[mpa.EigenmodeCoefficient],
+  frequencies: List[float],
+) -> None:
+  """Registers a list of monitors."""
+  for monitor in monitors:
+    monitor.register_monitors(frequencies)
+
+
+def install_design_region_monitors(
+  simulation: mp.Simulation,
+  design_regions: List[mpa.DesignRegion],
+  frequencies: List[float],
+) -> List[mp.DftFields]:
+  """Installs DFT field monitors at the design regions of the simulation."""
+  design_region_monitors = [
+    simulation.add_dft_fields(
+      _ADJOINT_FIELD_COMPONENTS,
+      frequencies,
+      where=design_region.volume,
+      yee_grid=True,
+    ) for design_region in design_regions
+  ]
+  return design_region_monitors
+
+
+def gather_monitor_values(monitors: List[mpa.EigenmodeCoefficient]) -> onp.ndarray:
+  """Gathers the mode monitor overlap values as a rank 2 ndarray.
+
+  Args:
+    monitors: the mode monitors.
+
+  Returns:
+    a rank-2 ndarray, where the dimensions are (monitor, frequency), of dtype
+    complex128.  Note that these values refer to the mode as oriented (i.e. they
+    are unidirectional).
+  """
+  monitor_values = []
+  for monitor in monitors:
+    monitor_values.append(monitor())
+  monitor_values = onp.array(monitor_values)
+  assert monitor_values.ndim in [1, 2]
+  monitor_values = _make_at_least_nd(monitor_values, 2)
+  return monitor_values
+
+
+def gather_design_region_fields(
+  simulation: mp.Simulation,
+  design_region_monitors: List[mp.DftFields],
+  frequencies: List[float],
+) -> List[List[onp.ndarray]]:
+  """Collects the design region DFT fields from the simulation.
+
+  Args:
+   simulation: the simulation object.
+   design_region_monitors: the installed design region monitors.
+   frequencies: the frequencies to monitor.
+
+  Returns:
+    A list of lists.  Each entry (list) in the overall list corresponds one-to-
+    one with a declared design region.  For each such contained list, the
+    entries correspond to the field components that are monitored.  The entries
+    are ndarrays of rank 4 with dimensions (freq, x, y, (z-or-pad)).
+
+    The design region fields are sampled on the *Yee grid*.  This makes them
+    fairly awkward to inspect directly.  Their primary use case is supporting
+    gradient calculations.
+  """
+  fwd_fields = []
+  for monitor in design_region_monitors:
+    fields_by_component = []
+    for component in _ADJOINT_FIELD_COMPONENTS:
+      fields_by_freq = []
+      for freq_idx, _ in enumerate(frequencies):
+        fields = simulation.get_dft_array(monitor, component, freq_idx)
+        fields_by_freq.append(_make_at_least_nd(fields))
+      fields_by_component.append(onp.stack(fields_by_freq))
+    fwd_fields.append(fields_by_component)
+  return fwd_fields
+
+
+def validate_and_update_design(design_regions: List[mpa.DesignRegion], design_variables: Iterable[onp.ndarray]):
+  """Validate the design regions and variables.
+
+  In particular the design variable should be 1,2,3-D and the design region
+  shape should match the design variable shape after dimension expansion.
+  The arguments are modified in place.
+
+  Args:
+    design_regions: List of mpa.DesignRegion,
+    design_variables: Iterable with numpy arrays represending design variables.
+
+  Raises:
+    ValueError if the validation of dimensions fails.
+  """
+  for i, (design_region, design_variable) in enumerate(zip(design_regions, design_variables)):
+    if design_variable.ndim not in [1, 2, 3]:
+      raise ValueError(
+        'Design variables should be 1D, 2D, or 3D, but the design variable '
+        'at index {} had a shape of {}.'.format(i, design_variable.shape))
+    design_region_shape = tuple(
+      int(x) for x in design_region.design_parameters.grid_size)
+    design_variable_padded_shape = design_variable.shape + (1,) * (3 - design_variable.ndim)
+    if design_variable_padded_shape != design_region_shape:
+      raise ValueError(
+        'The design variable at index {} with a shape of {} is '
+        'incompatible with the associated design region, which has a shape '
+        'of {}.'.format(i, design_variable.shape, design_region_shape))
+    design_variable = onp.asarray(design_variable, dtype=onp.float64)
+    # Update the design variable in Meep
+    design_region.update_design_parameters(design_variable.flatten())

--- a/python/adjoint/jax/wrapper.py
+++ b/python/adjoint/jax/wrapper.py
@@ -1,0 +1,323 @@
+"""Wrapper for converting a Meep simulation into a differentiable JAX callable function.
+
+Usage example:
+```
+import jax.numpy as jnp
+import meep as mp
+import meep.adjoint as mpa
+
+sources = [
+  mp.EigenModeSource(...)
+]
+
+monitors = [
+  mpa.EigenmodeCoefficient(...),
+  mpa.EigenmodeCoefficient(...),
+]
+
+design_regions = [
+  mpa.DesignRegion(...)
+]
+
+frequencies = [1/1.55, 1/1.60, 1/1.65, ...]
+
+simulation = mp.Simulation(...)
+
+wrapped_meep = MeepJaxWrapper(
+    simulation,
+    sources,
+    monitors,
+    design_regions,
+    frequencies,
+    measurement_interval = 50.0,
+    dft_field_components = (mp.Ez,),
+    dft_threshold = 1e-6,
+    minimum_run_time = 0,
+    maximum_run_time = onp.inf,
+    until_after_sources = True
+)
+
+def loss(x):
+    monitor_values = wrapped_meep([x])
+    t = monitor_values[0,:] / monitor_values[1,:]
+    # Mean transmission vs wavelength
+    return jnp.mean(jnp.abs(t))
+
+value, grad = jax.value_and_grad(loss)(x)
+```
+"""
+
+from typing import Callable, List, Tuple
+
+import jax
+import jax.numpy as jnp
+import meep as mp
+import meep.adjoint as mpa
+import numpy as onp
+
+import utils
+
+# The frequency axis in the array returned by `mp._get_gradient()`
+_GRADIENT_FREQ_AXIS = 1
+
+_log_fn = print
+_norm_fn = onp.linalg.norm
+_reduce_fn = onp.max
+
+
+class MeepJaxWrapper:
+  """Wraps a Meep simulation object into a JAX-differentiable callable.
+
+  Attributes:
+      simulation: the pre-configured Meep simulation object.
+      sources: a list of Meep sources for the forward simulation.
+      monitors: a list of eigenmode coefficient monitors from the `meep.adjoint`
+        module.
+      design_regions: a list of design regions from the `meep.adjoint` module.
+      frequencies: the list of frequencies, in normalized Meep units.
+      measurement_interval: the time interval between DFT field convergence
+        measurements, in Meep time units. The default value is 50.
+      dft_field_components: a list of Meep field components, such as `mp.Ex`,
+        `mp.Hy`, etc, whose DFT will be monitored for convergence to stop the
+        simulation. The default is `mp.Ez`.
+      dft_threshold: the threshold for DFT field convergence. Once the norm of the
+        change in the fields (the maximum over all design regions and field
+        components) is less than this value, the simulation will be stopped. The
+        default value is 1e-6.
+      minimum_run_time: the minimum run time of the simulation, in Meep time
+        units. The default value is 0.
+      maximum_run_time: the maximum run time of the simulation, in Meep time
+        units. The default value is infinity.
+      until_after_sources: whether `maximum_run_time` should be ignored until the
+        sources have turned off. This parameter specifies whether `until` or
+        `until_after_sources` is used. See
+        https://meep.readthedocs.io/en/latest/Python_User_Interface/#Simulation
+          for more information. The default is true.
+  """
+
+  def __init__(self,
+               simulation: mp.Simulation,
+               sources: List[mp.Source],
+               monitors: List[mpa.EigenmodeCoefficient],
+               design_regions: List[mpa.DesignRegion],
+               frequencies: List[float],
+               measurement_interval: float = 50.0,
+               dft_field_components: Tuple[int, ...] = (mp.Ez,),
+               dft_threshold: float = 1e-6,
+               minimum_run_time: float = 0,
+               maximum_run_time: float = onp.inf,
+               until_after_sources: bool = True):
+    self.simulation = simulation
+    self.sources = sources
+    self.monitors = monitors
+    self.design_regions = design_regions
+    self.frequencies = frequencies
+    self.measurement_interval = measurement_interval
+    self.dft_field_components = dft_field_components
+    self.dft_threshold = dft_threshold
+    self.minimum_run_time = minimum_run_time
+    self.maximum_run_time = maximum_run_time
+    self.until_after_sources = until_after_sources
+
+    self._reset_convergence_measurement()
+    self._simulate_fn = self._initialize_callable()
+
+  def __call__(self, designs: List[jnp.ndarray]) -> jnp.ndarray:
+    """Performs a Meep simulation, taking a list of designs and returning mode overlaps.
+
+    Args:
+      designs: a list of design variables as 1D, 2D, or 3D JAX arrays. Valid shapes for
+      design variables are (Nx, Ny, Nz) where Nx{y,z} match the elements of the
+      `grid_size` constructor argument of Meep's `MaterialGrid` used for the
+      corresponding design region. Singleton dimensions of the `grid_size` may be
+      omitted from the corresponding design variable. For example, a design variable
+      with a shape of either (10, 20) or (10, 20, 1) would be compatible with a
+      `grid_size` of (10, 20, 1). Similarly, a design variable with shapes of (25,),
+      (25, 1), or (25, 1, 1) would be compatible with a `grid_size` of (25, 1, 1).
+
+    Returns:
+      a complex-valued JAX ndarray of differentiable mode monitor overlaps values with
+      a shape of (num monitors, num frequencies).
+    """
+    return self._simulate_fn(designs)
+
+  def _reset_convergence_measurement(self, monitors: List[mp.DftFields] = None) -> None:
+    """Resets the DFT convergence measurement."""
+    if monitors is None:
+      monitors = []
+    self._dft_convergence_monitors = monitors
+    self._last_measurement_meep_time = 0.0
+    self._previous_fields = self._init_empty_dft_field_container()
+    self._dft_relative_change = []
+
+  def _run_fwd_simulation(self, design_variables):
+    """Runs forward simulation, returning monitor values and design region fields."""
+    utils.validate_and_update_design(self.design_regions, design_variables)
+    self.simulation.reset_meep()
+    self.simulation.change_sources(self.sources)
+    utils.register_monitors(self.monitors, self.frequencies)
+    design_region_monitors = utils.install_design_region_monitors(self.simulation, self.design_regions,
+                                                                  self.frequencies)
+
+    self.simulation.init_sim()
+    sim_run_args = {'until_after_sources' if self.until_after_sources else 'until': self._callback}
+    self._reset_convergence_measurement(design_region_monitors)
+    self.simulation.run(**sim_run_args)
+
+    monitor_values = utils.gather_monitor_values(self.monitors)
+    fwd_fields = utils.gather_design_region_fields(self.simulation, design_region_monitors, self.frequencies)
+
+    return (
+      jnp.asarray(monitor_values),
+      jax.tree_map(jnp.asarray, fwd_fields)
+    )
+
+  def _run_adjoint_simulation(self, monitor_values_grad):
+    """Runs adjoint simulation, returning design region fields."""
+    adjoint_sources = []
+    for monitor_idx, monitor in enumerate(self.monitors):
+      # `dj` for each monitor will have a shape of (num frequencies,)
+      dj = onp.asarray(monitor_values_grad[monitor_idx], dtype=onp.complex128)
+      if onp.any(dj):
+        adjoint_sources += monitor.place_adjoint_source(dj)
+    if not adjoint_sources:
+      raise RuntimeError('The gradient of all monitor values is zero, which '
+                         'means that no adjoint sources can be placed to set '
+                         'up an adjoint simulation in Meep. This could be due '
+                         'to the forward simulation not running for long '
+                         'enough to allow the input pulse(s) to reach the '
+                         'monitors. Additionally, the monitor values could be '
+                         'disconnected from the objective function output.')
+    self.simulation.reset_meep()
+    self.simulation.change_sources(adjoint_sources)
+    design_region_monitors = utils.install_design_region_monitors(self.simulation, self.design_regions,
+                                                                  self.frequencies, )
+
+    self.simulation.init_sim()
+    sim_run_args = {
+      'until_after_sources' if self.until_after_sources else 'until': self._callback
+    }
+    self._reset_convergence_measurement(design_region_monitors)
+    self.simulation.run(**sim_run_args)
+
+    return utils.gather_design_region_fields(self.simulation, design_region_monitors, self.frequencies)
+
+  def _calculate_vjps(self, fwd_fields, adj_fields, design_variable_shapes):
+    """Calculates the VJP for a given set of forward and adjoint fields."""
+    vjps = [
+      design_region.get_gradient(
+        self.simulation,
+        adj_fields[i],
+        fwd_fields[i],
+        self.frequencies,
+      ) for i, design_region in enumerate(self.design_regions)
+    ]
+    # This interface returns the *total* gradient, thus we sum over the frequency axis (if
+    # there is one)
+    vjps = [
+      onp.sum(vjp, axis=_GRADIENT_FREQ_AXIS)
+      if vjp.ndim == 2 else vjp for vjp in vjps
+    ]
+    vjps = [
+      onp.reshape(vjp, shape)
+      for vjp, shape in zip(vjps, design_variable_shapes)
+    ]
+    return vjps
+
+  def _initialize_callable(self) -> Callable[[List[jnp.ndarray]], jnp.ndarray]:
+    """Initializes the callable JAX function and registers its VJP."""
+
+    @jax.custom_vjp
+    def simulate(design_variables: List[jnp.ndarray]) -> jnp.ndarray:
+      monitor_values, _ = self._run_fwd_simulation(design_variables)
+      return monitor_values
+
+    def _simulate_fwd(design_variables):
+      """Runs forward simulation, returning monitor values and fields."""
+      monitor_values, fwd_fields = self._run_fwd_simulation(design_variables)
+      design_variable_shapes = [x.shape for x in design_variables]
+      return monitor_values, (fwd_fields, design_variable_shapes)
+
+    def _simulate_rev(res, monitor_values_grad):
+      """Runs adjoint simulation, returning VJP of design wrt monitor values."""
+      if not self.design_regions:
+        raise RuntimeError('An adjoint simulation was attempted when no design '
+                           'regions are present.')
+      fwd_fields = jax.tree_map(
+        lambda x: onp.asarray(x, dtype=onp.complex128),
+        res[0],
+      )
+      design_variable_shapes = res[1]
+      adj_fields = self._run_adjoint_simulation(monitor_values_grad)
+      vjps = self._calculate_vjps(fwd_fields, adj_fields, design_variable_shapes)
+      return ([jnp.asarray(vjp) for vjp in vjps],)
+
+    simulate.defvjp(_simulate_fwd, _simulate_rev)
+
+    return simulate
+
+  def _init_empty_dft_field_container(self) -> List[List[float]]:
+    """Initializes a nested list for storing DFT fields for convergence monitoring."""
+    num_components = len(self.dft_field_components)
+    num_monitors = len(self._dft_convergence_monitors)
+    return [[0.0 for _ in range(num_components)] for _ in range(num_monitors)]
+
+  def _are_dfts_converged(self, sim: mp.Simulation) -> bool:
+    """Callback to determine whether the DFT fields are converged below the threshold."""
+    if self.dft_threshold == 0 or not self._dft_convergence_monitors or not self.dft_field_components:
+      return False
+    relative_change = []
+    current_fields = self._init_empty_dft_field_container()
+    for monitor_idx, monitor in enumerate(self._dft_convergence_monitors):
+      for component_idx, component in enumerate(self.dft_field_components):
+        previous_fields = self._previous_fields[monitor_idx][component_idx]
+        current_fields[monitor_idx][component_idx] = sim.get_dft_array(
+          monitor,
+          component,
+          int(monitor.nfreqs // 2),
+        )
+        norm_previous = _norm_fn(previous_fields)
+        field_diff = previous_fields - current_fields[monitor_idx][component_idx]
+        if norm_previous != 0:
+          relative_change.append(_norm_fn(field_diff) / norm_previous)
+        else:
+          relative_change.append(1.0)
+    relative_change = _reduce_fn(relative_change)
+    self._dft_relative_change.append(relative_change)
+    self._previous_fields = current_fields
+    if mp.am_master() and mp.verbosity > 0:
+      print(f'At simulation time {sim.meep_time():.2f} the relative change in '
+            f'the DFT fields is {relative_change:.2e}.')
+    return relative_change < self.dft_threshold
+
+  def _callback(self, sim: mp.Simulation) -> bool:
+    """A callback function returning `True` when the simulation should stop.
+
+    This is a step function that gets called at each time step of the Meep
+    simulation, taking a Meep simulation object as an input and returning `True`
+    when the simulation should be terminated and returning `False` when the
+    simulation should continue. The resulting step function is designed to be
+    used with the `until` and `until_after_sources` arguments of the Meep
+    simulation `run()` routine.
+
+    Args:
+      sim: a Meep simulation object.
+
+    Returns:
+      a boolean indicating whether the simulation should be terminated.
+    """
+    current_meep_time = sim.round_time()
+    if current_meep_time <= self._last_measurement_meep_time + self.measurement_interval:
+      return False
+    if current_meep_time <= self.minimum_run_time:
+      if mp.am_master() and mp.verbosity > 0:
+        remaining_time = self.minimum_run_time - sim.round_time()
+        _log_fn(f'{remaining_time:.2f} to go until the minimum simulation runtime is reached.')
+      return False
+    if current_meep_time >= self.maximum_run_time:
+      if mp.am_master() and mp.verbosity > 0:
+        _log_fn(f'Stopping the simulation because the maximum simulation run '
+                f'time of {self.maximum_run_time:.2f} has been reached.')
+      return True
+    self._last_measurement_meep_time = current_meep_time
+    return self._are_dfts_converged(sim)

--- a/python/adjoint/jax/wrapper.py
+++ b/python/adjoint/jax/wrapper.py
@@ -57,7 +57,6 @@ import numpy as onp
 
 from . import utils
 
-_log_fn = print
 _norm_fn = onp.linalg.norm
 _reduce_fn = onp.max
 
@@ -91,6 +90,7 @@ class MeepJaxWrapper:
         https://meep.readthedocs.io/en/latest/Python_User_Interface/#Simulation
           for more information. The default is true.
   """
+  _log_fn = print
 
   def __init__(self,
                simulation: mp.Simulation,
@@ -179,8 +179,8 @@ class MeepJaxWrapper:
     if not self.design_regions:
       raise RuntimeError('An adjoint simulation was attempted when no design '
                          'regions are present.')
-    self.simulation.reset_meep()
     adjoint_sources = utils.create_adjoint_sources(self.monitors, monitor_values_grad)
+    self.simulation.reset_meep()
     self.simulation.change_sources(adjoint_sources)
     design_region_monitors = utils.install_design_region_monitors(
       self.simulation,
@@ -290,11 +290,11 @@ class MeepJaxWrapper:
     if current_meep_time <= self.minimum_run_time:
       if mp.am_master() and mp.verbosity > 0:
         remaining_time = self.minimum_run_time - sim.round_time()
-        _log_fn(f'{remaining_time:.2f} to go until the minimum simulation runtime is reached.')
+        self._log_fn(f'{remaining_time:.2f} to go until the minimum simulation runtime is reached.')
       return False
     if current_meep_time >= self.maximum_run_time:
       if mp.am_master() and mp.verbosity > 0:
-        _log_fn(f'Stopping the simulation because the maximum simulation run '
+        self._log_fn(f'Stopping the simulation because the maximum simulation run '
                 f'time of {self.maximum_run_time:.2f} has been reached.')
       return True
     self._last_measurement_meep_time = current_meep_time

--- a/python/adjoint/jax/wrapper.py
+++ b/python/adjoint/jax/wrapper.py
@@ -159,9 +159,10 @@ class MeepJaxWrapper:
       self.frequencies,
     )
     self.simulation.init_sim()
-    sim_run_args = {'until_after_sources' if self.until_after_sources else 'until': self._callback}
+    sim_run_args = {'until_after_sources' if self.until_after_sources else 'until': self._simulation_run_callback}
     self._reset_convergence_measurement(design_region_monitors)
     self.simulation.run(**sim_run_args)
+
     monitor_values = utils.gather_monitor_values(self.monitors)
     fwd_fields = utils.gather_design_region_fields(
       self.simulation,
@@ -188,10 +189,11 @@ class MeepJaxWrapper:
     )
     self.simulation.init_sim()
     sim_run_args = {
-      'until_after_sources' if self.until_after_sources else 'until': self._callback
+      'until_after_sources' if self.until_after_sources else 'until': self._simulation_run_callback
     }
     self._reset_convergence_measurement(design_region_monitors)
     self.simulation.run(**sim_run_args)
+
     return utils.gather_design_region_fields(self.simulation, design_region_monitors, self.frequencies)
 
   def _calculate_vjps(self, fwd_fields, adj_fields, design_variable_shapes, sum_freq_partials=True):
@@ -266,7 +268,7 @@ class MeepJaxWrapper:
             f'the DFT fields is {relative_change:.2e}.')
     return relative_change < self.dft_threshold
 
-  def _callback(self, sim: mp.Simulation) -> bool:
+  def _simulation_run_callback(self, sim: mp.Simulation) -> bool:
     """A callback function returning `True` when the simulation should stop.
 
     This is a step function that gets called at each time step of the Meep

--- a/python/tests/adjoint_jax.py
+++ b/python/tests/adjoint_jax.py
@@ -22,7 +22,7 @@ mp.verbosity(0)
 
 
 def build_straight_wg_simulation(
-  wg_width=0.7,
+  wg_width=0.5,
   wg_padding=1.0,
   wg_length=1.0,
   pml_width=1.0,

--- a/python/tests/adjoint_jax.py
+++ b/python/tests/adjoint_jax.py
@@ -6,7 +6,7 @@ from . import utils
 import jax
 import jax.numpy as jnp
 import meep as mp
-import adjoint as mpa
+import meep.adjoint as mpa
 import numpy as onp
 
 # The calculation of finite difference gradients requires that JAX be operated with double precision
@@ -16,7 +16,7 @@ jax.config.update('jax_enable_x64', True)
 _FD_STEP = 1e-4
 
 # The tolerance for the adjoint and finite difference gradient comparison
-_TOL = 1e-2
+_TOL = 2e-2
 
 mp.verbosity(0)
 
@@ -29,7 +29,7 @@ def build_straight_wg_simulation(
   source_to_pml=0.5,
   source_to_monitor=0.1,
   frequencies=[1 / 1.55],
-  gaussian_rel_width=0.4,
+  gaussian_rel_width=0.2,
   sim_resolution=20,
   design_region_resolution=20,
 ):
@@ -169,9 +169,9 @@ class UtilsTest(unittest.TestCase):
 class WrapperTest(utils.VectorComparisonMixin, unittest.TestCase):
 
   @parameterized.parameterized.expand([
-    ('1550_1600bw_01relative_gaussian', onp.linspace(1 / 1.55, 1 / 1.60, 3).tolist(), 0.2, 1.0),
-    ('1500_1600bw_02relative_gaussian', onp.linspace(1 / 1.50, 1 / 1.60, 3).tolist(), 0.25, 1.0),
-    ('1600_1700bw_03relative_gaussian', onp.linspace(1 / 1.60, 1 / 1.70, 4).tolist(), 0.1, 1.0),
+    ('1500_1550bw_01relative_gaussian', onp.linspace(1 / 1.50, 1 / 1.55, 3).tolist(), 0.1, 1.0),
+    ('1550_1600bw_02relative_gaussian', onp.linspace(1 / 1.55, 1 / 1.60, 3).tolist(), 0.2, 1.0),
+    ('1500_1600bw_03relative_gaussian', onp.linspace(1 / 1.50, 1 / 1.60, 4).tolist(), 0.3, 1.0),
   ])
   def test_wrapper_gradients(self, _, frequencies, gaussian_rel_width, design_variable_fill_value):
     """Tests gradient from the JAX-Meep wrapper against finite differences."""

--- a/python/tests/adjoint_jax.py
+++ b/python/tests/adjoint_jax.py
@@ -1,0 +1,237 @@
+import unittest
+import parameterized
+
+import jax
+import jax.numpy as jnp
+import meep as mp
+import meep.adjoint as mpa
+import numpy as onp
+
+# The calculation of finite difference gradients requires that JAX be operated with double precision
+jax.config.update('jax_enable_x64', True)
+
+# The step size for the finite difference gradient calculation
+_FD_STEP = 1e-4
+
+# The relative tolerance for the adjoing and finitie difference gradient comparison
+_RTOL = 5e-2
+
+mp.verbosity(0)
+
+
+def build_straight_wg_simulation(
+  wg_width=0.7,
+  wg_padding=1.0,
+  wg_length=1.0,
+  pml_width=1.0,
+  source_to_pml=0.5,
+  source_to_monitor=0.1,
+  frequencies=[1 / 1.55],
+  gaussian_rel_width=0.4,
+  sim_resolution=20,
+  design_region_resolution=20,
+):
+  """Builds a simulation of a straight waveguide with a design region segment."""
+  design_region_shape = (1.0, wg_width)
+
+  # Simulation domain size
+  sx = 2 * pml_width + 2 * wg_length + design_region_shape[0]
+  sy = 2 * pml_width + 2 * wg_padding + max(
+    wg_width,
+    design_region_shape[1],
+  )
+
+  # Mean / center frequency
+  fmean = onp.mean(frequencies)
+
+  si = mp.Medium(index=3.4)
+  sio2 = mp.Medium(index=1.44)
+
+  sources = [
+    mp.EigenModeSource(
+      mp.GaussianSource(frequency=fmean, fwidth=fmean * gaussian_rel_width),
+      eig_band=1,
+      direction=mp.NO_DIRECTION,
+      eig_kpoint=mp.Vector3(1, 0, 0),
+      size=mp.Vector3(0, wg_width + 2 * wg_padding, 0),
+      center=[-sx / 2 + pml_width + source_to_pml, 0, 0],
+    )
+  ]
+
+  nx = int(design_region_resolution * design_region_shape[0])
+  ny = int(design_region_resolution * design_region_shape[1])
+  mat_grid = mp.MaterialGrid(
+    mp.Vector3(nx, ny),
+    sio2,
+    si,
+    grid_type='U_DEFAULT',
+  )
+
+  design_regions = [
+    mpa.DesignRegion(
+      mat_grid,
+      volume=mp.Volume(
+        center=mp.Vector3(),
+        size=mp.Vector3(
+          design_region_shape[0],
+          design_region_shape[1],
+          0,
+        ),
+      ),
+    )
+  ]
+
+  geometry = [
+    mp.Block(
+      center=mp.Vector3(x=-design_region_shape[0] / 2 - wg_length / 2 - pml_width / 2),
+      material=si,
+      size=mp.Vector3(wg_length + pml_width, wg_width, 0)),  # left wg
+    mp.Block(
+      center=mp.Vector3(x=+design_region_shape[0] / 2 + wg_length / 2 + pml_width / 2),
+      material=si,
+      size=mp.Vector3(wg_length + pml_width, wg_width, 0)),  # right wg
+    mp.Block(
+      center=design_regions[0].center,
+      size=design_regions[0].size,
+      material=mat_grid),  # design region
+  ]
+
+  simulation = mp.Simulation(
+    cell_size=mp.Vector3(sx, sy),
+    boundary_layers=[mp.PML(pml_width)],
+    geometry=geometry,
+    sources=sources,
+    resolution=sim_resolution,
+  )
+
+  monitor_centers = [
+    mp.Vector3(-sx / 2 + pml_width + source_to_pml + source_to_monitor),
+    mp.Vector3(sx / 2 - pml_width - source_to_pml - source_to_monitor),
+  ]
+  monitor_size = mp.Vector3(y=wg_width + 2 * wg_padding)
+
+  monitors = [
+    mpa.EigenmodeCoefficient(
+      simulation,
+      mp.Volume(center=center, size=monitor_size),
+      mode=1,
+      forward=True) for center in monitor_centers
+  ]
+  return simulation, sources, monitors, design_regions, frequencies
+
+
+class UtilsTest(unittest.TestCase):
+  def setUp(self):
+    super().setUp()
+    (
+      self.simulation,
+      self.sources,
+      self.monitors,
+      self.design_regions,
+      self.frequencies,
+    ) = build_straight_wg_simulation()
+
+  def test_mode_monitor_helpers(self):
+    mpa.jax.utils.register_monitors(self.monitors, self.frequencies)
+    self.simulation.run(until=100)
+    monitor_values = mpa.jax.utils.gather_monitor_values(self.monitors)
+    self.assertEqual(monitor_values.dtype, onp.complex128)
+    self.assertEqual(monitor_values.shape,
+                     (len(self.monitors), len(self.frequencies)))
+
+  def test_design_region_monitor_helpers(self):
+    design_region_monitors = mpa.jax.utils.install_design_region_monitors(
+      self.simulation,
+      self.design_regions,
+      self.frequencies,
+    )
+    self.simulation.run(until=100)
+    design_region_fields = mpa.jax.utils.gather_design_region_fields(
+      self.simulation,
+      design_region_monitors,
+      self.frequencies,
+    )
+
+    self.assertIsInstance(design_region_fields, list)
+    self.assertEqual(len(design_region_fields), len(self.design_regions))
+
+    self.assertIsInstance(design_region_fields[0], list)
+    self.assertEqual(len(design_region_fields[0]), len(mpa.jax.utils._ADJOINT_FIELD_COMPONENTS))
+
+    for value in design_region_fields[0]:
+      self.assertIsInstance(value, onp.ndarray)
+      self.assertEqual(value.ndim, 4)  # dims: freq, x, y, pad
+      self.assertEqual(value.dtype, onp.complex128)
+
+
+class WrapperTest(unittest.TestCase):
+
+  @parameterized.parameterized.expand([
+    ('1550_1600bw_01relative_gaussian_10fill', onp.linspace(1 / 1.55, 1 / 1.60, 3).tolist(), 0.1, 1.0),
+    ('1500_1600bw_02relative_gaussian_10fill', onp.linspace(1 / 1.55, 1 / 1.60, 4).tolist(), 0.2, 1.0),
+    ('1600_1680bw_03relative_gaussian_10fill', onp.linspace(1 / 1.60, 1 / 1.68, 5).tolist(), 0.3, 1.0),
+    ('1550_1600bw_01relative_gaussian_05fill', onp.linspace(1 / 1.55, 1 / 1.60, 3).tolist(), 0.1, 0.5),
+    ('1500_1600bw_02relative_gaussian_05fill', onp.linspace(1 / 1.55, 1 / 1.60, 4).tolist(), 0.2, 0.5),
+    ('1600_1680bw_03relative_gaussian_05fill', onp.linspace(1 / 1.60, 1 / 1.68, 5).tolist(), 0.3, 0.5),
+  ])
+  def test_wrapper_gradients(self, _, frequencies, gaussian_rel_width, design_variable_fill_value):
+    """Tests gradient from the JAX-Meep wrapper against finite differences."""
+    (
+      simulation,
+      sources,
+      monitors,
+      design_regions,
+      frequencies,
+    ) = build_straight_wg_simulation(frequencies=frequencies, gaussian_rel_width=gaussian_rel_width)
+
+    wrapped_meep = mpa.jax.MeepJaxWrapper(
+      simulation,
+      sources,
+      monitors,
+      design_regions,
+      frequencies,
+      measurement_interval=50.0,
+      dft_field_components=(mp.Ez,),
+      dft_threshold=1e-6,
+      minimum_run_time=0,
+      maximum_run_time=onp.inf,
+      until_after_sources=True
+    )
+
+    design_shape = tuple(int(i) for i in design_regions[0].design_parameters.grid_size)[:2]
+    x = onp.ones(design_shape) * design_variable_fill_value
+
+    # Define a loss function
+    def loss_fn(x):
+      monitor_values = wrapped_meep([x])
+      t = monitor_values[1, :] / monitor_values[0, :]
+      # Mean transmission vs wavelength
+      return jnp.mean(jnp.square(jnp.abs(t)))
+
+    value, adjoint_grad = jax.value_and_grad(loss_fn)(x)
+
+    # Create dp
+    random_perturbation_vector = _FD_STEP * onp.random.random(x.shape)
+
+    # Calculate p + dp
+    x_perturbed = x + random_perturbation_vector
+
+    # Calculate T(p + dp)
+    value_perturbed = loss_fn(x_perturbed)
+
+    # Check that dp . ∇T ~ T(p + dp) - T(p)
+    onp.testing.assert_allclose(
+      onp.dot(
+        random_perturbation_vector.ravel(),
+        adjoint_grad.ravel(),
+      ),
+      value_perturbed - value,
+      rtol=_RTOL,
+      err_msg='The projection of the gradient computed via the adjoint simulation into a '
+              'random direction of the design parameter space does not agree with a finite '
+              'difference approximation of that same projection to the specified tolerance.'
+    )
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -1,5 +1,5 @@
+import unittest
 import numpy as np
-
 
 def compare_arrays(test_instance, exp, res, tol=1e-3):
     exp_1d = exp.ravel()
@@ -13,3 +13,16 @@ def compare_arrays(test_instance, exp, res, tol=1e-3):
     else:
         diff = np.linalg.norm(res_1d - exp_1d) / norm_exp
         test_instance.assertLess(diff, tol)
+
+
+class VectorComparisonMixin(unittest.TestCase):
+    """A mixin for adding proper floating point value and vector comparison."""
+
+    def assertVectorsClose(self, x, y, epsilon = 1e-2, msg = ''):
+        """Asserts that two values or vectors satisfy ‖x-y‖ ≤ ε * max(‖x‖, ‖y‖)."""
+        x = np.atleast_1d(x)
+        y = np.atleast_1d(y)
+        x_norm = np.linalg.norm(x, ord=np.inf)
+        y_norm = np.linalg.norm(y, ord=np.inf)
+        diff_norm = np.linalg.norm(x - y, ord=np.inf)
+        self.assertLessEqual(diff_norm, epsilon * np.maximum(x_norm, y_norm), msg)

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -20,8 +20,8 @@ class VectorComparisonMixin(unittest.TestCase):
 
     def assertVectorsClose(self, x, y, epsilon = 1e-2, msg = ''):
         """Asserts that two values or vectors satisfy ‖x-y‖ ≤ ε * max(‖x‖, ‖y‖)."""
-        x = np.atleast_1d(x)
-        y = np.atleast_1d(y)
+        x = np.atleast_1d(x).ravel()
+        y = np.atleast_1d(y).ravel()
         x_norm = np.linalg.norm(x, ord=np.inf)
         y_norm = np.linalg.norm(y, ord=np.inf)
         diff_norm = np.linalg.norm(x - y, ord=np.inf)


### PR DESCRIPTION
This PR is an initial implementation of a class for wrapping a Meep simulation into a JAX-differentiable callable. This API will allow users to flexibly compose one or more Meep simulations with other JAX functions with support for end-to-end differentiability.

This implementation uses JAX's [custom VJP](https://jax.readthedocs.io/en/latest/notebooks/Custom_derivative_rules_for_Python_code.html#use-jax-custom-vjp-to-define-custom-reverse-mode-only-rules) rule, which has one limitation in that it does not support defining batching rules. In practical terms, this unfortunately means that the interface implemented in this PR will _not_ be able to take advantage of Meep's parallelism over frequency in multi-objective (minimax style) optimizations. However, this interface will work well for scalar-valued loss functions that are widely used in inverse design and machine learning (via the `jax.value_and_grad` interface in JAX). 

In the future, to support frequency-parallelism in multi-objective optimizations, it may be worth investigating whether Meep can be wrapped into a [JAX primitive](https://jax.readthedocs.io/en/latest/notebooks/How_JAX_primitives_work.html), which has first-class support for batching rules. However, the challenge with this approach will be that, rather than directly defining the reverse mode differentiation rule, JAX requires the definition of a _forward_ mode differentiation rule as well as a _transpose_ rule for primitives. Together these two rules are used to create a _reverse_ mode differentiation rule. It's unclear whether we could pull this off with Meep.

The initial implementation of the JAX-Meep wrapper in this PR only has support for eigenmode coefficient outputs, but in a follow up we can enable support for differentiable DFT fields and near-to-far field transformations. Once some initial feedback has been received, I can add some test cases to this PR.