### PR TITLE
Restructure `connections`

### DIFF
--- a/src/fields.cpp
+++ b/src/fields.cpp
@@ -176,12 +176,6 @@ fields_chunk::~fields_chunk() {
     delete[] f_cond_backup[c][cmp];
   }
   delete[] f_rderiv_int;
-  FOR_FIELD_TYPES(ft) {
-    for (int ip = 0; ip < 3; ip++)
-      for (int io = 0; io < 2; io++)
-        delete[] connections[ft][ip][io];
-  }
-  FOR_FIELD_TYPES(ft) { delete[] connection_phases[ft]; }
   while (dft_chunks) {
     dft_chunk *nxt = dft_chunks->next_in_chunk;
     delete dft_chunks;
@@ -250,12 +244,6 @@ fields_chunk::fields_chunk(structure_chunk *the_s, const char *od, double m, dou
   }
   f_rderiv_int = NULL;
   FOR_FIELD_TYPES(ft) {
-    for (int ip = 0; ip < 3; ip++)
-      num_connections[ft][ip][Incoming] = num_connections[ft][ip][Outgoing] = 0;
-    connection_phases[ft] = 0;
-    for (int ip = 0; ip < 3; ip++)
-      for (int io = 0; io < 2; io++)
-        connections[ft][ip][io] = NULL;
     zeroes[ft] = NULL;
     num_zeroes[ft] = 0;
   }
@@ -334,12 +322,6 @@ fields_chunk::fields_chunk(const fields_chunk &thef, int chunkidx) : gv(thef.gv)
     }
   }
   FOR_FIELD_TYPES(ft) {
-    for (int ip = 0; ip < 3; ip++)
-      num_connections[ft][ip][Incoming] = num_connections[ft][ip][Outgoing] = 0;
-    connection_phases[ft] = 0;
-    for (int ip = 0; ip < 3; ip++)
-      for (int io = 0; io < 2; io++)
-        connections[ft][ip][io] = NULL;
     zeroes[ft] = NULL;
     num_zeroes[ft] = 0;
   }

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1438,9 +1438,10 @@ public:
 
   realnum **zeroes[NUM_FIELD_TYPES]; // Holds pointers to metal points.
   size_t num_zeroes[NUM_FIELD_TYPES];
-  realnum **connections[NUM_FIELD_TYPES][NUM_CONNECT_PHASE_TYPES][Outgoing + 1];
-  size_t num_connections[NUM_FIELD_TYPES][NUM_CONNECT_PHASE_TYPES][Outgoing + 1];
-  std::complex<realnum> *connection_phases[NUM_FIELD_TYPES];
+  std::unordered_map<comms_key, std::vector<realnum *>, comms_key_hash_fn> connections_in;
+  std::unordered_map<comms_key, std::vector<realnum *>, comms_key_hash_fn> connections_out;
+  std::unordered_map<comms_key, std::vector<std::complex<realnum> >, comms_key_hash_fn>
+      connection_phases;
 
   int npol[NUM_FIELD_TYPES];                // only E_stuff and H_stuff are used
   polarization_state *pol[NUM_FIELD_TYPES]; // array of npol[i] polarization_state structures
@@ -1542,8 +1543,6 @@ private:
   void initialize_field(component, std::complex<double> f(const vec &));
   void initialize_with_nth_te(int n, double kz);
   void initialize_with_nth_tm(int n, double kz);
-  // boundaries.cpp
-  void alloc_extra_connections(field_type, connect_phase, in_or_out, size_t);
   // dft.cpp
   void update_dfts(double timeE, double timeH, int current_step);
 


### PR DESCRIPTION
* Replace `connections` with separate maps for incoming and outgoing connections.
* Maintain separate connections for each chunk pair.

These changes unblock some of the improvements discussed on #1710 and #1670, in particular overlapped processing of incoming data.