### PR TITLE
pass binary-tree partition to structure constructor

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1456,9 +1456,6 @@ void _get_gradient(PyObject *grad, PyObject *fields_a, PyObject *fields_f, PyObj
 
 %typemap(in) meep::binary_partition * {
     $1 = py_bp_to_bp($input);
-    if(!$1) {
-        SWIG_fail;
-    }
 }
 
 %typemap(arginit) meep::binary_partition * {

--- a/python/meep.i
+++ b/python/meep.i
@@ -1891,7 +1891,8 @@ meep::structure *create_structure_and_set_materials(vector3 cell_size,
                                                     bool split_chunks_evenly,
                                                     bool set_materials,
                                                     meep::structure *existing_s,
-                                                    bool output_chunk_costs) {
+                                                    bool output_chunk_costs,
+                                                    meep::binary_partition *my_bp) {
     // Initialize fragment_stats static members (used for creating chunks in choose_chunkdivision)
     meep_geom::fragment_stats::geom = gobj_list;
     meep_geom::fragment_stats::dft_data_list = dft_data_list_;
@@ -1909,7 +1910,11 @@ meep::structure *create_structure_and_set_materials(vector3 cell_size,
 
     if (output_chunk_costs) {
          meep::volume thev = gv.surroundings();
-         std::vector<grid_volume> chunk_vols = meep::choose_chunkdivision(gv, thev, num_chunks, sym);
+         meep::binary_partition *bp = NULL;
+         if (!my_bp) bp = meep::choose_chunkdivision(gv, thev, num_chunks, sym);
+         std::vector<grid_volume> chunk_vols;
+         std::vector<int> ids;
+         meep::split_by_binarytree(gv, chunk_vols, ids, (!my_bp) ? bp : my_bp);
          for (size_t i = 0; i < chunk_vols.size(); ++i)
               master_printf("CHUNK:, %2zu, %f, %zu\n",i,chunk_vols[i].get_cost(),chunk_vols[i].surface_area());
          return NULL;
@@ -1921,7 +1926,7 @@ meep::structure *create_structure_and_set_materials(vector3 cell_size,
     }
     else {
       s = new meep::structure(gv, NULL, br, sym, num_chunks, Courant,
-                              use_anisotropic_averaging, tol, maxeval);
+                              use_anisotropic_averaging, tol, maxeval, my_bp);
     }
     s->shared_chunks = true;
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1693,15 +1693,16 @@ class Simulation(object):
             absorbers,
             self.extra_materials,
             self.split_chunks_evenly,
-            False if self.chunk_layout else True,
+            False if not isinstance(self.chunk_layout,mp.BinaryPartition) else True,
             None,
-            True if self._output_stats is not None else False
+            True if self._output_stats is not None else False,
+            self.chunk_layout if isinstance(self.chunk_layout,mp.BinaryPartition) else None
         )
 
         if self._output_stats is not None:
             sys.exit(0)
 
-        if self.chunk_layout:
+        if self.chunk_layout and not isinstance(self.chunk_layout,mp.BinaryPartition):
             self.load_chunk_layout(br, self.chunk_layout)
             self.set_materials()
 
@@ -1846,7 +1847,8 @@ class Simulation(object):
             self.split_chunks_evenly,
             True,
             self.structure,
-            False
+            False,
+            None
         )
 
     def dump_structure(self, fname):
@@ -1883,7 +1885,7 @@ class Simulation(object):
             ids = source.structure.get_chunk_owners()
             self.structure.load_chunk_layout(vols, [int(f) for f in ids], br)
         else:
-            ## source is either filename (string) or BinaryPartition class object
+            ## source is either filename (string)
             self.structure.load_chunk_layout(source, br)
 
     def init_sim(self):

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1693,10 +1693,10 @@ class Simulation(object):
             absorbers,
             self.extra_materials,
             self.split_chunks_evenly,
-            False if not isinstance(self.chunk_layout,mp.BinaryPartition) else True,
+            False if self.chunk_layout and not isinstance(self.chunk_layout,mp.BinaryPartition) else True,
             None,
             True if self._output_stats is not None else False,
-            self.chunk_layout if isinstance(self.chunk_layout,mp.BinaryPartition) else None
+            self.chunk_layout if self.chunk_layout and isinstance(self.chunk_layout,mp.BinaryPartition) else None
         )
 
         if self._output_stats is not None:

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -729,11 +729,13 @@ public:
   structure(const grid_volume &gv, material_function &eps,
             const boundary_region &br = boundary_region(), const symmetry &s = meep::identity(),
             int num_chunks = 0, double Courant = 0.5, bool use_anisotropic_averaging = false,
-            double tol = DEFAULT_SUBPIXEL_TOL, int maxeval = DEFAULT_SUBPIXEL_MAXEVAL);
+            double tol = DEFAULT_SUBPIXEL_TOL, int maxeval = DEFAULT_SUBPIXEL_MAXEVAL,
+            const binary_partition *bp = NULL);
   structure(const grid_volume &gv, double eps(const vec &),
             const boundary_region &br = boundary_region(), const symmetry &s = meep::identity(),
             int num_chunks = 0, double Courant = 0.5, bool use_anisotropic_averaging = false,
-            double tol = DEFAULT_SUBPIXEL_TOL, int maxeval = DEFAULT_SUBPIXEL_MAXEVAL);
+            double tol = DEFAULT_SUBPIXEL_TOL, int maxeval = DEFAULT_SUBPIXEL_MAXEVAL,
+            const binary_partition *bp = NULL);
   structure(const structure *);
   structure(const structure &);
 
@@ -776,7 +778,6 @@ public:
   void dump_chunk_layout(const char *filename);
   void load(const char *filename);
   void load_chunk_layout(const char *filename, boundary_region &br);
-  void load_chunk_layout(const binary_partition *bp, boundary_region &br);
   void load_chunk_layout(const std::vector<grid_volume> &gvs,
                          const std::vector<int> &ids,
                          boundary_region &br);
@@ -805,7 +806,7 @@ private:
   void use_pml(direction d, boundary_side b, double dx);
   void add_to_effort_volumes(const grid_volume &new_effort_volume, double extra_effort);
   void choose_chunkdivision(const grid_volume &gv, int num_chunks, const boundary_region &br,
-                            const symmetry &s);
+                            const symmetry &s, const binary_partition *bp);
   void check_chunks();
   void changing_chunks();
   // Helper methods for dumping and loading susceptibilities
@@ -814,11 +815,16 @@ private:
 };
 
 // defined in structure.cpp
-std::vector<grid_volume> choose_chunkdivision(grid_volume &gv,
-                                              volume &v,
-                                              int num_chunks,
-                                              const symmetry &s);
+binary_partition *choose_chunkdivision(grid_volume &gv,
+                                       volume &v,
+                                       int num_chunks,
+                                       const symmetry &s);
 
+// defined in structure_dump.cpp
+void split_by_binarytree(grid_volume gvol,
+                         std::vector<grid_volume> &result_gvs,
+                         std::vector<int> &result_ids,
+                         const binary_partition *bp);
 class src_vol;
 class fields;
 class fields_chunk;

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -430,10 +430,10 @@ binary_partition::binary_partition(direction _split_dir, double _split_pos) {
   right = NULL;
 }
 
-static void split_by_binarytree(grid_volume gvol,
-                                std::vector<grid_volume> &result_gvs,
-                                std::vector<int> &result_ids,
-                                const binary_partition *bp) {
+void split_by_binarytree(grid_volume gvol,
+                         std::vector<grid_volume> &result_gvs,
+                         std::vector<int> &result_ids,
+                         const binary_partition *bp) {
   // reached a leaf
   if ((bp->left == NULL) && (bp->right == NULL)) {
     result_gvs.push_back(gvol);
@@ -454,13 +454,6 @@ static void split_by_binarytree(grid_volume gvol,
     grid_volume right_gvol = gvol.split_at_fraction(true, split_point, bp->split_dir);
     split_by_binarytree(right_gvol, result_gvs, result_ids, bp->right);
   }
-}
-
-void structure::load_chunk_layout(const binary_partition *bp, boundary_region &br) {
-  std::vector<grid_volume> gvs;
-  std::vector<int> ids;
-  split_by_binarytree(gv, gvs, ids, bp);
-  load_chunk_layout(gvs, ids, br);
 }
 
 void structure::load_chunk_layout(const char *filename, boundary_region &br) {


### PR DESCRIPTION
Fixes #1573.

Based on a [suggestion in #1528](https://github.com/NanoComp/meep/pull/1528#issuecomment-805453121) by @stevengj, this PR revamps the `structure` class constructor to accept a `binary_partition` argument which enables specifying the chunk volumes *once* when the user passes in a `BinaryPartition` object from the Python API. Correspondingly, the Python function `load_chunk_layout` has been removed since it is no longer necessary. The main changes involved the function `split_by_cost` in `structure.cpp` which now returns a `binary_partition` object rather than writing the chunk volumes into an array. 

This PR enables creating the PML regions as separate chunks using the existing code `structure::choose_chunkdivision`. As a result, the example test described in #1573 now produces the correct chunk layout:

![bp_chunk_layout](https://user-images.githubusercontent.com/7152530/119235996-f37af500-bae9-11eb-991d-d4826fd0c145.png)

All the C++ tests are passing yet several of the Python tests are failing. This is due to a SWIG-related issue that needs to be resolved before this PR can be merged. An additional argument has been added to the C++/Python function `create_structure_and_set_materials` in the SWIG typemaps file `meep.i` in order to pass in the `BinaryPartition` pointer object (which is then passed to the `structure` class constructor). The problem is that trying to pass in a `None` (for a `NULL` pointer) for this argument produces an error:

```
======================================================================
ERROR: test_dft_energy (__main__.TestDftEnergy)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "dft_energy.py", line 29, in test_dft_energy
    sim.run(until_after_sources=100)
  File "/meep/python/meep/simulation.py", line 3637, in run
    self.init_sim()
  File "/meep/python/meep/simulation.py", line 1909, in init_sim
    self._init_structure(self.k_point)
  File "/meep/python/meep/simulation.py", line 1699, in _init_structure
    self.chunk_layout if isinstance(self.chunk_layout,mp.BinaryPartition) else None
SystemError: <built-in function create_structure_and_set_materials> returned NULL without setting an error
```
The issue is that SWIG is expecting a `meep::binary_partition *my_bp` type argument and does not accept `NULL`.
