### PR TITLE
Add ability to override MEEP_SINGLE from the compiler command line

### DIFF
--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -34,7 +34,10 @@ namespace meep {
    point rather than double precision (the default). The reduced
    precision can provide for up to a factor of 2X improvement in the
    time-stepping rate with generally negligible loss in accuracy. */
+#ifndef MEEP_SINGLE
 #define MEEP_SINGLE 0 // 1 for single precision, 0 for double
+#endif
+
 #if MEEP_SINGLE
 typedef float realnum;
 #else


### PR DESCRIPTION
Hi there!  I'd be interested to make it easier to inject "-DMEEP_SINGLE=1" from the compiler command line, without modifying source.  This change enables that.

It might also make sense to hook this up to the autogen/configure code, and if you tell me how you'd like it done, I'm happy to take a stab at it for you.

I know Ardavan is working on making this configurability available at runtime, and I don't want to step on his toes, so please just let me know if this isn't something you folks are interested in at this time.