### PR TITLE
Run `pip install` unconditionally in CI workflow

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -123,7 +123,6 @@ jobs:
         restore-keys: ${{ runner.os }}-py${{ matrix.python-version }}-mpi-${{ matrix.enable-mpi }}-pip-
 
     - name: Install Python dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
       run: pip install -r python/requirements.txt
 
     - name: Install mpi4py


### PR DESCRIPTION
The cache is not guaranteed to be complete or up to date. The CI workflow is currently not running any of the Python tests because of a missing Numpy package.