### PR TITLE
Delete `items` in `geometic_object_list` correctly

### DIFF
--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -1028,7 +1028,7 @@ static PyObject *gobj_list_to_py_list(geometric_object_list *objs) {
     geometric_object_destroy(objs->items[i]);
   }
 
-  free(objs->items);
+  delete[] objs->items;
 
   return py_res;
 }


### PR DESCRIPTION
Use `delete []` instead of `free` because `new []` is used in `py_list_to_gobj_list`.