### PR TITLE
minor cleanups in meepgeom.hpp

### DIFF
--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -23,31 +23,30 @@
 #include <math.h>
 #include <vector>
 
-#include "meep.hpp"
 #include "material_data.hpp"
 
 namespace meep_geom {
 
 // constants from meep-ctl-const.hpp
-#define CYLINDRICAL -2
+const int CYLINDRICAL = -2;
 
 /* should be the same as meep::direction enum */
-#define X_DIR 0
-#define Y_DIR 1
-#define Z_DIR 2
-#define R_DIR 4
-#define PHI_DIR 5
+const int X_DIR = 0;
+const int Y_DIR = 1;
+const int Z_DIR = 2;
+const int R_DIR = 4;
+const int PHI_DIR = 5;
 
 // constant used in meep.scm
-#define ALL_SIDES -1
-#define ALL_DIRECTIONS -1
+const int ALL_SIDES = -1;
+const int ALL_DIRECTIONS = -1;
 
+// FIXME: we should really purge these ancient hacks and just use Inf and 0.0.
 // large (but not strictly inf!) floating-point number for
 // effectively infinite lengths
-#define ENORMOUS 1e20
-
+const double ENORMOUS = 1e20;
 // tiny floating-point number for effectively zero lengths
-#define TINY 1e-20
+const double TINY = 1e-20;
 
 struct dft_data {
   int num_freqs;

--- a/tests/absorber-1d-ll.cpp
+++ b/tests/absorber-1d-ll.cpp
@@ -49,8 +49,8 @@ int main(int argc, char *argv[]) {
   if (verbose) master_printf("Using %s.\n", use_pml ? "pml" : "absorber");
 
   double resolution = 20.0;
-  geometry_lattice.size.x = TINY;
-  geometry_lattice.size.y = TINY;
+  geometry_lattice.size.x = meep_geom::TINY;
+  geometry_lattice.size.y = meep_geom::TINY;
   geometry_lattice.size.z = 10.0;
   grid_volume gv = volone(10.0, resolution);
   gv.center_origin();

--- a/tests/array-slice-ll.cpp
+++ b/tests/array-slice-ll.cpp
@@ -140,10 +140,10 @@ int main(int argc, char *argv[]) {
   vector3 xhat = v3(1.0, 0.0, 0.0);
   vector3 yhat = v3(0.0, 1.0, 0.0);
   vector3 zhat = v3(0.0, 0.0, 1.0);
-  vector3 size = v3(ENORMOUS, w, ENORMOUS);
+  vector3 size = v3(meep_geom::ENORMOUS, w, meep_geom::ENORMOUS);
   double x0 = 0.5 * d;
   double deltax = 1.0;
-  double height = ENORMOUS;
+  double height = meep_geom::ENORMOUS;
   objects[0] = make_block(dielectric, origin, xhat, yhat, zhat, size);
   int no = 1;
   for (int n = 0; n < N; n++) {

--- a/tests/dft-fields.cpp
+++ b/tests/dft-fields.cpp
@@ -62,8 +62,8 @@ void Run(bool Pulse, double resolution, cdouble **field_array = 0, int *array_ra
   geometric_object objects[2];
   vector3 v3zero = {0.0, 0.0, 0.0};
   vector3 zaxis = {0.0, 0.0, 1.0};
-  objects[0] = make_cylinder(dielectric, v3zero, r + w, ENORMOUS, zaxis);
-  objects[1] = make_cylinder(meep_geom::vacuum, v3zero, r, ENORMOUS, zaxis);
+  objects[0] = make_cylinder(dielectric, v3zero, r + w, meep_geom::ENORMOUS, zaxis);
+  objects[1] = make_cylinder(meep_geom::vacuum, v3zero, r, meep_geom::ENORMOUS, zaxis);
   geometric_object_list g = {2, objects};
   meep_geom::set_materials_from_geometry(&the_structure, g);
   fields f(&the_structure);

--- a/tests/ring-ll.cpp
+++ b/tests/ring-ll.cpp
@@ -82,8 +82,8 @@ int main(int argc, char *argv[]) {
   geometric_object objects[2];
   vector3 v3zero = {0.0, 0.0, 0.0};
   vector3 zaxis = {0.0, 0.0, 1.0};
-  objects[0] = make_cylinder(dielectric, v3zero, r + w, ENORMOUS, zaxis);
-  objects[1] = make_cylinder(meep_geom::vacuum, v3zero, r, ENORMOUS, zaxis);
+  objects[0] = make_cylinder(dielectric, v3zero, r + w, meep_geom::ENORMOUS, zaxis);
+  objects[1] = make_cylinder(meep_geom::vacuum, v3zero, r, meep_geom::ENORMOUS, zaxis);
   geometric_object_list g = {2, objects};
   meep_geom::set_materials_from_geometry(&the_structure, g);
   fields f(&the_structure);


### PR DESCRIPTION
rm a superfluous dependency on `meep.hpp`, and turn a few `#defines` into `consts` so that they are namespaced.