### PR TITLE
Enable nonzero k_point in adjoint solver

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -149,7 +149,7 @@ jobs:
 
     - name: Run configure
       if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }}
-      run: ./configure --enable-maintainer-mode --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF}
+      run: ./configure --enable-maintainer-mode --with-coverage --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF}
 
     - name: Run configure with single-precision floating point
       if: ${{ matrix.enable-mpi == true && matrix.python-version == 3.9 }}

--- a/configure.ac
+++ b/configure.ac
@@ -514,7 +514,7 @@ fi
 
 ##############################################################################
 # Miscellaneous function and header checks
-AC_CHECK_HEADERS([sys/time.h])
+AC_CHECK_HEADERS([sys/time.h immintrin.h])
 AC_CHECK_FUNCS([BSDgettimeofday gettimeofday cblas_ddot cblas_daxpy jn])
 
 ##############################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -538,6 +538,9 @@ if test "$USE_MAINTAINER_MODE" = yes && (test "x$with_python" = "xyes" || test "
   AC_MSG_ERROR([SWIG not found; configure --without-python --without-scheme or use a release tarball])
 fi
 
+AC_ARG_WITH(coverage, [AS_HELP_STRING([--with-coverage],[enable Python coverage tests])],
+            with_coverage=$withval, with_coverage=no)
+
 if test "x$with_python" = xno; then
   have_python=no
 else
@@ -572,14 +575,15 @@ else
           AC_MSG_WARN([disabling Python wrappers])
           have_python=no],[#include <Python.h>])
 
-        AC_MSG_CHECKING([for coverage module])
-        $PYTHON -c 'import coverage' 2>/dev/null
-        if test $? = 0; then
-          AC_MSG_RESULT([yes])
-          have_coverage=yes
-        else
-          AC_MSG_RESULT([no])
-          have_coverage=no
+        if test x"$with_coverage" = xyes; then
+          AC_MSG_CHECKING([for coverage module])
+          $PYTHON -c 'import coverage' 2>/dev/null
+          if test $? = 0; then
+            AC_MSG_RESULT([yes])
+          else
+            AC_MSG_RESULT([no])
+            with_coverage=no
+          fi
         fi
       fi
 
@@ -591,7 +595,7 @@ fi # with_python
 
 AC_SUBST(PYTHON_INCLUDES)
 AM_CONDITIONAL(WITH_PYTHON, test x"$have_python" = "xyes")
-AM_CONDITIONAL(WITH_COVERAGE, test x"$have_coverage" = "xyes")
+AM_CONDITIONAL(WITH_COVERAGE, test x"$with_coverage" = "xyes")
 
 if test "x$with_scheme" = xyes; then
    # Copy/symlink casimir.scm and materials.scm to builddir for out-of-tree builds

--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -94,7 +94,7 @@ class ObjectiveQuantity(abc.ABC):
             scale = dV * iomega / adj_src_phase
         # compensate for the fact that real fields take the real part of the current,
         # which halves the Fourier amplitude at the positive frequency (Re[J] = (J + J*)/2)
-        if not self.sim.using_real_fields():
+        if self.sim.using_real_fields():
             scale *= 2
         return scale
 

--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -94,7 +94,7 @@ class ObjectiveQuantity(abc.ABC):
             scale = dV * iomega / adj_src_phase
         # compensate for the fact that real fields take the real part of the current,
         # which halves the Fourier amplitude at the positive frequency (Re[J] = (J + J*)/2)
-        if not self.sim.force_complex_fields:
+        if not self.sim.using_real_fields():
             scale *= 2
         return scale
 

--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -92,6 +92,10 @@ class ObjectiveQuantity(abc.ABC):
         else:
             # multi frequency simulations
             scale = dV * iomega / adj_src_phase
+        # compensate for the fact that real fields take the real part of the current,
+        # which halves the Fourier amplitude at the positive frequency (Re[J] = (J + J*)/2)
+        if not self.sim.force_complex_fields:
+            scale *= 2
         return scale
 
     def _create_time_profile(self, fwidth_frac=0.1):
@@ -262,7 +266,7 @@ class FourierFields(ObjectiveQuantity):
                 for yi in range(y_dim):
                     for xi in range(x_dim):
                         '''We only need to add a current source if the
-                        jacobian is nonzero for all frequencies at 
+                        jacobian is nonzero for all frequencies at
                         that particular point. Otherwise, the fitting
                         algorithm is going to fail.
                         '''
@@ -340,7 +344,7 @@ class Near2FarFields(ObjectiveQuantity):
                     time_src.frequency,
                     self._frequencies,
                     scale,
-                    dt,
+                    self.sim.fields.dt,
                 )
                 (num_basis, num_pts) = src.nodes.shape
                 for basis_i in range(num_basis):

--- a/python/adjoint/optimization_problem.py
+++ b/python/adjoint/optimization_problem.py
@@ -287,6 +287,8 @@ class OptimizationProblem(object):
     def adjoint_run(self):
         # set up adjoint sources and monitors
         self.prepare_adjoint_run()
+        if self.sim.k_point: self.sim.k_point *= -1
+        print(self.sim.k_point)
         for ar in range(len(self.objective_functions)):
             # Reset the fields
             self.sim.reset_meep()
@@ -329,6 +331,7 @@ class OptimizationProblem(object):
                             self.sim.get_dft_array(dgm, c, f))
 
         # update optimizer's state
+        if self.sim.k_point: self.sim.k_point *= -1
         self.current_state = "ADJ"
 
     def calculate_gradient(self):

--- a/python/adjoint/optimization_problem.py
+++ b/python/adjoint/optimization_problem.py
@@ -288,7 +288,6 @@ class OptimizationProblem(object):
         # set up adjoint sources and monitors
         self.prepare_adjoint_run()
         if self.sim.k_point: self.sim.k_point *= -1
-        print(self.sim.k_point)
         for ar in range(len(self.objective_functions)):
             # Reset the fields
             self.sim.reset_meep()

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1928,15 +1928,7 @@ class Simulation(object):
             self.fields.require_component(mp.Ez)
             self.fields.require_component(mp.Hz)
 
-        def use_real(self):
-            cond1 = self.is_cylindrical and self.m != 0
-            cond2 = any([s.phase.imag for s in self.symmetries])
-            cond3 = not self.k_point
-            cond4 = self.special_kz and self.k_point.x == 0 and self.k_point.y == 0
-            cond5 = not (cond3 or cond4 or self.k_point == Vector3())
-            return not (self.force_complex_fields or cond1 or cond2 or cond5)
-
-        if use_real(self):
+        if self.using_real_fields():
             self.fields.use_real_fields()
         elif verbosity.meep > 0:
             print("Meep: using complex fields.")
@@ -1951,6 +1943,14 @@ class Simulation(object):
             hook()
 
         self._is_initialized = True
+        
+    def using_real_fields(self):
+        cond1 = self.is_cylindrical and self.m != 0
+        cond2 = any([s.phase.imag for s in self.symmetries])
+        cond3 = not self.k_point
+        cond4 = self.special_kz and self.k_point.x == 0 and self.k_point.y == 0
+        cond5 = not (cond3 or cond4 or self.k_point == Vector3())
+        return not (self.force_complex_fields or cond1 or cond2 or cond5)
 
     def initialize_field(self, cmpnt, amp_func):
         """

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3068,7 +3068,8 @@ class Simulation(object):
         self._evaluate_dft_objects()
         return self.fields.solve_cw(tol, maxiters, L)
 
-    def solve_eigfreq(self, tol=1e-7, maxiters=100, guessfreq=None, cwtol=None, cwmaxiters=10000, L=10):
+    def solve_eigfreq(self, tol=1e-7, maxiters=100,
+                      guessfreq=None, cwtol=None, cwmaxiters=10000, L=10):
         if self.fields is None:
             raise RuntimeError('Fields must be initialized before using solve_cw')
         if cwtol is None:

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -40,6 +40,7 @@ except ImportError:
 
 verbosity = Verbosity(mp.cvar, 'meep', 1)
 
+mp.set_zero_subnormals(True)
 
 # Send output from Meep, ctlgeom, and MPB to Python's stdout
 mp.set_meep_printf_callback(mp.py_master_printf_wrap)

--- a/python/tests/test_3rd_harm_1d.py
+++ b/python/tests/test_3rd_harm_1d.py
@@ -2,9 +2,9 @@ from __future__ import division
 
 import unittest
 import meep as mp
-from utils import VectorComparisonMixin
+from utils import ApproxComparisonTestCase
 
-class Test3rdHarm1d(VectorComparisonMixin, unittest.TestCase):
+class Test3rdHarm1d(ApproxComparisonTestCase):
 
     def setUp(self):
         self.sz = 100
@@ -53,7 +53,7 @@ class Test3rdHarm1d(VectorComparisonMixin, unittest.TestCase):
         harmonics = [self.k, self.amp, mp.get_fluxes(self.trans1)[0], mp.get_fluxes(self.trans3)[0]]
 
         tol = 3e-5 if mp.is_single_precision() else 1e-7
-        self.assertVectorsClose(expected_harmonics, harmonics, epsilon=tol)
+        self.assertClose(expected_harmonics, harmonics, epsilon=tol)
 
 
 if __name__ == '__main__':

--- a/python/tests/test_adjoint_jax.py
+++ b/python/tests/test_adjoint_jax.py
@@ -1,7 +1,7 @@
 import unittest
 import parameterized
 
-from utils import VectorComparisonMixin
+from utils import ApproxComparisonTestCase
 
 import jax
 import jax.numpy as jnp
@@ -166,7 +166,7 @@ class UtilsTest(unittest.TestCase):
       self.assertEqual(value.dtype, onp.complex128)
 
 
-class WrapperTest(VectorComparisonMixin, unittest.TestCase):
+class WrapperTest(ApproxComparisonTestCase):
 
   @parameterized.parameterized.expand([
     ('1500_1550bw_01relative_gaussian', onp.linspace(1 / 1.50, 1 / 1.55, 3).tolist(), 0.1, 1.0),
@@ -237,7 +237,7 @@ class WrapperTest(VectorComparisonMixin, unittest.TestCase):
     fd_projection = onp.stack(fd_projection)
 
     # Check that dp . ∇T ~ T(p + dp) - T(p)
-    self.assertVectorsClose(
+    self.assertClose(
       projection,
       fd_projection,
       epsilon=_TOL,

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -109,11 +109,7 @@ def forward_simulation(design_params,mon_type,frequencies=None, use_complex=Fals
         return Ez2
 
 
-<<<<<<< HEAD
-def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False):
-=======
 def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False, k=False):
->>>>>>> 314b6057f1408aa3c89c286253c24cc633fb179f
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
@@ -205,7 +201,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
             tol = 0.3 if mp.is_single_precision() else 0.01
-            self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
+            self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 
     def test_adjoint_solver_eigenmode(self):
@@ -222,7 +218,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
 
                     ## compare objective results
                     print("S12 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
-                    self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
+                    self.assertClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
 
                     ## compute perturbed S12
                     S12_perturbed = forward_simulation(p+dp, MonitorObject.EIGENMODE, frequencies, use_complex, k)
@@ -234,7 +230,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                     fd_grad = S12_perturbed-S12_unperturbed
                     print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
                     tol = 0.1 if mp.is_single_precision() else 0.03
-                    self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
+                    self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
     def test_gradient_backpropagation(self):
         print("*** TESTING BACKPROP FEATURES ***")

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -269,7 +269,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@bp_adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.04 if mp.is_single_precision() else 0.03
+            tol = 0.05 if mp.is_single_precision() else 0.03
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -8,7 +8,7 @@ from autograd import numpy as npa
 from autograd import tensor_jacobian_product
 import unittest
 from enum import Enum
-from utils import VectorComparisonMixin
+from utils import ApproxComparisonTestCase
 
 MonitorObject = Enum('MonitorObject', 'EIGENMODE DFT')
 
@@ -173,7 +173,7 @@ def mapping(x,filter_radius,eta,beta):
     return projected_field.flatten()
 
 
-class TestAdjointSolver(VectorComparisonMixin, unittest.TestCase):
+class TestAdjointSolver(ApproxComparisonTestCase):
 
     def test_adjoint_solver_DFT_fields(self):
         print("*** TESTING DFT ADJOINT FEATURES ***")
@@ -187,7 +187,7 @@ class TestAdjointSolver(VectorComparisonMixin, unittest.TestCase):
 
             ## compare objective results
             print("|Ez|^2 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
-            self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
+            self.assertClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
 
             ## compute perturbed S12
             S12_perturbed = forward_simulation(p+dp, MonitorObject.DFT, frequencies)
@@ -199,7 +199,7 @@ class TestAdjointSolver(VectorComparisonMixin, unittest.TestCase):
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
             tol = 0.3 if mp.is_single_precision() else 0.01
-            self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
+            self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 
     def test_adjoint_solver_eigenmode(self):
@@ -215,7 +215,7 @@ class TestAdjointSolver(VectorComparisonMixin, unittest.TestCase):
 
                 ## compare objective results
                 print("S12 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
-                self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
+                self.assertClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
 
                 ## compute perturbed S12
                 S12_perturbed = forward_simulation(p+dp, MonitorObject.EIGENMODE, frequencies, use_complex)
@@ -227,7 +227,7 @@ class TestAdjointSolver(VectorComparisonMixin, unittest.TestCase):
                 fd_grad = S12_perturbed-S12_unperturbed
                 print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
                 tol = 0.1 if mp.is_single_precision() else 0.03
-                self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
+                self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 
     def test_gradient_backpropagation(self):
@@ -257,7 +257,7 @@ class TestAdjointSolver(VectorComparisonMixin, unittest.TestCase):
             ## compare objective results
             print("S12 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
             tol = 1e-2 if mp.is_single_precision() else 1e-3
-            self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=tol)
+            self.assertClose(adjsol_obj,S12_unperturbed,epsilon=tol)
 
             ## compute perturbed S12
             S12_perturbed = forward_simulation(mapping(p+dp,filter_radius,eta,beta), MonitorObject.EIGENMODE,frequencies)
@@ -268,7 +268,7 @@ class TestAdjointSolver(VectorComparisonMixin, unittest.TestCase):
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
             tol = 0.04 if mp.is_single_precision() else 0.03
-            self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
+            self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 
 if __name__ == '__main__':

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -47,13 +47,13 @@ waveguide_geometry = [mp.Block(material=silicon,
 fcen = 1/1.55
 df = 0.23*fcen
 sources = [mp.EigenModeSource(src=mp.GaussianSource(fcen,fwidth=df),
-                              center=mp.Vector3(-0.5*sxy+dpml,0),
-                              size=mp.Vector3(0,sxy),
+                              center=mp.Vector3(-0.5*sxy+dpml+0.1,0),
+                              size=mp.Vector3(0,sxy-2*dpml),
                               eig_band=1,
                               eig_parity=eig_parity)]
 
 
-def forward_simulation(design_params,mon_type,frequencies=None, use_complex=False):
+def forward_simulation(design_params,mon_type,frequencies=None, use_complex=False, k=False):
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
@@ -71,13 +71,14 @@ def forward_simulation(design_params,mon_type,frequencies=None, use_complex=Fals
                         boundary_layers=boundary_layers,
                         sources=sources,
                         geometry=geometry,
-                        force_complex_fields=use_complex)
+                        force_complex_fields=use_complex,
+                        k_point = k)
     if not frequencies:
         frequencies = [fcen]
 
     if mon_type.name == 'EIGENMODE':
         mode = sim.add_mode_monitor(frequencies,
-                                    mp.ModeRegion(center=mp.Vector3(0.5*sxy-dpml),size=mp.Vector3(0,sxy,0)),
+                                    mp.ModeRegion(center=mp.Vector3(0.5*sxy-dpml-0.1),size=mp.Vector3(0,sxy-2*dpml,0)),
                                     yee_grid=True)
 
     elif mon_type.name == 'DFT':
@@ -110,6 +111,7 @@ def forward_simulation(design_params,mon_type,frequencies=None, use_complex=Fals
 
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False):
 =======
 def adjoint_solver(design_params, mon_type, frequencies=None, use_complex):
@@ -117,6 +119,9 @@ def adjoint_solver(design_params, mon_type, frequencies=None, use_complex):
 =======
 def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False):
 >>>>>>> fix
+=======
+def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False, k=False):
+>>>>>>> kpoint
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
@@ -137,14 +142,15 @@ def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False)
                         boundary_layers=boundary_layers,
                         sources=sources,
                         geometry=geometry,
-                        force_complex_fields=use_complex)
+                        force_complex_fields=use_complex,
+                        k_point = k)
     if not frequencies:
         frequencies = [fcen]
 
     if mon_type.name == 'EIGENMODE':
         obj_list = [mpa.EigenmodeCoefficient(sim,
-                                             mp.Volume(center=mp.Vector3(0.5*sxy-dpml),
-                                                       size=mp.Vector3(0,sxy,0)),1)]
+                                             mp.Volume(center=mp.Vector3(0.5*sxy-dpml-0.1),
+                                                       size=mp.Vector3(0,sxy-2*dpml,0)),1)]
 
         def J(mode_mon):
             return npa.abs(mode_mon)**2
@@ -213,6 +219,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
     def test_adjoint_solver_eigenmode(self):
         print("*** TESTING EIGENMODE ADJOINT FEATURES ***")
         ## test the single frequency and multi frequency cases
+<<<<<<< HEAD
         for use_complex in [True, False]:
             for frequencies in [[fcen], [1/1.58, fcen, 1/1.53]]:
                 ## compute gradient using adjoint solver
@@ -245,6 +252,33 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                 tol = 0.04 if mp.is_single_precision() else 0.03
                 self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
 >>>>>>> fix factor 2
+=======
+        for k in [False, mp.Vector3(), mp.Vector3(1.8, 1.6)]:
+            for k in [False, mp.Vector3(), mp.Vector3(0.8, 0.6)]:
+                for use_complex in [True, False]:
+                    for frequencies in [[fcen], [1/1.58, fcen, 1/1.53]]:
+                        ## compute gradient using adjoint solver
+                        adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.EIGENMODE, frequencies, use_complex, k)
+
+                        ## compute unperturbed S12
+                        S12_unperturbed = forward_simulation(p, MonitorObject.EIGENMODE, frequencies, use_complex, k)
+
+                        ## compare objective results
+                        print("S12 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
+                        self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
+
+                        ## compute perturbed S12
+                        S12_perturbed = forward_simulation(p+dp, MonitorObject.EIGENMODE, frequencies, use_complex, k)
+
+                        ## compare gradients
+                        if adjsol_grad.ndim < 2:
+                            adjsol_grad = np.expand_dims(adjsol_grad,axis=1)
+                        adj_scale = (dp[None,:]@adjsol_grad).flatten()
+                        fd_grad = S12_perturbed-S12_unperturbed
+                        print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
+                        tol = 0.04 if mp.is_single_precision() else 0.03
+                        self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
+>>>>>>> kpoint
 
 
     def test_gradient_backpropagation(self):

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -109,19 +109,7 @@ def forward_simulation(design_params,mon_type,frequencies=None, use_complex=Fals
         return Ez2
 
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False):
-=======
-def adjoint_solver(design_params, mon_type, frequencies=None, use_complex):
->>>>>>> fix factor 2
-=======
-def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False):
->>>>>>> fix
-=======
-def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False, k=False):
->>>>>>> kpoint
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
@@ -220,6 +208,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
         print("*** TESTING EIGENMODE ADJOINT FEATURES ***")
         ## test the single frequency and multi frequency cases
 <<<<<<< HEAD
+<<<<<<< HEAD
         for use_complex in [True, False]:
             for frequencies in [[fcen], [1/1.58, fcen, 1/1.53]]:
                 ## compute gradient using adjoint solver
@@ -279,6 +268,32 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                         tol = 0.04 if mp.is_single_precision() else 0.03
                         self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
 >>>>>>> kpoint
+=======
+        for k in [False, mp.Vector3(), mp.Vector3(0.8, 0.6)]:
+            for use_complex in [True, False]:
+                for frequencies in [[fcen], [1/1.58, fcen, 1/1.53]]:
+                    ## compute gradient using adjoint solver
+                    adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.EIGENMODE, frequencies, use_complex, k)
+
+                    ## compute unperturbed S12
+                    S12_unperturbed = forward_simulation(p, MonitorObject.EIGENMODE, frequencies, use_complex, k)
+
+                    ## compare objective results
+                    print("S12 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
+                    self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
+
+                    ## compute perturbed S12
+                    S12_perturbed = forward_simulation(p+dp, MonitorObject.EIGENMODE, frequencies, use_complex, k)
+
+                    ## compare gradients
+                    if adjsol_grad.ndim < 2:
+                        adjsol_grad = np.expand_dims(adjsol_grad,axis=1)
+                    adj_scale = (dp[None,:]@adjsol_grad).flatten()
+                    fd_grad = S12_perturbed-S12_unperturbed
+                    print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
+                    tol = 0.04 if mp.is_single_precision() else 0.03
+                    self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
+>>>>>>> fix
 
 
     def test_gradient_backpropagation(self):

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -229,7 +229,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                     adj_scale = (dp[None,:]@adjsol_grad).flatten()
                     fd_grad = S12_perturbed-S12_unperturbed
                     print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-                    tol = 0.1 if mp.is_single_precision() else 0.03
+                    tol = 0.15 if mp.is_single_precision() else 0.03
                     self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
     def test_gradient_backpropagation(self):

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -53,7 +53,11 @@ sources = [mp.EigenModeSource(src=mp.GaussianSource(fcen,fwidth=df),
                               eig_parity=eig_parity)]
 
 
+<<<<<<< HEAD
 def forward_simulation(design_params,mon_type,frequencies=None, use_complex=False):
+=======
+def forward_simulation(design_params,mon_type,frequencies=None, use_complex):
+>>>>>>> fix factor 2
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
@@ -108,7 +112,11 @@ def forward_simulation(design_params,mon_type,frequencies=None, use_complex=Fals
         return Ez2
 
 
+<<<<<<< HEAD
 def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False):
+=======
+def adjoint_solver(design_params, mon_type, frequencies=None, use_complex):
+>>>>>>> fix factor 2
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
@@ -215,7 +223,11 @@ class TestAdjointSolver(ApproxComparisonTestCase):
 
                 ## compare objective results
                 print("S12 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
+<<<<<<< HEAD
                 self.assertClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
+=======
+                self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
+>>>>>>> fix factor 2
 
                 ## compute perturbed S12
                 S12_perturbed = forward_simulation(p+dp, MonitorObject.EIGENMODE, frequencies, use_complex)
@@ -226,8 +238,13 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                 adj_scale = (dp[None,:]@adjsol_grad).flatten()
                 fd_grad = S12_perturbed-S12_unperturbed
                 print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
+<<<<<<< HEAD
                 tol = 0.1 if mp.is_single_precision() else 0.03
                 self.assertClose(adj_scale,fd_grad,epsilon=tol)
+=======
+                tol = 0.04 if mp.is_single_precision() else 0.03
+                self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
+>>>>>>> fix factor 2
 
 
     def test_gradient_backpropagation(self):

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -201,7 +201,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
             tol = 0.3 if mp.is_single_precision() else 0.01
-            self.assertClose(adj_scale,fd_grad,epsilon=tol)
+            self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
 
 
     def test_adjoint_solver_eigenmode(self):
@@ -229,7 +229,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                     adj_scale = (dp[None,:]@adjsol_grad).flatten()
                     fd_grad = S12_perturbed-S12_unperturbed
                     print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-                    tol = 0.04 if mp.is_single_precision() else 0.03
+                    tol = 0.1 if mp.is_single_precision() else 0.03
                     self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
 
     def test_gradient_backpropagation(self):

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -206,69 +206,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
 
     def test_adjoint_solver_eigenmode(self):
         print("*** TESTING EIGENMODE ADJOINT FEATURES ***")
-        ## test the single frequency and multi frequency cases
-<<<<<<< HEAD
-<<<<<<< HEAD
-        for use_complex in [True, False]:
-            for frequencies in [[fcen], [1/1.58, fcen, 1/1.53]]:
-                ## compute gradient using adjoint solver
-                adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.EIGENMODE, frequencies, use_complex)
-
-                ## compute unperturbed S12
-                S12_unperturbed = forward_simulation(p, MonitorObject.EIGENMODE, frequencies, use_complex)
-
-                ## compare objective results
-                print("S12 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
-<<<<<<< HEAD
-                self.assertClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
-=======
-                self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
->>>>>>> fix factor 2
-
-                ## compute perturbed S12
-                S12_perturbed = forward_simulation(p+dp, MonitorObject.EIGENMODE, frequencies, use_complex)
-
-                ## compare gradients
-                if adjsol_grad.ndim < 2:
-                    adjsol_grad = np.expand_dims(adjsol_grad,axis=1)
-                adj_scale = (dp[None,:]@adjsol_grad).flatten()
-                fd_grad = S12_perturbed-S12_unperturbed
-                print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-<<<<<<< HEAD
-                tol = 0.1 if mp.is_single_precision() else 0.03
-                self.assertClose(adj_scale,fd_grad,epsilon=tol)
-=======
-                tol = 0.04 if mp.is_single_precision() else 0.03
-                self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
->>>>>>> fix factor 2
-=======
-        for k in [False, mp.Vector3(), mp.Vector3(1.8, 1.6)]:
-            for k in [False, mp.Vector3(), mp.Vector3(0.8, 0.6)]:
-                for use_complex in [True, False]:
-                    for frequencies in [[fcen], [1/1.58, fcen, 1/1.53]]:
-                        ## compute gradient using adjoint solver
-                        adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.EIGENMODE, frequencies, use_complex, k)
-
-                        ## compute unperturbed S12
-                        S12_unperturbed = forward_simulation(p, MonitorObject.EIGENMODE, frequencies, use_complex, k)
-
-                        ## compare objective results
-                        print("S12 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
-                        self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
-
-                        ## compute perturbed S12
-                        S12_perturbed = forward_simulation(p+dp, MonitorObject.EIGENMODE, frequencies, use_complex, k)
-
-                        ## compare gradients
-                        if adjsol_grad.ndim < 2:
-                            adjsol_grad = np.expand_dims(adjsol_grad,axis=1)
-                        adj_scale = (dp[None,:]@adjsol_grad).flatten()
-                        fd_grad = S12_perturbed-S12_unperturbed
-                        print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-                        tol = 0.04 if mp.is_single_precision() else 0.03
-                        self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
->>>>>>> kpoint
-=======
+        ## test the single frequency and multi frequency case
         for k in [False, mp.Vector3(), mp.Vector3(0.8, 0.6)]:
             for use_complex in [True, False]:
                 for frequencies in [[fcen], [1/1.58, fcen, 1/1.53]]:
@@ -293,8 +231,6 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                     print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
                     tol = 0.04 if mp.is_single_precision() else 0.03
                     self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
->>>>>>> fix
-
 
     def test_gradient_backpropagation(self):
         print("*** TESTING BACKPROP FEATURES ***")

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -53,13 +53,13 @@ sources = [mp.EigenModeSource(src=mp.GaussianSource(fcen,fwidth=df),
                               eig_parity=eig_parity)]
 
 
-def forward_simulation(design_params,mon_type,frequencies=None):
+def forward_simulation(design_params,mon_type,frequencies=None, use_complex=False):
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
                               weights=design_params.reshape(Nx,Ny),
                               grid_type='U_MEAN')
-            
+
     matgrid_geometry = [mp.Block(center=mp.Vector3(),
                                  size=mp.Vector3(design_shape.x,design_shape.y,0),
                                  material=matgrid)]
@@ -70,7 +70,8 @@ def forward_simulation(design_params,mon_type,frequencies=None):
                         cell_size=cell_size,
                         boundary_layers=boundary_layers,
                         sources=sources,
-                        geometry=geometry)
+                        geometry=geometry,
+                        force_complex_fields=use_complex)
     if not frequencies:
         frequencies = [fcen]
 
@@ -107,7 +108,7 @@ def forward_simulation(design_params,mon_type,frequencies=None):
         return Ez2
 
 
-def adjoint_solver(design_params, mon_type, frequencies=None):
+def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False):
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
@@ -127,7 +128,8 @@ def adjoint_solver(design_params, mon_type, frequencies=None):
                         cell_size=cell_size,
                         boundary_layers=boundary_layers,
                         sources=sources,
-                        geometry=geometry)
+                        geometry=geometry,
+                        force_complex_fields=use_complex)
     if not frequencies:
         frequencies = [fcen]
 
@@ -182,14 +184,14 @@ class TestAdjointSolver(VectorComparisonMixin, unittest.TestCase):
 
             ## compute unperturbed S12
             S12_unperturbed = forward_simulation(p, MonitorObject.DFT, frequencies)
-            
+
             ## compare objective results
             print("|Ez|^2 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
             self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
 
             ## compute perturbed S12
             S12_perturbed = forward_simulation(p+dp, MonitorObject.DFT, frequencies)
-            
+
             ## compare gradients
             if adjsol_grad.ndim < 2:
                 adjsol_grad = np.expand_dims(adjsol_grad,axis=1)
@@ -203,28 +205,29 @@ class TestAdjointSolver(VectorComparisonMixin, unittest.TestCase):
     def test_adjoint_solver_eigenmode(self):
         print("*** TESTING EIGENMODE ADJOINT FEATURES ***")
         ## test the single frequency and multi frequency cases
-        for frequencies in [[fcen], [1/1.58, fcen, 1/1.53]]:
-            ## compute gradient using adjoint solver
-            adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.EIGENMODE, frequencies)
+        for use_complex in [True, False]:
+            for frequencies in [[fcen], [1/1.58, fcen, 1/1.53]]:
+                ## compute gradient using adjoint solver
+                adjsol_obj, adjsol_grad = adjoint_solver(p, MonitorObject.EIGENMODE, frequencies, use_complex)
 
-            ## compute unperturbed S12
-            S12_unperturbed = forward_simulation(p, MonitorObject.EIGENMODE, frequencies)
+                ## compute unperturbed S12
+                S12_unperturbed = forward_simulation(p, MonitorObject.EIGENMODE, frequencies, use_complex)
 
-            ## compare objective results
-            print("S12 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
-            self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
+                ## compare objective results
+                print("S12 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
+                self.assertVectorsClose(adjsol_obj,S12_unperturbed,epsilon=1e-3)
 
-            ## compute perturbed S12
-            S12_perturbed = forward_simulation(p+dp, MonitorObject.EIGENMODE, frequencies)
+                ## compute perturbed S12
+                S12_perturbed = forward_simulation(p+dp, MonitorObject.EIGENMODE, frequencies, use_complex)
 
-            ## compare gradients
-            if adjsol_grad.ndim < 2:
-                adjsol_grad = np.expand_dims(adjsol_grad,axis=1)
-            adj_scale = (dp[None,:]@adjsol_grad).flatten()
-            fd_grad = S12_perturbed-S12_unperturbed
-            print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.04 if mp.is_single_precision() else 0.03
-            self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
+                ## compare gradients
+                if adjsol_grad.ndim < 2:
+                    adjsol_grad = np.expand_dims(adjsol_grad,axis=1)
+                adj_scale = (dp[None,:]@adjsol_grad).flatten()
+                fd_grad = S12_perturbed-S12_unperturbed
+                print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
+                tol = 0.1 if mp.is_single_precision() else 0.03
+                self.assertVectorsClose(adj_scale,fd_grad,epsilon=tol)
 
 
     def test_gradient_backpropagation(self):

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -53,11 +53,7 @@ sources = [mp.EigenModeSource(src=mp.GaussianSource(fcen,fwidth=df),
                               eig_parity=eig_parity)]
 
 
-<<<<<<< HEAD
 def forward_simulation(design_params,mon_type,frequencies=None, use_complex=False):
-=======
-def forward_simulation(design_params,mon_type,frequencies=None, use_complex):
->>>>>>> fix factor 2
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
@@ -113,10 +109,14 @@ def forward_simulation(design_params,mon_type,frequencies=None, use_complex):
 
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False):
 =======
 def adjoint_solver(design_params, mon_type, frequencies=None, use_complex):
 >>>>>>> fix factor 2
+=======
+def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False):
+>>>>>>> fix
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,

--- a/python/tests/test_array_metadata.py
+++ b/python/tests/test_array_metadata.py
@@ -1,8 +1,9 @@
 import meep as mp
 import unittest
 import numpy as np
+from utils import ApproxComparisonTestCase
 
-class TestArrayMetadata(unittest.TestCase):
+class TestArrayMetadata(ApproxComparisonTestCase):
 
     def test_array_metadata(self):
         resolution = 25
@@ -80,11 +81,8 @@ class TestArrayMetadata(unittest.TestCase):
         vec_func_sum = np.sum(W*(xm**2 + 2*ym**2))
         pulse_modal_volume = np.sum(W*EpsE2)/np.max(EpsE2) * vec_func_sum
 
-        if ((mp.count_processors() % 2 == 0) and mp.is_single_precision()):
-            ref_val = 0.94
-        else:
-            ref_val = 1.00
-        self.assertAlmostEqual(cw_modal_volume/pulse_modal_volume, ref_val, places=2)
+        tol = 5e-2 if mp.is_single_precision() else 1e-2
+        self.assertClose(cw_modal_volume/pulse_modal_volume, 1.0, epsilon=tol)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/test_array_metadata.py
+++ b/python/tests/test_array_metadata.py
@@ -43,7 +43,7 @@ class TestArrayMetadata(ApproxComparisonTestCase):
                             boundary_layers=pml_layers)
 
         sim.init_sim()
-        sim.solve_cw(1e-6, 1000, 10)
+        sim.solve_cw(1e-5 if mp.is_single_precision() else 1e-6, 1000, 10)
 
         def electric_energy(r, ez, eps):
             return np.real(eps * np.conj(ez)*ez)

--- a/python/tests/test_cavity_arrayslice.py
+++ b/python/tests/test_cavity_arrayslice.py
@@ -1,11 +1,11 @@
 import meep as mp
-from utils import VectorComparisonMixin
+from utils import ApproxComparisonTestCase
 import os
 import unittest
 import numpy as np
 
 
-class TestCavityArraySlice(VectorComparisonMixin, unittest.TestCase):
+class TestCavityArraySlice(ApproxComparisonTestCase):
 
     data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
     expected_1d = np.load(os.path.join(data_dir, 'cavity_arrayslice_1d.npy'))
@@ -59,14 +59,14 @@ class TestCavityArraySlice(VectorComparisonMixin, unittest.TestCase):
         vol = mp.Volume(center=self.center_1d, size=self.size_1d)
         hl_slice1d = self.sim.get_array(mp.Hz, vol)
         tol = 1e-5 if mp.is_single_precision() else 1e-8
-        self.assertVectorsClose(self.expected_1d, hl_slice1d, epsilon=tol)
+        self.assertClose(self.expected_1d, hl_slice1d, epsilon=tol)
 
     def test_2d_slice(self):
         self.sim.run(until_after_sources=0)
         vol = mp.Volume(center=self.center_2d, size=self.size_2d)
         hl_slice2d = self.sim.get_array(mp.Hz, vol)
         tol = 1e-5 if mp.is_single_precision() else 1e-8
-        self.assertVectorsClose(self.expected_2d, hl_slice2d, epsilon=tol)
+        self.assertClose(self.expected_2d, hl_slice2d, epsilon=tol)
 
     def test_1d_slice_user_array(self):
         self.sim.run(until_after_sources=0)
@@ -74,7 +74,7 @@ class TestCavityArraySlice(VectorComparisonMixin, unittest.TestCase):
         vol = mp.Volume(center=self.center_1d, size=self.size_1d)
         self.sim.get_array(mp.Hz, vol, arr=arr)
         tol = 1e-5 if mp.is_single_precision() else 1e-8
-        self.assertVectorsClose(self.expected_1d, arr, epsilon=tol)
+        self.assertClose(self.expected_1d, arr, epsilon=tol)
 
     def test_2d_slice_user_array(self):
         self.sim.run(until_after_sources=0)
@@ -82,7 +82,7 @@ class TestCavityArraySlice(VectorComparisonMixin, unittest.TestCase):
         vol = mp.Volume(center=self.center_2d, size=self.size_2d)
         self.sim.get_array(mp.Hz, vol, arr=arr)
         tol = 1e-5 if mp.is_single_precision() else 1e-8
-        self.assertVectorsClose(self.expected_2d, arr, epsilon=tol)
+        self.assertClose(self.expected_2d, arr, epsilon=tol)
 
     def test_illegal_user_array(self):
         self.sim.run(until_after_sources=0)

--- a/python/tests/test_cavity_farfield.py
+++ b/python/tests/test_cavity_farfield.py
@@ -1,11 +1,11 @@
 import meep as mp
-from utils import VectorComparisonMixin
+from utils import ApproxComparisonTestCase
 import os
 import unittest
 import h5py
 
 
-class TestCavityFarfield(VectorComparisonMixin, unittest.TestCase):
+class TestCavityFarfield(ApproxComparisonTestCase):
 
     data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
 
@@ -76,12 +76,12 @@ class TestCavityFarfield(VectorComparisonMixin, unittest.TestCase):
             ref_hz = mp.complexarray(f['hz.r'][()], f['hz.i'][()])
 
             tol = 1e-5 if mp.is_single_precision() else 1e-7
-            self.assertVectorsClose(ref_ex, result['Ex'], epsilon=tol)
-            self.assertVectorsClose(ref_ey, result['Ey'], epsilon=tol)
-            self.assertVectorsClose(ref_ez, result['Ez'], epsilon=tol)
-            self.assertVectorsClose(ref_hx, result['Hx'], epsilon=tol)
-            self.assertVectorsClose(ref_hy, result['Hy'], epsilon=tol)
-            self.assertVectorsClose(ref_hz, result['Hz'], epsilon=tol)
+            self.assertClose(ref_ex, result['Ex'], epsilon=tol)
+            self.assertClose(ref_ey, result['Ey'], epsilon=tol)
+            self.assertClose(ref_ez, result['Ez'], epsilon=tol)
+            self.assertClose(ref_hx, result['Hx'], epsilon=tol)
+            self.assertClose(ref_hy, result['Hy'], epsilon=tol)
+            self.assertClose(ref_hz, result['Hz'], epsilon=tol)
 
 
     def test_cavity_farfield(self):

--- a/python/tests/test_dispersive_eigenmode.py
+++ b/python/tests/test_dispersive_eigenmode.py
@@ -1,19 +1,19 @@
 
 # dispersive_eigenmode.py - Tests the meep eigenmode features (eigenmode source,
 # eigenmode decomposition, and get_eigenmode) with dispersive materials.
-# TODO: 
+# TODO:
 #  * check materials with off diagonal components
 #  * check magnetic profiles
 #  * once imaginary component is supported, check that
 
 import meep as mp
-from utils import VectorComparisonMixin
+from utils import ApproxComparisonTestCase
 import unittest
 import numpy as np
 import h5py
 import os
 
-class TestDispersiveEigenmode(VectorComparisonMixin, unittest.TestCase):
+class TestDispersiveEigenmode(ApproxComparisonTestCase):
     # ----------------------------------------- #
     # ----------- Helper Functions ------------ #
     # ----------------------------------------- #
@@ -35,7 +35,7 @@ class TestDispersiveEigenmode(VectorComparisonMixin, unittest.TestCase):
         n_actual = np.real(np.sqrt(material.epsilon(frequency).astype(np.complex128)))
 
         tol = 1e-6 if mp.is_single_precision() else 1e-8
-        self.assertVectorsClose(n, n_actual, epsilon=tol)
+        self.assertClose(n, n_actual, epsilon=tol)
 
     @classmethod
     def setUpClass(cls):
@@ -52,7 +52,7 @@ class TestDispersiveEigenmode(VectorComparisonMixin, unittest.TestCase):
         chi1inv = np.diag(chi1inv)
         N = chi1inv.size
         n = np.sqrt(N/np.sum(chi1inv))
-        
+
         sim = mp.Simulation(cell_size=mp.Vector3(2,2,2),
                             default_material=material,
                             resolution=20,
@@ -60,7 +60,7 @@ class TestDispersiveEigenmode(VectorComparisonMixin, unittest.TestCase):
                             )
         sim.use_output_directory(self.temp_dir)
         sim.init_sim()
-        
+
         # Check to make sure the get_slice routine is working with frequency
         n_slice = np.sqrt(np.max(sim.get_epsilon(frequency=frequency,snap=True)))
         self.assertAlmostEqual(n,n_slice, places=4)
@@ -74,17 +74,17 @@ class TestDispersiveEigenmode(VectorComparisonMixin, unittest.TestCase):
         with h5py.File(filename, 'r') as f:
             n_h5 = np.sqrt(np.max(mp.complexarray(f['eps.r'][()],f['eps.i'][()])))
         self.assertAlmostEqual(n,n_h5, places=4)
-    
+
     # ----------------------------------------- #
     # ----------- Test Routines --------------- #
     # ----------------------------------------- #
     def test_chi1_routine(self):
-        # Checks the newly implemented get_chi1inv routines within the 
-        # fields and structure classes by comparing their output to the 
+        # Checks the newly implemented get_chi1inv routines within the
+        # fields and structure classes by comparing their output to the
         # python epsilon output.
 
         from meep.materials import Si, Ag, LiNbO3, Au
-        
+
         # Check Silicon
         w0 = Si.valid_freq_range.min
         w1 = Si.valid_freq_range.max
@@ -101,7 +101,7 @@ class TestDispersiveEigenmode(VectorComparisonMixin, unittest.TestCase):
         w0 = Au.valid_freq_range.min
         w1 = Au.valid_freq_range.max
         self.call_chi1(Au,w0)
-        self.call_chi1(Au,w1)   
+        self.call_chi1(Au,w1)
 
         # Check Lithium Niobate (X,X)
         w0 = LiNbO3.valid_freq_range.min
@@ -115,13 +115,13 @@ class TestDispersiveEigenmode(VectorComparisonMixin, unittest.TestCase):
         rotLiNbO3.rotate(mp.Vector3(1,1,1),np.radians(34))
         self.call_chi1(rotLiNbO3,w0)
         self.call_chi1(rotLiNbO3,w1)
-    
+
     def test_get_with_dispersion(self):
         # Checks the get_array_slice and output_fields method
         # with dispersive materials.
 
         from meep.materials import Si, Ag, LiNbO3, Au
-        
+
         # Check Silicon
         w0 = Si.valid_freq_range.min
         w1 = Si.valid_freq_range.max
@@ -138,7 +138,7 @@ class TestDispersiveEigenmode(VectorComparisonMixin, unittest.TestCase):
         w0 = Au.valid_freq_range.min
         w1 = Au.valid_freq_range.max
         self.verify_output_and_slice(Au,w0)
-        self.verify_output_and_slice(Au,w1)       
+        self.verify_output_and_slice(Au,w1)
 
         # Check Lithium Niobate
         w0 = LiNbO3.valid_freq_range.min
@@ -152,7 +152,7 @@ class TestDispersiveEigenmode(VectorComparisonMixin, unittest.TestCase):
         rotLiNbO3.rotate(mp.Vector3(1,1,1),np.radians(34))
         self.verify_output_and_slice(rotLiNbO3,w0)
         self.verify_output_and_slice(rotLiNbO3,w1)
-        
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/test_holey_wvg_cavity.py
+++ b/python/tests/test_holey_wvg_cavity.py
@@ -1,9 +1,9 @@
 import meep as mp
-from utils import VectorComparisonMixin
+from utils import ApproxComparisonTestCase
 import unittest
 
 
-class TestHoleyWvgCavity(VectorComparisonMixin, unittest.TestCase):
+class TestHoleyWvgCavity(ApproxComparisonTestCase):
 
     def setUp(self):
         eps = 13
@@ -72,7 +72,7 @@ class TestHoleyWvgCavity(VectorComparisonMixin, unittest.TestCase):
         res = [m.freq, m.decay, m.Q, abs(m.amp), m.amp.real, m.amp.imag]
 
         tol = 1e-6 if mp.is_single_precision() else 1e-8
-        self.assertVectorsClose(expected, res, epsilon=tol)
+        self.assertClose(expected, res, epsilon=tol)
 
     def test_transmission_spectrum(self):
         expected = [
@@ -145,7 +145,7 @@ class TestHoleyWvgCavity(VectorComparisonMixin, unittest.TestCase):
 
         tol = 1e-8 if mp.is_single_precision() else 1e-10
         for e, r in zip(expected, res):
-            self.assertVectorsClose(e, r, epsilon=tol)
+            self.assertClose(e, r, epsilon=tol)
 
 
 

--- a/python/tests/test_physical.py
+++ b/python/tests/test_physical.py
@@ -41,7 +41,7 @@ class TestPhysical(unittest.TestCase):
                             sources=sources,
                             force_complex_fields=True)
         sim.init_sim()
-        sim.solve_cw(tol=1e-6)
+        sim.solve_cw(tol=1e-5 if mp.is_single_precision() else 1e-6)
 
         p1 = mp.Vector3()
         p2 = mp.Vector3(dx)

--- a/python/tests/test_pw_source.py
+++ b/python/tests/test_pw_source.py
@@ -2,9 +2,9 @@ import meep as mp
 import cmath
 import math
 import unittest
+from utils import ApproxComparisonTestCase
 
-
-class TestPwSource(unittest.TestCase):
+class TestPwSource(ApproxComparisonTestCase):
 
     def setUp(self):
         s = 11
@@ -69,8 +69,8 @@ class TestPwSource(unittest.TestCase):
         pt1 = self.sim.get_field_point(mp.Ez, v1)
         pt2 = self.sim.get_field_point(mp.Ez, v2)
 
-        places = 3 if mp.is_single_precision() else 7
-        self.assertAlmostEqual(pt1 / pt2, 27.557668029008262, places=places)
+        tol = 1e-4 if mp.is_single_precision() else 1e-9
+        self.assertClose(pt1 / pt2, 27.557668029008262, epsilon=tol)
 
         self.assertAlmostEqual(cmath.exp(1j * self.k.dot(v1 - v2)), 0.7654030066070924 - 0.6435512702783076j)
 

--- a/python/tests/test_refl_angular.py
+++ b/python/tests/test_refl_angular.py
@@ -1,11 +1,11 @@
 import meep as mp
-from utils import VectorComparisonMixin
+from utils import ApproxComparisonTestCase
 import math
 import unittest
 import numpy as np
 
 
-class TestReflAngular(VectorComparisonMixin, unittest.TestCase):
+class TestReflAngular(ApproxComparisonTestCase):
 
     def test_refl_angular(self):
         resolution = 100
@@ -121,7 +121,7 @@ class TestReflAngular(VectorComparisonMixin, unittest.TestCase):
         ]
 
         tol = 1e-7 if mp.is_single_precision() else 1e-8
-        self.assertVectorsClose(expected, list(zip(freqs, refl_flux)), epsilon=tol)
+        self.assertClose(expected, list(zip(freqs, refl_flux)), epsilon=tol)
 
 
 if __name__ == '__main__':

--- a/python/tests/test_ring_cyl.py
+++ b/python/tests/test_ring_cyl.py
@@ -2,9 +2,9 @@ from __future__ import division
 
 import unittest
 import meep as mp
-from utils import VectorComparisonMixin
+from utils import ApproxComparisonTestCase
 
-class TestRingCyl(VectorComparisonMixin, unittest.TestCase):
+class TestRingCyl(ApproxComparisonTestCase):
 
     def setUp(self):
         n = 3.4
@@ -66,7 +66,7 @@ class TestRingCyl(VectorComparisonMixin, unittest.TestCase):
         res = [m.freq, m.decay, m.Q, abs(m.amp), m.amp.real, m.amp.imag]
 
         tol = 1e-6 if mp.is_single_precision() else 1e-7
-        self.assertVectorsClose(expected, res, epsilon=tol)
+        self.assertClose(expected, res, epsilon=tol)
 
 
 if __name__ == '__main__':

--- a/python/tests/test_source.py
+++ b/python/tests/test_source.py
@@ -120,7 +120,7 @@ class TestSourceTypemaps(unittest.TestCase):
         sim.run(mp.after_sources(h), until_after_sources=200)
         fp = sim.get_field_point(mp.Ez, mp.Vector3(1))
 
-        self.assertAlmostEqual(fp, -0.021997617628500023 + 0j)
+        self.assertAlmostEqual(fp, -0.021997617628500023 + 0j, 5 if mp.is_single_precision() else 7)
 
 
 def amp_fun(p):

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -15,10 +15,10 @@ def compare_arrays(test_instance, exp, res, tol=1e-3):
         test_instance.assertLess(diff, tol)
 
 
-class VectorComparisonMixin(unittest.TestCase):
+class ApproxComparisonTestCase(unittest.TestCase):
     """A mixin for adding proper floating point value and vector comparison."""
 
-    def assertVectorsClose(self, x, y, epsilon = 1e-2, msg = ''):
+    def assertClose(self, x, y, epsilon = 1e-2, msg = ''):
         """Asserts that two values or vectors satisfy ‖x-y‖ ≤ ε * max(‖x‖, ‖y‖)."""
         x = np.atleast_1d(x).ravel()
         y = np.atleast_1d(y).ravel()

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -2332,6 +2332,9 @@ private:
   std::unique_ptr<binary_partition> right;
 };
 
+// control whether CPU flushes subnormal values; see mympi.cpp
+void set_zero_subnormals(bool iszero);
+
 } /* namespace meep */
 
 #endif /* MEEP_H */

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1824,8 +1824,9 @@ public:
   // cw_fields.cpp:
   bool solve_cw(double tol, int maxiters, std::complex<double> frequency, int L = 2,
                 std::complex<double> *eigfreq = NULL, double eigtol = 1e-8, int eigiters = 20);
-  bool solve_cw(double tol = 1e-8, int maxiters = 10000, int L = 2,
-                std::complex<double> *eigfreq = NULL, double eigtol = 1e-8, int eigiters = 20);
+  bool solve_cw(double tol = sizeof(realnum) == sizeof(float) ? 1e-5 : 1e-8, int maxiters = 10000,
+                int L = 2, std::complex<double> *eigfreq = NULL, double eigtol = 1e-8,
+                int eigiters = 20);
 
   // sources.cpp:
   double last_source_time();

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -408,7 +408,7 @@ meep::vec material_grid_grad(vector3 p, material_data *md, const geometric_objec
 #undef D
 
   // [du_dx,du_dy,du_dz] is the gradient ∇u with respect to the transformed coordinate
-  // r1 of the matgrid_val function but what we want is the gradient of u(g(r2)) with 
+  // r1 of the matgrid_val function but what we want is the gradient of u(g(r2)) with
   // respect to r2 where g(r2) is the to_geom_object_coords function (in libctl/utils/geom.c).
   // computing this quantity involves using the chain rule and thus the vector-Jacobian product
   // ∇u J where J is the Jacobian matrix of g.
@@ -2579,9 +2579,9 @@ double get_material_gradient(
   if ((mm->E_susceptibilities.size() == 0) && mm->D_conductivity_diag.x == 0 &&
       mm->D_conductivity_diag.y == 0 && mm->D_conductivity_diag.z == 0){
         switch (field_dir){
-          case meep::Ex: return 2 * (m2->epsilon_diag.x - m1->epsilon_diag.x) * (fields_a * fields_f).real();
-          case meep::Ey: return 2 * (m2->epsilon_diag.y - m1->epsilon_diag.y) * (fields_a * fields_f).real();
-          case meep::Ez: return 2 * (m2->epsilon_diag.z - m1->epsilon_diag.z) * (fields_a * fields_f).real();
+          case meep::Ex: return (m2->epsilon_diag.x - m1->epsilon_diag.x) * (fields_a * fields_f).real();
+          case meep::Ey: return (m2->epsilon_diag.y - m1->epsilon_diag.y) * (fields_a * fields_f).real();
+          case meep::Ez: return (m2->epsilon_diag.z - m1->epsilon_diag.z) * (fields_a * fields_f).real();
           default: meep::abort("Invalid field component specified in gradient.");
         }
       }
@@ -2612,7 +2612,7 @@ double get_material_gradient(
     meep::abort("Invalid adjoint field component");
 
   std::complex<double> result = fields_a * dA_du[3 * dir_idx + dir_idx] * fields_f;
-  return 2 * result.real();
+  return result.real();
 }
 
 /* add the weights from linear_interpolate (see the linear_interpolate

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -424,7 +424,7 @@ binary_partition::binary_partition(const split_plane &_split_plane,
   if (!left || !right) { meep::abort("Binary partition tree is required to be full"); }
 }
 
-binary_partition::binary_partition(const binary_partition& other) : proc_id{other.proc_id}, plane{other.plane} {
+binary_partition::binary_partition(const binary_partition& other) : proc_id(other.proc_id), plane(other.plane) {
   if (!other.is_leaf()) {
     left.reset(new binary_partition(*other.left));
     right.reset(new binary_partition(*other.right));

--- a/tests/dft-fields.cpp
+++ b/tests/dft-fields.cpp
@@ -92,7 +92,7 @@ void Run(bool Pulse, double resolution, cdouble **field_array = 0, int *array_ra
   }
   else {
     f.add_point_source(Ez, continuous_src_time(fcen, df), x0);
-    f.solve_cw(1e-8, 10000, 10);
+    f.solve_cw(sizeof(realnum) == sizeof(float) ? 1e-5 : 1e-8, 10000, 10);
     h5file *file = f.open_h5file("cw-fields", h5file::WRITE, 0, false);
     f.output_hdf5(Ez, f.v, file);
     f.output_hdf5(Hx, f.v, file);

--- a/tests/harmonics.cpp
+++ b/tests/harmonics.cpp
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
 
   double a2, a3, a2_2, a3_2;
 
-  double thresh = sizeof(realnum) == sizeof(float) ? 1e-4 : 1e-5;
+  double thresh = sizeof(realnum) == sizeof(float) ? 1e-3 : 1e-5;
   harmonics(freq, 0.27e-4, 1e-4, 1.0, a2, a3);
   if (different(a2, 9.80330e-07, thresh, "2nd harmonic mismatches known val")) return 1;
   if (sizeof(realnum) == sizeof(float)) {

--- a/tests/near2far.cpp
+++ b/tests/near2far.cpp
@@ -44,7 +44,7 @@ int check_cyl(double sr, double sz, double a) {
   continuous_src_time src(w);
   vec x0 = veccyl(0.5 * sr, 0);
   f.add_point_source(c0, src, x0);
-  f.solve_cw(1e-6);
+  f.solve_cw(sizeof(realnum) == sizeof(float) ? 1e-5 : 1e-6);
 
   component c = Ep;
   const int N = 20;
@@ -137,7 +137,7 @@ int check_2d_3d(ndim dim, const double xmax, double a, component c0, component c
   continuous_src_time src(w);
   f.add_point_source(c0, src, zero_vec(dim));
   if (c1 != NO_COMPONENT) f.add_point_source(c1, src, zero_vec(dim), 0.7654321);
-  f.solve_cw(1e-6);
+  f.solve_cw(sizeof(realnum) == sizeof(float) ? 1e-5 : 1e-6);
 
   FOR_E_AND_H(c) {
     if (gv.has_field(c)) {

--- a/tests/physical.cpp
+++ b/tests/physical.cpp
@@ -42,7 +42,7 @@ int radiating_2D(const double xmax) {
 
   // let the source reach steady state
 #if 1
-  f.solve_cw(1e-6);
+  f.solve_cw(sizeof(realnum) == sizeof(float) ? 1e-5 : 1e-6);
 #else
   while (f.time() < 400)
     f.step();


### PR DESCRIPTION
Fixes https://github.com/NanoComp/meep/issues/1667. The [test_adjoint_solver.py](https://github.com/NanoComp/meep/blob/master/python/tests/test_adjoint_solver.py) is updated correspondingly to include when ``k_point`` is ``False``, zero, and nonzero.