### PR TITLE
tweak relative tolerance of two failing unit tests for multithreading and single precision

### DIFF
--- a/python/tests/test_force.py
+++ b/python/tests/test_force.py
@@ -35,7 +35,9 @@ class TestForce(unittest.TestCase):
         f = mp.get_forces(self.myforce)
 
         self.assertAlmostEqual(f[0], -0.11039089113393187)
-        self.assertAlmostEqual(f[0], mp.get_forces(self.myforce_decimated)[0])
+
+        places = 6 if mp.is_single_precision() else 7
+        self.assertAlmostEqual(f[0], mp.get_forces(self.myforce_decimated)[0], places=places)
 
 
 if __name__ == '__main__':

--- a/python/tests/test_holey_wvg_bands.py
+++ b/python/tests/test_holey_wvg_bands.py
@@ -65,7 +65,7 @@ class TestHoleyWvgBands(unittest.TestCase):
         ]
 
         self.assertTrue(h.modes)
-        places = 5 if mp.is_single_precision() else 7
+        places = 4 if mp.is_single_precision() else 7
         for (r, i), m in zip(expected, h.modes):
             self.assertAlmostEqual(m.freq, r, places=places)
             self.assertAlmostEqual(m.decay, i, places=places)


### PR DESCRIPTION
Slightly adjusts the relative tolerance of two unit tests which are failing when compiling using multithreading (`--with-openmp`) and single-precision floating point for the fields arrays (`--enable-single`). Unfortunately, this setup is not part of the current CI which is why these failing tests were not detected by #1628.

Might be useful to add a separate test environment for multithreading and single precision but that can be done in a separate PR.