### PR TITLE
Adjoint cleanup

### DIFF
--- a/python/adjoint/basis.py
+++ b/python/adjoint/basis.py
@@ -1,10 +1,6 @@
 import meep as mp
 import numpy as np
 from scipy import sparse
-#from autograd import grad, jacobian, vector_jacobian_product
-import autograd.numpy as npa
-from autograd import grad, jacobian
-#invoke python's 'abstract base class' formalism in a version-agnostic way
 from abc import ABCMeta, abstractmethod
 
 ABC = ABCMeta('ABC', (object, ), {'__slots__':

--- a/python/adjoint/filter_source.py
+++ b/python/adjoint/filter_source.py
@@ -1,4 +1,3 @@
-import meep as mp
 import numpy as np
 from scipy import signal, linalg
 from meep import CustomSource
@@ -85,7 +84,6 @@ class FilteredSource(CustomSource):
 
     def rect(self, t, f0):
         n = np.rint((t) / self.dt)
-        return np.exp(-1j * 2 * np.pi * f0 * t)
         return np.where(n.any() < 0.0 or n.any() > self.N, 0,
                         np.exp(-1j * 2 * np.pi * f0 * t))
 

--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -37,7 +37,7 @@ class EigenmodeCoefficient(ObjectiveQuantity):
         self.sim = sim
         self.volume = volume
         self.mode = mode
-        self.forward = 0 if forward else 1
+        self.forward = forward
         self.normal_direction = None
         self.kpoint_func = kpoint_func
         self.eval = None
@@ -56,7 +56,7 @@ class EigenmodeCoefficient(ObjectiveQuantity):
     def place_adjoint_source(self, dJ):
         dJ = np.atleast_1d(dJ)
         dt = self.sim.fields.dt
-        direction_scalar = 1 if self.forward else -1
+        direction_scalar = -1 if self.forward else 1
         if self.kpoint_func is None:
             if self.normal_direction == 0:
                 k0 = direction_scalar * mp.Vector3(x=1)
@@ -112,7 +112,7 @@ class EigenmodeCoefficient(ObjectiveQuantity):
             **self.EigenMode_kwargs,
         )
         # record eigenmode coefficients for scaling
-        self.eval = np.squeeze(ob.alpha[:, :, self.forward])
+        self.eval = np.squeeze(ob.alpha[:, :, int(not self.forward)])
         self.cscale = ob.cscale  # pull scaling factor
         return self.eval
 

--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -1,6 +1,6 @@
 """Handling of objective functions and objective quantities."""
 
-from abc import ABC, abstractmethod
+import abc
 import numpy as np
 import meep as mp
 from .filter_source import FilteredSource
@@ -8,29 +8,25 @@ from .optimization_problem import Grid
 from meep.simulation import py_v3_to_vec
 
 
-class ObjectiveQuantitiy(ABC):
-    @abstractmethod
-    def __init__(self):
-        return
-
-    @abstractmethod
-    def register_monitors(self):
-        return
-
-    @abstractmethod
-    def place_adjoint_source(self):
-        return
-
-    @abstractmethod
+class ObjectiveQuantity(abc.ABC):
+    @abc.abstractmethod
     def __call__(self):
-        return
+        """Evaluates the objective quantity."""
 
-    @abstractmethod
+    @abc.abstractmethod
+    def register_monitors(self, frequencies):
+        """Registers monitors in the forward simulation."""
+
+    @abc.abstractmethod
+    def place_adjoint_source(self, dJ):
+        """Places appropriate sources for the adjoint simulation."""
+
+    @abc.abstractmethod
     def get_evaluation(self):
-        return
+        """Evaluates the objective quantity."""
 
 
-class EigenmodeCoefficient(ObjectiveQuantitiy):
+class EigenmodeCoefficient(ObjectiveQuantity):
     def __init__(self,
                  sim,
                  volume,
@@ -38,8 +34,6 @@ class EigenmodeCoefficient(ObjectiveQuantitiy):
                  forward=True,
                  kpoint_func=None,
                  **kwargs):
-        '''
-        '''
         self.sim = sim
         self.volume = volume
         self.mode = mode
@@ -48,26 +42,20 @@ class EigenmodeCoefficient(ObjectiveQuantitiy):
         self.kpoint_func = kpoint_func
         self.eval = None
         self.EigenMode_kwargs = kwargs
-        return
 
     def register_monitors(self, frequencies):
         self.frequencies = np.asarray(frequencies)
-        self.monitor = self.sim.add_mode_monitor(frequencies,
-                                                 mp.ModeRegion(
-                                                     center=self.volume.center,
-                                                     size=self.volume.size),
-                                                 yee_grid=True)
+        self.monitor = self.sim.add_mode_monitor(
+            frequencies,
+            mp.ModeRegion(center=self.volume.center, size=self.volume.size),
+            yee_grid=True,
+        )
         self.normal_direction = self.monitor.normal_direction
         return self.monitor
 
     def place_adjoint_source(self, dJ):
-        '''Places an equivalent eigenmode monitor facing the opposite direction. Calculates the
-        correct scaling/time profile.
-        dJ ........ the user needs to pass the dJ/dMonitor evaluation
-        '''
         dJ = np.atleast_1d(dJ)
-        dt = self.sim.fields.dt  # the timestep size from sim.fields.dt of the forward sim
-        # determine starting kpoint for reverse mode eigenmode source
+        dt = self.sim.fields.dt
         direction_scalar = 1 if self.forward else -1
         if self.kpoint_func is None:
             if self.normal_direction == 0:
@@ -75,7 +63,7 @@ class EigenmodeCoefficient(ObjectiveQuantitiy):
             elif self.normal_direction == 1:
                 k0 = direction_scalar * mp.Vector3(y=1)
             elif self.normal_direction == 2:
-                k0 == direction_scalar * mp.Vector3(z=1)
+                k0 = direction_scalar * mp.Vector3(z=1)
         else:
             k0 = direction_scalar * self.kpoint_func(self.time_src.frequency,
                                                      1)
@@ -86,21 +74,18 @@ class EigenmodeCoefficient(ObjectiveQuantitiy):
         scale = adj_src_scale(self, dt)
 
         if self.frequencies.size == 1:
-            # Single frequency simulations. We need to drive it with a time profile.
-            amp = da_dE * dJ * scale  # final scale factor
+            amp = da_dE * dJ * scale
             src = self.time_src
         else:
-            # multi frequency simulations
             scale = da_dE * dJ * scale
             src = FilteredSource(
                 self.time_src.frequency,
                 self.frequencies,
                 scale,
                 dt,
-            )  # generate source from broadband response
+            )
             amp = 1
 
-        # generate source object
         self.source = [
             mp.EigenModeSource(
                 src,
@@ -114,11 +99,9 @@ class EigenmodeCoefficient(ObjectiveQuantitiy):
                 **self.EigenMode_kwargs,
             )
         ]
-
         return self.source
 
     def __call__(self):
-        # Eigenmode data
         self.time_src = create_time_profile(self)
         direction = mp.NO_DIRECTION if self.kpoint_func else mp.AUTOMATIC
         ob = self.sim.get_eigenmode_coefficients(
@@ -128,15 +111,12 @@ class EigenmodeCoefficient(ObjectiveQuantitiy):
             kpoint_func=self.kpoint_func,
             **self.EigenMode_kwargs,
         )
-        self.eval = np.squeeze(ob.alpha[:, :, self.forward]
-                               )  # record eigenmode coefficients for scaling
+        # record eigenmode coefficients for scaling
+        self.eval = np.squeeze(ob.alpha[:, :, self.forward])
         self.cscale = ob.cscale  # pull scaling factor
-
         return self.eval
 
     def get_evaluation(self):
-        '''Returns the requested eigenmode coefficient.
-        '''
         try:
             return self.eval
         except AttributeError:
@@ -145,13 +125,12 @@ class EigenmodeCoefficient(ObjectiveQuantitiy):
             )
 
 
-class FourierFields(ObjectiveQuantitiy):
+class FourierFields(ObjectiveQuantity):
     def __init__(self, sim, volume, component):
         self.sim = sim
         self.volume = volume
         self.eval = None
         self.component = component
-        return
 
     def register_monitors(self, frequencies):
         self.frequencies = np.asarray(frequencies)
@@ -254,14 +233,13 @@ class FourierFields(ObjectiveQuantitiy):
             raise RuntimeError("You must first run a forward simulation.")
 
 
-class Near2FarFields(ObjectiveQuantitiy):
+class Near2FarFields(ObjectiveQuantity):
     def __init__(self, sim, Near2FarRegions, far_pts):
         self.sim = sim
         self.Near2FarRegions = Near2FarRegions
         self.eval = None
         self.far_pts = far_pts  #list of far pts
         self.nfar_pts = len(far_pts)
-        return
 
     def register_monitors(self, frequencies):
         self.frequencies = np.asarray(frequencies)

--- a/python/adjoint/optimization_problem.py
+++ b/python/adjoint/optimization_problem.py
@@ -1,6 +1,5 @@
 import meep as mp
 import numpy as np
-import autograd.numpy as npa
 from autograd import grad, jacobian
 from collections import namedtuple
 

--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -140,7 +140,7 @@ def validate_and_update_design(
 
     Args:
       design_regions: List of mpa.DesignRegion,
-      design_variables: Iterable with numpy arrays represending design variables.
+      design_variables: Iterable with numpy arrays representing design variables.
 
     Raises:
       ValueError if the validation of dimensions fails.
@@ -168,7 +168,7 @@ def validate_and_update_design(
 
 
 def create_adjoint_sources(
-        monitors: ObjectiveQuantity,
+        monitors: Iterable[ObjectiveQuantity],
         monitor_values_grad: onp.ndarray) -> List[mp.Source]:
     monitor_values_grad = onp.asarray(monitor_values_grad,
                                       dtype=onp.complex128)

--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -3,7 +3,7 @@ from typing import List, Iterable, Tuple
 import meep as mp
 import numpy as onp
 
-from . import ObjectiveQuantitiy, DesignRegion
+from . import ObjectiveQuantity, DesignRegion
 
 # Meep field components used to compute adjoint sensitivities
 _ADJOINT_FIELD_COMPONENTS = [mp.Ex, mp.Ey, mp.Ez]
@@ -49,7 +49,7 @@ def calculate_vjps(
 
 
 def register_monitors(
-    monitors: List[ObjectiveQuantitiy],
+    monitors: List[ObjectiveQuantity],
     frequencies: List[float],
 ) -> None:
     """Registers a list of monitors."""
@@ -74,7 +74,7 @@ def install_design_region_monitors(
     return design_region_monitors
 
 
-def gather_monitor_values(monitors: List[ObjectiveQuantitiy]) -> onp.ndarray:
+def gather_monitor_values(monitors: List[ObjectiveQuantity]) -> onp.ndarray:
     """Gathers the mode monitor overlap values as a rank 2 ndarray.
 
     Args:
@@ -168,7 +168,7 @@ def validate_and_update_design(
 
 
 def create_adjoint_sources(
-        monitors: ObjectiveQuantitiy,
+        monitors: ObjectiveQuantity,
         monitor_values_grad: onp.ndarray) -> List[mp.Source]:
     monitor_values_grad = onp.asarray(monitor_values_grad,
                                       dtype=onp.complex128)


### PR DESCRIPTION
This PR bases off of #1586 to clean up the adjoint module code by:

- ~~Applying formatting to the Python code to make it more readable~~ (Moved to #1590)
- Fixing several small bugs (equality rather than assignment, duplicated return statements, etc.)
- Adding method signatures to the abstract `ObjectiveQuantity` class
- Removing some non-standard Python things like `return` statements at the end of `__init__` methods
- Correcting spelling errors
- Removing unused imports

In a subsequent PR I will propose a fix for #1585.