### PR TITLE
WIP: revamped adjoint filters

### DIFF
--- a/python/adjoint/basis.py
+++ b/python/adjoint/basis.py
@@ -14,13 +14,11 @@ ABC = ABCMeta('ABC', (object, ), {'__slots__':
 class Basis(ABC):
     """
     """
-    def __init__(
-            self,
-            rho_vector=None,
-            volume=None,
-            size=None,
-            center=mp.Vector3(),
-    ):
+    def __init__(self,
+                 rho_vector=None,
+                 volume=None,
+                 size=None,
+                 center=mp.Vector3()):
         self.volume = volume if volume else mp.Volume(center=center, size=size)
         self.rho_vector = rho_vector
 
@@ -54,6 +52,9 @@ class BilinearInterpolationBasis(Basis):
     Simple bilinear interpolation basis set.
     '''
     def __init__(self, resolution, symmetry=None, **kwargs):
+        ''' 
+        
+        '''
         self.dim = 2
 
         super(BilinearInterpolationBasis, self).__init__(**kwargs)
@@ -194,14 +195,8 @@ class BilinearInterpolationBasis(Basis):
 
         return weights, interp_idx
 
-    def gen_interpolation_matrix(
-        self,
-        rho_x,
-        rho_y,
-        rho_x_interp,
-        rho_y_interp,
-        rho_z_interp,
-    ):
+    def gen_interpolation_matrix(self, rho_x, rho_y, rho_x_interp,
+                                 rho_y_interp, rho_z_interp):
         '''
         Generates a bilinear interpolation matrix.
         

--- a/python/adjoint/filter_source.py
+++ b/python/adjoint/filter_source.py
@@ -4,14 +4,12 @@ from meep import CustomSource
 
 
 class FilteredSource(CustomSource):
-    def __init__(
-        self,
-        center_frequency,
-        frequencies,
-        frequency_response,
-        dt,
-        time_src=None,
-    ):
+    def __init__(self,
+                 center_frequency,
+                 frequencies,
+                 frequency_response,
+                 dt,
+                 time_src=None):
         dt = dt / 2  # divide by two to compensate for staggered E,H time interval
         self.dt = dt
         self.frequencies = frequencies

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -7,7 +7,18 @@ import jax
 from jax import numpy as npj
 import meep as mp
 from scipy import special
-from .optimization_problem import atleast_3d
+
+
+def atleast_3d(ary):
+    if ary.ndim == 0:
+        result = npj.expand_dims(ary, axis=(0,1,2))#ary.reshape(1, 1, 1)
+    elif ary.ndim == 1:
+        result = npj.expand_dims(ary, axis=(1,2))
+    elif ary.ndim == 2:
+        result = npj.expand_dims(ary, axis=(2))
+    else:
+        result = ary
+    return result
 
 
 def _centered(arr, newshape):
@@ -17,8 +28,8 @@ def _centered(arr, newshape):
     https://github.com/scipy/scipy/blob/v1.4.1/scipy/signal/signaltools.py#L263-L270
     '''
     # Return the center newshape portion of the array.
-    newshape = np.asarray(newshape)
-    currshape = np.array(arr.shape)
+    newshape = npj.array(newshape)
+    currshape = npj.array(arr.shape)
     startind = (currshape - newshape) // 2
     endind = startind + newshape
     myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
@@ -44,17 +55,6 @@ def meep_filter(x,kernel):
     # remove paddings
     return _centered(yp,x_shape)
 
-def symmetric_kernel(kernel,dims):
-    '''
-    Given a 1D array for a kernel, do sucessive outer products
-    to get higher dimensional equivalents.
-    '''
-    k = kernel.copy()
-    for k in range(dims-1):
-        k = npj.unfunc.outer(k,kernel)
-    
-    return k
-
 def cylindrical_filter(x,radius):
     x = atleast_3d(x)
     xl = npj.linspace(-x.shape[0]/2,x.shape[0]/2,x.shape[0])
@@ -64,10 +64,8 @@ def cylindrical_filter(x,radius):
     X,Y,Z = npj.meshgrid(xl,yl,zl,sparse=True)
     kernel = X**2+Y**2+Z**2 <= radius**2
     kernel = kernel/npj.sum(kernel.flatten()) # normalize
-    
-    return meep_filter(npj.squeeze(x),npj.squeeze(kernel))
 
-    
+    return meep_filter(npj.squeeze(x),npj.squeeze(kernel))
 
 def conic_filter(x,radius):
     x = atleast_3d(x)

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -84,7 +84,7 @@ def meep_filter(x,kernel):
     npad = *((s,s) for s in x_shape),
     kernelp = npj.pad(kernel,npad,mode='edge')
     xp = npj.pad(x,npad,mode='edge')
-    
+
     # convolve
     '''
     As is the case with any convolution, the filter will
@@ -96,8 +96,9 @@ def meep_filter(x,kernel):
     twice, however. We sqrt the kernel in the frequency domain
     to somewhat compensate for this.
     '''
-    yp = fft.fftshift(fft.ifftn(fft.fftn(xp) * npj.sqrt(fft.fftn(kernelp)))).real
-    yp = fft.fftshift(fft.ifftn(fft.fftn(npj.flip(yp,axis=None)) * npj.sqrt(fft.fftn(kernelp)))).real
+
+    yp = fft.fftshift(fft.ifftn(fft.fftn(xp) * fft.fftn(kernelp))).real
+    yp = fft.fftshift(fft.ifftn(fft.fftn(npj.flip(yp,axis=None)) * fft.fftn(kernelp))).real
     
     # remove paddings
     return _centered(yp,x_shape)

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -942,17 +942,17 @@ def M_diff_open_close(x,f_open,f_close,p=1):
     '''
 
     '''
-    return npj.mean(npj.abs(f_close(x.flatten())-f_open(x.flatten()))**p)
+    return npj.mean(npj.abs(f_close(x.flatten())-f_open(x.flatten()))**p) * 100
 
 def M_diff_identity_open(x,f_open,p=1):
     '''
 
     '''
-    return npj.mean(npj.abs(x.flatten()-f_open(x.flatten()))**p)
+    return npj.mean(npj.abs(x.flatten()-f_open(x.flatten()))**p) * 100
 
 def M_diff_identity_close(x,f_close,p=1):
     '''
 
     '''
-    return npj.mean(npj.abs(x.flatten()-f_close(x.flatten()))**p)
+    return npj.mean(npj.abs(x.flatten()-f_close(x.flatten()))**p) * 100
 

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -97,7 +97,7 @@ def meep_filter(x,kernel):
     to somewhat compensate for this.
     '''
 
-    yp = fft.fftshift(fft.ifftn(fft.fftn(xp) * fft.fftn(kernelp))).real
+    yp = fft.fftshift(fft.ifftn(fft.fftn(xp) * (fft.fftn(kernelp)))).real
     yp = npj.flip(fft.fftshift(fft.ifftn(fft.fftn(npj.flip(yp,axis=None)) * fft.fftn(kernelp))).real,axis=None)
     
     # remove paddings

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -3,9 +3,11 @@ General filter functions to be used in other projection and morphological transf
 """
 
 import numpy as np
+import jax
 from jax import numpy as npj
 import meep as mp
 from scipy import special
+from .optimization_problem import atleast_3d
 
 
 def _centered(arr, newshape):
@@ -22,291 +24,83 @@ def _centered(arr, newshape):
     myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
     return arr[tuple(myslice)]
 
-
-def _edge_pad(arr, pad):
-
-    # fill sides
-    left = npj.tile(arr[0,:],(pad[0][0],1)) # left side
-    right = npj.tile(arr[-1,:],(pad[0][1],1)) # right side
-    top = npj.tile(arr[:,0],(pad[1][0],1)).transpose() # top side
-    bottom = npj.tile(arr[:,-1],(pad[1][1],1)).transpose() # bottom side)
-    
-    # fill corners
-    top_left = npj.tile(arr[0,0], (pad[0][0],pad[1][0])) # top left
-    top_right = npj.tile(arr[-1,0], (pad[0][1],pad[1][0])) # top right
-    bottom_left = npj.tile(arr[0,-1], (pad[0][0],pad[1][1])) # bottom left
-    bottom_right = npj.tile(arr[-1,-1], (pad[0][1],pad[1][1])) # bottom right
-    
-    out = npj.concatenate((
-        npj.concatenate((top_left,top,top_right)),
-        npj.concatenate((left,arr,right)),
-        npj.concatenate((bottom_left,bottom,bottom_right))    
-    ),axis=1)
-    
-    return out
-
-
-def _zero_pad(arr, pad):
-
-    # fill sides
-    left = npj.tile(0,(pad[0][0],arr.shape[1])) # left side
-    right = npj.tile(0,(pad[0][1],arr.shape[1])) # right side
-    top = npj.tile(0,(arr.shape[0],pad[1][0])) # top side
-    bottom = npj.tile(0,(arr.shape[0],pad[1][1])) # bottom side
-    
-    # fill corners
-    top_left = npj.tile(0, (pad[0][0],pad[1][0])) # top left
-    top_right = npj.tile(0, (pad[0][1],pad[1][0])) # top right
-    bottom_left = npj.tile(0, (pad[0][0],pad[1][1])) # bottom left
-    bottom_right = npj.tile(0, (pad[0][1],pad[1][1])) # bottom right
-    
-    out = npj.concatenate((
-        npj.concatenate((top_left,top,top_right)),
-        npj.concatenate((left,arr,right)),
-        npj.concatenate((bottom_left,bottom,bottom_right))    
-    ),axis=1)
-    
-    return out
-
-
-def simple_2d_filter(x, kernel, Lx, Ly, resolution, symmetries=[]):
-    """A simple 2d filter algorithm that is differentiable with autograd.
-    Uses a 2D fft approach since it is typically faster and preserves the shape
-    of the input and output arrays.
-    
-    The ffts pad the operation to prevent any circular convolution garbage.
-
-    Parameters
-    ----------
-    x : array_like (2D)
-        Input array to be filtered. Must be 2D.
-    kernel : array_like (2D)
-        Filter kernel (before the DFT). Must be same size as `x`
-    Lx : float
-        Length of design region in X direction (in "meep units")
-    Ly : float
-        Length of design region in Y direction (in "meep units")
-    resolution : int
-        Resolution of the design grid (not the meep simulation resolution)
-    symmetries : list
-        Symmetries to impose on the parameter field (either mp.X or mp.Y)
-    
-    Returns
-    -------
-    array_like (2D)
-        The output of the 2d convolution.
-    """
-    # Get 2d parameter space shape
-    Nx = int(Lx * resolution)
-    Ny = int(Ly * resolution)
-    (kx, ky) = kernel.shape
-
-    # Adjust parameter space shape for symmetries
-    if mp.X in symmetries:
-        Nx = int(Nx / 2)
-    if mp.Y in symmetries:
-        Ny = int(Ny / 2)
-
-    # Ensure the input is 2D
-    x = x.reshape(Nx, Ny)
-
-    # Perform the required reflections for symmetries
-    if mp.X in symmetries:
-        if kx % 2 == 1:
-            x = npj.concatenate((x,x[-1,:][None,:],x[::-1,:]), axis=0)
-        else:
-            x = npj.concatenate((x,x[::-1,:]), axis=0)
-    if mp.Y in symmetries:
-        if ky % 2 == 1:
-            x = npj.concatenate((x[:,::-1],x[:,-1][:,None],x), axis=1)
-        else:
-            x = npj.concatenate((x[:,::-1],x), axis=1)
-    
-    # pad the kernel and input to avoid circular convolution and
-    # to ensure boundary conditions are met.
-    kernel = _zero_pad(kernel, ((kx, kx), (ky, ky)))
-    x = _edge_pad(x, ((kx, kx), (ky, ky)))
-
-    # Transform to frequency domain for fast convolution
-    H = npj.fft.fft2(kernel)
-    X = npj.fft.fft2(x)
-    
-    # Convolution (multiplication in frequency domain)
-    Y = H * X
-
-    # We need to fftshift since we padded both sides if each dimension of our input and kernel.
-    y = npj.fft.fftshift(npj.real(npj.fft.ifft2(Y)))
-    
-    # Remove all the extra padding
-    y = _centered(y, (kx, ky))
-
-    # Remove the added symmetry domains
-    if mp.X in symmetries:
-        y = y[0:Nx, :]
-    if mp.Y in symmetries:
-        y = y[:, -Ny:]
-
-    return y
-
-
-def cylindrical_filter(x, radius, Lx, Ly, resolution, symmetries=[]):
-    '''A uniform cylindrical filter [1]. Typically allows for sharper transitions. 
-    
-    Parameters
-    ----------
-    x : array_like (2D)
-        Design parameters
-    radius : float
-        Filter radius (in "meep units")
-    Lx : float
-        Length of design region in X direction (in "meep units")
-    Ly : float
-        Length of design region in Y direction (in "meep units")
-    resolution : int
-        Resolution of the design grid (not the meep simulation resolution)
-    symmetries : list
-        Symmetries to impose on the parameter field (either mp.X or mp.Y)
-
-    Returns
-    -------
-    array_like (2D)
-        Filtered design parameters.
-    
-    References
-    ----------
-    [1] Lazarov, B. S., Wang, F., & Sigmund, O. (2016). Length scale and manufacturability in 
-    density-based topology optimization. Archive of Applied Mechanics, 86(1-2), 189-218.
+def meep_filter(x,kernel):
     '''
-    # Get 2d parameter space shape
-    Nx = int(Lx * resolution)
-    Ny = int(Ly * resolution)
+    General convolution for 1D, 2D, and 3D design spaces.
 
-    # Formulate grid over entire design region
-    xv, yv = np.meshgrid(np.linspace(-Lx / 2, Lx / 2, Nx),
-                         np.linspace(-Ly / 2, Ly / 2, Ny),
-                         sparse=True,
-                         indexing='ij')
-
-    # Calculate kernel
-    kernel = np.where(np.abs(xv**2 + yv**2) <= radius**2, 1, 0).T
-
-    # Normalize kernel
-    kernel = kernel / np.sum(kernel.flatten())  # Normalize the filter
-
-    # Filter the response
-    y = simple_2d_filter(x, kernel, Lx, Ly, resolution, symmetries)
-
-    return y
-
-
-def conic_filter(x, radius, Lx, Ly, resolution, symmetries=[]):
-    '''A linear conic filter, also known as a "Hat" filter in the literature [1].
-    
-    Parameters
-    ----------
-    x : array_like (2D)
-        Design parameters
-    radius : float
-        Filter radius (in "meep units")
-    Lx : float
-        Length of design region in X direction (in "meep units")
-    Ly : float
-        Length of design region in Y direction (in "meep units")
-    resolution : int
-        Resolution of the design grid (not the meep simulation resolution)
-    symmetries : list
-        Symmetries to impose on the parameter field (either mp.X or mp.Y)
-
-    Returns
-    -------
-    array_like (2D)
-        Filtered design parameters.
-    
-    References
-    ----------
-    [1] Lazarov, B. S., Wang, F., & Sigmund, O. (2016). Length scale and manufacturability in 
-    density-based topology optimization. Archive of Applied Mechanics, 86(1-2), 189-218.
+    x and kernel must have the shape you wish to filter.
     '''
-    # Get 2d parameter space shape
-    Nx = int(Lx * resolution)
-    Ny = int(Ly * resolution)
+    # store shapes
+    x_shape = x.shape; k_shape = kernel.shape
 
-    # Formulate grid over entire design region
-    xv, yv = np.meshgrid(np.linspace(-Lx / 2, Lx / 2, Nx),
-                         np.linspace(-Ly / 2, Ly / 2, Ny),
-                         sparse=True,
-                         indexing='ij')
-
-    # Calculate kernel
-    kernel = np.where(
-        np.abs(xv**2 + yv**2) <= radius**2,
-        (1 - np.sqrt(abs(xv**2 + yv**2)) / radius), 0)
-
-    # Normalize kernel
-    kernel = kernel / np.sum(kernel.flatten())  # Normalize the filter
-
-    # Filter the response
-    y = simple_2d_filter(x, kernel, Lx, Ly, resolution, symmetries)
-
-    return y
-
-
-def gaussian_filter(x, sigma, Lx, Ly, resolution, symmetries=[]):
-    '''A simple gaussian filter of the form exp(-x **2 / sigma ** 2) [1].
+    # edge pad
+    npad = *((s,s) for s in x_shape),
+    kernelp = npj.pad(kernel,npad,mode='edge')
+    xp = npj.pad(x,npad,mode='edge')
     
-    Parameters
-    ----------
-    x : array_like (2D)
-        Design parameters
-    sigma : float
-        Filter radius (in "meep units")
-    Lx : float
-        Length of design region in X direction (in "meep units")
-    Ly : float
-        Length of design region in Y direction (in "meep units")
-    resolution : int
-        Resolution of the design grid (not the meep simulation resolution)
-
-    Returns
-    -------
-    array_like (2D)
-        Filtered design parameters.
+    # convolve
+    yp = jax.scipy.signal.convolve(xp,kernelp,mode='same')
     
-    References
-    ----------
-    [1] Wang, E. W., Sell, D., Phan, T., & Fan, J. A. (2019). Robust design of 
-    topology-optimized metasurfaces. Optical Materials Express, 9(2), 469-482.
+    # remove paddings
+    return _centered(yp,x_shape)
+
+def symmetric_kernel(kernel,dims):
     '''
-    # Get 2d parameter space shape
-    Nx = int(Lx * resolution)
-    Ny = int(Ly * resolution)
+    Given a 1D array for a kernel, do sucessive outer products
+    to get higher dimensional equivalents.
+    '''
+    k = kernel.copy()
+    for k in range(dims-1):
+        k = npj.unfunc.outer(k,kernel)
+    
+    return k
 
-    gaussian = lambda x, sigma: np.exp(-x**2 / sigma**2)
+def cylindrical_filter(x,radius):
+    x = atleast_3d(x)
+    xl = npj.linspace(-x.shape[0]/2,x.shape[0]/2,x.shape[0])
+    yl = npj.linspace(-x.shape[1]/2,x.shape[1]/2,x.shape[1])
+    zl = npj.linspace(-x.shape[2]/2,x.shape[2]/2,x.shape[2])
 
-    # Formulate grid over entire design region
-    xv = np.linspace(-Lx / 2, Lx / 2, Nx)
-    yv = np.linspace(-Ly / 2, Ly / 2, Ny)
+    X,Y,Z = npj.meshgrid(xl,yl,zl,sparse=True)
+    kernel = X**2+Y**2+Z**2 <= radius**2
+    kernel = kernel/npj.sum(kernel.flatten()) # normalize
+    
+    return meep_filter(npj.squeeze(x),npj.squeeze(kernel))
 
-    # Calculate kernel
-    kernel = np.outer(gaussian(xv, sigma),
-                      gaussian(yv, sigma))  # Gaussian filter kernel
+    
 
-    # Normalize kernel
-    kernel = kernel / np.sum(kernel.flatten())  # Normalize the filter
+def conic_filter(x,radius):
+    x = atleast_3d(x)
+    xl = npj.linspace(-x.shape[0]/2,x.shape[0]/2,x.shape[0])
+    yl = npj.linspace(-x.shape[1]/2,x.shape[1]/2,x.shape[1])
+    zl = npj.linspace(-x.shape[2]/2,x.shape[2]/2,x.shape[2])
 
-    # Filter the response
-    y = simple_2d_filter(x, kernel, Lx, Ly, resolution, symmetries)
+    X,Y,Z = npj.meshgrid(xl,yl,zl,sparse=True)
+    kernel = np.where(np.abs(X**2+Y**2+Z**2) <= radius**2,(1-np.sqrt(npj.abs(X**2+Y**2+Z**2))/radius),0)
+    kernel = kernel/npj.sum(kernel.flatten()) # normalize
 
-    return y
+    return meep_filter(npj.squeeze(x),npj.squeeze(kernel))
+
+def gaussian_filter(x,sigma):
+    gaussian = lambda x,sigma: np.exp(-x**2/sigma**2)
+    x = atleast_3d(x)
+    xl = npj.linspace(-x.shape[0]/2,x.shape[0]/2,x.shape[0])
+    yl = npj.linspace(-x.shape[1]/2,x.shape[1]/2,x.shape[1])
+    zl = npj.linspace(-x.shape[2]/2,x.shape[2]/2,x.shape[2])
+
+    X,Y,Z = npj.meshgrid(xl,yl,zl,sparse=True)
+    kernel = np.multiply.outer(np.outer(gaussian(X, sigma), gaussian(Y, sigma)),gaussian(Z, sigma)) # Gaussian filter kernel
+    kernel = kernel/npj.sum(kernel.flatten()) # normalize
+
+    return meep_filter(npj.squeeze(x),npj.squeeze(kernel))
 
 
 '''
 # ------------------------------------------------------------------------------------ #
 Erosion and dilation operators
 '''
-
-
-def exponential_erosion(x, radius, beta, Lx, Ly, resolution):
+    
+def exponential_erosion(x,radius,beta):
     ''' Performs and exponential erosion operation.
     
     Parameters
@@ -339,14 +133,9 @@ def exponential_erosion(x, radius, beta, Lx, Ly, resolution):
     '''
     
     x_hat = npj.exp(beta*(1-x))
-    return 1 - npj.log(cylindrical_filter(x_hat,radius,Lx,Ly,resolution).flatten()) / beta
+    return 1 - npj.log(cylindrical_filter(x_hat,radius)) / beta
 
-    x_hat = npa.exp(beta * (1 - x))
-    return 1 - npa.log(
-        cylindrical_filter(x_hat, radius, Lx, Ly, resolution).flatten()) / beta
-
-
-def exponential_dilation(x, radius, beta, Lx, Ly, resolution):
+def exponential_dilation(x,radius,beta):
     ''' Performs a exponential dilation operation.
     
     Parameters
@@ -379,14 +168,9 @@ def exponential_dilation(x, radius, beta, Lx, Ly, resolution):
     '''
     
     x_hat = npj.exp(beta*x)
-    return npj.log(cylindrical_filter(x_hat,radius,Lx,Ly,resolution).flatten()) / beta
+    return npj.log(cylindrical_filter(x_hat,radius)) / beta
 
-    x_hat = npa.exp(beta * x)
-    return npa.log(
-        cylindrical_filter(x_hat, radius, Lx, Ly, resolution).flatten()) / beta
-
-
-def heaviside_erosion(x, radius, beta, Lx, Ly, resolution):
+def heaviside_erosion(x,radius,beta):
     ''' Performs a heaviside erosion operation.
     
     Parameters
@@ -416,14 +200,10 @@ def heaviside_erosion(x, radius, beta, Lx, Ly, resolution):
     numerical methods in engineering, 61(2), 238-254.
     '''
     
-    x_hat = cylindrical_filter(x,radius,Lx,Ly,resolution).flatten()
+    x_hat = cylindrical_filter(x,radius)
     return npj.exp(-beta*(1-x_hat)) + npj.exp(-beta)*(1-x_hat)
 
-    x_hat = cylindrical_filter(x, radius, Lx, Ly, resolution).flatten()
-    return npa.exp(-beta * (1 - x_hat)) + npa.exp(-beta) * (1 - x_hat)
-
-
-def heaviside_dilation(x, radius, beta, Lx, Ly, resolution):
+def heaviside_dilation(x,radius,beta):
     ''' Performs a heaviside dilation operation.
     
     Parameters
@@ -453,14 +233,10 @@ def heaviside_dilation(x, radius, beta, Lx, Ly, resolution):
     numerical methods in engineering, 61(2), 238-254.
     '''
     
-    x_hat = cylindrical_filter(x,radius,Lx,Ly,resolution).flatten()
+    x_hat = cylindrical_filter(x,radius)
     return 1 - npj.exp(-beta*x_hat) + npj.exp(-beta)*x_hat
 
-    x_hat = cylindrical_filter(x, radius, Lx, Ly, resolution).flatten()
-    return 1 - npa.exp(-beta * x_hat) + npa.exp(-beta) * x_hat
-
-
-def geometric_erosion(x, radius, alpha, Lx, Ly, resolution):
+def geometric_erosion(x,radius,alpha):
     ''' Performs a geometric erosion operation.
     
     Parameters
@@ -489,10 +265,9 @@ def geometric_erosion(x, radius, alpha, Lx, Ly, resolution):
     Pythagorean means. Structural and Multidisciplinary Optimization, 48(5), 859-875.
     '''
     x_hat = npj.log(x + alpha)
-    return npj.exp(cylindrical_filter(x_hat,radius,Lx,Ly,resolution)).flatten() - alpha
+    return npj.exp(cylindrical_filter(x_hat,radius)) - alpha
 
-
-def geometric_dilation(x, radius, alpha, Lx, Ly, resolution):
+def geometric_dilation(x,radius,alpha):
     ''' Performs a geometric dilation operation.
     
     Parameters
@@ -522,9 +297,9 @@ def geometric_dilation(x, radius, alpha, Lx, Ly, resolution):
     '''
 
     x_hat = npj.log(1 - x + alpha)
-    return -npj.exp(cylindrical_filter(x_hat,radius,Lx,Ly,resolution)).flatten() + alpha + 1
+    return -npj.exp(cylindrical_filter(x_hat,radius)) + alpha + 1
 
-def harmonic_erosion(x, radius, alpha, Lx, Ly, resolution):
+def harmonic_erosion(x,radius,alpha):
     ''' Performs a harmonic erosion operation.
     
     Parameters
@@ -554,11 +329,9 @@ def harmonic_erosion(x, radius, alpha, Lx, Ly, resolution):
     '''
 
     x_hat = 1 / (x + alpha)
-    return 1 / cylindrical_filter(x_hat, radius, Lx, Ly,
-                                  resolution).flatten() - alpha
+    return 1 / cylindrical_filter(x_hat,radius) - alpha
 
-
-def harmonic_dilation(x, radius, alpha, Lx, Ly, resolution):
+def harmonic_dilation(x,radius,alpha):
     ''' Performs a harmonic dilation operation.
     
     Parameters
@@ -588,9 +361,7 @@ def harmonic_dilation(x, radius, alpha, Lx, Ly, resolution):
     '''
 
     x_hat = 1 / (1 - x + alpha)
-    return 1 - 1 / cylindrical_filter(x_hat, radius, Lx, Ly,
-                                      resolution).flatten() + alpha
-
+    return 1 - 1 / cylindrical_filter(x_hat,radius) + alpha
 
 '''
 # ------------------------------------------------------------------------------------ #

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -9,6 +9,18 @@ import meep as mp
 from scipy import special
 import jax.numpy.fft as fft
 
+def centered(arr, newshape):
+    '''Helper function that reformats the padded array of the fft filter operation.
+    Borrowed from scipy:
+    https://github.com/scipy/scipy/blob/v1.4.1/scipy/signal/signaltools.py#L263-L270
+    '''
+    # Return the center newshape portion of the array.
+    newshape = np.asarray(newshape)
+    currshape = np.array(arr.shape)
+    startind = (currshape - newshape) // 2
+    endind = startind + newshape
+    myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
+    return arr[tuple(myslice)]
 
 def atleast_3d(ary):
     if ary.ndim == 0:
@@ -80,6 +92,10 @@ def meep_filter(x,kernel):
     return _centered(yp,x_shape)
 
 def cylindrical_filter(x,radius):
+    # filter radius is in pixels, so make sure radius >= 1
+    if radius < 1:
+        raise ValueError("The filter radius must be at least 1 pixel") 
+
     x = atleast_3d(x)
     xl = npj.linspace(-x.shape[0]/2,x.shape[0]/2,x.shape[0])
     yl = npj.linspace(-x.shape[1]/2,x.shape[1]/2,x.shape[1])

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -98,7 +98,7 @@ def meep_filter(x,kernel):
     '''
 
     yp = fft.fftshift(fft.ifftn(fft.fftn(xp) * fft.fftn(kernelp))).real
-    yp = fft.fftshift(fft.ifftn(fft.fftn(npj.flip(yp,axis=None)) * fft.fftn(kernelp))).real
+    yp = npj.flip(fft.fftshift(fft.ifftn(fft.fftn(npj.flip(yp,axis=None)) * fft.fftn(kernelp))).real,axis=None)
     
     # remove paddings
     return _centered(yp,x_shape)
@@ -751,29 +751,29 @@ def gray_indicator(x):
     [1] Lazarov, B. S., Wang, F., & Sigmund, O. (2016). Length scale and manufacturability in 
     density-based topology optimization. Archive of Applied Mechanics, 86(1-2), 189-218.
     '''
-    return npj.mean(4 * x.flatten() * (1-x.flatten())) * 100
+    return npj.mean(4 * x.flatten() * (1-x.flatten()))
 
-def F_diff_open_close(x,f_open,f_close,beta=64):
+def F_diff_open_close(x,f_open,f_close,beta=64,p=2):
     '''
 
     '''
-    return npj.mean(tanh_projection(npj.abs(f_close(x.flatten())-f_open(x.flatten()))),beta,0.5)
+    return npj.mean(tanh_projection(npj.abs(f_close(x)-f_open(x)).flatten()**2),beta,0.5) * 100
 
-def M_diff_open_close(x,f_open,f_close,p=1):
+def M_diff_open_close(x,f_open,f_close,p=2):
     '''
 
     '''
-    return npj.mean(npj.abs(f_close(x.flatten())-f_open(x.flatten()))**p) * 100
+    return npj.mean(npj.abs(f_close(x)-f_open(x)).flatten()**p) * 100
 
-def M_diff_identity_open(x,f_open,p=1):
+def M_diff_identity_open(x,f_open,p=2):
     '''
 
     '''
-    return npj.mean(npj.abs(x.flatten()-f_open(x.flatten()))**p) * 100
+    return npj.mean(npj.abs(x-f_open(x)).flatten()**p) * 100
 
-def M_diff_identity_close(x,f_close,p=1):
+def M_diff_identity_close(x,f_close,p=2):
     '''
 
     '''
-    return npj.mean(npj.abs(x.flatten()-f_close(x.flatten()))**p) * 100
+    return npj.mean(npj.abs(x-f_close(x)).flatten()**p) * 100
 

--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -320,11 +320,8 @@ class Near2FarFields(ObjectiveQuantity):
         dJ = dJ.flatten()
         farpt_list = np.array([list(pi) for pi in self.far_pts]).flatten()
         far_pt0 = self.far_pts[0]
-        far_pt_vec = py_v3_to_vec(
-            self.sim.dimensions,
-            far_pt0,
-            self.sim.is_cylindrical,
-        )
+        far_pt_vec = py_v3_to_vec(self.sim.dimensions, far_pt0,
+                                  self.sim.is_cylindrical)
 
         all_nearsrcdata = self._monitor.swigobj.near_sourcedata(
             far_pt_vec, farpt_list, self._nfar_pts, dJ)

--- a/python/adjoint/optimization_problem.py
+++ b/python/adjoint/optimization_problem.py
@@ -1,6 +1,6 @@
 import meep as mp
 import numpy as np
-from autograd import grad, jacobian
+from jax import grad, jacobian
 from collections import namedtuple
 
 Grid = namedtuple('Grid', ['x', 'y', 'z', 'w'])

--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -80,11 +80,11 @@ def gather_monitor_values(monitors: List[ObjectiveQuantity]) -> onp.ndarray:
     Args:
       monitors: the mode monitors.
 
-    Returns:
-      a rank-2 ndarray, where the dimensions are (monitor, frequency), of dtype
-      complex128.  Note that these values refer to the mode as oriented (i.e. they
-      are unidirectional).
-    """
+  Returns:
+    a rank-2 ndarray, where the dimensions are (monitor, frequency), of dtype
+    complex128.  Note that these values refer to the mode as oriented (i.e. they
+    are unidirectional).
+  """
     monitor_values = []
     for monitor in monitors:
         monitor_values.append(monitor())
@@ -101,21 +101,21 @@ def gather_design_region_fields(
 ) -> List[List[onp.ndarray]]:
     """Collects the design region DFT fields from the simulation.
 
-    Args:
-     simulation: the simulation object.
-     design_region_monitors: the installed design region monitors.
-     frequencies: the frequencies to monitor.
+  Args:
+   simulation: the simulation object.
+   design_region_monitors: the installed design region monitors.
+   frequencies: the frequencies to monitor.
 
-    Returns:
-      A list of lists.  Each entry (list) in the overall list corresponds one-to-
-      one with a declared design region.  For each such contained list, the
-      entries correspond to the field components that are monitored.  The entries
-      are ndarrays of rank 4 with dimensions (freq, x, y, (z-or-pad)).
+  Returns:
+    A list of lists.  Each entry (list) in the overall list corresponds one-to-
+    one with a declared design region.  For each such contained list, the
+    entries correspond to the field components that are monitored.  The entries
+    are ndarrays of rank 4 with dimensions (freq, x, y, (z-or-pad)).
 
-      The design region fields are sampled on the *Yee grid*.  This makes them
-      fairly awkward to inspect directly.  Their primary use case is supporting
-      gradient calculations.
-    """
+    The design region fields are sampled on the *Yee grid*.  This makes them
+    fairly awkward to inspect directly.  Their primary use case is supporting
+    gradient calculations.
+  """
     fwd_fields = []
     for monitor in design_region_monitors:
         fields_by_component = []
@@ -134,17 +134,17 @@ def validate_and_update_design(
         design_variables: Iterable[onp.ndarray]) -> None:
     """Validate the design regions and variables.
 
-    In particular the design variable should be 1,2,3-D and the design region
-    shape should match the design variable shape after dimension expansion.
-    The arguments are modified in place.
+  In particular the design variable should be 1,2,3-D and the design region
+  shape should match the design variable shape after dimension expansion.
+  The arguments are modified in place.
 
     Args:
       design_regions: List of mpa.DesignRegion,
       design_variables: Iterable with numpy arrays representing design variables.
 
-    Raises:
-      ValueError if the validation of dimensions fails.
-    """
+  Raises:
+    ValueError if the validation of dimensions fails.
+  """
     for i, (design_region,
             design_variable) in enumerate(zip(design_regions,
                                               design_variables)):

--- a/python/adjoint/wrapper.py
+++ b/python/adjoint/wrapper.py
@@ -64,48 +64,46 @@ _reduce_fn = onp.max
 class MeepJaxWrapper:
     """Wraps a Meep simulation object into a JAX-differentiable callable.
 
-    Attributes:
-        simulation: the pre-configured Meep simulation object.
-        sources: a list of Meep sources for the forward simulation.
-        monitors: a list of eigenmode coefficient monitors from the `meep.adjoint`
-          module.
-        design_regions: a list of design regions from the `meep.adjoint` module.
-        frequencies: the list of frequencies, in normalized Meep units.
-        measurement_interval: the time interval between DFT field convergence
-          measurements, in Meep time units. The default value is 50.
-        dft_field_components: a list of Meep field components, such as `mp.Ex`,
-          `mp.Hy`, etc, whose DFT will be monitored for convergence to stop the
-          simulation. The default is `mp.Ez`.
-        dft_threshold: the threshold for DFT field convergence. Once the norm of the
-          change in the fields (the maximum over all design regions and field
-          components) is less than this value, the simulation will be stopped. The
-          default value is 1e-6.
-        minimum_run_time: the minimum run time of the simulation, in Meep time
-          units. The default value is 0.
-        maximum_run_time: the maximum run time of the simulation, in Meep time
-          units. The default value is infinity.
-        until_after_sources: whether `maximum_run_time` should be ignored until the
-          sources have turned off. This parameter specifies whether `until` or
-          `until_after_sources` is used. See
-          https://meep.readthedocs.io/en/latest/Python_User_Interface/#Simulation
+  Attributes:
+      simulation: the pre-configured Meep simulation object.
+      sources: a list of Meep sources for the forward simulation.
+      monitors: a list of eigenmode coefficient monitors from the `meep.adjoint`
+        module.
+      design_regions: a list of design regions from the `meep.adjoint` module.
+      frequencies: the list of frequencies, in normalized Meep units.
+      measurement_interval: the time interval between DFT field convergence
+        measurements, in Meep time units. The default value is 50.
+      dft_field_components: a list of Meep field components, such as `mp.Ex`,
+        `mp.Hy`, etc, whose DFT will be monitored for convergence to stop the
+        simulation. The default is `mp.Ez`.
+      dft_threshold: the threshold for DFT field convergence. Once the norm of the
+        change in the fields (the maximum over all design regions and field
+        components) is less than this value, the simulation will be stopped. The
+        default value is 1e-6.
+      minimum_run_time: the minimum run time of the simulation, in Meep time
+        units. The default value is 0.
+      maximum_run_time: the maximum run time of the simulation, in Meep time
+        units. The default value is infinity.
+      until_after_sources: whether `maximum_run_time` should be ignored until the
+        sources have turned off. This parameter specifies whether `until` or
+        `until_after_sources` is used. See
+        https://meep.readthedocs.io/en/latest/Python_User_Interface/#Simulation
           for more information. The default is true.
-    """
+  """
     _log_fn = print
 
-    def __init__(
-        self,
-        simulation: mp.Simulation,
-        sources: List[mp.Source],
-        monitors: List[EigenmodeCoefficient],
-        design_regions: List[DesignRegion],
-        frequencies: List[float],
-        measurement_interval: float = 50.0,
-        dft_field_components: Tuple[int, ...] = (mp.Ez, ),
-        dft_threshold: float = 1e-6,
-        minimum_run_time: float = 0,
-        maximum_run_time: float = onp.inf,
-        until_after_sources: bool = True,
-    ):
+    def __init__(self,
+                 simulation: mp.Simulation,
+                 sources: List[mp.Source],
+                 monitors: List[EigenmodeCoefficient],
+                 design_regions: List[DesignRegion],
+                 frequencies: List[float],
+                 measurement_interval: float = 50.0,
+                 dft_field_components: Tuple[int, ...] = (mp.Ez, ),
+                 dft_threshold: float = 1e-6,
+                 minimum_run_time: float = 0,
+                 maximum_run_time: float = onp.inf,
+                 until_after_sources: bool = True):
         self.simulation = simulation
         self.sources = sources
         self.monitors = monitors
@@ -124,20 +122,20 @@ class MeepJaxWrapper:
     def __call__(self, designs: List[jnp.ndarray]) -> jnp.ndarray:
         """Performs a Meep simulation, taking a list of designs and returning mode overlaps.
 
-        Args:
-          designs: a list of design variables as 1D, 2D, or 3D JAX arrays. Valid shapes for
-          design variables are (Nx, Ny, Nz) where Nx{y,z} match the elements of the
-          `grid_size` constructor argument of Meep's `MaterialGrid` used for the
-          corresponding design region. Singleton dimensions of the `grid_size` may be
-          omitted from the corresponding design variable. For example, a design variable
-          with a shape of either (10, 20) or (10, 20, 1) would be compatible with a
-          `grid_size` of (10, 20, 1). Similarly, a design variable with shapes of (25,),
-          (25, 1), or (25, 1, 1) would be compatible with a `grid_size` of (25, 1, 1).
+    Args:
+      designs: a list of design variables as 1D, 2D, or 3D JAX arrays. Valid shapes for
+      design variables are (Nx, Ny, Nz) where Nx{y,z} match the elements of the
+      `grid_size` constructor argument of Meep's `MaterialGrid` used for the
+      corresponding design region. Singleton dimensions of the `grid_size` may be
+      omitted from the corresponding design variable. For example, a design variable
+      with a shape of either (10, 20) or (10, 20, 1) would be compatible with a
+      `grid_size` of (10, 20, 1). Similarly, a design variable with shapes of (25,),
+      (25, 1), or (25, 1, 1) would be compatible with a `grid_size` of (25, 1, 1).
 
-        Returns:
-          a complex-valued JAX ndarray of differentiable mode monitor overlaps values with
-          a shape of (num monitors, num frequencies).
-        """
+    Returns:
+      a complex-valued JAX ndarray of differentiable mode monitor overlaps values with
+      a shape of (num monitors, num frequencies).
+    """
         return self._simulate_fn(designs)
 
     def _reset_convergence_measurement(self,
@@ -202,19 +200,15 @@ class MeepJaxWrapper:
         self._reset_convergence_measurement(design_region_monitors)
         self.simulation.run(**sim_run_args)
 
-        return utils.gather_design_region_fields(
-            self.simulation,
-            design_region_monitors,
-            self.frequencies,
-        )
+        return utils.gather_design_region_fields(self.simulation,
+                                                 design_region_monitors,
+                                                 self.frequencies)
 
-    def _calculate_vjps(
-        self,
-        fwd_fields,
-        adj_fields,
-        design_variable_shapes,
-        sum_freq_partials=True,
-    ):
+    def _calculate_vjps(self,
+                        fwd_fields,
+                        adj_fields,
+                        design_variable_shapes,
+                        sum_freq_partials=True):
         """Calculates the VJP for a given set of forward and adjoint fields."""
         return utils.calculate_vjps(
             self.simulation,
@@ -298,19 +292,19 @@ class MeepJaxWrapper:
     def _simulation_run_callback(self, sim: mp.Simulation) -> bool:
         """A callback function returning `True` when the simulation should stop.
 
-        This is a step function that gets called at each time step of the Meep
-        simulation, taking a Meep simulation object as an input and returning `True`
-        when the simulation should be terminated and returning `False` when the
-        simulation should continue. The resulting step function is designed to be
-        used with the `until` and `until_after_sources` arguments of the Meep
-        simulation `run()` routine.
+    This is a step function that gets called at each time step of the Meep
+    simulation, taking a Meep simulation object as an input and returning `True`
+    when the simulation should be terminated and returning `False` when the
+    simulation should continue. The resulting step function is designed to be
+    used with the `until` and `until_after_sources` arguments of the Meep
+    simulation `run()` routine.
 
-        Args:
-          sim: a Meep simulation object.
+    Args:
+      sim: a Meep simulation object.
 
-        Returns:
-          a boolean indicating whether the simulation should be terminated.
-        """
+    Returns:
+      a boolean indicating whether the simulation should be terminated.
+    """
         current_meep_time = sim.round_time()
         if current_meep_time <= self._last_measurement_meep_time + self.measurement_interval:
             return False


### PR DESCRIPTION
Updates all the adjoint filters/projections to:
* use `jax` rather than `autograd`.
* filter/project along any arbitrary dimension (i.e. support for 1D, 2D, and 3D designs)
* simplifies the interface for various filters/projections
* various bug fixes

TODO
- [ ] Update adjoint test with new filter function API
- [ ] Update tutorials
- [ ] Allow for different filter radii in each dimension (for nonuniform lengthscale constraints)

@mochen4 to pull into an existing dev branch, make sure you rebase on top of `master`, as described [here](https://github.com/NanoComp/meep/pull/1590#issuecomment-854951694).