### PR TITLE
Add code coverage to CI

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -170,7 +170,7 @@ jobs:
         popd
 
     - name: Generate coverage report
-      if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }
+      if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }}
       run: |
         pushd python/ &&
         coverage xml -i &&

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -125,6 +125,10 @@ jobs:
     - name: Install Python dependencies
       run: pip install -r python/requirements.txt
 
+    - name: Install coverage
+      if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }}
+      run: pip install coverage==4.5.4
+
     - name: Install mpi4py
       if: ${{ matrix.enable-mpi && steps.cache.outputs.cache-hit != true }}
       run: pip install mpi4py
@@ -136,28 +140,60 @@ jobs:
         echo "MEEP_VERSION=${MEEP_VERSION}" >> $GITHUB_ENV
 
     - name: Run configure
+      if: ${{ !(matrix.enable-mpi == false && matrix.python-version == 3.6) }}
       run: |
         mkdir -p build &&
         pushd build &&
         ../configure --enable-maintainer-mode --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF} &&
         popd
 
+    - name: Run configure
+      if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }}
+      run: ./configure --enable-maintainer-mode --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF}
+
+    - name: Run make
+      if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }}
+      run: make ${MKCHECKFLAGS}
+
+    - name: Run make check
+      if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }}
+      run: |
+        pushd python/ &&
+        make ${MKCHECKFLAGS} check &&
+        popd
+
     - name: Run make distcheck
+      if: ${{ !(matrix.enable-mpi == false && matrix.python-version == 3.6) }}
       run: |
         pushd build &&
         make ${MKCHECKFLAGS} distcheck DISTCHECK_CONFIGURE_FLAGS="--with-libctl=${HOME}/local/share/libctl ${MPICONF}" &&
         popd
 
+    - name: Generate coverage report
+      if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }
+      run: |
+        pushd python/ &&
+        coverage xml -i &&
+        popd
+
+    - name: Upload coverage to Codecov
+      if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }}
+      uses: codecov/codecov-action@v1
+      with:
+        files: ./python/coverage.xml
+        env_vars: ${{ runner.os }},${{ matrix.python-version }}
+        fail_ci_if_error: true
+
     - name: Archive C++ test logs
+      if: ${{ failure() && !(matrix.enable-mpi == false && matrix.python-version == 3.6) }}
       uses: actions/upload-artifact@v2
-      if: failure()
       with:
         name: cpp-tests-mpi-${{ matrix.enable-mpi }}-log
         path: ${{ github.workspace }}/build/meep-${{ env.MEEP_VERSION }}/_build/sub/tests/test-suite.log
 
     - name: Archive Python test logs
+      if: ${{ failure() && !(matrix.enable-mpi == false && matrix.python-version == 3.6) }}
       uses: actions/upload-artifact@v2
-      if: failure()
       with:
         name: py${{ matrix.python-version }}-tests-mpi-${{ matrix.enable-mpi }}-log
         path: ${{ github.workspace }}/build/meep-${{ env.MEEP_VERSION }}/_build/sub/python/test-suite.log

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -173,6 +173,7 @@ jobs:
       if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }}
       run: |
         pushd python/ &&
+        coverage report -i &&
         coverage xml -i &&
         popd
 

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -181,9 +181,7 @@ jobs:
       if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }}
       uses: codecov/codecov-action@v1
       with:
-        files: ./python/coverage.xml
-        env_vars: ${{ runner.os }},${{ matrix.python-version }}
-        fail_ci_if_error: true
+        files: ${{ github.workspace }}/python/coverage.xml
 
     - name: Archive C++ test logs
       if: ${{ failure() && !(matrix.enable-mpi == false && matrix.python-version == 3.6) }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI](https://github.com/NanoComp/meep/actions/workflows/build-ci.yml/badge.svg)](https://github.com/NanoComp/meep/actions/workflows/build-ci.yml)
 [![Sanitizers](https://github.com/NanoComp/meep/actions/workflows/build-san.yml/badge.svg)](https://github.com/NanoComp/meep/actions/workflows/build-san.yml)
-[![codecov](https://codecov.io/gh/oskooi/meep/branch/master/graph/badge.svg?token=06W3NJS69D)](https://codecov.io/gh/oskooi/meep)
 [![Latest Docs](https://readthedocs.org/projects/meep/badge/?version=latest)](http://meep.readthedocs.io/en/latest/)
 ![Python versions 3.6–3.9](https://img.shields.io/badge/python-3.6%2C%203.7%2C%203.8%2C%203.9-brightgreen.svg)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/NanoComp/meep/actions/workflows/build-ci.yml/badge.svg)](https://github.com/NanoComp/meep/actions/workflows/build-ci.yml)
 [![Sanitizers](https://github.com/NanoComp/meep/actions/workflows/build-san.yml/badge.svg)](https://github.com/NanoComp/meep/actions/workflows/build-san.yml)
+[![codecov](https://codecov.io/gh/oskooi/meep/branch/master/graph/badge.svg?token=06W3NJS69D)](https://codecov.io/gh/oskooi/meep)
 [![Latest Docs](https://readthedocs.org/projects/meep/badge/?version=latest)](http://meep.readthedocs.io/en/latest/)
 ![Python versions 3.6–3.9](https://img.shields.io/badge/python-3.6%2C%203.7%2C%203.8%2C%203.9-brightgreen.svg)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+        target: auto
+    patch: false
+    changes: false
+
+comment: off
+
+ignore:
+  - "python/tests/*”

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,3 @@ coverage:
     changes: false
 
 comment: off
-
-ignore:
-  - "python/tests/*”

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,8 @@ coverage:
       default:
         informational: true
 
-comment: false
+comment:
+  layout: "reach, diff, files"
 
 fixes:
   - "meep/::python/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,13 @@
 coverage:
-  precision: 2
-  round: down
   status:
     project:
       default:
-        target: auto
-    patch: false
-    changes: false
+        informational: true
+    patch:
+      default:
+        informational: true
 
-comment: off
+comment: false
+
+fixes:
+  - "meep/::python/"

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -88,7 +88,7 @@ TESTS =                                   \
     $(WVG_SRC_TEST)
 
 if WITH_COVERAGE
-  PY_LOG_COMPILER = coverage run -a --source=$(top_srcdir)/python/meep --omit=$(top_srcdir)/python/tests/*,${HOME}/virtualenv/*,$(top_srcdir)/python/examples/*
+  PY_LOG_COMPILER = coverage run -a --source=$(top_srcdir)/python/meep --omit=$(top_srcdir)/python/tests/*,$(top_srcdir)/python/examples/*,$(top_srcdir)/python/meep/materials.py
 else
   PY_LOG_COMPILER = $(RUNCODE) $(PYTHON)
 endif

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -88,7 +88,7 @@ TESTS =                                   \
     $(WVG_SRC_TEST)
 
 if WITH_COVERAGE
-  PY_LOG_COMPILER = coverage run -a --omit=$(top_srcdir)/python/tests/*,${HOME}/virtualenv/*,$(top_srcdir)/python/examples/*
+  PY_LOG_COMPILER = coverage run -a --source=$(top_srcdir)/python/meep --omit=$(top_srcdir)/python/tests/*,${HOME}/virtualenv/*,$(top_srcdir)/python/examples/*
 else
   PY_LOG_COMPILER = $(RUNCODE) $(PYTHON)
 endif


### PR DESCRIPTION
Adds code coverage using [Coverage.py](https://coverage.readthedocs.io/en/coverage-5.0/index.html) to the CI via [CodeCov](https://github.com/codecov/codecov-action). ~~Setting this up requires activating [CodeCov](https://github.com/marketplace/actions/codecov)  for the `NanoComp` organization on GitHub (the link to the badge will also need to be updated).~~ Coverage is only run for serial Python 3.6. This setup is similar to the previous coveralls feature added in #550.

See this [link](https://codecov.io/gh/oskooi/meep/commit/3140ac89c872745cf3f98b59f90752656d82fca8/graphs) for a sample of what the output looks like. The current coverage for the entire Python API is 65.66%. For a breakdown by file for just the adjoint-solver module, see [here](https://codecov.io/gh/oskooi/meep/tree/3140ac89c872745cf3f98b59f90752656d82fca8/python/adjoint).