### PR TITLE
make fields::reset_timers a public member

### DIFF
--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -2207,9 +2207,9 @@ public:
   // Returns a map from time_sink to the vector of total times each MPI process spent on the
   // indicated category.
   std::unordered_map<time_sink, std::vector<double>, std::hash<int> > get_timing_data() const;
+  void reset_timers();
 
 private:
-  void reset_timers();
   timing_scope with_timing_scope(time_sink sink);
 
   // The following is an array that is num_chunks by num_chunks.  Actually


### PR DESCRIPTION
The function `fields::reset_timers()` was originally a public member used mainly as part of benchmarking studies to reset the timing stack after the very first timestep. This is necessary because the first timestep usually takes much longer than subsequent timesteps due to the field initialization involved which can therefore skew the timing statistics. #1682 (inadvertently?) changed `fields::reset_timers()` to a private member thereby breaking some of these benchmarking tests. This PR reverts that change.