### PR TITLE
Take ownership of geometric objects in `mode_solver`

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -801,10 +801,8 @@ void mode_solver::init_epsilon(geometric_object_list *geometry_in) {
   // Persist geometry data and move it out of the input argument.
   clear_geometry_list();
   if (geometry_in->num_items && geometry_in->items) {
-    geometry_list.items = new geometric_object[geometry_in->num_items];
-    std::copy_n(geometry_in->items, geometry_in->num_items, geometry_list.items);
+    geometry_list.items = geometry_in->items;
     geometry_list.num_items = geometry_in->num_items;
-    delete [] geometry_in->items;
     geometry_in->items = NULL;
     geometry_in->num_items = 0;
   }

--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -199,34 +199,21 @@ mode_solver::mode_solver(int num_bands, double resolution[3], lattice lat, doubl
                          std::string epsilon_input_file, std::string mu_input_file, bool force_mu,
                          bool use_simple_preconditioner, vector3 grid_size, int eigensolver_nwork,
                          int eigensolver_block_size)
-    : num_bands(num_bands), target_freq(target_freq), tolerance(tolerance), mesh_size(mesh_size),
+    : num_bands(num_bands), resolution{resolution[0], resolution[1], resolution[2]},
+      target_freq(target_freq), tolerance(tolerance), mesh_size(mesh_size),
       negative_epsilon_ok(negative_epsilon_ok), epsilon_input_file(epsilon_input_file),
       mu_input_file(mu_input_file), force_mu(force_mu),
       use_simple_preconditioner(use_simple_preconditioner), grid_size(grid_size), nwork_alloc(0),
       eigensolver_nwork(eigensolver_nwork), eigensolver_block_size(eigensolver_block_size),
-      last_parity(-2), iterations(0), eigensolver_flops(flops), vol(0), mdata(NULL), mtdata(NULL),
-      curfield_band(0), freqs(num_bands), verbose(verbose), deterministic(deterministic),
-      kpoint_index(0), curfield(NULL), curfield_type('-'), eps(true) {
+      last_parity(-2), iterations(0), eigensolver_flops(flops), geometry_list{},
+      geometry_tree(NULL),  vol(0), R{}, G{},  mdata(NULL), mtdata(NULL),
+      curfield_band(0), H{}, Hblock{}, muinvH{}, W{}, freqs(num_bands), verbose(verbose),
+      deterministic(deterministic), kpoint_index(0), curfield(NULL), curfield_type('-'), eps(true) {
 
+  // See geom-ctl-io-defaults.c in libctl
   geometry_lattice = lat;
   dimensions = dims;
   ensure_periodicity = periodicity;
-  geometry_tree = NULL;
-  H.data = NULL;
-  Hblock.data = NULL;
-  muinvH.data = NULL;
-
-  for (int i = 0; i < MAX_NWORK; i++) {
-    W[i].data = NULL;
-  }
-
-  for (int i = 0; i < 3; ++i) {
-    this->resolution[i] = resolution[i];
-    for (int j = 0; j < 3; ++j) {
-      R[i][j] = 0.0;
-      G[i][j] = 0.0;
-    }
-  }
 
 #ifndef WITH_HERMITIAN_EPSILON
   meep_geom::medium_struct *m;
@@ -240,6 +227,7 @@ mode_solver::~mode_solver() {
   destroy_maxwell_data(mdata);
   destroy_maxwell_target_data(mtdata);
   destroy_geom_box_tree(geometry_tree);
+  clear_geometry_list();
   destroy_evectmatrix(H);
 
   for (int i = 0; i < nwork_alloc; ++i) {
@@ -684,7 +672,7 @@ void mode_solver::get_material_pt(meep_geom::material_type &material, vector3 p)
 
 bool mode_solver::using_mu() { return mdata && mdata->mu_inv != NULL; }
 
-void mode_solver::init(int p, bool reset_fields, geometric_object_list geometry,
+void mode_solver::init(int p, bool reset_fields, geometric_object_list *geometry,
                        meep_geom::material_data *_default_material) {
   int have_old_fields = 0;
 
@@ -769,7 +757,7 @@ void mode_solver::init(int p, bool reset_fields, geometric_object_list geometry,
 
   if (target_freq != 0.0) { mtdata = create_maxwell_target_data(mdata, target_freq); }
 
-  init_epsilon(&geometry);
+  init_epsilon(geometry);
 
   if (check_maxwell_dielectric(mdata, 0)) { meep::abort("invalid dielectric function for MPB"); }
 
@@ -809,7 +797,17 @@ void mode_solver::init(int p, bool reset_fields, geometric_object_list geometry,
   evectmatrix_flops = eigensolver_flops;
 }
 
-void mode_solver::init_epsilon(geometric_object_list *geometry) {
+void mode_solver::init_epsilon(geometric_object_list *geometry_in) {
+  // Persist geometry data and move it out of the input argument.
+  clear_geometry_list();
+  if (geometry_in->num_items && geometry_in->items) {
+    geometry_list.items = new geometric_object[geometry_in->num_items];
+    std::copy_n(geometry_in->items, geometry_in->num_items, geometry_list.items);
+    geometry_list.num_items = geometry_in->num_items;
+    delete [] geometry_in->items;
+    geometry_in->items = NULL;
+    geometry_in->num_items = 0;
+  }
   mpb_real no_size_x = geometry_lattice.size.x == 0 ? 1 : geometry_lattice.size.x;
   mpb_real no_size_y = geometry_lattice.size.y == 0 ? 1 : geometry_lattice.size.y;
   mpb_real no_size_z = geometry_lattice.size.z == 0 ? 1 : geometry_lattice.size.z;
@@ -843,19 +841,19 @@ void mode_solver::init_epsilon(geometric_object_list *geometry) {
   matrix3x3_to_arr(R, Rm);
   matrix3x3_to_arr(G, Gm);
 
-  geom_fix_object_list(*geometry);
+  geom_fix_object_list(geometry_list);
 
   if (mpb_verbosity >= 1)
     meep::master_printf("Geometric objects:\n");
   if (meep::am_master()) {
-    for (int i = 0; i < geometry->num_items; ++i) {
+    for (int i = 0; i < geometry_list.num_items; ++i) {
 
 #ifndef WITH_HERMITIAN_EPSILON
       meep_geom::medium_struct *mm;
-      if (meep_geom::is_medium(geometry->items[i].material, &mm)) { mm->check_offdiag_im_zero_or_abort(); }
+      if (meep_geom::is_medium(geometry_list.items[i].material, &mm)) { mm->check_offdiag_im_zero_or_abort(); }
 #endif
 
-      display_geometric_object_info(5, geometry->items[i]);
+      display_geometric_object_info(5, geometry_list.items[i]);
 
       // meep_geom::medium_struct *mm;
       // if (meep_geom::is_medium(geometry.items[i].material, &mm)) {
@@ -882,7 +880,7 @@ void mode_solver::init_epsilon(geometric_object_list *geometry) {
     b0.high.x += tmp_size.x / mdata->nx;
     b0.high.y += tmp_size.y / mdata->ny;
     b0.high.z += tmp_size.z / mdata->nz;
-    geometry_tree = create_geom_box_tree0(*geometry, b0);
+    geometry_tree = create_geom_box_tree0(geometry_list, b0);
   }
 
   if (verbose && meep::am_master()) {
@@ -897,11 +895,11 @@ void mode_solver::init_epsilon(geometric_object_list *geometry) {
   if (mpb_verbosity >= 1)
     meep::master_printf("Geometric object tree has depth %d and %d object nodes"
                         " (vs. %d actual objects)\n",
-                        tree_depth, tree_nobjects, geometry->num_items);
+                        tree_depth, tree_nobjects, geometry_list.num_items);
 
   // restricted_tree = geometry_tree;
 
-  reset_epsilon(geometry);
+  reset_epsilon(&geometry_list);
 }
 
 void mode_solver::reset_epsilon(geometric_object_list *geometry) {
@@ -1628,6 +1626,19 @@ double mode_solver::compute_field_energy_internal(mpb_real comp_sum[6]) {
   curfield_type = toupper(curfield_type);
 
   return energy_sum;
+}
+
+void mode_solver::clear_geometry_list() {
+  if (geometry_list.num_items && geometry_list.items) {
+    for(int i = 0; i < geometry_list.num_items; ++i) {
+      material_free((meep_geom::material_data *)geometry_list.items[i].material);
+      delete (meep_geom::material_data *)geometry_list.items[i].material;
+      geometric_object_destroy(geometry_list.items[i]);
+    }
+    delete[] geometry_list.items;
+    geometry_list.items = NULL;
+    geometry_list.num_items = 0;
+  }
 }
 
 /* Replace curfield (either d or h) with the scalar energy density function,

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -1,6 +1,7 @@
 #ifndef PYMPB_H
 #define PYMPB_H
 
+#include <string>
 #include <vector>
 
 #include "ctlgeom.h"
@@ -32,15 +33,14 @@ typedef mpb_real (*field_integral_energy_func)(mpb_real, mpb_real, vector3, void
 typedef cnumber (*field_integral_func)(cvector3, mpb_real, vector3, void *);
 
 struct mode_solver {
-  static const int MAX_NWORK = 10;
-  static const char epsilon_CURFIELD_TYPE = 'n';
-  static const char mu_CURFIELD_TYPE = 'm';
-  static const int NUM_FFT_BANDS = 20;
+  static constexpr int MAX_NWORK = 10;
+  static constexpr char epsilon_CURFIELD_TYPE = 'n';
+  static constexpr char mu_CURFIELD_TYPE = 'm';
+  static constexpr int NUM_FFT_BANDS = 20;
 
   int num_bands;
   double resolution[3];
   double target_freq;
-  lattice lat;
   double tolerance;
   int mesh_size;
   bool negative_epsilon_ok;
@@ -65,6 +65,7 @@ struct mode_solver {
   int iterations;
   double eigensolver_flops;
 
+  geometric_object_list geometry_list;
   geom_box_tree geometry_tree;
 
   mpb_real vol;
@@ -100,7 +101,9 @@ struct mode_solver {
 
   ~mode_solver();
 
-  void init(int p, bool reset_fields, geometric_object_list geometry,
+  // Initializes the mode_solver. Geometric objects are moved out of `geometry`
+  // and deallocated upon destruction of the mode_solver.
+  void init(int p, bool reset_fields, geometric_object_list *geometry,
             meep_geom::material_data *_default_material);
   void solve_kpoint(vector3 kpoint);
   bool using_mu();
@@ -118,7 +121,7 @@ struct mode_solver {
                    mpb_real d2, mpb_real d3, mpb_real tol, const mpb_real r[3]);
 
   void randomize_fields();
-  void init_epsilon(geometric_object_list *geometry);
+  void init_epsilon(geometric_object_list *geometry_in);
   void reset_epsilon(geometric_object_list *geometry);
   bool has_mu(geometric_object_list *geometry);
   bool material_has_mu(void *mt);
@@ -199,6 +202,7 @@ private:
   bool eps;
 
   double compute_field_energy_internal(mpb_real comp_sum[6]);
+  void clear_geometry_list();
 };
 } // namespace py_mpb
 #endif

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -1033,6 +1033,15 @@ static PyObject *gobj_list_to_py_list(geometric_object_list *objs) {
   return py_res;
 }
 
+void gobj_list_freearg(geometric_object_list* objs) {
+    for(int i = 0; i < objs->num_items; ++i) {
+        material_free((material_data *)objs->items[i].material);
+        delete (material_data *)objs->items[i].material;
+        geometric_object_destroy(objs->items[i]);
+    }
+    delete[] objs->items;
+}
+
 static meep::binary_partition *py_bp_to_bp(PyObject *pybp) {
     meep::binary_partition *bp = NULL;
     if (pybp == Py_None) return bp;


### PR DESCRIPTION
* Move all geometric objects into a member variable in `mode_solver::init_epsilon`
* Deallocate these geometric objects in the destructor
* Add a typemap for `geometric_object_list *` to the Meep SWIG wrapper
* Cleanup of the `mode_solver` constructor
* Use `material_free` more consistently in the SWIG wrapper

#1600 