### PR TITLE
fixes for clang compatibility

### DIFF
--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -715,10 +715,10 @@ boundary_region pml(double thickness, double Rasymptotic = 1e-15, double mean_st
 class binary_partition;
 
 enum in_or_out { Incoming = 0, Outgoing };
-constexpr std::initializer_list<in_or_out> all_in_or_out{Incoming, Outgoing};
+const std::initializer_list<in_or_out> all_in_or_out{Incoming, Outgoing};
 
 enum connect_phase { CONNECT_PHASE = 0, CONNECT_NEGATE = 1, CONNECT_COPY = 2 };
-constexpr std::initializer_list<connect_phase> all_connect_phases{
+const std::initializer_list<connect_phase> all_connect_phases{
      CONNECT_PHASE, CONNECT_NEGATE, CONNECT_COPY};
 constexpr int NUM_CONNECT_PHASE_TYPES = 3;
 
@@ -740,8 +740,8 @@ class comms_key_hash_fn {
 public:
   inline std::size_t operator()(const comms_key &key) const {
     // Unroll hash combination to promote the generatiion of efficient code.
-    std::size_t ret = ft_hasher(key.ft);
-    ret ^= connect_phase_hasher(key.phase) + kHashAddConst + (ret << 6) + (ret >> 2);
+    std::size_t ret = int_hasher(int(key.ft));
+    ret ^= int_hasher(int(key.phase)) + kHashAddConst + (ret << 6) + (ret >> 2);
     ret ^= int_hasher(key.pair.first) + kHashAddConst + (ret << 6) + (ret >> 2);
     ret ^= int_hasher(key.pair.second) + kHashAddConst + (ret << 6) + (ret >> 2);
     return ret;
@@ -750,8 +750,6 @@ public:
 private:
   static constexpr size_t kHashAddConst = 0x9e3779b9;
   std::hash<int> int_hasher;
-  std::hash<connect_phase> connect_phase_hasher;
-  std::hash<field_type> ft_hasher;
 };
 
 // Represents a communication operation between chunks.


### PR DESCRIPTION
Without this patch, clang (`Apple clang version 12.0.5`) gives an error for the `constexpr` with `initializer_list`:
```
./meep.hpp:721:48: error: constexpr variable cannot have non-literal type 'const std::initializer_list<connect_phase>'
constexpr std::initializer_list<connect_phase> all_connect_phases{
                                               ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/initializer_list:58:28: note: 'initializer_list<meep::connect_phase>' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
class _LIBCPP_TEMPLATE_VIS initializer_list
```
and another error for using `std::hash` with an `enum`:
```
./meep.hpp:754:25: error: implicit instantiation of undefined template 'std::__1::hash<meep::field_type>'
  std::hash<field_type> ft_hasher;
```