### PR TITLE
Streamline communications

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1469,7 +1469,15 @@ void _get_gradient(PyObject *grad, PyObject *fields_a, PyObject *fields_f, PyObj
 %ignore is_medium;
 %ignore is_medium;
 %ignore is_metal;
+%ignore meep::all_in_or_out;
+%ignore meep::all_connect_phases;
 %ignore meep::choose_chunkdivision;
+%ignore meep::comms_key;
+%ignore meep::comms_key_hash_fn;
+%ignore meep::comms_manager;
+%ignore meep::comms_operation;
+%ignore meep::comms_sequence;
+%ignore meep::create_comms_manager;
 %ignore meep::fields_chunk;
 %ignore meep::infinity;
 

--- a/scheme/Makefile.am
+++ b/scheme/Makefile.am
@@ -39,7 +39,7 @@ endif
 
 # workaround missing namespace prefix in swig
 meep_renames.i: $(LIBHDRS)
-	(echo "// AUTOMATICALLY GENERATED -- DO NOT EDIT"; perl -pe 's/^ *class +([A-Za-z_0-9:]*)( *| *:[^{]*){.*$$/%rename(meep_\1) meep::\1;/' $(LIBHDRS) | grep "%rename" | sed '/meep_fields_chunk/d' | sort -u; echo; grep -hv typedef $(LIBHDRS) | perl -pe 's/(inline|const|extern|static) +//g' | perl -pe 's/^[A-Za-z_0-9:<>]+[* ]+([A-Za-z_0-9:]*) *\(.*$$/%rename(meep_\1) meep::\1;/' | grep "%rename" | sed '/choose_chunkdivision/d' | sort -u; ) > $@
+	(echo "// AUTOMATICALLY GENERATED -- DO NOT EDIT"; perl -pe 's/^ *class +([A-Za-z_0-9:]*)( *| *:[^{]*){.*$$/%rename(meep_\1) meep::\1;/' $(LIBHDRS) | grep "%rename" | sed '/meep_fields_chunk/d ; /meep_comms_manager/d ; /meep_comms_key_hash_fn/d' | sort -u; echo; grep -hv typedef $(LIBHDRS) | perl -pe 's/(inline|const|extern|static) +//g' | perl -pe 's/^[A-Za-z_0-9:<>]+[* ]+([A-Za-z_0-9:]*) *\(.*$$/%rename(meep_\1) meep::\1;/' | grep "%rename" | sed '/choose_chunkdivision/d ; /meep_create_comms_manager/d' | sort -u; ) > $@
 
 # work around bug in swig, where it doesn't prepend namespace to friend funcs
 meep_swig_bug_workaround.i: $(LIBHDRS)

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -280,7 +280,15 @@ static meep::vec my_kpoint_func(double freq, int mode, void *user_data) {
 
 %warnfilter(302,325,451,503,509);
 
+%ignore meep::all_in_or_out;
+%ignore meep::all_connect_phases;
 %ignore meep::choose_chunkdivision;
+%ignore meep::comms_key;
+%ignore meep::comms_key_hash_fn;
+%ignore meep::comms_manager;
+%ignore meep::comms_operation;
+%ignore meep::comms_sequence;
+%ignore meep::create_comms_manager;
 %ignore meep::fields_chunk;
 %ignore meep_geom::fragment_stats;
 
@@ -300,4 +308,3 @@ static meep::vec my_kpoint_func(double freq, int mode, void *user_data) {
 %}
 
 %include "meep-ctl-swig.hpp"
-

--- a/src/fields.cpp
+++ b/src/fields.cpp
@@ -58,11 +58,6 @@ fields::fields(structure *s, double m, double beta, bool zero_fields_near_cylori
   for (int i = 0; i < num_chunks; i++)
     chunks[i] = new fields_chunk(s->chunks[i], outdir, m, beta, zero_fields_near_cylorigin, i);
   FOR_FIELD_TYPES(ft) {
-    for (int ip = 0; ip < 3; ip++) {
-      comm_sizes[ft][ip] = new size_t[num_chunks * num_chunks];
-      for (int i = 0; i < num_chunks * num_chunks; i++)
-        comm_sizes[ft][ip][i] = 0;
-    }
     typedef realnum *realnum_ptr;
     comm_blocks[ft] = new realnum_ptr[num_chunks * num_chunks];
     for (int i = 0; i < num_chunks * num_chunks; i++)
@@ -116,11 +111,6 @@ fields::fields(const fields &thef)
   for (int i = 0; i < num_chunks; i++)
     chunks[i] = new fields_chunk(*thef.chunks[i], i);
   FOR_FIELD_TYPES(ft) {
-    for (int ip = 0; ip < 3; ip++) {
-      comm_sizes[ft][ip] = new size_t[num_chunks * num_chunks];
-      for (int i = 0; i < num_chunks * num_chunks; i++)
-        comm_sizes[ft][ip][i] = 0;
-    }
     typedef realnum *realnum_ptr;
     comm_blocks[ft] = new realnum_ptr[num_chunks * num_chunks];
     for (int i = 0; i < num_chunks * num_chunks; i++)
@@ -140,8 +130,6 @@ fields::~fields() {
     for (int i = 0; i < num_chunks * num_chunks; i++)
       delete[] comm_blocks[ft][i];
     delete[] comm_blocks[ft];
-    for (int ip = 0; ip < 3; ip++)
-      delete[] comm_sizes[ft][ip];
   }
   delete sources;
   delete fluxes;
@@ -770,6 +758,10 @@ double linear_interpolate(double rx, double ry, double rz, double *data,
               dz);
 
 #undef D
+}
+
+bool operator==(const comms_key &lhs, const comms_key &rhs) {
+  return (lhs.ft == rhs.ft) && (lhs.phase == rhs.phase) && (lhs.pair == rhs.pair);
 }
 
 } // namespace meep

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -17,7 +17,10 @@
 #ifndef MEEP_H
 #define MEEP_H
 
+#include <functional>
+#include <limits>
 #include <memory>
+#include <unordered_map>
 #include <stdio.h>
 #include <stddef.h>
 #include <math.h>
@@ -711,6 +714,81 @@ boundary_region pml(double thickness, double Rasymptotic = 1e-15, double mean_st
 
 class binary_partition;
 
+enum in_or_out { Incoming = 0, Outgoing };
+constexpr std::initializer_list<in_or_out> all_in_or_out{Incoming, Outgoing};
+
+enum connect_phase { CONNECT_PHASE = 0, CONNECT_NEGATE = 1, CONNECT_COPY = 2 };
+constexpr std::initializer_list<connect_phase> all_connect_phases{
+     CONNECT_PHASE, CONNECT_NEGATE, CONNECT_COPY};
+constexpr int NUM_CONNECT_PHASE_TYPES = 3;
+
+// Communication pair(i, j) implies data being sent from i to j.
+using chunk_pair = std::pair<int, int>;
+
+// Key for the map that stored communication sizes.
+struct comms_key {
+  field_type ft;
+  connect_phase phase;
+  chunk_pair pair;
+};
+
+// Defined in fields.cpp
+bool operator==(const comms_key &lhs, const comms_key &rhs);
+
+class comms_key_hash_fn {
+
+public:
+  inline std::size_t operator()(const comms_key &key) const {
+    // Unroll hash combination to promote the generatiion of efficient code.
+    std::size_t ret = ft_hasher(key.ft);
+    ret ^= connect_phase_hasher(key.phase) + kHashAddConst + (ret << 6) + (ret >> 2);
+    ret ^= int_hasher(key.pair.first) + kHashAddConst + (ret << 6) + (ret >> 2);
+    ret ^= int_hasher(key.pair.second) + kHashAddConst + (ret << 6) + (ret >> 2);
+    return ret;
+  }
+
+private:
+  static constexpr size_t kHashAddConst = 0x9e3779b9;
+  std::hash<int> int_hasher;
+  std::hash<connect_phase> connect_phase_hasher;
+  std::hash<field_type> ft_hasher;
+};
+
+// Represents a communication operation between chunks.
+struct comms_operation {
+  ptrdiff_t my_chunk_idx;
+  ptrdiff_t other_chunk_idx;
+  int other_proc_id;
+  int pair_idx;  // The numeric pair index used in many communications related arrays.
+  size_t transfer_size;
+  in_or_out comm_direction;
+  int tag;
+};
+
+struct comms_sequence {
+  std::vector<comms_operation> receive_ops;
+  std::vector<comms_operation> send_ops;
+
+  void clear() {
+    receive_ops.clear();
+    send_ops.clear();
+  }
+};
+
+// RAII based comms_manager that allows asynchronous send and receive functions to be initiated.
+// Upon destruction, the comms_manager waits for completion of all enqueued operations.
+class comms_manager {
+ public:
+  virtual ~comms_manager() {}
+  virtual void send_real_async(const void *buf, size_t count, int dest, int tag) = 0;
+  virtual void receive_real_async(void *buf, size_t count, int source, int tag) = 0;
+  virtual size_t max_transfer_size() const { return std::numeric_limits<size_t>::max(); };
+};
+
+// Factory function for `comms_manager`.
+std::unique_ptr<comms_manager> create_comms_manager();
+
+
 class structure {
 public:
   structure_chunk **chunks;
@@ -1320,8 +1398,6 @@ public:
   volume where;
 };
 
-enum in_or_out { Incoming = 0, Outgoing };
-enum connect_phase { CONNECT_PHASE = 0, CONNECT_NEGATE = 1, CONNECT_COPY = 2 };
 
 // data for each susceptibility
 typedef struct polarization_state_s {
@@ -1359,8 +1435,8 @@ public:
 
   realnum **zeroes[NUM_FIELD_TYPES]; // Holds pointers to metal points.
   size_t num_zeroes[NUM_FIELD_TYPES];
-  realnum **connections[NUM_FIELD_TYPES][CONNECT_COPY + 1][Outgoing + 1];
-  size_t num_connections[NUM_FIELD_TYPES][CONNECT_COPY + 1][Outgoing + 1];
+  realnum **connections[NUM_FIELD_TYPES][NUM_CONNECT_PHASE_TYPES][Outgoing + 1];
+  size_t num_connections[NUM_FIELD_TYPES][NUM_CONNECT_PHASE_TYPES][Outgoing + 1];
   std::complex<realnum> *connection_phases[NUM_FIELD_TYPES];
 
   int npol[NUM_FIELD_TYPES];                // only E_stuff and H_stuff are used
@@ -1569,19 +1645,6 @@ public:
   src_time *sources;
   flux_vol *fluxes;
   symmetry S;
-
-  // The following is an array that is num_chunks by num_chunks.  Actually
-  // it is two arrays, one for the imaginary and one for the real part.
-  realnum **comm_blocks[NUM_FIELD_TYPES];
-  // This is the same size as each comm_blocks array, and store the sizes
-  // of the comm blocks themselves for each connection-phase type
-  size_t *comm_sizes[NUM_FIELD_TYPES][CONNECT_COPY + 1];
-  size_t comm_size_tot(int f, int pair) const {
-    size_t sum = 0;
-    for (int ip = 0; ip < 3; ++ip)
-      sum += comm_sizes[f][ip][pair];
-    return sum;
-  }
 
   double a, dt; // The resolution a and timestep dt=Courant/a
   grid_volume gv, user_volume;
@@ -2057,8 +2120,6 @@ private:
   bool locate_point_in_user_volume(ivec *, std::complex<double> *phase) const;
   void locate_volume_source_in_user_volume(const vec p1, const vec p2, vec newp1[8], vec newp2[8],
                                            std::complex<double> kphase[8], int &ncopies) const;
-  // mympi.cpp
-  void boundary_communications(field_type);
   // step.cpp
   void phase_material();
   void step_db(field_type ft);
@@ -2081,6 +2142,31 @@ public:
   void am_now_working_on(time_sink);
   void finished_working();
   void reset_timers();
+
+ private:
+  // The following is an array that is num_chunks by num_chunks.  Actually
+  // it is two arrays, one for the imaginary and one for the real part.
+  realnum **comm_blocks[NUM_FIELD_TYPES];
+  // Map with all non-zero communication block sizes.
+  std::unordered_map<comms_key, size_t, comms_key_hash_fn> comm_sizes;
+  // The sequence of send and receive operations for each field type.
+  comms_sequence comms_sequence_for_field[NUM_FIELD_TYPES];
+
+  size_t get_comm_size(const comms_key& key) const {
+    auto it = comm_sizes.find(key);
+    return (it != comm_sizes.end()) ? it->second : 0;
+  }
+
+  size_t comm_size_tot(field_type ft, const chunk_pair& pair) const {
+    size_t sum = 0;
+    for (auto ip : all_connect_phases)
+      sum += get_comm_size({ft, ip, pair});
+    return sum;
+  }
+
+  int chunk_pair_to_index(const chunk_pair& pair) const {
+    return pair.first + num_chunks * pair.second;
+  }
 };
 
 class flux_vol {

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -25,8 +25,8 @@
 
 namespace meep {
 
-const int NUM_FIELD_COMPONENTS = 20;
-const int NUM_FIELD_TYPES = 8;
+constexpr int NUM_FIELD_COMPONENTS = 20;
+constexpr int NUM_FIELD_TYPES = 8;
 
 enum component {
   Ex = 0,

--- a/src/step.cpp
+++ b/src/step.cpp
@@ -15,6 +15,8 @@
 %  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
+#include <array>
+#include <map>
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
@@ -133,65 +135,119 @@ void fields_chunk::phase_material(int phasein_time) {
 void fields::step_boundaries(field_type ft) {
   connect_chunks(); // re-connect if !chunk_connections_valid
 
-  // Do the metals first!
-  for (int i = 0; i < num_chunks; i++)
-    if (chunks[i]->is_mine()) chunks[i]->zero_metal(ft);
+  {
+    // Initiate receive operations as early as possible.
+    std::unique_ptr<comms_manager> manager = create_comms_manager();
 
-  /* Note that the copying of data to/from buffers is order-sensitive,
-     and must be kept consistent with the code in boundaries.cpp.
-     In particular, we require that boundaries.cpp set up the connections
-     array so that all of the connections for process i come before all
-     of the connections for process i' for i < i'  */
-
-  // First copy outgoing data to buffers...
-  am_now_working_on(Boundaries);
-  for (int j = 0; j < num_chunks; j++)
-    if (chunks[j]->is_mine()) {
-      int wh[3] = {0, 0, 0};
-      for (int i = 0; i < num_chunks; i++) {
-        const int pair = j + i * num_chunks;
-        size_t n0 = 0;
-        for (int ip = 0; ip < 3; ip++) {
-          for (size_t n = 0; n < comm_sizes[ft][ip][pair]; n++)
-            comm_blocks[ft][pair][n0 + n] = *(chunks[j]->connections[ft][ip][Outgoing][wh[ip]++]);
-          n0 += comm_sizes[ft][ip][pair];
-        }
+    const auto &sequence = comms_sequence_for_field[ft];
+    for (const comms_operation &op : sequence.receive_ops) {
+      if (chunks[op.other_chunk_idx]->is_mine()) {
+        continue;
       }
+      manager->receive_real_async(comm_blocks[ft][op.pair_idx], static_cast<int>(op.transfer_size),
+                                  op.other_proc_id, op.tag);
     }
-  finished_working();
 
-  am_now_working_on(MpiOneTime);
-  boundary_communications(ft);
+    // Do the metals first!
+    for (int i = 0; i < num_chunks; i++)
+      if (chunks[i]->is_mine()) chunks[i]->zero_metal(ft);
+
+    /* Note that the copying of data to/from buffers is order-sensitive,
+       and must be kept consistent with the code in boundaries.cpp.
+       In particular, we require that boundaries.cpp set up the connections
+       array so that all of the connections for process i come before all
+       of the connections for process i' for i < i'  */
+
+    // Copy outgoing data into buffers while following the predefined sequence of comms operations.
+    // Trigger the asynchronous send immediately once the outgoing comms buffer has been filled.
+    using offset_array = std::array<ptrdiff_t, NUM_CONNECT_PHASE_TYPES>;
+    std::map<int, offset_array> connection_offset_by_chunk;
+    am_now_working_on(Boundaries);
+
+    for (const comms_operation &op : sequence.send_ops) {
+      if (!connection_offset_by_chunk.count(op.my_chunk_idx)) {
+        connection_offset_by_chunk.emplace(std::make_pair(op.my_chunk_idx, offset_array{}));
+      }
+      const std::pair<int, int> comm_pair{op.my_chunk_idx, op.other_chunk_idx};
+      const int pair_idx = op.pair_idx;
+      size_t n0 = 0;
+
+      for (connect_phase ip : all_connect_phases) {
+        const size_t pair_comm_size = get_comm_size({ft, ip, comm_pair});
+        ptrdiff_t &connection_offset = connection_offset_by_chunk[op.my_chunk_idx][ip];
+        for (size_t n = 0; n < pair_comm_size; ++n) {
+          comm_blocks[ft][pair_idx][n0 + n] =
+              *(chunks[op.my_chunk_idx]->connections[ft][ip][Outgoing][connection_offset++]);
+        }
+        n0 += pair_comm_size;
+      }
+      if (chunks[op.other_chunk_idx]->is_mine()) {
+        continue;
+      }
+      manager->send_real_async(comm_blocks[ft][pair_idx], static_cast<int>(op.transfer_size),
+                               op.other_proc_id, op.tag);
+    }
+    finished_working();
+
+    am_now_working_on(MpiOneTime);
+    // Let the communication manager drop out of scope to complete all outstanding requests.
+  }
   finished_working();
 
   // Finally, copy incoming data to the fields themselves, multiplying phases:
   am_now_working_on(Boundaries);
-  for (int i = 0; i < num_chunks; i++)
-    if (chunks[i]->is_mine()) {
-      int wh[3] = {0, 0, 0};
-      for (int j = 0; j < num_chunks; j++) {
-        const int pair = j + i * num_chunks;
-        connect_phase ip = CONNECT_PHASE;
-        for (size_t n = 0; n < comm_sizes[ft][ip][pair]; n += 2, wh[ip] += 2) {
-          const double phr = real(chunks[i]->connection_phases[ft][wh[ip] / 2]);
-          const double phi = imag(chunks[i]->connection_phases[ft][wh[ip] / 2]);
-          *(chunks[i]->connections[ft][ip][Incoming][wh[ip]]) =
-              phr * comm_blocks[ft][pair][n] - phi * comm_blocks[ft][pair][n + 1];
-          *(chunks[i]->connections[ft][ip][Incoming][wh[ip] + 1]) =
-              phr * comm_blocks[ft][pair][n + 1] + phi * comm_blocks[ft][pair][n];
+  for (int i = 0; i < num_chunks; i++) {
+    if (!chunks[i]->is_mine()) continue;
+
+    ptrdiff_t connection_phase_offset = 0;
+    ptrdiff_t negate_phase_offset = 0;
+    ptrdiff_t copy_phase_offset = 0;
+    const std::complex<realnum> *connection_phase_for_ft = chunks[i]->connection_phases[ft];
+
+    for (int j = 0; j < num_chunks; j++) {
+      const chunk_pair pair{j, i};
+      const int pair_idx = chunk_pair_to_index(pair);
+      const realnum *pair_comm_block = static_cast<realnum *>(comm_blocks[ft][pair_idx]);
+
+      {
+        const std::complex<realnum> *pair_comm_block_complex =
+            reinterpret_cast<const std::complex<realnum> *>(pair_comm_block);
+        const connect_phase ip = CONNECT_PHASE;
+        realnum **dst = chunks[i]->connections[ft][ip][Incoming];
+        size_t num_transfers = get_comm_size({ft, ip, pair}) / 2; // Two realnums per complex
+
+        for (size_t n = 0; n < num_transfers; ++n) {
+          std::complex<realnum> temp =  connection_phase_for_ft[connection_phase_offset + n] * pair_comm_block_complex[n];
+          *(dst[2*(connection_phase_offset + n)]) = temp.real();
+          *(dst[2*(connection_phase_offset + n)+1]) = temp.imag();
         }
-        size_t n0 = comm_sizes[ft][ip][pair];
-        ip = CONNECT_NEGATE;
-        for (size_t n = 0; n < comm_sizes[ft][ip][pair]; ++n)
-          *(chunks[i]->connections[ft][ip][Incoming][wh[ip]++]) = -comm_blocks[ft][pair][n0 + n];
-        n0 += comm_sizes[ft][ip][pair];
-        ip = CONNECT_COPY;
-        for (size_t n = 0; n < comm_sizes[ft][ip][pair]; ++n)
-          *(chunks[i]->connections[ft][ip][Incoming][wh[ip]++]) = comm_blocks[ft][pair][n0 + n];
+        connection_phase_offset += num_transfers;
+        pair_comm_block += 2 * num_transfers;
+      }
+
+      {
+        const connect_phase ip = CONNECT_NEGATE;
+        const size_t num_transfers = get_comm_size({ft, ip, pair});
+        realnum **dst = chunks[i]->connections[ft][ip][Incoming];
+        for (size_t n = 0; n < num_transfers; ++n) {
+          *(dst[negate_phase_offset + n]) = -pair_comm_block[n];
+        }
+        negate_phase_offset += num_transfers;
+        pair_comm_block += num_transfers;
+      }
+
+      {
+        connect_phase ip = CONNECT_COPY;
+        const size_t num_transfers = get_comm_size({ft, ip, pair});
+        realnum **dst = chunks[i]->connections[ft][ip][Incoming];
+        for (size_t n = 0; n < num_transfers; ++n) {
+          *(dst[copy_phase_offset + n]) = pair_comm_block[n];
+        }
+        copy_phase_offset += num_transfers;
       }
     }
+  }
   finished_working();
-
 }
 
 void fields::step_source(field_type ft, bool including_integrated) {


### PR DESCRIPTION
* Calculate the sequence of sends and receives once after `connect_the_chunks`
* Initiate asynchronous receives as early as possible
* Initiate asynchronous sends immediately after copying data into the communication buffers
* Prioritize chunks based on the data transfer size
* Introduce an RAII-based communications manager class that waits for requests to finish upon destruction
* Store nonzero communication sizes in a hash map instead of an array of size `#chunks x #chunks`

Performance increase by about 15% in smaller sims with light communications (small transfer sizes), e.g. a 2D sim with 12 processes on a single physical node.
Not as noticeable for larger 3D sims (e.g. 24 processes across 2 physical nodes), likely because the increased communication efficiency is overshadowed by the effects of uneven chunk balancing.

Future improvements:
* Start processing received messages immediately by using `MPI_Testsome` instead of `MPI_Waitall`. This should overlap network communications more with the copying of data into the field array.
* Combine the sequential boundary updates of {PH, H}, {PE, E} into a single [Set up Rx, copy data, trigger Tx, process Rx data] cycle
* Prioritize send operations by target process instead of source chunk. This requires more careful management of the subranges in the comms buffer array.