### PR TITLE
add --with-coverage to control usage of Python coverage tests

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -144,7 +144,7 @@ jobs:
       run: |
         mkdir -p build &&
         pushd build &&
-        ../configure --enable-maintainer-mode --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF} &&
+        ../configure --enable-maintainer-mode --with-coverage --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF} &&
         popd
 
     - name: Run configure

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -144,12 +144,12 @@ jobs:
       run: |
         mkdir -p build &&
         pushd build &&
-        ../configure --enable-maintainer-mode --with-coverage --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF} &&
+        ../configure --enable-maintainer-mode --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF} &&
         popd
 
     - name: Run configure
       if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }}
-      run: ./configure --enable-maintainer-mode --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF}
+      run: ./configure --enable-maintainer-mode --with-coverage --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF}
 
     - name: Run configure with single-precision floating point
       if: ${{ matrix.enable-mpi == true && matrix.python-version == 3.9 }}

--- a/configure.ac
+++ b/configure.ac
@@ -538,6 +538,9 @@ if test "$USE_MAINTAINER_MODE" = yes && (test "x$with_python" = "xyes" || test "
   AC_MSG_ERROR([SWIG not found; configure --without-python --without-scheme or use a release tarball])
 fi
 
+AC_ARG_WITH(coverage, [AS_HELP_STRING([--with-coverage],[enable Python coverage tests])],
+            with_coverage=$withval, with_coverage=no)
+
 if test "x$with_python" = xno; then
   have_python=no
 else
@@ -572,14 +575,15 @@ else
           AC_MSG_WARN([disabling Python wrappers])
           have_python=no],[#include <Python.h>])
 
-        AC_MSG_CHECKING([for coverage module])
-        $PYTHON -c 'import coverage' 2>/dev/null
-        if test $? = 0; then
-          AC_MSG_RESULT([yes])
-          have_coverage=yes
-        else
-          AC_MSG_RESULT([no])
-          have_coverage=no
+        if test x"$with_coverage" = xyes; then
+          AC_MSG_CHECKING([for coverage module])
+          $PYTHON -c 'import coverage' 2>/dev/null
+          if test $? = 0; then
+            AC_MSG_RESULT([yes])
+          else
+            AC_MSG_RESULT([no])
+            with_coverage=no
+          fi
         fi
       fi
 
@@ -591,7 +595,7 @@ fi # with_python
 
 AC_SUBST(PYTHON_INCLUDES)
 AM_CONDITIONAL(WITH_PYTHON, test x"$have_python" = "xyes")
-AM_CONDITIONAL(WITH_COVERAGE, test x"$have_coverage" = "xyes")
+AM_CONDITIONAL(WITH_COVERAGE, test x"$with_coverage" = "xyes")
 
 if test "x$with_scheme" = xyes; then
    # Copy/symlink casimir.scm and materials.scm to builddir for out-of-tree builds


### PR DESCRIPTION
Enables `--with-coverage` during CI, but the Python `coverage` module should not be used by default simply because it is present on a user's machine.