### PR TITLE
add fields::dft_fields_norm2

### DIFF
--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -304,27 +304,27 @@ double dft_chunk::dft_fields_norm2() const {
   return sum;
 }
 
-// return the minimum abs(freq) over all DFT chunks
-double fields::dft_minfreq() const {
-  double minfreq = meep::infinity;
+// return the maximum abs(freq) over all DFT chunks
+double fields::dft_maxfreq() const {
+  double maxfreq = 0;
   for (int i = 0; i < num_chunks; i++)
     if (chunks[i]->is_mine())
-      minfreq = std::min(minfreq, chunks[i]->dft_minfreq());
-  return -max_to_all(-minfreq); // == min_to_all(minfreq)
+      maxfreq = std::max(maxfreq, chunks[i]->dft_maxfreq());
+  return max_to_all(maxfreq);
 }
 
-double fields_chunk::dft_minfreq() const {
-  double minomega = meep::infinity;
+double fields_chunk::dft_maxfreq() const {
+  double maxomega = 0;
   for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_chunk)
-    minomega = std::min(minomega, cur->minomega());
-  return minomega / (2*meep::pi);
+    maxomega = std::max(maxomega, cur->maxomega());
+  return maxomega / (2*meep::pi);
 }
 
-double dft_chunk::minomega() const {
-  double minomega = meep::infinity;
+double dft_chunk::maxomega() const {
+  double maxomega = 0;
   for (const auto& o : omega)
-    minomega = std::min(minomega, std::abs(o));
-  return minomega;
+    maxomega = std::max(maxomega, std::abs(o));
+  return maxomega;
 }
 
 void dft_chunk::scale_dft(complex<double> scale) {

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -304,6 +304,29 @@ double dft_chunk::dft_fields_norm2() const {
   return sum;
 }
 
+// return the minimum abs(freq) over all DFT chunks
+double fields::dft_minfreq() const {
+  double minfreq = meep::infinity;
+  for (int i = 0; i < num_chunks; i++)
+    if (chunks[i]->is_mine())
+      minfreq = std::min(minfreq, chunks[i]->dft_minfreq());
+  return -max_to_all(-minfreq); // == min_to_all(minfreq)
+}
+
+double fields_chunk::dft_minfreq() const {
+  double minomega = meep::infinity;
+  for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_chunk)
+    minomega = std::min(minomega, cur->minomega());
+  return minomega / (2*meep::pi);
+}
+
+double dft_chunk::minomega() const {
+  double minomega = meep::infinity;
+  for (const auto& o : omega)
+    minomega = std::min(minomega, std::abs(o));
+  return minomega;
+}
+
 void dft_chunk::scale_dft(complex<double> scale) {
   for (size_t i = 0; i < N * omega.size(); ++i)
     dft[i] *= scale;

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -264,16 +264,16 @@ void dft_chunk::update_dft(double time) {
   }
 }
 
-/* Return the L2 norm^2 of all of the fields used to update DFTs.  This is useful
+/* Return the L2 norm of all of the fields used to update DFTs.  This is useful
    to check whether the simulation is finished (whether all relevant fields have decayed).
    (Collective operation.) */
-double fields::dft_fields_norm2() {
+double fields::dft_fields_norm() {
   am_now_working_on(Other);
   double sum = 0.0;
   for (int i = 0; i < num_chunks; i++)
     if (chunks[i]->is_mine()) sum += chunks[i]->dft_fields_norm2();
   finished_working();
-  return sum_to_all(sum);
+  return std::sqrt(sum_to_all(sum));
 }
 
 double fields_chunk::dft_fields_norm2() const {

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1095,6 +1095,7 @@ public:
   ~dft_chunk();
 
   void update_dft(double time);
+  double dft_fields_norm2() const;
 
   void scale_dft(std::complex<double> scale);
 
@@ -1546,6 +1547,7 @@ private:
   void alloc_extra_connections(field_type, connect_phase, in_or_out, size_t);
   // dft.cpp
   void update_dfts(double timeE, double timeH, int current_step);
+  double dft_fields_norm2() const;
 
   void changing_structure();
 };
@@ -1958,6 +1960,7 @@ public:
   dft_chunk *add_dft(const volume_list *where, const std::vector<double> &freq,
                      bool include_dV = true);
   void update_dfts();
+  double dft_fields_norm2();
   dft_flux add_dft_flux(const volume_list *where, const double *freq, size_t Nfreq,
                         bool use_symmetry = true, bool centered_grid = true);
   dft_flux add_dft_flux(const volume_list *where, const std::vector<double> &freq,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1960,7 +1960,7 @@ public:
   dft_chunk *add_dft(const volume_list *where, const std::vector<double> &freq,
                      bool include_dV = true);
   void update_dfts();
-  double dft_fields_norm2();
+  double dft_fields_norm();
   dft_flux add_dft_flux(const volume_list *where, const double *freq, size_t Nfreq,
                         bool use_symmetry = true, bool centered_grid = true);
   dft_flux add_dft_flux(const volume_list *where, const std::vector<double> &freq,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1096,6 +1096,7 @@ public:
 
   void update_dft(double time);
   double dft_fields_norm2() const;
+  double minomega() const;
 
   void scale_dft(std::complex<double> scale);
 
@@ -1548,6 +1549,7 @@ private:
   // dft.cpp
   void update_dfts(double timeE, double timeH, int current_step);
   double dft_fields_norm2() const;
+  double dft_minfreq() const;
 
   void changing_structure();
 };
@@ -1961,6 +1963,7 @@ public:
                      bool include_dV = true);
   void update_dfts();
   double dft_fields_norm();
+  double dft_minfreq() const;
   dft_flux add_dft_flux(const volume_list *where, const double *freq, size_t Nfreq,
                         bool use_symmetry = true, bool centered_grid = true);
   dft_flux add_dft_flux(const volume_list *where, const std::vector<double> &freq,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1549,7 +1549,7 @@ private:
   // dft.cpp
   void update_dfts(double timeE, double timeH, int current_step);
   double dft_fields_norm2() const;
-  double dft_minfreq() const;
+  double dft_maxfreq() const;
 
   void changing_structure();
 };
@@ -1963,7 +1963,7 @@ public:
                      bool include_dV = true);
   void update_dfts();
   double dft_fields_norm();
-  double dft_minfreq() const;
+  double dft_maxfreq() const;
   dft_flux add_dft_flux(const volume_list *where, const double *freq, size_t Nfreq,
                         bool use_symmetry = true, bool centered_grid = true);
   dft_flux add_dft_flux(const volume_list *where, const std::vector<double> &freq,


### PR DESCRIPTION
Fix #1711 by adding a `fields::dft_fields_norm2()` function that returns the squared L2 norm of all of the fields used in DFT monitor regions.   This can be computed in parallel, and should be a reasonable quantity to use for convergence tests, similar to `stop_when_fields_decayed` but specific to DFT monitors.

Performance should be good (comparable to updating the DFTs), and is not too important since this will not typically be called every timestep.

To do:
- [ ] Add `stop_when_dft_fields_decayed` or similar function — this should use `fields.dft_maxfreq()` to determine how often to run, e.g. it can run every `5.1/fields.dft_maxfreq()` time units.
- [ ] Switch to new convergence check in tests
- [ ] Switch to new convergence check in adjoint solver

cc @smartalecH 