### PR TITLE
save test logs in the event of a test failure during CI

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -123,8 +123,27 @@ jobs:
 
     - name: Run configure
       run: |
-        mkdir -p build && pushd build
-        ../configure --enable-maintainer-mode --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF}
+        mkdir -p build &&
+        pushd build &&
+        ../configure --enable-maintainer-mode --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF} &&
+        popd
 
     - name: Run make distcheck
-      run: pushd build && make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}"
+      run: |
+        pushd build &&
+        make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}" &&
+        popd
+
+    - name: Archive C++ test logs
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: cpp-tests-mpi-${{ matrix.enable-mpi }}-log
+        path: ${{ github.workspace }}/build/meep-${{ env.MEEP_VERSION }}/_build/sub/tests/test-suite.log
+
+    - name: Archive Python test logs
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: py${{ matrix.python-version }}-tests-mpi-${{ matrix.enable-mpi }}-log
+        path: ${{ github.workspace }}/build/meep-${{ env.MEEP_VERSION }}/_build/sub/python/test-suite.log

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ![](doc/docs/images/Meep-banner.png)
 
+[![CI](https://github.com/NanoComp/meep/actions/workflows/build-ci.yml/badge.svg)](https://github.com/NanoComp/meep/actions/workflows/build-ci.yml)
+[![Sanitizers](https://github.com/NanoComp/meep/actions/workflows/build-san.yml/badge.svg)](https://github.com/NanoComp/meep/actions/workflows/build-san.yml)
 [![Latest Docs](https://readthedocs.org/projects/meep/badge/?version=latest)](http://meep.readthedocs.io/en/latest/)
-[![Build Status](https://travis-ci.org/NanoComp/meep.svg?branch=master)](https://travis-ci.org/NanoComp/meep)
-[![Coverage Status](https://coveralls.io/repos/github/stevengj/meep/badge.svg?branch=master)](https://coveralls.io/github/stevengj/meep?branch=master)
-![Python versions 2.7–3.6](https://img.shields.io/badge/python-2.7%2C%203.4%2C%203.5%2C%203.6-brightgreen.svg)
+![Python versions 3.6–3.9](https://img.shields.io/badge/python-3.6%2C%203.7%2C%203.8%2C%203.9-brightgreen.svg)
 
 **Meep** is a free and open-source software package for [electromagnetics](https://en.wikipedia.org/wiki/Electromagnetism) simulation via the [finite-difference time-domain](https://en.wikipedia.org/wiki/Finite-difference_time-domain_method) (FDTD) method spanning a broad range of applications.
 


### PR DESCRIPTION
Currently, if there is a failure during `make check` as part of the CI, the workflow terminates at that step with an error. In order to facilitate debugging in the event of a failure, this PR changes this behavior to instead save the test logs as separate files for the C++ and Python tests.

Also, the defunct "Build Status" and "Coverage Status" badges from Travis/Coveralls have been removed from the `README.md` and replaced with the badges for CI and Sanitizer from GitHub Actions.