### PR TITLE
Store the binary partition in `structure`

### DIFF
--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -424,6 +424,13 @@ binary_partition::binary_partition(const split_plane &_split_plane,
   if (!left || !right) { meep::abort("Binary partition tree is required to be full"); }
 }
 
+binary_partition::binary_partition(const binary_partition& other) : proc_id{other.proc_id}, plane{other.plane} {
+  if (!other.is_leaf()) {
+    left.reset(new binary_partition(*other.left));
+    right.reset(new binary_partition(*other.right));
+  }
+}
+
 bool binary_partition::is_leaf() const { return !left && !right; }
 
 int binary_partition::get_proc_id() const {


### PR DESCRIPTION
* Store the binary partition - whether passed in externally or generated
via `choose_chunkdivision` in `structure` and expose it via a getter.
* Remove the unused default constructor of `structure`.
* Remove a redundant and unused copy constructor of `structure`.
* Clean up the copy constructor of `structure`.
* Make `binary_partition` copyable.

Prepares for making the BinaryPartition visible in Python (#1648).