### PR TITLE
Remove yee_grid=True when register monitors in Near2FarFields

### DIFF
--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -308,7 +308,6 @@ class Near2FarFields(ObjectiveQuantity):
         self._monitor = self.sim.add_near2far(
             self._frequencies,
             *self.Near2FarRegions,
-            yee_grid=True,
         )
         return self._monitor
 


### PR DESCRIPTION
Fix https://github.com/NanoComp/meep/issues/1725