### PR TITLE
Restore timing stack correctness

### DIFF
--- a/python/tests/test_simulation.py
+++ b/python/tests/test_simulation.py
@@ -621,6 +621,14 @@ class TestSimulation(unittest.TestCase):
             for t in timing_data[sink]:
                 self.assertEqual(t, 0)
 
+        self.assertGreaterEqual(
+            sum(timing_data[mp.Stepping]),
+            sum(timing_data[mp.FieldUpdateB]) +
+            sum(timing_data[mp.FieldUpdateH]) +
+            sum(timing_data[mp.FieldUpdateD]) +
+            sum(timing_data[mp.FieldUpdateE]) +
+            sum(timing_data[mp.FourierTransforming]))
+
     def test_source_slice(self):
         sim = self.init_simple_simulation()
         sim.run(until=1)

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1585,6 +1585,7 @@ public:
   // ownership of it.
   explicit timing_scope(time_sink_to_duration_map *timers_, time_sink sink_ = Other);
   ~timing_scope();
+  timing_scope &operator=(const timing_scope &other);
   // Stops time accumulation for the timing_scope.
   void exit();
 

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -100,6 +100,15 @@ void timing_scope::exit() {
   active = false;
 }
 
+timing_scope &timing_scope::operator=(const timing_scope &other) {
+  exit();
+  timers = other.timers;
+  sink = other.sink;
+  active = other.active;
+  t_start = other.t_start;
+  return *this;
+}
+
 timing_scope fields::with_timing_scope(time_sink sink) { return timing_scope(&times_spent, sink); }
 
 void fields::finished_working() {


### PR DESCRIPTION
Add a copy assignment operator to `timing_scope`.