### PR TITLE
fix bug in copy assignment for material grid

### DIFF
--- a/src/material_data.hpp
+++ b/src/material_data.hpp
@@ -310,8 +310,8 @@ struct material_data {
       memcpy(weights, from.weights, N * sizeof(double));
     }
 
-    medium_1.copy_from(medium_1);
-    medium_2.copy_from(medium_2);
+    medium_1.copy_from(from.medium_1);
+    medium_2.copy_from(from.medium_2);
     beta = from.beta;
     eta = from.eta;
   }

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -29,13 +29,13 @@ material_data vacuum_material_data;
 material_type vacuum = &vacuum_material_data;
 
 static void set_default_material(material_type _default_material) {
-  if (default_material != NULL) {
+  if ((default_material != NULL) && (default_material != _default_material)) {
     material_free((material_type)default_material);
     delete (material_type)default_material;
     default_material = NULL;
   }
 
-  if (_default_material != NULL) {
+  if ((_default_material != NULL) && (_default_material != default_material)) {
     material_type new_material = new material_data();
     new_material->copy_from(*_default_material);
     default_material = (void *)new_material;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -29,13 +29,15 @@ material_data vacuum_material_data;
 material_type vacuum = &vacuum_material_data;
 
 static void set_default_material(material_type _default_material) {
-  if ((default_material != NULL) && (default_material != _default_material)) {
+
+  if (default_material != NULL) {
+    if (default_material == _default_material) return;
     material_free((material_type)default_material);
     delete (material_type)default_material;
     default_material = NULL;
   }
 
-  if ((_default_material != NULL) && (_default_material != default_material)) {
+  if (_default_material != NULL) {
     material_type new_material = new material_data();
     new_material->copy_from(*_default_material);
     default_material = (void *)new_material;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -29,7 +29,6 @@ material_data vacuum_material_data;
 material_type vacuum = &vacuum_material_data;
 
 static void set_default_material(material_type _default_material) {
-
   if (default_material != NULL) {
     if (default_material == _default_material) return;
     material_free((material_type)default_material);


### PR DESCRIPTION
Fixes a bug introduced in #1583 which is causing the unit test for a `MaterialGrid` as a default material (in `python/tests/material_grid.py`) to currently fail.