### PR TITLE
Refactor interfaces and internal state of adjoint module objective quantities

### DIFF
--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -47,7 +47,7 @@ class ObjectiveQuantity(abc.ABC):
             return self._eval
         else:
             raise RuntimeError(
-                'You must first run a forward simulation before resquesting the evaluation of an `ObjectiveQuantity`.'
+                'You must first run a forward simulation before requesting the evaluation of an objective quantity.'
             )
 
     def _adj_src_scale(self, include_resolution=True):
@@ -57,9 +57,7 @@ class ObjectiveQuantity(abc.ABC):
         src = self._create_time_profile()
 
         if include_resolution:
-            num_dims = ((self.sim.cell_size.x != 0) +
-                        (self.sim.cell_size.y != 0) +
-                        (self.sim.cell_size.z != 0))
+            num_dims = self.sim._infer_dimensions(self.sim.k_point)
             dV = 1 / self.sim.resolution**num_dims
         else:
             dV = 1

--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -9,6 +9,26 @@ from meep.simulation import py_v3_to_vec
 
 
 class ObjectiveQuantity(abc.ABC):
+    """A differentiable objective quantity.
+
+    Attributes:
+        sim: the Meep simulation object with which the objective quantity is registered.
+        frequencies: the frequencies at which the objective quantity is evaluated.
+        num_freq: the number of frequencies at which the objective quantity is evaluated.
+    """
+    def __init__(self, sim):
+        self.sim = sim
+        self._eval = None
+        self._frequencies = None
+
+    @property
+    def frequencies(self):
+        return self._frequencies
+
+    @property
+    def num_freq(self):
+        return len(self.frequencies)
+
     @abc.abstractmethod
     def __call__(self):
         """Evaluates the objective quantity."""
@@ -21,9 +41,75 @@ class ObjectiveQuantity(abc.ABC):
     def place_adjoint_source(self, dJ):
         """Places appropriate sources for the adjoint simulation."""
 
-    @abc.abstractmethod
     def get_evaluation(self):
         """Evaluates the objective quantity."""
+        if self._eval:
+            return self._eval
+        else:
+            raise RuntimeError(
+                'You must first run a forward simulation before resquesting the evaluation of an `ObjectiveQuantity`.'
+            )
+
+    def _adj_src_scale(self, include_resolution=True):
+        """Calculates the scale for the adjoint sources."""
+        T = self.sim.meep_time()
+        dt = self.sim.fields.dt
+        src = self._create_time_profile()
+
+        if include_resolution:
+            num_dims = ((self.sim.cell_size.x != 0) +
+                        (self.sim.cell_size.y != 0) +
+                        (self.sim.cell_size.z != 0))
+            dV = 1 / self.sim.resolution**num_dims
+        else:
+            dV = 1
+
+        iomega = (1.0 - np.exp(-1j * (2 * np.pi * self._frequencies) * dt)) * (
+            1.0 / dt
+        )  # scaled frequency factor with discrete time derivative fix
+
+        # an ugly way to calcuate the scaled dtft of the forward source
+        y = np.array([src.swigobj.current(t, dt)
+                      for t in np.arange(0, T, dt)])  # time domain signal
+        fwd_dtft = np.matmul(
+            np.exp(1j * 2 * np.pi * self._frequencies[:, np.newaxis] *
+                   np.arange(y.size) * dt), y) * dt / np.sqrt(
+                       2 * np.pi)  # dtft
+
+        # Interestingly, the real parts of the DTFT and fourier transform match, but the imaginary parts are very different...
+        #fwd_dtft = src.fourier_transform(src.frequency)
+        '''
+        For some reason, there seems to be an additional phase
+        factor at the center frequency that needs to be applied
+        to *all* frequencies...
+        '''
+        src_center_dtft = np.matmul(
+            np.exp(1j * 2 * np.pi * np.array([src.frequency])[:, np.newaxis] *
+                   np.arange(y.size) * dt), y) * dt / np.sqrt(2 * np.pi)
+        adj_src_phase = np.exp(1j * np.angle(src_center_dtft))
+
+        if self._frequencies.size == 1:
+            # Single frequency simulations. We need to drive it with a time profile.
+            scale = dV * iomega / fwd_dtft / adj_src_phase  # final scale factor
+        else:
+            # multi frequency simulations
+            scale = dV * iomega / adj_src_phase
+        return scale
+
+    def _create_time_profile(self, fwidth_frac=0.1):
+        """Creates a time domain waveform for normalizing the adjoint source(s).
+
+        For single frequency objective functions, we should generate a guassian pulse with a reasonable
+        bandwidth centered at said frequency.
+
+        TODO:
+        The user may specify a scalar valued objective function across multiple frequencies (e.g. MSE) in
+        which case we should check that all the frequencies fit in the specified bandwidth.
+        """
+        return mp.GaussianSource(
+            np.mean(self._frequencies),
+            fwidth=fwidth_frac * np.mean(self._frequencies),
+        )
 
 
 class EigenmodeCoefficient(ObjectiveQuantity):
@@ -34,139 +120,125 @@ class EigenmodeCoefficient(ObjectiveQuantity):
                  forward=True,
                  kpoint_func=None,
                  **kwargs):
-        self.sim = sim
+        super().__init__(sim)
         self.volume = volume
         self.mode = mode
         self.forward = forward
-        self.normal_direction = None
         self.kpoint_func = kpoint_func
-        self.eval = None
-        self.EigenMode_kwargs = kwargs
+        self.eigenmode_kwargs = kwargs
+        self._monitor = None
+        self._normal_direction = None
+        self._cscale = None
 
     def register_monitors(self, frequencies):
-        self.frequencies = np.asarray(frequencies)
-        self.monitor = self.sim.add_mode_monitor(
+        self._frequencies = np.asarray(frequencies)
+        self._monitor = self.sim.add_mode_monitor(
             frequencies,
             mp.ModeRegion(center=self.volume.center, size=self.volume.size),
             yee_grid=True,
         )
-        self.normal_direction = self.monitor.normal_direction
-        return self.monitor
+        self._normal_direction = self._monitor.normal_direction
+        return self._monitor
 
     def place_adjoint_source(self, dJ):
         dJ = np.atleast_1d(dJ)
-        dt = self.sim.fields.dt
         direction_scalar = -1 if self.forward else 1
+        time_src = self._create_time_profile()
         if self.kpoint_func is None:
-            if self.normal_direction == 0:
+            if self._normal_direction == 0:
                 k0 = direction_scalar * mp.Vector3(x=1)
-            elif self.normal_direction == 1:
+            elif self._normal_direction == 1:
                 k0 = direction_scalar * mp.Vector3(y=1)
-            elif self.normal_direction == 2:
+            elif self._normal_direction == 2:
                 k0 = direction_scalar * mp.Vector3(z=1)
         else:
-            k0 = direction_scalar * self.kpoint_func(self.time_src.frequency,
-                                                     1)
+            k0 = direction_scalar * self.kpoint_func(time_src.frequency, 1)
         if dJ.ndim == 2:
             dJ = np.sum(dJ, axis=1)
-        da_dE = 0.5 * self.cscale  # scalar popping out of derivative
+        da_dE = 0.5 * self._cscale  # scalar popping out of derivative
 
-        scale = adj_src_scale(self, dt)
+        scale = self._adj_src_scale()
 
-        if self.frequencies.size == 1:
+        if self._frequencies.size == 1:
             amp = da_dE * dJ * scale
-            src = self.time_src
+            src = time_src
         else:
             scale = da_dE * dJ * scale
             src = FilteredSource(
-                self.time_src.frequency,
-                self.frequencies,
+                time_src.frequency,
+                self._frequencies,
                 scale,
-                dt,
+                self.sim.fields.dt,
             )
             amp = 1
 
-        self.source = [
-            mp.EigenModeSource(
-                src,
-                eig_band=self.mode,
-                direction=mp.NO_DIRECTION,
-                eig_kpoint=k0,
-                amplitude=amp,
-                eig_match_freq=True,
-                size=self.volume.size,
-                center=self.volume.center,
-                **self.EigenMode_kwargs,
-            )
-        ]
-        return self.source
+        source = mp.EigenModeSource(
+            src,
+            eig_band=self.mode,
+            direction=mp.NO_DIRECTION,
+            eig_kpoint=k0,
+            amplitude=amp,
+            eig_match_freq=True,
+            size=self.volume.size,
+            center=self.volume.center,
+            **self.eigenmode_kwargs,
+        )
+        return [source]
 
     def __call__(self):
-        self.time_src = create_time_profile(self)
         direction = mp.NO_DIRECTION if self.kpoint_func else mp.AUTOMATIC
         ob = self.sim.get_eigenmode_coefficients(
-            self.monitor,
+            self._monitor,
             [self.mode],
             direction=direction,
             kpoint_func=self.kpoint_func,
-            **self.EigenMode_kwargs,
+            **self.eigenmode_kwargs,
         )
         # record eigenmode coefficients for scaling
-        self.eval = np.squeeze(ob.alpha[:, :, int(not self.forward)])
-        self.cscale = ob.cscale  # pull scaling factor
-        return self.eval
-
-    def get_evaluation(self):
-        try:
-            return self.eval
-        except AttributeError:
-            raise RuntimeError(
-                "You must first run a forward simulation before resquesting an eigenmode coefficient."
-            )
+        self._eval = np.squeeze(ob.alpha[:, :, int(not self.forward)])
+        self._cscale = ob.cscale  # pull scaling factor
+        return self._eval
 
 
 class FourierFields(ObjectiveQuantity):
     def __init__(self, sim, volume, component):
-        self.sim = sim
+        super().__init__(sim)
         self.volume = volume
-        self.eval = None
         self.component = component
 
     def register_monitors(self, frequencies):
-        self.frequencies = np.asarray(frequencies)
-        self.num_freq = len(self.frequencies)
-        self.monitor = self.sim.add_dft_fields(
+        self._frequencies = np.asarray(frequencies)
+        self._monitor = self.sim.add_dft_fields(
             [self.component],
-            self.frequencies,
+            self._frequencies,
             where=self.volume,
             yee_grid=False,
         )
-        return self.monitor
+        return self._monitor
 
     def place_adjoint_source(self, dJ):
-        dt = self.sim.fields.dt  # the timestep size from sim.fields.dt of the forward sim
-        self.sources = []
-        scale = adj_src_scale(self, dt)
+        time_src = self._create_time_profile()
+        sources = []
+        scale = self._adj_src_scale()
 
-        x_dim, y_dim, z_dim = len(self.dg.x), len(self.dg.y), len(self.dg.z)
+        x_dim, y_dim, z_dim = len(self._dg.x), len(self._dg.y), len(self._dg.z)
 
         if self.num_freq == 1:
             amp = -dJ[0].copy().reshape(x_dim, y_dim, z_dim) * scale
-            src = self.time_src
             if self.component in [mp.Hx, mp.Hy, mp.Hz]:
                 amp = -amp
             for zi in range(z_dim):
                 for yi in range(y_dim):
                     for xi in range(x_dim):
                         if amp[xi, yi, zi] != 0:
-                            self.sources += [
+                            sources += [
                                 mp.Source(
-                                    src,
+                                    time_src,
                                     component=self.component,
                                     amplitude=amp[xi, yi, zi],
-                                    center=mp.Vector3(self.dg.x[xi],
-                                                      self.dg.y[yi],
-                                                      self.dg.z[zi]),
+                                    center=mp.Vector3(self._dg.x[xi],
+                                                      self._dg.y[yi],
+                                                      self._dg.z[zi]),
                                 )
                             ]
         else:
@@ -199,61 +271,52 @@ class FourierFields(ObjectiveQuantity):
                         if not np.all((dJ_4d[:, xi, yi, zi] == 0)):
                             final_scale = -dJ_4d[:, xi, yi, zi] * scale
                             src = FilteredSource(
-                                self.time_src.frequency,
-                                self.frequencies,
+                                time_src.frequency,
+                                self._frequencies,
                                 final_scale,
-                                dt,
+                                self.sim.fields.dt,
                             )
-                            self.sources += [
+                            sources += [
                                 mp.Source(
                                     src,
                                     component=self.component,
                                     amplitude=1,
-                                    center=mp.Vector3(self.dg.x[xi],
-                                                      self.dg.y[yi],
-                                                      self.dg.z[zi]),
+                                    center=mp.Vector3(self._dg.x[xi],
+                                                      self._dg.y[yi],
+                                                      self._dg.z[zi]),
                                 )
                             ]
 
-        return self.sources
+        return sources
 
     def __call__(self):
-        self.dg = Grid(*self.sim.get_array_metadata(dft_cell=self.monitor))
-        self.eval = np.array([
-            self.sim.get_dft_array(self.monitor, self.component, i)
+        self._dg = Grid(*self.sim.get_array_metadata(dft_cell=self._monitor))
+        self._eval = np.array([
+            self.sim.get_dft_array(self._monitor, self.component, i)
             for i in range(self.num_freq)
         ])
-        self.time_src = create_time_profile(self)
-        return self.eval
-
-    def get_evaluation(self):
-        try:
-            return self.eval
-        except AttributeError:
-            raise RuntimeError("You must first run a forward simulation.")
+        return self._eval
 
 
 class Near2FarFields(ObjectiveQuantity):
     def __init__(self, sim, Near2FarRegions, far_pts):
-        self.sim = sim
+        super().__init__(sim)
         self.Near2FarRegions = Near2FarRegions
-        self.eval = None
         self.far_pts = far_pts  #list of far pts
-        self.nfar_pts = len(far_pts)
+        self._nfar_pts = len(far_pts)
 
     def register_monitors(self, frequencies):
-        self.frequencies = np.asarray(frequencies)
-        self.num_freq = len(self.frequencies)
-        self.monitor = self.sim.add_near2far(
-            self.frequencies,
+        self._frequencies = np.asarray(frequencies)
+        self._monitor = self.sim.add_near2far(
+            self._frequencies,
             *self.Near2FarRegions,
             yee_grid=True,
         )
-        return self.monitor
+        return self._monitor
 
     def place_adjoint_source(self, dJ):
-        dt = self.sim.fields.dt  # the timestep size from sim.fields.dt of the forward sim
-        self.sources = []
+        time_src = self._create_time_profile()
+        sources = []
         if dJ.ndim == 4:
             dJ = np.sum(dJ, axis=0)
         dJ = dJ.flatten()
@@ -265,27 +328,25 @@ class Near2FarFields(ObjectiveQuantity):
             self.sim.is_cylindrical,
         )
 
-        self.all_nearsrcdata = self.monitor.swigobj.near_sourcedata(
-            far_pt_vec, farpt_list, self.nfar_pts, dJ)
-        for near_data in self.all_nearsrcdata:
+        all_nearsrcdata = self._monitor.swigobj.near_sourcedata(
+            far_pt_vec, farpt_list, self._nfar_pts, dJ)
+        for near_data in all_nearsrcdata:
             cur_comp = near_data.near_fd_comp
             amp_arr = np.array(near_data.amp_arr).reshape(-1, self.num_freq)
-            scale = amp_arr * adj_src_scale(self, dt, include_resolution=False)
+            scale = amp_arr * self._adj_src_scale(include_resolution=False)
 
             if self.num_freq == 1:
-                self.sources += [
-                    mp.IndexedSource(self.time_src, near_data, scale[:, 0])
-                ]
+                sources += [mp.IndexedSource(time_src, near_data, scale[:, 0])]
             else:
                 src = FilteredSource(
-                    self.time_src.frequency,
-                    self.frequencies,
+                    time_src.frequency,
+                    self._frequencies,
                     scale,
                     dt,
                 )
                 (num_basis, num_pts) = src.nodes.shape
                 for basis_i in range(num_basis):
-                    self.sources += [
+                    sources += [
                         mp.IndexedSource(
                             src.time_src_bf[basis_i],
                             near_data,
@@ -293,87 +354,11 @@ class Near2FarFields(ObjectiveQuantity):
                         )
                     ]
 
-        return self.sources
+        return sources
 
     def __call__(self):
-        self.time_src = create_time_profile(self)
-        self.eval = np.array([
-            self.sim.get_farfield(self.monitor, far_pt)
+        self._eval = np.array([
+            self.sim.get_farfield(self._monitor, far_pt)
             for far_pt in self.far_pts
-        ]).reshape((self.nfar_pts, self.num_freq, 6))
-        return self.eval
-
-    def get_evaluation(self):
-        try:
-            return self.eval
-        except AttributeError:
-            raise RuntimeError("You must first run a forward simulation.")
-
-
-def create_time_profile(obj_quantity, fwidth_frac=0.1):
-    '''
-    For single frequency objective functions, we should
-    generate a guassian pulse with a reasonable bandwidth
-    centered at said frequency.
-    
-    TODO:
-    The user may specify a scalar valued objective
-    function across multiple frequencies (e.g. MSE)
-    in which case we should check that all the frequencies
-    fit in the specified bandwidth.
-    '''
-    return mp.GaussianSource(
-        np.mean(obj_quantity.frequencies),
-        fwidth=fwidth_frac * np.mean(obj_quantity.frequencies),
-    )
-
-
-def adj_src_scale(obj_quantity, dt, include_resolution=True):
-    # -------------------------------------- #
-    # Get scaling factor
-    # -------------------------------------- #
-    # leverage linearity and combine source for multiple frequencies
-    T = obj_quantity.sim.meep_time()
-
-    if not include_resolution:
-        dV = 1
-    elif obj_quantity.sim.cell_size.y == 0:
-        dV = 1 / obj_quantity.sim.resolution
-    elif obj_quantity.sim.cell_size.z == 0:
-        dV = 1 / obj_quantity.sim.resolution * 1 / obj_quantity.sim.resolution
-    else:
-        dV = 1 / obj_quantity.sim.resolution * 1 / obj_quantity.sim.resolution * 1 / obj_quantity.sim.resolution
-
-    iomega = (1.0 -
-              np.exp(-1j * (2 * np.pi * obj_quantity.frequencies) * dt)) * (
-                  1.0 / dt
-              )  # scaled frequency factor with discrete time derivative fix
-
-    src = obj_quantity.time_src
-
-    # an ugly way to calcuate the scaled dtft of the forward source
-    y = np.array([src.swigobj.current(t, dt)
-                  for t in np.arange(0, T, dt)])  # time domain signal
-    fwd_dtft = np.matmul(
-        np.exp(1j * 2 * np.pi * obj_quantity.frequencies[:, np.newaxis] *
-               np.arange(y.size) * dt), y) * dt / np.sqrt(2 * np.pi)  # dtft
-
-    # Interestingly, the real parts of the DTFT and fourier transform match, but the imaginary parts are very different...
-    #fwd_dtft = src.fourier_transform(src.frequency)
-    '''
-    For some reason, there seems to be an additional phase
-    factor at the center frequency that needs to be applied
-    to *all* frequencies...
-    '''
-    src_center_dtft = np.matmul(
-        np.exp(1j * 2 * np.pi * np.array([src.frequency])[:, np.newaxis] *
-               np.arange(y.size) * dt), y) * dt / np.sqrt(2 * np.pi)
-    adj_src_phase = np.exp(1j * np.angle(src_center_dtft))
-
-    if obj_quantity.frequencies.size == 1:
-        # Single frequency simulations. We need to drive it with a time profile.
-        scale = dV * iomega / fwd_dtft / adj_src_phase  # final scale factor
-    else:
-        # multi frequency simulations
-        scale = dV * iomega / adj_src_phase
-    return scale
+        ]).reshape((self._nfar_pts, self.num_freq, 6))
+        return self._eval


### PR DESCRIPTION
This PR picks up where #1588 left off with some refactoring of the `mpa.ObjectiveQuantity` child classes:

 - Many attributes of the `mpa.ObjectiveQuantity` child classes are not correctly indicated as being private
 - Some attributes of the `mpa.ObjectiveQuantity` child classes (e.g. `source` in `EigenmodeCoefficient`) should apparently not even be part of the internal state (since they're unused) and are initialized in an adhoc manner throughout different methods of the classes
 - Functions such as `adj_src_scale()` and `create_time_profile()` should actually be methods of `mpa.ObjectiveQuantity`

In an effort to streamline the process of debugging tricky issues such as #1585, the interfaces, attributes, and data marshaling in the adjoint module should be standardized in the `mpa.ObjectiveQuantity`.

