### PR TITLE
Assign ranks to leaves of binary partition in depth-first order

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -132,7 +132,7 @@ void structure::choose_chunkdivision(const grid_volume &thegv, int desired_num_c
   num_chunks = 0;
   chunks = new structure_chunk_ptr[chunk_volumes.size() * num_effort_volumes];
   for (size_t i = 0, stop = chunk_volumes.size(); i < stop; ++i) {
-    const int proc = (!_bp) ? i * count_processors() / chunk_volumes.size() : ids[i] % count_processors();
+    const int proc = ids[i] % count_processors();
     for (int j = 0; j < num_effort_volumes; ++j) {
       grid_volume vc;
       if (chunk_volumes[i].intersect_with(effort_volumes[j], &vc)) {

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -66,7 +66,8 @@ structure::structure(const grid_volume &thegv, double eps(const vec &), const bo
 
 static std::unique_ptr<binary_partition> split_by_cost(int n, grid_volume gvol,
                                                        bool fragment_cost, int &proc_id) {
-  if (n == 1) { return std::unique_ptr<binary_partition>(new binary_partition(proc_id++)); }
+  if (n == 1) return std::unique_ptr<binary_partition>(new binary_partition(proc_id++
+                                                                            % count_processors()));
 
   int best_split_point;
   direction best_split_direction;


### PR DESCRIPTION
Fixes the bug described in [#1673 (comment)](https://github.com/NanoComp/meep/pull/1673#issuecomment-881215159).

With this change, the unit test added in #1673 for `test_chunk_layout.py` passes and thus #1673 needs only to be rebased after this is merged.