### PR TITLE
Add unit test for backward-propagating mode in oblique waveguide

### DIFF
--- a/python/tests/test_mode_decomposition.py
+++ b/python/tests/test_mode_decomposition.py
@@ -126,6 +126,7 @@ class TestModeDecomposition(unittest.TestCase):
                                                kpoint_func=lambda f,n: kpoint).alpha[0,0,0]
 
         print("oblique-waveguide-flux:, {:.6f}, {:.6f}".format(-flux, abs(coeff)**2))
+        ## the magnitude of |flux| is 100.008731 and so we check three significant digits of accuracy
         self.assertAlmostEqual(-flux, abs(coeff)**2, places=1)
 
 if __name__ == '__main__':

--- a/python/tests/test_mode_decomposition.py
+++ b/python/tests/test_mode_decomposition.py
@@ -109,7 +109,7 @@ class TestModeDecomposition(unittest.TestCase):
                              material=mp.Medium(index=3.5))]
 
         sim = mp.Simulation(cell_size=cell_size,
-                            resolution=40,
+                            resolution=20,
                             boundary_layers=pml_layers,
                             sources=sources,
                             geometry=geometry)
@@ -126,8 +126,8 @@ class TestModeDecomposition(unittest.TestCase):
                                                kpoint_func=lambda f,n: kpoint).alpha[0,0,0]
 
         print("oblique-waveguide-flux:, {:.6f}, {:.6f}".format(-flux, abs(coeff)**2))
-        ## the magnitude of |flux| is 100.008731 and so we check three significant digits of accuracy
-        self.assertAlmostEqual(-flux, abs(coeff)**2, places=1)
+        ## the magnitude of |flux| is 100.008731 and so we check two significant digits of accuracy
+        self.assertAlmostEqual(-1,abs(coeff)**2/flux,places=2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds a unit test to verify that for a backward-propagating mode launched within an oblique (single-mode) waveguide, the Poynting flux and the square of the mode coefficient computed downstream from the source are the same.

The figure shows the simulation setup and a snapshot of the E<sub>z</sub> fields: an eigenmode source (red line) launches a *leftward*-propagating mode. The DFT fields monitor (blue line) computes the Poynting flux exiting the waveguide as well as the mode coefficient of the backward-propagating mode. (In this figure, the time-profile of the source is a continuous wave whereas in the actual unit test it is a pulse.)

![oblique_waveguide_ang35](https://user-images.githubusercontent.com/7152530/121560364-48fd4000-c9cc-11eb-89b2-b62832334c11.png)
