### PR TITLE
Prevent memory leaks in binary_partition

### DIFF
--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -1042,34 +1042,34 @@ void gobj_list_freearg(geometric_object_list* objs) {
     delete[] objs->items;
 }
 
-static meep::binary_partition *py_bp_to_bp(PyObject *pybp) {
-    meep::binary_partition *bp = NULL;
-    if (pybp == Py_None) return bp;
+static std::unique_ptr<meep::binary_partition> py_bp_to_bp(PyObject *pybp) {
+  std::unique_ptr<meep::binary_partition> bp;
+  if (pybp == Py_None) return bp;
 
-    PyObject *id = PyObject_GetAttrString(pybp, "proc_id");
-    PyObject *split_dir = PyObject_GetAttrString(pybp, "split_dir");
-    PyObject *split_pos = PyObject_GetAttrString(pybp, "split_pos");
-    PyObject *left = PyObject_GetAttrString(pybp, "left");
-    PyObject *right = PyObject_GetAttrString(pybp, "right");
+  PyObject *id = PyObject_GetAttrString(pybp, "proc_id");
+  PyObject *split_dir = PyObject_GetAttrString(pybp, "split_dir");
+  PyObject *split_pos = PyObject_GetAttrString(pybp, "split_pos");
+  PyObject *left = PyObject_GetAttrString(pybp, "left");
+  PyObject *right = PyObject_GetAttrString(pybp, "right");
 
-    if (!id || !split_dir || !split_pos || !left || !right) {
-      meep::abort("BinaryPartition class object is incorrectly defined.");
-    }
+  if (!id || !split_dir || !split_pos || !left || !right) {
+    meep::abort("BinaryPartition class object is incorrectly defined.");
+  }
 
-    if (PyLong_Check(id)) {
-         bp = new meep::binary_partition(PyLong_AsLong(id));
-    } else {
-         bp = new meep::binary_partition(direction(PyLong_AsLong(split_dir)), PyFloat_AsDouble(split_pos));
-         bp->left = py_bp_to_bp(left);
-         bp->right = py_bp_to_bp(right);
-    }
+  if (PyLong_Check(id)) { bp.reset(new meep::binary_partition(PyLong_AsLong(id))); }
+  else {
+    bp.reset(new meep::binary_partition(
+        meep::split_plane{direction(PyLong_AsLong(split_dir)), PyFloat_AsDouble(split_pos)},
+        py_bp_to_bp(left),
+        py_bp_to_bp(right)));
+  }
 
-    Py_XDECREF(id);
-    Py_XDECREF(split_dir);
-    Py_XDECREF(split_pos);
-    Py_XDECREF(left);
-    Py_XDECREF(right);
-    return bp;
+  Py_XDECREF(id);
+  Py_XDECREF(split_dir);
+  Py_XDECREF(split_pos);
+  Py_XDECREF(left);
+  Py_XDECREF(right);
+  return bp;
 }
 
 static PyObject *py_binary_partition_object() {

--- a/scheme/Makefile.am
+++ b/scheme/Makefile.am
@@ -39,7 +39,7 @@ endif
 
 # workaround missing namespace prefix in swig
 meep_renames.i: $(LIBHDRS)
-	(echo "// AUTOMATICALLY GENERATED -- DO NOT EDIT"; perl -pe 's/^ *class +([A-Za-z_0-9:]*)( *| *:[^{]*){.*$$/%rename(meep_\1) meep::\1;/' $(LIBHDRS) | grep "%rename" | sort -u; echo; grep -hv typedef $(LIBHDRS) | perl -pe 's/(inline|const|extern|static) +//g' | perl -pe 's/^[A-Za-z_0-9:<>]+[* ]+([A-Za-z_0-9:]*) *\(.*$$/%rename(meep_\1) meep::\1;/' | grep "%rename" | sort -u; ) > $@
+	(echo "// AUTOMATICALLY GENERATED -- DO NOT EDIT"; perl -pe 's/^ *class +([A-Za-z_0-9:]*)( *| *:[^{]*){.*$$/%rename(meep_\1) meep::\1;/' $(LIBHDRS) | grep "%rename" | sort -u; echo; grep -hv typedef $(LIBHDRS) | perl -pe 's/(inline|const|extern|static) +//g' | perl -pe 's/^[A-Za-z_0-9:<>]+[* ]+([A-Za-z_0-9:]*) *\(.*$$/%rename(meep_\1) meep::\1;/' | grep "%rename" | sed '/choose_chunkdivision/d' | sort -u; ) > $@
 
 # work around bug in swig, where it doesn't prepend namespace to friend funcs
 meep_swig_bug_workaround.i: $(LIBHDRS)

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -280,6 +280,7 @@ static meep::vec my_kpoint_func(double freq, int mode, void *user_data) {
 
 %warnfilter(302,325,451,503,509);
 
+%ignore meep::choose_chunkdivision;
 %ignore meep_geom::fragment_stats;
 
 %include "meep_renames.i"
@@ -298,3 +299,4 @@ static meep::vec my_kpoint_func(double freq, int mode, void *user_data) {
 %}
 
 %include "meep-ctl-swig.hpp"
+


### PR DESCRIPTION
* Use unique_ptrs to take ownership of the left and right subtrees.
* Introduce the struct `split_plane` to combine split direction and
position. This struct could be used in the future to simplify the
signatures of several volume related functions.
* Adjust SWIG typemaps
* Hide `choose_chunkdivision` from Python.