### PR TITLE
Propagate chunk_layout to Python meep.Simulation object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.pyc
 _build
 .vscode
+.idea
 
 # autotools stuff
 Makefile

--- a/python/meep.i
+++ b/python/meep.i
@@ -1429,6 +1429,10 @@ void _get_gradient(PyObject *grad, PyObject *fields_a, PyObject *fields_f, PyObj
   $1 = temp.get();
 }
 
+%typemap(out) const meep::binary_partition * {
+  $result = bp_to_py_bp($1);
+}
+
 %typemap(arginit) meep::binary_partition * {
     $1 = NULL;
 }

--- a/python/tests/test_chunk_layout.py
+++ b/python/tests/test_chunk_layout.py
@@ -53,6 +53,21 @@ class TestChunkLayoutBinaryPartition(unittest.TestCase):
 
         self.assertListEqual([int(f) for f in owners],[f % mp.count_processors() for f in process_ids])
         self.assertListEqual(areas,chunk_areas)
-        
+
+    def test_meep_default_chunk_layout(self):
+        cell_size = mp.Vector3(10.0,5.0,0)
+        sim = mp.Simulation(cell_size=cell_size,
+                            resolution=10)
+
+        sim.init_sim()
+        owners = sim.structure.get_chunk_owners()
+        areas = [ v.surroundings().full_volume() for v in sim.structure.get_chunk_volumes() ]
+
+        chunk_layout = sim.chunk_layout
+        traverse_tree(chunk_layout,-0.5*cell_size,0.5*cell_size)
+
+        self.assertListEqual([int(f) for f in owners],[f % mp.count_processors() for f in process_ids])
+        self.assertListEqual(areas,chunk_areas)
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/test_chunk_layout.py
+++ b/python/tests/test_chunk_layout.py
@@ -71,7 +71,7 @@ class TestChunkLayoutBinaryPartition(unittest.TestCase):
         areas = [ v.surroundings().full_volume() for v in sim.structure.get_chunk_volumes() ]
 
         chunk_layout = sim.chunk_layout
-        
+
         process_ids, chunk_areas = traverse_tree(chunk_layout,-0.5*cell_size,0.5*cell_size)
 
         self.assertListEqual([int(f) for f in owners],[f % mp.count_processors() for f in process_ids])

--- a/python/tests/test_chunk_layout.py
+++ b/python/tests/test_chunk_layout.py
@@ -2,36 +2,43 @@ import meep as mp
 import copy
 import unittest
 
-process_ids = []
-chunk_areas = []
 
 def traverse_tree(bp=None,min_corner=None,max_corner=None):
-    if ((min_corner.x > max_corner.x) or (min_corner.y > max_corner.y)):
-        raise RuntimeError("min_corner/max_corner have been incorrectly defined.")
 
-    ## reached a leaf
-    if (bp.left is None and bp.right is None):
-        process_ids.append(bp.proc_id)
-        chunk_area = (max_corner.x-min_corner.x)*(max_corner.y-min_corner.y)
-        chunk_areas.append(chunk_area)
+    process_ids = []
+    chunk_areas = []
 
-    ## traverse the left branch
-    if (bp.left is not None):
-        new_max_corner = copy.deepcopy(max_corner)
-        if bp.split_dir == mp.X:
-            new_max_corner.x = bp.split_pos
-        else:
-            new_max_corner.y = bp.split_pos
-        traverse_tree(bp.left,min_corner,new_max_corner)
+    def _traverse_tree(bp=None,min_corner=None,max_corner=None):
+        if ((min_corner.x > max_corner.x) or (min_corner.y > max_corner.y)):
+            raise RuntimeError("min_corner/max_corner have been incorrectly defined.")
 
-    ## traverse the right branch                                      
-    if (bp.right is not None):
-        new_min_corner = copy.deepcopy(min_corner)
-        if bp.split_dir == mp.X:
-            new_min_corner.x = bp.split_pos
-        else:
-            new_min_corner.y = bp.split_pos
-        traverse_tree(bp.right,new_min_corner,max_corner)
+        ## reached a leaf
+        if (bp.left is None and bp.right is None):
+            process_ids.append(bp.proc_id)
+            chunk_area = (max_corner.x-min_corner.x)*(max_corner.y-min_corner.y)
+            chunk_areas.append(chunk_area)
+
+        ## traverse the left branch
+        if (bp.left is not None):
+            new_max_corner = copy.deepcopy(max_corner)
+            if bp.split_dir == mp.X:
+                new_max_corner.x = bp.split_pos
+            else:
+                new_max_corner.y = bp.split_pos
+            _traverse_tree(bp.left,min_corner,new_max_corner)
+
+        ## traverse the right branch
+        if (bp.right is not None):
+            new_min_corner = copy.deepcopy(min_corner)
+            if bp.split_dir == mp.X:
+                new_min_corner.x = bp.split_pos
+            else:
+                new_min_corner.y = bp.split_pos
+            _traverse_tree(bp.right,new_min_corner,max_corner)
+
+    _traverse_tree(bp=bp, min_corner=min_corner, max_corner=max_corner)
+
+    return process_ids, chunk_areas
 
 
 class TestChunkLayoutBinaryPartition(unittest.TestCase):
@@ -49,7 +56,7 @@ class TestChunkLayoutBinaryPartition(unittest.TestCase):
         owners = sim.structure.get_chunk_owners()
         areas = [ v.surroundings().full_volume() for v in sim.structure.get_chunk_volumes() ]
 
-        traverse_tree(chunk_layout,-0.5*cell_size,0.5*cell_size)
+        process_ids, chunk_areas = traverse_tree(chunk_layout,-0.5*cell_size,0.5*cell_size)
 
         self.assertListEqual([int(f) for f in owners],[f % mp.count_processors() for f in process_ids])
         self.assertListEqual(areas,chunk_areas)
@@ -64,7 +71,8 @@ class TestChunkLayoutBinaryPartition(unittest.TestCase):
         areas = [ v.surroundings().full_volume() for v in sim.structure.get_chunk_volumes() ]
 
         chunk_layout = sim.chunk_layout
-        traverse_tree(chunk_layout,-0.5*cell_size,0.5*cell_size)
+        
+        process_ids, chunk_areas = traverse_tree(chunk_layout,-0.5*cell_size,0.5*cell_size)
 
         self.assertListEqual([int(f) for f in owners],[f % mp.count_processors() for f in process_ids])
         self.assertListEqual(areas,chunk_areas)

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -15,7 +15,6 @@
 %  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
-#include <iostream>
 #include <memory>
 #include <stdio.h>
 #include <stdlib.h>
@@ -961,7 +960,6 @@ double structure_chunk::max_eps() const {
 }
 
 bool structure::equal_layout(const structure &s) const {
-  std::cout << "equal_layout num_chunks " << num_chunks << " s.num_chunks " << s.num_chunks << "\n";
   if (a != s.a || num_chunks != s.num_chunks || v != s.v || S != s.S) return false;
   for (int i = 0; i < num_chunks; ++i)
     if (chunks[i]->a != s.chunks[i]->a || chunks[i]->v != s.chunks[i]->v) return false;

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -15,6 +15,7 @@
 %  Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */
 
+#include <iostream>
 #include <memory>
 #include <stdio.h>
 #include <stdlib.h>
@@ -958,6 +959,7 @@ double structure_chunk::max_eps() const {
 }
 
 bool structure::equal_layout(const structure &s) const {
+  std::cout << "equal_layout num_chunks " << num_chunks << " s.num_chunks " << s.num_chunks << "\n";
   if (a != s.a || num_chunks != s.num_chunks || v != s.v || S != s.S) return false;
   for (int i = 0; i < num_chunks; ++i)
     if (chunks[i]->a != s.chunks[i]->a || chunks[i]->v != s.chunks[i]->v) return false;


### PR DESCRIPTION
If a `meep.Simulation` object is created without specifying `chunk_layout`, then the default logic for choosing chunk partitionings is invoked when `sim.init_sim()` is called. However, the `chunk_layout` attribute on the Python `meep.Simulation` object previously was not updated and would still read as `None`. This pull request adds a `bp_to_py_bp()` function to convert the C++ object into a Python `meep.BinaryPartition` object and updates the `sim.chunk_layout` attribute (and for consistency, `sim.num_chunks`), in `sim._init_structure()`. (Fixes #1648)