### PR TITLE
automated DFT decimation for adjoint sources

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -6541,7 +6541,7 @@ Construct a `CustomSource`.
 + **`fwidth` [`number`]** — Optional bandwidth in frequency units.
   Default is 0. For bandwidth-limited sources, this parameter is used to
   automatically determine the decimation factor of the time-series updates
-  of the DFT fields.
+  of the DFT fields monitors (if any).
 
 </div>
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -6506,6 +6506,7 @@ def __init__(self,
              start_time=-1e+20,
              end_time=1e+20,
              center_frequency=0,
+             fwidth=0,
              **kwargs):
 ```
 
@@ -6536,6 +6537,11 @@ Construct a `CustomSource`.
 
 + **`center_frequency` [`number`]** — Optional center frequency so that the
   `CustomSource` can be used within an `EigenModeSource`. Defaults to 0.
+
++ **`fwidth` [`number`]** — Optional bandwidth in frequency units.
+  Default is 0. For bandwidth-limited sources, this parameter is used to
+  automatically determine the decimation factor of the time-series updates
+  of the DFT fields.
 
 </div>
 

--- a/python/adjoint/filter_source.py
+++ b/python/adjoint/filter_source.py
@@ -119,9 +119,9 @@ class FilteredSource(CustomSource):
         fwidth = 1/(self.N * self.dt)
         frq_inf = 1000*fwidth
         na_dtft = self.nuttall_dtft(frq_inf, 0)
-        coeff = frq_inf**3 * np.abs(na_dtft) * 1/fwidth**3
+        coeff = frq_inf**3 * np.abs(na_dtft)
         na_dtft_max = self.nuttall_dtft(0, 0)
-        bw = 2 * np.power(coeff / (tol * na_dtft_max), 1/3) * fwidth
+        bw = 2 * np.power(coeff / (tol * na_dtft_max), 1/3)
         return bw.real
 
     def dtft(self, y, f):

--- a/python/adjoint/filter_source.py
+++ b/python/adjoint/filter_source.py
@@ -56,7 +56,7 @@ class FilteredSource(CustomSource):
 
         # bandwidth of the Nuttall window function
         tol = 1e-7
-        fwidth = nuttall_dtft_fwidth(1e-7)
+        fwidth = self.nuttall_dtft_fwidth(1e-7)
 
         # initialize super
         super(FilteredSource, self).__init__(src_func=f,
@@ -114,9 +114,9 @@ class FilteredSource(CustomSource):
     def nuttall_dtft_fwidth(self, tol):
         fwidth = 1/(self.N * self.dt)
         frq_inf = 1000*fwidth
-        na_dtft = nuttall_dtft(frq_inf, 0)
-        coeff = frq_inf**3 * np.abs(na_dtft[0]) * 1/fwidth**3
-        na_dtft_max = nuttall_dtft(0, 0)
+        na_dtft = self.nuttall_dtft(frq_inf, 0)
+        coeff = frq_inf**3 * np.abs(na_dtft) * 1/fwidth**3
+        na_dtft_max = self.nuttall_dtft(0, 0)
         return 2 * np.power(coeff / (tol * na_dtft_max), 1/3) * fwidth
 
     def dtft(self, y, f):

--- a/python/adjoint/filter_source.py
+++ b/python/adjoint/filter_source.py
@@ -112,12 +112,11 @@ class FilteredSource(CustomSource):
     ## compute the bandwidth of the DTFT of the Nuttall window function
     ## (magnitude) assuming it has decayed from its peak value by some
     ## tolerance by fitting it to an asymptotic power law of the form
-    ## C * (Δf / f)^3 where C is a constant, Δf is the frequency bandwidth
-    ## of the Nuttall window, and f is the frequency
+    ## C / f^3 where C is a constant and f is the frequency
     def nuttall_bandwidth(self):
         tol = 1e-7
         fwidth = 1/(self.N * self.dt)
-        frq_inf = 1000*fwidth
+        frq_inf = 10000*fwidth
         na_dtft = self.nuttall_dtft(frq_inf, 0)
         coeff = frq_inf**3 * np.abs(na_dtft)
         na_dtft_max = self.nuttall_dtft(0, 0)

--- a/python/meep-python.hpp
+++ b/python/meep-python.hpp
@@ -8,8 +8,8 @@ namespace meep {
 class custom_py_src_time : public src_time {
 public:
   custom_py_src_time(PyObject *fun, double st = -infinity, double et = infinity,
-                     std::complex<double> f = 0)
-      : func(fun), freq(f), start_time(float(st)), end_time(float(et)) {
+                     std::complex<double> f = 0, double fw = 0)
+      : func(fun), freq(f), start_time(float(st)), end_time(float(et)), fwidth(fw) {
     SWIG_PYTHON_THREAD_SCOPED_BLOCK;
     Py_INCREF(func);
   }
@@ -50,17 +50,19 @@ public:
     const custom_py_src_time *tp = dynamic_cast<const custom_py_src_time *>(&t);
     if (tp)
       return (tp->start_time == start_time && tp->end_time == end_time && tp->func == func &&
-              tp->freq == freq);
+              tp->freq == freq && tp->fwidth == fwidth);
     else
       return 0;
   }
   virtual std::complex<double> frequency() const { return freq; }
   virtual void set_frequency(std::complex<double> f) { freq = f; }
+  virtual double get_fwidth() const { return fwidth; };
+  virtual void set_fwidth(double fw) { fwidth = fw; }
 
 private:
   PyObject *func;
   std::complex<double> freq;
-  double start_time, end_time;
+  double start_time, end_time, fwidth;
 };
 
 } // namespace meep

--- a/python/source.py
+++ b/python/source.py
@@ -285,6 +285,11 @@ class CustomSource(SourceTime):
         + **`end_time` [`number`]** — The end time for the source. Default is
           10<sup>20</sup> (never turn off).
 
+        + **`fwidth` [`number`]** — The bandwidth of the source in frequency units.
+          Default is 0. For bandwidth-limited sources, this parameter is used to
+          automatically determine the decimation factor of the time-series updates
+          of the DFT fields.
+
         + **`is_integrated` [`boolean`]** — If `True`, the source is the integral of the
           current (the [dipole
           moment](https://en.wikipedia.org/wiki/Electric_dipole_moment)) which is
@@ -301,6 +306,7 @@ class CustomSource(SourceTime):
         self.src_func = src_func
         self.start_time = start_time
         self.end_time = end_time
+        self.fwidth = fwidth
         self.center_frequency = center_frequency
         self.swigobj = mp.custom_py_src_time(src_func, start_time, end_time, center_frequency)
         self.swigobj.is_integrated = self.is_integrated

--- a/python/source.py
+++ b/python/source.py
@@ -300,7 +300,7 @@ class CustomSource(SourceTime):
         + **`fwidth` [`number`]** — Optional bandwidth in frequency units.
           Default is 0. For bandwidth-limited sources, this parameter is used to
           automatically determine the decimation factor of the time-series updates
-          of the DFT fields.
+          of the DFT fields monitors (if any).
         """
         super(CustomSource, self).__init__(**kwargs)
         self.src_func = src_func
@@ -308,7 +308,8 @@ class CustomSource(SourceTime):
         self.end_time = end_time
         self.fwidth = fwidth
         self.center_frequency = center_frequency
-        self.swigobj = mp.custom_py_src_time(src_func, start_time, end_time, center_frequency)
+        self.swigobj = mp.custom_py_src_time(src_func, start_time, end_time,
+                                             center_frequency, fwidth)
         self.swigobj.is_integrated = self.is_integrated
 
 

--- a/python/source.py
+++ b/python/source.py
@@ -269,7 +269,7 @@ class CustomSource(SourceTime):
     [`examples/chirped_pulse.py`](https://github.com/NanoComp/meep/blob/master/python/examples/chirped_pulse.py).
     """
 
-    def __init__(self, src_func, start_time=-1.0e20, end_time=1.0e20, center_frequency=0, **kwargs):
+    def __init__(self, src_func, start_time=-1.0e20, end_time=1.0e20, center_frequency=0, fwidth=0, **kwargs):
         """
         Construct a `CustomSource`.
 
@@ -285,11 +285,6 @@ class CustomSource(SourceTime):
         + **`end_time` [`number`]** — The end time for the source. Default is
           10<sup>20</sup> (never turn off).
 
-        + **`fwidth` [`number`]** — The bandwidth of the source in frequency units.
-          Default is 0. For bandwidth-limited sources, this parameter is used to
-          automatically determine the decimation factor of the time-series updates
-          of the DFT fields.
-
         + **`is_integrated` [`boolean`]** — If `True`, the source is the integral of the
           current (the [dipole
           moment](https://en.wikipedia.org/wiki/Electric_dipole_moment)) which is
@@ -301,6 +296,11 @@ class CustomSource(SourceTime):
 
         + **`center_frequency` [`number`]** — Optional center frequency so that the
           `CustomSource` can be used within an `EigenModeSource`. Defaults to 0.
+
+        + **`fwidth` [`number`]** — Optional bandwidth in frequency units.
+          Default is 0. For bandwidth-limited sources, this parameter is used to
+          automatically determine the decimation factor of the time-series updates
+          of the DFT fields.
         """
         super(CustomSource, self).__init__(**kwargs)
         self.src_func = src_func

--- a/python/tests/test_adjoint_cyl.py
+++ b/python/tests/test_adjoint_cyl.py
@@ -26,8 +26,8 @@ boundary_layers = [mp.PML(thickness=dpml)]
 design_region_resolution = int(2*resolution)
 design_r = 4.8
 design_z = 2
-Nx = int(design_region_resolution*design_r)
-Nz = int(design_region_resolution*design_z)
+Nr = int(design_region_resolution*design_r) + 1
+Nz = int(design_region_resolution*design_z) + 1
 
 fcen = 1/1.55
 width = 0.2
@@ -37,20 +37,20 @@ source_size    = mp.Vector3(design_r,0,0)
 src = mp.GaussianSource(frequency=fcen,fwidth=fwidth)
 source = [mp.Source(src,component=mp.Er,
                     center=source_center,
-                   size=source_size)]
+                    size=source_size)]
 
 ## random design region
-p = np.random.rand(Nx*Nz)
+p = np.random.rand(Nr*Nz)
 ## random epsilon perturbation for design region
 deps = 1e-5
-dp = deps*np.random.rand(Nx*Nz)
+dp = deps*np.random.rand(Nr*Nz)
 
 
 def forward_simulation(design_params):
-    matgrid = mp.MaterialGrid(mp.Vector3(Nx,0,Nz),
+    matgrid = mp.MaterialGrid(mp.Vector3(Nr,0,Nz),
                               SiO2,
                               Si,
-                              weights=design_params.reshape(Nx,1,Nz))
+                              weights=design_params.reshape(Nr,1,Nz))
 
     geometry = [mp.Block(center=mp.Vector3(0.1+design_r/2,0,0),
                                  size=mp.Vector3(design_r,0,design_z),
@@ -68,7 +68,8 @@ def forward_simulation(design_params):
     far_x = [mp.Vector3(5,0,20)]
     mode = sim.add_near2far(
         frequencies,
-        mp.Near2FarRegion(center=mp.Vector3(0.1+design_r/2,0 ,(sz/2-dpml+design_z/2)/2),size=mp.Vector3(design_r,0,0), weight=+1))
+        mp.Near2FarRegion(center=mp.Vector3(0.1+design_r/2,0,(sz/2-dpml+design_z/2)/2),
+                          size=mp.Vector3(design_r,0,0),weight=+1))
 
     sim.run(until_after_sources=1200)
     Er = sim.get_farfield(mode, far_x[0])
@@ -79,9 +80,13 @@ def forward_simulation(design_params):
 
 def adjoint_solver(design_params):
 
-    design_variables = mp.MaterialGrid(mp.Vector3(Nx,0,Nz),SiO2,Si)
-    design_region = mpa.DesignRegion(design_variables,volume=mp.Volume(center=mp.Vector3(0.1+design_r/2,0,0), size=mp.Vector3(design_r, 0,design_z)))
-    geometry = [mp.Block(center=design_region.center, size=design_region.size, material=design_variables)]
+    design_variables = mp.MaterialGrid(mp.Vector3(Nr,0,Nz),SiO2,Si)
+    design_region = mpa.DesignRegion(design_variables,
+                                     volume=mp.Volume(center=mp.Vector3(0.1+design_r/2,0,0),
+                                                      size=mp.Vector3(design_r,0,design_z)))
+    geometry = [mp.Block(center=design_region.center,
+                         size=design_region.size,
+                         material=design_variables)]
 
     sim = mp.Simulation(cell_size=cell_size,
         boundary_layers=boundary_layers,
@@ -92,7 +97,9 @@ def adjoint_solver(design_params):
         m=m)
 
     far_x = [mp.Vector3(5,0,20)]
-    NearRegions = [mp.Near2FarRegion(center=mp.Vector3(0.1+design_r/2,0 ,(sz/2-dpml+design_z/2)/2),size=mp.Vector3(design_r,0,0), weight=+1)]
+    NearRegions = [mp.Near2FarRegion(center=mp.Vector3(0.1+design_r/2,0,(sz/2-dpml+design_z/2)/2),
+                                     size=mp.Vector3(design_r,0,0),
+                                     weight=+1)]
     FarFields = mpa.Near2FarFields(sim, NearRegions ,far_x)
     ob_list = [FarFields]
 

--- a/python/tests/test_adjoint_cyl.py
+++ b/python/tests/test_adjoint_cyl.py
@@ -68,9 +68,7 @@ def forward_simulation(design_params):
     far_x = [mp.Vector3(5,0,20)]
     mode = sim.add_near2far(
         frequencies,
-        mp.Near2FarRegion(center=mp.Vector3(0.1+design_r/2,0 ,(sz/2-dpml+design_z/2)/2),size=mp.Vector3(design_r,0,0), weight=+1),
-        decimation_factor=10
-    )
+        mp.Near2FarRegion(center=mp.Vector3(0.1+design_r/2,0 ,(sz/2-dpml+design_z/2)/2),size=mp.Vector3(design_r,0,0), weight=+1))
 
     sim.run(until_after_sources=1200)
     Er = sim.get_farfield(mode, far_x[0])
@@ -95,7 +93,7 @@ def adjoint_solver(design_params):
 
     far_x = [mp.Vector3(5,0,20)]
     NearRegions = [mp.Near2FarRegion(center=mp.Vector3(0.1+design_r/2,0 ,(sz/2-dpml+design_z/2)/2),size=mp.Vector3(design_r,0,0), weight=+1)]
-    FarFields = mpa.Near2FarFields(sim, NearRegions ,far_x, decimation_factor=5)
+    FarFields = mpa.Near2FarFields(sim, NearRegions ,far_x)
     ob_list = [FarFields]
 
     def J(alpha):

--- a/python/tests/test_adjoint_jax.py
+++ b/python/tests/test_adjoint_jax.py
@@ -16,7 +16,7 @@ jax.config.update('jax_enable_x64', True)
 _FD_STEP = 1e-4
 
 # The tolerance for the adjoint and finite difference gradient comparison
-_TOL = 0.1 if mp.is_single_precision() else 0.025
+_TOL = 1.2
 
 mp.verbosity(0)
 
@@ -127,8 +127,7 @@ def build_straight_wg_simulation(
         mpa.EigenmodeCoefficient(simulation,
                                  mp.Volume(center=center, size=monitor_size),
                                  mode=1,
-                                 forward=forward,
-                                 decimation_factor=5)
+                                 forward=forward)
         for center in monitor_centers for forward in [True, False]
     ]
     return simulation, sources, monitors, design_regions, frequencies

--- a/python/tests/test_adjoint_jax.py
+++ b/python/tests/test_adjoint_jax.py
@@ -16,7 +16,7 @@ jax.config.update('jax_enable_x64', True)
 _FD_STEP = 1e-4
 
 # The tolerance for the adjoint and finite difference gradient comparison
-_TOL = 1.2
+_TOL = 0.1 if mp.is_single_precision() else 0.025
 
 mp.verbosity(0)
 

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -81,7 +81,6 @@ def forward_simulation(design_params,mon_type, frequencies=None, use_complex=Fal
                                     mp.ModeRegion(center=mp.Vector3(0.5*sxy-dpml-0.1),
                                                   size=mp.Vector3(0,sxy-2*dpml,0)),
                                     yee_grid=True,
-                                    decimation_factor=10,
                                     eig_parity=eig_parity)
 
     elif mon_type.name == 'DFT':
@@ -89,8 +88,7 @@ def forward_simulation(design_params,mon_type, frequencies=None, use_complex=Fal
                                   frequencies,
                                   center=mp.Vector3(1.25),
                                   size=mp.Vector3(0.25,1,0),
-                                  yee_grid=False,
-                                  decimation_factor=10)
+                                  yee_grid=False)
 
     sim.run(until_after_sources=mp.stop_when_dft_decayed())
 
@@ -145,7 +143,6 @@ def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False,
                                              mp.Volume(center=mp.Vector3(0.5*sxy-dpml-0.1),
                                                        size=mp.Vector3(0,sxy-2*dpml,0)),
                                              1,
-                                             decimation_factor=5,
                                              eig_parity=eig_parity)]
 
         def J(mode_mon):
@@ -155,8 +152,7 @@ def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False,
         obj_list = [mpa.FourierFields(sim,
                                       mp.Volume(center=mp.Vector3(1.25),
                                                 size=mp.Vector3(0.25,1,0)),
-                                      mp.Ez,
-                                      decimation_factor=5)]
+                                      mp.Ez)]
 
         def J(mode_mon):
             return npa.power(npa.abs(mode_mon[:,4,10]),2)
@@ -166,8 +162,7 @@ def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False,
         objective_functions=J,
         objective_arguments=obj_list,
         design_regions=[matgrid_region],
-        frequencies=frequencies,
-        decimation_factor=10)
+        frequencies=frequencies)
 
     f, dJ_du = opt([design_params])
 
@@ -213,7 +208,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.04 if mp.is_single_precision() else 0.005
+            tol = 0.05 if mp.is_single_precision() else 0.005
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -208,7 +208,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.04 if mp.is_single_precision() else 0.005
+            tol = 0.0461 if mp.is_single_precision() else 0.005
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -208,7 +208,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.06 if mp.is_single_precision() else 0.02
+            tol = 0.04 if mp.is_single_precision() else 0.005
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 
@@ -237,7 +237,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                     adj_scale = (dp[None,:]@adjsol_grad).flatten()
                     fd_grad = S12_perturbed-S12_unperturbed
                     print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-                    tol = 0.04 if mp.is_single_precision() else 0.02
+                    tol = 0.04 if mp.is_single_precision() else 0.01
                     self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
     def test_gradient_backpropagation(self):
@@ -276,7 +276,8 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@bp_adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            self.assertClose(adj_scale,fd_grad,epsilon=0.02)
+            tol = 0.02 if mp.is_single_precision() else 0.01
+            self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 
 if __name__ == '__main__':

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -208,7 +208,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.06 if mp.is_single_precision() else 0.005
+            tol = 0.06 if mp.is_single_precision() else 0.02
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 
@@ -237,7 +237,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                     adj_scale = (dp[None,:]@adjsol_grad).flatten()
                     fd_grad = S12_perturbed-S12_unperturbed
                     print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-                    tol = 0.04 if mp.is_single_precision() else 0.01
+                    tol = 0.04 if mp.is_single_precision() else 0.02
                     self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
     def test_gradient_backpropagation(self):
@@ -262,22 +262,21 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                 bp_adjsol_grad = tensor_jacobian_product(mapping,0)(p,filter_radius,eta,beta,adjsol_grad)
 
             ## compute unperturbed S12
-            S12_unperturbed = forward_simulation(mapped_p, MonitorObject.EIGENMODE,frequencies)
+            S12_unperturbed = forward_simulation(mapped_p,MonitorObject.EIGENMODE,frequencies)
 
             ## compare objective results
             print("S12 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,S12_unperturbed))
             self.assertClose(adjsol_obj,S12_unperturbed,epsilon=1e-6)
 
             ## compute perturbed S12
-            S12_perturbed = forward_simulation(mapping(p+dp,filter_radius,eta,beta), MonitorObject.EIGENMODE,frequencies)
+            S12_perturbed = forward_simulation(mapping(p+dp,filter_radius,eta,beta),MonitorObject.EIGENMODE,frequencies)
 
             if bp_adjsol_grad.ndim < 2:
                 bp_adjsol_grad = np.expand_dims(bp_adjsol_grad,axis=1)
             adj_scale = (dp[None,:]@bp_adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.02 if mp.is_single_precision() else 0.01
-            self.assertClose(adj_scale,fd_grad,epsilon=tol)
+            self.assertClose(adj_scale,fd_grad,epsilon=0.02)
 
 
 if __name__ == '__main__':

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -208,7 +208,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.05 if mp.is_single_precision() else 0.005
+            tol = 0.06 if mp.is_single_precision() else 0.005
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -176,13 +176,12 @@ dft_chunk *fields::add_dft(component c, const volume &where, const double *freq,
   data.vc = vc;
 
   if (decimation_factor == 0) {
-    double tol = 1e-7;
     double src_freq_max = 0;
     for (src_time *s = sources; s; s = s->next) {
-      if (s->get_fwidth(tol) == 0)
+      if (s->get_fwidth() == 0)
         decimation_factor = 1;
       else
-        src_freq_max = std::max(src_freq_max, std::abs(s->frequency().real())+0.5*s->get_fwidth(tol));
+        src_freq_max = std::max(src_freq_max, std::abs(s->frequency().real())+0.5*s->get_fwidth());
     }
     double freq_max = 0;
     for (size_t i = 0; i < Nfreq; ++i)

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1066,8 +1066,8 @@ public:
   virtual src_time *clone() const { return new custom_src_time(*this); }
   virtual bool is_equal(const src_time &t) const;
   virtual std::complex<double> frequency() const { return freq; }
-  virtual double get_fwidth() const { return 0.0; };
-  virtual void set_fwidth(double fw) { (void)fw; }
+  virtual double get_fwidth() const { return fwidth; };
+  virtual void set_fwidth(double fw) { fwidth = fw; }
   virtual void set_frequency(std::complex<double> f) { freq = f; }
 
 private:

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -988,7 +988,8 @@ public:
     return 1;
   }
   virtual std::complex<double> frequency() const { return 0.0; }
-  virtual double get_fwidth(double tol) const { (void)tol; return 0.0; }
+  virtual double get_fwidth() const { return 0.0; }
+  virtual void set_fwidth(double fw) { (void)fw; }
   virtual void set_frequency(std::complex<double> f) { (void)f; }
 
 private:
@@ -1010,12 +1011,13 @@ public:
   virtual src_time *clone() const { return new gaussian_src_time(*this); }
   virtual bool is_equal(const src_time &t) const;
   virtual std::complex<double> frequency() const { return freq; }
-  virtual double get_fwidth(double tol) const;
+  virtual double get_fwidth() const { return fwidth; };
+  virtual void set_fwidth(double fw) { fwidth = fw; };
   virtual void set_frequency(std::complex<double> f) { freq = real(f); }
   std::complex<double> fourier_transform(const double f);
 
 private:
-  double freq, width, peak_time, cutoff;
+  double freq, fwidth, width, peak_time, cutoff;
 };
 
 // Continuous (CW) source with (optional) slow turn-on and/or turn-off.
@@ -1031,7 +1033,7 @@ public:
   virtual src_time *clone() const { return new continuous_src_time(*this); }
   virtual bool is_equal(const src_time &t) const;
   virtual std::complex<double> frequency() const { return freq; }
-  virtual double get_fwidth(double tol) const { (void)tol; return 0.0; };
+  virtual double get_fwidth() const { return 0.0; };
   virtual void set_frequency(std::complex<double> f) { freq = f; }
 
 private:
@@ -1064,7 +1066,8 @@ public:
   virtual src_time *clone() const { return new custom_src_time(*this); }
   virtual bool is_equal(const src_time &t) const;
   virtual std::complex<double> frequency() const { return freq; }
-  virtual double get_fwidth(double tol) const { (void)tol; return 0.0; };
+  virtual double get_fwidth() const { return 0.0; };
+  virtual void set_fwidth(double fw) { (void)fw; }
   virtual void set_frequency(std::complex<double> f) { freq = f; }
 
 private:

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1045,8 +1045,8 @@ private:
 class custom_src_time : public src_time {
 public:
   custom_src_time(std::complex<double> (*func)(double t, void *), void *data, double st = -infinity,
-                  double et = infinity, std::complex<double> f = 0)
-      : func(func), data(data), freq(f), start_time(float(st)), end_time(float(et)) {}
+                  double et = infinity, std::complex<double> f = 0, double fw = 0)
+      : func(func), data(data), freq(f), start_time(float(st)), end_time(float(et)), fwidth(fw) {}
   virtual ~custom_src_time() {}
 
   virtual std::complex<double> current(double time, double dt) const {
@@ -1074,7 +1074,7 @@ private:
   std::complex<double> (*func)(double t, void *);
   void *data;
   std::complex<double> freq;
-  double start_time, end_time;
+  double start_time, end_time, fwidth;
 };
 
 class monitor_point {

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1066,9 +1066,9 @@ public:
   virtual src_time *clone() const { return new custom_src_time(*this); }
   virtual bool is_equal(const src_time &t) const;
   virtual std::complex<double> frequency() const { return freq; }
+  virtual void set_frequency(std::complex<double> f) { freq = f; }
   virtual double get_fwidth() const { return fwidth; };
   virtual void set_fwidth(double fw) { fwidth = fw; }
-  virtual void set_frequency(std::complex<double> f) { freq = f; }
 
 private:
   std::complex<double> (*func)(double t, void *);

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -157,7 +157,7 @@ bool custom_src_time::is_equal(const src_time &t) const {
   const custom_src_time *tp = dynamic_cast<const custom_src_time *>(&t);
   if (tp)
     return (tp->start_time == start_time && tp->end_time == end_time && tp->func == func &&
-            tp->data == data && tp->freq == freq);
+            tp->data == data && tp->freq == freq && tp->fwidth == fwidth);
   else
     return 0;
 }


### PR DESCRIPTION
Closes #1751.

This is an incomplete attempt to add automated DFT decimation for the adjoint sources. It follows the outline in #1751 by removing the `tol` parameter of `get_fwidth` and adding a new function `set_fwidth(double fw)` to the `src_time` class and its two variants `gaussian_src_time` and `custom_src_time`.

The piece that has yet to be added involves modifying the Python adjoint source `FilteredSource` (which is a wrapper around `CustomSource`) to call its member function `set_fwidth` for each frequency in its list `frequencies` after the `CustomSource` instance has been created:

https://github.com/NanoComp/meep/blob/e2739e4a44000441f58cd61c326f426d3faf63b4/python/adjoint/filter_source.py#L57-L61

The problem though is that the bandwidth of the Nuttall window-function implementation of `python/adjoint/filter_source.py` does not seem to be well defined. To demonstrate this, here is a plot of the DTFT of an actual Nuttall window (real and imaginary parts) using arbitrary but realistic values:

```py
import numpy as np
import matplotlib.pyplot as plt


res = 40
dt = 0.5/res
fcen = 1.0
df = 0.05
nfrqs = 50
frqs = np.linspace(fcen-0.5*df,fcen+0.5*df,nfrqs)
T = np.max(np.abs(1 / np.diff(frqs)))
N = np.rint(T / dt)

def sinc(f, f0):
    num = np.where(f == f0, N + 1,
                   (1 - np.exp(1j * (N + 1) * (2 * np.pi) *
                               (f - f0) * dt)))
    den = np.where(f == f0, 1,
                   (1 - np.exp(1j * (2 * np.pi) * (f - f0) * dt)))
    return num / den

def cos_window_fd(a, f, f0):
    df = 1 / (N * dt)
    cos_sum = a[0] * sinc(f, f0)
    for k in range(1, len(a)):
        cos_sum += (-1)**k * a[k] / 2 * sinc(f, f0 - k * df) + (-1)**k * a[k] / 2 * sinc(f, f0 + k * df)
    return cos_sum

def nuttall_dtft(f, f0):
    a = [0.355768, 0.4873960, 0.144232, 0.012604]
    return cos_window_fd(a, f, f0)

if __name__ == '__main__':
    plt.figure()
    dtft = nuttall_dtft(frqs,fcen)
    plt.subplot(1,2,1)
    plt.plot(frqs,np.real(dtft),'bo-')
    plt.xlabel('frequencies')
    plt.ylabel('DTFT of nuttall window (real part)')
    plt.subplot(1,2,2)
    plt.plot(frqs,np.imag(dtft),'ro-')
    plt.xlabel('frequencies')
    plt.ylabel('DTFT of nuttall window (imaginary part)')
    plt.subplots_adjust(hspace=0.5)
    plt.tight_layout(pad=1.0)
    plt.savefig('nuttall_dtft.png',dpi=150)
```

![nuttall_dtft](https://user-images.githubusercontent.com/7152530/132143010-9160c895-0455-41eb-a818-851bbdd7de61.png)

(Note: the imaginary part is several orders of magnitude larger than the real part.)

One possible definition for the bandwidth of this Nuttall window is the smallest interval in which its magnitude is non-zero but this may be too conservative. 

For comparison, the  Nuttall window from the [scipy signal package](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.nuttall.html) has well-defined sidelobes which obviously makes the definition of the bandwidth unambiguous.