### PR TITLE
Cache Python dependencies for CI

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -108,11 +108,26 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        python -m pip install --upgrade pip wheel
+        echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: pip cache
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-mpi-${{ matrix.enable-mpi }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: ${{ runner.os }}-py${{ matrix.python-version }}-mpi-${{ matrix.enable-mpi }}-pip-
+
     - name: Install Python dependencies
-      run: pip install autograd h5py jax jaxlib matplotlib numpy parameterized pytest scipy
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: pip install -r python/requirements.txt
 
     - name: Install mpi4py
-      if: matrix.enable-mpi
+      if: ${{ matrix.enable-mpi && steps.cache.outputs.cache-hit != true }}
       run: pip install mpi4py
 
     - name: Run autoreconf

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,9 @@
+autograd
+h5py
+jax
+jaxlib
+matplotlib
+numpy
+parameterized
+pytest
+scipy


### PR DESCRIPTION
Modifies the CI workflow to [cache the Python dependencies installed via pip](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows). This reduces the runtime by more than a factor of 2 from ~25 m to ~11 m.