### PR TITLE
removing trailing backslash from Python makefile

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -222,7 +222,7 @@ adjoint_PYTHON  = $(srcdir)/adjoint/__init__.py              \
                   $(srcdir)/adjoint/filter_source.py         \
                   $(srcdir)/adjoint/jax/__init__.py          \
                   $(srcdir)/adjoint/jax/wrapper.py           \
-                  $(srcdir)/adjoint/jax/utils.py             \
+                  $(srcdir)/adjoint/jax/utils.py
 
 ######################################################################
 # finally, specification of what gets installed in the meep python


### PR DESCRIPTION
#1569 added a new source file to `python/Makefile.am` followed by an unnecessary trailing backslash which is causing a build failure when switching back and forth to/from commits/branches prior to this commit:

```
CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/bash /home/meep/missing aclocal-1.15 -I m4
 cd . && /bin/bash /home/meep/missing automake-1.15 --foreign
python/Makefile.am:226: error: blank line following trailing backslash
Makefile:421: recipe for target 'Makefile.in' failed
make: *** [Makefile.in] Error 1
```