### PR TITLE
Fix memory leaks in `src_vol`

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1470,6 +1470,7 @@ void _get_gradient(PyObject *grad, PyObject *fields_a, PyObject *fields_f, PyObj
 %ignore is_medium;
 %ignore is_metal;
 %ignore meep::choose_chunkdivision;
+%ignore meep::fields_chunk;
 %ignore meep::infinity;
 
 %ignore std::vector<meep::volume>::vector(size_type);

--- a/scheme/Makefile.am
+++ b/scheme/Makefile.am
@@ -39,7 +39,7 @@ endif
 
 # workaround missing namespace prefix in swig
 meep_renames.i: $(LIBHDRS)
-	(echo "// AUTOMATICALLY GENERATED -- DO NOT EDIT"; perl -pe 's/^ *class +([A-Za-z_0-9:]*)( *| *:[^{]*){.*$$/%rename(meep_\1) meep::\1;/' $(LIBHDRS) | grep "%rename" | sort -u; echo; grep -hv typedef $(LIBHDRS) | perl -pe 's/(inline|const|extern|static) +//g' | perl -pe 's/^[A-Za-z_0-9:<>]+[* ]+([A-Za-z_0-9:]*) *\(.*$$/%rename(meep_\1) meep::\1;/' | grep "%rename" | sed '/choose_chunkdivision/d' | sort -u; ) > $@
+	(echo "// AUTOMATICALLY GENERATED -- DO NOT EDIT"; perl -pe 's/^ *class +([A-Za-z_0-9:]*)( *| *:[^{]*){.*$$/%rename(meep_\1) meep::\1;/' $(LIBHDRS) | grep "%rename" | sed '/meep_fields_chunk/d' | sort -u; echo; grep -hv typedef $(LIBHDRS) | perl -pe 's/(inline|const|extern|static) +//g' | perl -pe 's/^[A-Za-z_0-9:<>]+[* ]+([A-Za-z_0-9:]*) *\(.*$$/%rename(meep_\1) meep::\1;/' | grep "%rename" | sed '/choose_chunkdivision/d' | sort -u; ) > $@
 
 # work around bug in swig, where it doesn't prepend namespace to friend funcs
 meep_swig_bug_workaround.i: $(LIBHDRS)

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -281,6 +281,7 @@ static meep::vec my_kpoint_func(double freq, int mode, void *user_data) {
 %warnfilter(302,325,451,503,509);
 
 %ignore meep::choose_chunkdivision;
+%ignore meep::fields_chunk;
 %ignore meep_geom::fragment_stats;
 
 %include "meep_renames.i"

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -174,18 +174,18 @@ static void get_source_slice_chunkloop(fields_chunk *fc, int ichnk, component cg
   if (has_direction(dim, Y)) NY = ((slice_imax - slice_imin).in_direction(Y) / 2) + 1;
 
   for (int ft = 0; ft < NUM_FIELD_TYPES; ft++)
-    for (src_vol *s = fc->sources[ft]; s; s = s->next) {
+    for (const src_vol &s : fc->get_sources(static_cast<field_type>(ft))) {
       component cS = S.transform(data->source_component, -sn);
-      if (s->c != cS) continue;
+      if (s.c != cS) continue;
 
       // loop over point sources in this src_vol. for each point source,
       // the src_vol stores the amplitude and the global index of the
       // symmetry-parent grid point, from which we need to compute the
       // local index of the symmetry-child grid point within this
       // slice (that is, if it even lies within the slice)
-      for (size_t npt = 0; npt < s->npts; npt++) {
-        complex<double> amp = s->A[npt];
-        ptrdiff_t chunk_index = s->index[npt];
+      for (size_t npt = 0; npt < s.num_points(); npt++) {
+        const complex<double> &amp = s.amplitude_at(npt);
+        ptrdiff_t chunk_index = s.index_at(npt);
         ivec iloc_parent = fc->gv.iloc(Dielectric, chunk_index);
         ivec iloc_child = S.transform(iloc_parent, sn) + shift;
         if (!in_subgrid(slice_imin, iloc_child, slice_imax)) continue; // source point outside slice

--- a/src/dft_ldos.cpp
+++ b/src/dft_ldos.cpp
@@ -102,41 +102,41 @@ void dft_ldos::update(fields &f) {
 
   for (int ic = 0; ic < f.num_chunks; ic++)
     if (f.chunks[ic]->is_mine()) {
-      for (src_vol *sv = f.chunks[ic]->sources[D_stuff]; sv; sv = sv->next) {
-        component c = direction_component(Ex, component_direction(sv->c));
+      for (const src_vol &sv : f.chunks[ic]->get_sources(D_stuff)) {
+        component c = direction_component(Ex, component_direction(sv.c));
         realnum *fr = f.chunks[ic]->f[c][0];
         realnum *fi = f.chunks[ic]->f[c][1];
         if (fr && fi) // complex E
-          for (size_t j = 0; j < sv->npts; j++) {
-            const ptrdiff_t idx = sv->index[j];
-            const complex<double> A = sv->A[j];
+          for (size_t j = 0; j < sv.num_points(); j++) {
+            const ptrdiff_t idx = sv.index_at(j);
+            const complex<double>& A = sv.amplitude_at(j);
             EJ += complex<double>(fr[idx], fi[idx]) * conj(A);
             Jsum += abs(A);
           }
         else if (fr) { // E is purely real
-          for (size_t j = 0; j < sv->npts; j++) {
-            const ptrdiff_t idx = sv->index[j];
-            const complex<double> A = sv->A[j];
+          for (size_t j = 0; j < sv.num_points(); j++) {
+            const ptrdiff_t idx = sv.index_at(j);
+            const complex<double>& A = sv.amplitude_at(j);
             EJ += double(fr[idx]) * conj(A);
             Jsum += abs(A);
           }
         }
       }
-      for (src_vol *sv = f.chunks[ic]->sources[B_stuff]; sv; sv = sv->next) {
-        component c = direction_component(Hx, component_direction(sv->c));
+      for (const src_vol& sv : f.chunks[ic]->get_sources(B_stuff)) {
+        component c = direction_component(Hx, component_direction(sv.c));
         realnum *fr = f.chunks[ic]->f[c][0];
         realnum *fi = f.chunks[ic]->f[c][1];
         if (fr && fi) // complex H
-          for (size_t j = 0; j < sv->npts; j++) {
-            const ptrdiff_t idx = sv->index[j];
-            const complex<double> A = sv->A[j];
+          for (size_t j = 0; j < sv.num_points(); j++) {
+            const ptrdiff_t idx = sv.index_at(j);
+            const complex<double>& A = sv.amplitude_at(j);
             HJ += complex<double>(fr[idx], fi[idx]) * conj(A);
             Jsum += abs(A);
           }
         else if (fr) { // H is purely real
-          for (size_t j = 0; j < sv->npts; j++) {
-            const ptrdiff_t idx = sv->index[j];
-            const complex<double> A = sv->A[j];
+          for (size_t j = 0; j < sv.num_points(); j++) {
+            const ptrdiff_t idx = sv.index_at(j);
+            const complex<double>& A = sv.amplitude_at(j);
             HJ += double(fr[idx]) * conj(A);
             Jsum += abs(A);
           }

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1370,7 +1370,7 @@ public:
   bool zero_fields_near_cylorigin; // fields=0 m pixels near r=0 for stability
   double beta;
   int is_real;
-  src_vol *sources[NUM_FIELD_TYPES];
+  std::vector<src_vol> sources[NUM_FIELD_TYPES];
   structure_chunk *new_s;
   structure_chunk *s;
   const char *outdir;
@@ -1398,6 +1398,10 @@ public:
 
   std::complex<double> get_chi1inv(component, direction, const ivec &iloc,
                                    double frequency = 0) const;
+  // Returns the vector of sources volumes for field type `ft`.
+  const std::vector<src_vol> &get_sources(field_type ft) const { return sources[ft]; }
+  // Adds a source volume of field type `ft` and takes ownership of `src`.
+  void add_source(field_type ft, src_vol &&src);
 
   void backup_component(component c);
   void average_with_backup(component c);

--- a/src/step.cpp
+++ b/src/step.cpp
@@ -199,22 +199,22 @@ void fields::step_source(field_type ft, bool including_integrated) {
 }
 void fields_chunk::step_source(field_type ft, bool including_integrated) {
   if (doing_solve_cw && !including_integrated) return;
-  for (src_vol *sv = sources[ft]; sv; sv = sv->next) {
-    component c = direction_component(first_field_component(ft), component_direction(sv->c));
-    const realnum *cndinv = s->condinv[c][component_direction(sv->c)];
-    if ((including_integrated || !sv->t->is_integrated) && f[c][0] &&
-        ((ft == D_stuff && is_electric(sv->c)) || (ft == B_stuff && is_magnetic(sv->c)))) {
+  for (const src_vol &sv : sources[ft]) {
+    component c = direction_component(first_field_component(ft), component_direction(sv.c));
+    const realnum *cndinv = s->condinv[c][component_direction(sv.c)];
+    if ((including_integrated || !sv.t()->is_integrated) && f[c][0] &&
+        ((ft == D_stuff && is_electric(sv.c)) || (ft == B_stuff && is_magnetic(sv.c)))) {
       if (cndinv)
-        for (size_t j = 0; j < sv->npts; j++) {
-          const ptrdiff_t i = sv->index[j];
-          const complex<double> A = sv->current(j) * dt * double(cndinv[i]);
+        for (size_t j = 0; j < sv.num_points(); j++) {
+          const ptrdiff_t i = sv.index_at(j);
+          const complex<double> A = sv.current(j) * dt * double(cndinv[i]);
           f[c][0][i] -= real(A);
           if (!is_real) f[c][1][i] -= imag(A);
         }
       else
-        for (size_t j = 0; j < sv->npts; j++) {
-          const complex<double> A = sv->current(j) * dt;
-          const ptrdiff_t i = sv->index[j];
+        for (size_t j = 0; j < sv.num_points(); j++) {
+          const complex<double> A = sv.current(j) * dt;
+          const ptrdiff_t i = sv.index_at(j);
           f[c][0][i] -= real(A);
           if (!is_real) f[c][1][i] -= imag(A);
         }

--- a/src/update_eh.cpp
+++ b/src/update_eh.cpp
@@ -44,11 +44,12 @@ bool fields_chunk::update_eh(field_type ft, bool skip_w_components) {
 
   bool have_int_sources = false;
   if (!doing_solve_cw) {
-    for (src_vol *sv = sources[ft2]; sv; sv = sv->next)
-      if (sv->t->is_integrated) {
+    for (const src_vol &sv : sources[ft2]) {
+      if (sv.t()->is_integrated) {
         have_int_sources = true;
         break;
       }
+    }
   }
 
   FOR_FT_COMPONENTS(ft, ec) {
@@ -100,12 +101,12 @@ bool fields_chunk::update_eh(field_type ft, bool skip_w_components) {
   // Next, subtract time-integrated sources (i.e. polarizations, not currents)
 
   if (have_f_minus_p && !doing_solve_cw) {
-    for (src_vol *sv = sources[ft2]; sv; sv = sv->next) {
-      if (sv->t->is_integrated && f[sv->c][0] && ft == type(sv->c)) {
-        component c = field_type_component(ft2, sv->c);
-        for (size_t j = 0; j < sv->npts; ++j) {
-          const complex<double> A = sv->dipole(j);
-          DOCMP { f_minus_p[c][cmp][sv->index[j]] -= (cmp) ? imag(A) : real(A); }
+    for (const src_vol &sv : sources[ft2]) {
+      if (sv.t()->is_integrated && f[sv.c][0] && ft == type(sv.c)) {
+        component c = field_type_component(ft2, sv.c);
+        for (size_t j = 0; j < sv.num_points(); ++j) {
+          const complex<double> A = sv.dipole(j);
+          DOCMP { f_minus_p[c][cmp][sv.index_at(j)] -= (cmp) ? imag(A) : real(A); }
         }
       }
     }


### PR DESCRIPTION
The old implementation's weak point was the `add_to` method, which
sometimes transferred memory ownership correctly and sometimes did not.

* Rewrite `src_vol` using STL containers.
* Replace the linked list of source volumes in `fields_chunk` with a
vector. Adjust code that iterates over source volumes accordingly.
* Exclude `fields_chunk` from SWIG wrappers.