### PR TITLE
Raise runtime error in get_dft_array and output_dft if monitor's SWIG object does not exist

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2446,6 +2446,9 @@ class Simulation(object):
         if self.fields is None:
             self.init_sim()
 
+        if not self.dft_objects:
+            raise RuntimeError('DFT monitor dft_fields must be initialized before calling output_dft')
+
         if hasattr(dft_fields, 'swigobj'):
             dft_fields_swigobj = dft_fields.swigobj
         else:
@@ -3228,6 +3231,9 @@ class Simulation(object):
           where `nfreq` is the number of frequencies stored in `dft_obj` as set by the
           `nfreq` parameter to `add_dft_fields`, `add_flux`, etc.
         """
+        if not self.dft_objects:
+            raise RuntimeError('DFT monitor dft_obj must be initialized before calling get_dft_array')
+
         if hasattr(dft_obj, 'swigobj'):
             dft_swigobj = dft_obj.swigobj
         else:


### PR DESCRIPTION
Currently, the following sequence aborts with an error:
```py
dft_mon = sim.add_dft_fields(...)
...
sim.reset_meep()
...
sim.get_dft_array(dft_mon, ...)
```
This is because calling `add_dft_fields` adds the `DftFields` class object to the *internal* list `dft_objects` which are then used to create the SWIG objects via `_evaluate_dft_objects` called as part of the `run` function:

https://github.com/NanoComp/meep/blob/fdc4aa89a796bd7a4f7be013d7106bc587d61135/python/simulation.py#L2427-L2428

https://github.com/NanoComp/meep/blob/fdc4aa89a796bd7a4f7be013d7106bc587d61135/python/simulation.py#L2398-L2401

The problem occurs because `reset_meep()` clears `dft_objects` but the user is unaware of this and may therefore continue to use `dft_mon` even though its SWIG object no longer exists:
https://github.com/NanoComp/meep/blob/fdc4aa89a796bd7a4f7be013d7106bc587d61135/python/simulation.py#L3590-L3598

The user has to manually redefine `dft_mon` after calling `reset_meep()`. To prevent a segmentation fault from occurring and instead provide for a graceful exit in case the user forgets to do this, this PR adds a check inside `get_dft_array` and `output_dft` that aborts with a `RuntimeError` in case `dft_objects` is empty.