### PR TITLE
add multithreading check to CI

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -139,15 +139,15 @@ jobs:
         MEEP_VERSION=$(./configure -V | grep meep | awk '{print $3}')
         echo "MEEP_VERSION=${MEEP_VERSION}" >> $GITHUB_ENV
 
-    - name: Run configure
+    - name: Run configure with OpenMP
       if: ${{ !(matrix.enable-mpi == false && matrix.python-version == 3.6) && !(matrix.enable-mpi == true && matrix.python-version == 3.9) }}
       run: |
         mkdir -p build &&
         pushd build &&
-        ../configure --enable-maintainer-mode --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF} &&
+        ../configure --enable-maintainer-mode --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF} --with-openmp &&
         popd
 
-    - name: Run configure
+    - name: Run configure with coverage
       if: ${{ matrix.enable-mpi == false && matrix.python-version == 3.6 }}
       run: ./configure --enable-maintainer-mode --with-coverage --prefix=${HOME}/local --with-libctl=${HOME}/local/share/libctl ${MPICONF}
 


### PR DESCRIPTION
To facilitate #1628's attempt to add support for multithreading via OpenMP, this PR adds multithreading to 2/4 test environments (serial and MPI) of the CI. I verified using the output of `config.log` from the actual CI runs that the GCC compiler supports OpenMP (and that it therefore does not need to be installed separately).

The current default behavior when compiling with the `--with-openmp` flag is to use two threads:
https://github.com/NanoComp/meep/blob/3da561301ab26c84fc770970d065a271552dad8e/configure.ac#L261-L264

We may want to consider changing this default value as part of the CI as well. 
