### PR TITLE
Move `check_offdiag` into `medium_struct`.

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -230,7 +230,7 @@ mode_solver::mode_solver(int num_bands, double resolution[3], lattice lat, doubl
 
 #ifndef WITH_HERMITIAN_EPSILON
   meep_geom::medium_struct *m;
-  if (meep_geom::is_medium(_default_material, &m)) { meep_geom::check_offdiag(m); }
+  if (meep_geom::is_medium(_default_material, &m)) { m->check_offdiag_im_zero_or_abort(); }
 #else
   (void)_default_material;
 #endif
@@ -534,7 +534,7 @@ void mode_solver::material_epsmu(meep_geom::material_type material, symmetric_ma
 #ifndef WITH_HERMITIAN_EPSILON
   if (md->which_subclass == meep_geom::material_data::MATERIAL_USER ||
       md->which_subclass == meep_geom::material_data::MATERIAL_FILE) {
-    meep_geom::check_offdiag(&md->medium);
+    md->medium.check_offdiag_im_zero_or_abort();
   }
 #endif
 
@@ -852,7 +852,7 @@ void mode_solver::init_epsilon(geometric_object_list *geometry) {
 
 #ifndef WITH_HERMITIAN_EPSILON
       meep_geom::medium_struct *mm;
-      if (meep_geom::is_medium(geometry->items[i].material, &mm)) { meep_geom::check_offdiag(mm); }
+      if (meep_geom::is_medium(geometry->items[i].material, &mm)) { mm->check_offdiag_im_zero_or_abort(); }
 #endif
 
       display_geometric_object_info(5, geometry->items[i]);

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -167,7 +167,7 @@ meep-python.cxx: $(MEEP_SWIG_SRC) $(HPPFILES)
 
 if WITH_MPB
 MPB_SWIG_SRC = mpb.i
-mpb-python.cxx: $(MPB_SWIG_SRC) $(top_srcdir)/libpympb/pympb.hpp $(top_srcdir)/src/meepgeom.hpp $(top_srcdir)/src/material_data.hpp
+mpb-python.cxx: $(MPB_SWIG_SRC) $(top_srcdir)/libpympb/pympb.hpp $(top_srcdir)/src/meepgeom.hpp $(top_srcdir)/src/material_data.hpp $(top_srcdir)/src/material_data.cpp
 	$(SWIG) -Wextra $(AM_CPPFLAGS) $(PYMPBINCLUDE) -outdir $(builddir) -c++ -nofastunpack -python -o $@ $(srcdir)/mpb.i
 mpb.py: mpb-python.cxx
 MPB_PY = mpb.py

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@ libmeep_la_SOURCES = array_slice.cpp anisotropic_averaging.cpp 		\
 bands.cpp boundaries.cpp bicgstab.cpp casimir.cpp 	\
 cw_fields.cpp dft.cpp dft_ldos.cpp energy_and_flux.cpp 	\
 fields.cpp loop_in_chunks.cpp h5fields.cpp h5file.cpp 	\
-initialize.cpp integrate.cpp integrate2.cpp monitor.cpp mympi.cpp 	\
+initialize.cpp integrate.cpp integrate2.cpp material_data.cpp monitor.cpp mympi.cpp 	\
 multilevel-atom.cpp near2far.cpp output_directory.cpp random.cpp 	\
 sources.cpp step.cpp step_db.cpp stress.cpp structure.cpp structure_dump.cpp		\
 susceptibility.cpp time.cpp update_eh.cpp mpb.cpp update_pols.cpp 	\

--- a/src/material_data.cpp
+++ b/src/material_data.cpp
@@ -1,0 +1,46 @@
+/* Copyright (C) 2005-2021 Massachusetts Institute of Technology
+%
+%  This program is free software; you can redistribute it and/or modify
+%  it under the terms of the GNU General Public License as published by
+%  the Free Software Foundation; either version 2, or (at your option)
+%  any later version.
+%
+%  This program is distributed in the hope that it will be useful,
+%  but WITHOUT ANY WARRANTY; without even the implied warranty of
+%  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%  GNU General Public License for more details.
+%
+%  You should have received a copy of the GNU General Public License
+%  along with this program; if not, write to the Free Software Foundation,
+%  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+*/
+
+#include "material_data.hpp"
+
+#include "meep/mympi.hpp"
+
+namespace meep_geom {
+
+medium_struct::medium_struct(double epsilon) :
+      epsilon_diag{epsilon, epsilon, epsilon},
+      epsilon_offdiag{},
+      mu_diag{1, 1, 1},
+      mu_offdiag{},
+      E_susceptibilities(), H_susceptibilities(),
+      E_chi2_diag{},
+      E_chi3_diag{},
+      H_chi2_diag{},
+      H_chi3_diag{},
+      D_conductivity_diag{},
+      B_conductivity_diag{}
+    {}
+
+void medium_struct::check_offdiag_im_zero_or_abort() const {
+  if (epsilon_offdiag.x.im != 0 || epsilon_offdiag.y.im != 0 ||
+      epsilon_offdiag.z.im != 0 || mu_offdiag.x.im != 0 || mu_offdiag.y.im != 0 ||
+      mu_offdiag.z.im != 0) {
+    meep::abort("Found non-zero imaginary part of epsilon or mu offdiag.\n");
+  }
+}
+
+}  // namespace meep_geom

--- a/src/material_data.hpp
+++ b/src/material_data.hpp
@@ -88,19 +88,10 @@ struct medium_struct {
   vector3 D_conductivity_diag;
   vector3 B_conductivity_diag;
 
-  medium_struct(double epsilon = 1) :
-      epsilon_diag{epsilon, epsilon, epsilon},
-      epsilon_offdiag{},
-      mu_diag{1, 1, 1},
-      mu_offdiag{},
-      E_susceptibilities(), H_susceptibilities(),
-      E_chi2_diag{},
-      E_chi3_diag{},
-      H_chi2_diag{},
-      H_chi3_diag{},
-      D_conductivity_diag{},
-      B_conductivity_diag{}
-    {}
+  explicit medium_struct(double epsilon = 1);
+
+  // Aborts Meep if a non-zero imaginary part of an offdiagonal mu or epsilon entry is found.
+  void check_offdiag_im_zero_or_abort() const;
 };
 
 // prototype for user-defined material function,

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -188,7 +188,6 @@ bool is_file(void *md);
 bool is_medium(material_type md, medium_struct **m);
 bool is_medium(void *md, medium_struct **m);
 bool is_metal(meep::field_type ft, const material_type *material);
-void check_offdiag(medium_struct *m);
 geom_box gv2box(const meep::volume &v);
 void get_epsilon_grid(geometric_object_list gobj_list,
                       material_type_list mlist,


### PR DESCRIPTION
Start moving `material_data` implementation into a `cpp` file.

Issues with the current implementation:
* It takes a `medium_struct *` argument even though it is effectively
`const`.
* The check logically belongs to `medium_struct`
* It is exposed via the Python interface, even though it is not usable
from there due to incorrect typemapping.