### PR TITLE
check if the volume should be split into two parts in split_by_cost before splitting

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -92,7 +92,7 @@ static binary_partition *split_by_cost(int n, grid_volume gvol, bool fragment_co
       gvol.num_direction(best_split_direction);
     binary_partition *bp_split = new binary_partition(best_split_direction, best_split_position);
     const int num_left = (size_t)(left_effort_fraction * n + 0.5);
-    if (num_left > 0) {
+    if (num_left > 0 && num_left < n) {
       grid_volume left_gvol = gvol.split_at_fraction(false, best_split_point, best_split_direction);
       bp_split->left = split_by_cost(num_left, left_gvol, fragment_cost);
       grid_volume right_gvol = gvol.split_at_fraction(true, best_split_point, best_split_direction);

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -91,11 +91,13 @@ static binary_partition *split_by_cost(int n, grid_volume gvol, bool fragment_co
       (gvol.surroundings().in_direction(best_split_direction) * best_split_point) /
       gvol.num_direction(best_split_direction);
     binary_partition *bp_split = new binary_partition(best_split_direction, best_split_position);
-    grid_volume left_gvol = gvol.split_at_fraction(false, best_split_point, best_split_direction);
     const int num_left = (size_t)(left_effort_fraction * n + 0.5);
-    bp_split->left = split_by_cost(num_left, left_gvol, fragment_cost);
-    grid_volume right_gvol = gvol.split_at_fraction(true, best_split_point, best_split_direction);
-    bp_split->right = split_by_cost(n - num_left, right_gvol, fragment_cost);
+    if (num_left > 0) {
+      grid_volume left_gvol = gvol.split_at_fraction(false, best_split_point, best_split_direction);
+      bp_split->left = split_by_cost(num_left, left_gvol, fragment_cost);
+      grid_volume right_gvol = gvol.split_at_fraction(true, best_split_point, best_split_direction);
+      bp_split->right = split_by_cost(n - num_left, right_gvol, fragment_cost);
+    }
     return bp_split;
   }
 }


### PR DESCRIPTION
Adds a check to the `split_by_cost` routine to determine whether the `grid_volume` actually needs to be split into two parts prior to the actual splitting based on a *non-zero* number of chunks in the left half of the splitting. I discovered this check was necessary because the cost-splitting routine (`split_chunks_evenly=False`) was aborting with this error when trying to find the cell partition for certain configurations:

https://github.com/NanoComp/meep/blob/bcb90f30951c1a4a2d008ced0cd32e159b3e0098/src/vec.cpp#L1040