### PR TITLE
markdown documentation for stop_when_dft_decayed

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -2691,12 +2691,12 @@ def stop_when_fields_decayed(dt=None, c=None, pt=None, decay_by=None):
 <div class="function_docstring" markdown="1">
 
 Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
-or `until_after_sources` parameter, that examines the component `c` (e.g. `Ex`, etc.)
+or `until_after_sources` parameter, that examines the component `c` (e.g. `meep.Ex`, etc.)
 at the point `pt` (a `Vector3`) and keeps running until its absolute value *squared*
 has decayed by at least `decay_by` from its maximum previous value. In particular, it
 keeps incrementing the run time by `dt` (in Meep units) and checks the maximum value
 over that time period &mdash; in this way, it won't be fooled just because the field
-happens to go through 0 at some instant.
+happens to go through zero at some instant.
 
 Note that, if you make `decay_by` very small, you may need to increase the `cutoff`
 property of your source(s), to decrease the amplitude of the small high-frequency
@@ -2719,8 +2719,8 @@ def stop_when_dft_decayed(tol=None,
 Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
 or `until_after_sources` parameter, that checks the `Simulation`'s dft objects every `dt`
 timesteps, and stops the simulation once all the field components and frequencies of *every*
-dft object have decayed by at least some tolerance `tol` (no default value). The optimal `dt`
-is determined automatically based on the frequency content in the DFT monitors.
+dft object have decayed by at least some tolerance `tol` (no default value). The time interval
+`dt` is determined automatically based on the frequency content in the DFT monitors.
 There are two optional parameters: a minimum run time `minimum_run_time` (default: 0) or a
 maximum run time `maximum_run_time` (no default).
 
@@ -7516,12 +7516,12 @@ def stop_when_fields_decayed(dt=None, c=None, pt=None, decay_by=None):
 <div class="function_docstring" markdown="1">
 
 Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
-or `until_after_sources` parameter, that examines the component `c` (e.g. `Ex`, etc.)
+or `until_after_sources` parameter, that examines the component `c` (e.g. `meep.Ex`, etc.)
 at the point `pt` (a `Vector3`) and keeps running until its absolute value *squared*
 has decayed by at least `decay_by` from its maximum previous value. In particular, it
 keeps incrementing the run time by `dt` (in Meep units) and checks the maximum value
 over that time period &mdash; in this way, it won't be fooled just because the field
-happens to go through 0 at some instant.
+happens to go through zero at some instant.
 
 Note that, if you make `decay_by` very small, you may need to increase the `cutoff`
 property of your source(s), to decrease the amplitude of the small high-frequency

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -2685,7 +2685,7 @@ In particular, a useful value for `until_after_sources` or `until` is often `sto
 <a id="stop_when_fields_decayed"></a>
 
 ```python
-def stop_when_fields_decayed(dt, c, pt, decay_by):
+def stop_when_fields_decayed(dt=None, c=None, pt=None, decay_by=None):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -2694,7 +2694,7 @@ Return a `condition` function, suitable for passing to `Simulation.run` as the `
 or `until_after_sources` parameter, that examines the component `c` (e.g. `Ex`, etc.)
 at the point `pt` (a `Vector3`) and keeps running until its absolute value *squared*
 has decayed by at least `decay_by` from its maximum previous value. In particular, it
-keeps incrementing the run time by `dT` (in Meep units) and checks the maximum value
+keeps incrementing the run time by `dt` (in Meep units) and checks the maximum value
 over that time period &mdash; in this way, it won't be fooled just because the field
 happens to go through 0 at some instant.
 
@@ -2703,6 +2703,26 @@ property of your source(s), to decrease the amplitude of the small high-frequenc
 components that are excited when the source turns off. High frequencies near the
 [Nyquist frequency](https://en.wikipedia.org/wiki/Nyquist_frequency) of the grid have
 slow group velocities and are absorbed poorly by [PML](Perfectly_Matched_Layer.md).
+
+</div>
+
+<a id="stop_when_dft_decayed"></a>
+
+```python
+def stop_when_dft_decayed(tol=None,
+                      minimum_run_time=0,
+                      maximum_run_time=None):
+```
+
+<div class="function_docstring" markdown="1">
+
+Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
+or `until_after_sources` parameter, that checks all of the `Simulation`'s dft objects
+every `dt` timesteps, and stops the simulation once *all* the field components and frequencies
+of *every* dft object have decayed by at least some tolerance `tol` (no default value).
+The optimal `dt` is determined automatically based on the frequency content in the DFT monitors.
+There are two optional parameters: a minimum run time `minimum_run_time` (default: 0) or a
+maximum run time `maximum_run_time` (no default).
 
 </div>
 
@@ -2733,7 +2753,6 @@ system, the simulation will abort time stepping and continue executing any code 
 follows the `run` function (e.g., outputting fields).
 
 </div>
-
 
 Finally, another run function, useful for computing ω(**k**) band diagrams, is available via these `Simulation` methods:
 
@@ -7491,7 +7510,7 @@ fr = mp.FluxRegion(volume=mp.GDSII_vol(fname, layer, zmin, zmax))
 <a id="stop_when_fields_decayed"></a>
 
 ```python
-def stop_when_fields_decayed(dt, c, pt, decay_by):
+def stop_when_fields_decayed(dt=None, c=None, pt=None, decay_by=None):
 ```
 
 <div class="function_docstring" markdown="1">
@@ -7500,7 +7519,7 @@ Return a `condition` function, suitable for passing to `Simulation.run` as the `
 or `until_after_sources` parameter, that examines the component `c` (e.g. `Ex`, etc.)
 at the point `pt` (a `Vector3`) and keeps running until its absolute value *squared*
 has decayed by at least `decay_by` from its maximum previous value. In particular, it
-keeps incrementing the run time by `dT` (in Meep units) and checks the maximum value
+keeps incrementing the run time by `dt` (in Meep units) and checks the maximum value
 over that time period &mdash; in this way, it won't be fooled just because the field
 happens to go through 0 at some instant.
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -2717,10 +2717,10 @@ def stop_when_dft_decayed(tol=None,
 <div class="function_docstring" markdown="1">
 
 Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
-or `until_after_sources` parameter, that checks all of the `Simulation`'s dft objects
-every `dt` timesteps, and stops the simulation once *all* the field components and frequencies
-of *every* dft object have decayed by at least some tolerance `tol` (no default value).
-The optimal `dt` is determined automatically based on the frequency content in the DFT monitors.
+or `until_after_sources` parameter, that checks the `Simulation`'s dft objects every `dt`
+timesteps, and stops the simulation once all the field components and frequencies of *every*
+dft object have decayed by at least some tolerance `tol` (no default value). The optimal `dt`
+is determined automatically based on the frequency content in the DFT monitors.
 There are two optional parameters: a minimum run time `minimum_run_time` (default: 0) or a
 maximum run time `maximum_run_time` (no default).
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -2709,7 +2709,7 @@ slow group velocities and are absorbed poorly by [PML](Perfectly_Matched_Layer.m
 <a id="stop_when_dft_decayed"></a>
 
 ```python
-def stop_when_dft_decayed(tol=None,
+def stop_when_dft_decayed(tol=1e-11,
                       minimum_run_time=0,
                       maximum_run_time=None):
 ```
@@ -2719,7 +2719,7 @@ def stop_when_dft_decayed(tol=None,
 Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
 or `until_after_sources` parameter, that checks the `Simulation`'s dft objects every `dt`
 timesteps, and stops the simulation once all the field components and frequencies of *every*
-dft object have decayed by at least some tolerance `tol` (no default value). The time interval
+dft object have decayed by at least some tolerance `tol` (default is 1e-11). The time interval
 `dt` is determined automatically based on the frequency content in the DFT monitors.
 There are two optional parameters: a minimum run time `minimum_run_time` (default: 0) or a
 maximum run time `maximum_run_time` (no default).

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -450,9 +450,9 @@ A common point of confusion is described in [The Run Function Is Not A Loop](The
 In particular, a useful value for `until_after_sources` or `until` is often `stop_when_field_decayed`, which is demonstrated in [Tutorial/Basics](Python_Tutorials/Basics.md#transmittance-spectrum-of-a-waveguide-bend). These top-level functions are available:
 
 @@ stop_when_fields_decayed @@
+@@ stop_when_dft_decayed @@
 @@ stop_after_walltime @@
 @@ stop_on_interrupt @@
-
 
 Finally, another run function, useful for computing ω(**k**) band diagrams, is available via these `Simulation` methods:
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4357,12 +4357,12 @@ def to_appended(fname, *step_funcs):
 def stop_when_fields_decayed(dt=None, c=None, pt=None, decay_by=None):
     """
     Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
-    or `until_after_sources` parameter, that examines the component `c` (e.g. `Ex`, etc.)
+    or `until_after_sources` parameter, that examines the component `c` (e.g. `meep.Ex`, etc.)
     at the point `pt` (a `Vector3`) and keeps running until its absolute value *squared*
     has decayed by at least `decay_by` from its maximum previous value. In particular, it
     keeps incrementing the run time by `dt` (in Meep units) and checks the maximum value
     over that time period &mdash; in this way, it won't be fooled just because the field
-    happens to go through 0 at some instant.
+    happens to go through zero at some instant.
 
     Note that, if you make `decay_by` very small, you may need to increase the `cutoff`
     property of your source(s), to decrease the amplitude of the small high-frequency
@@ -4371,7 +4371,7 @@ def stop_when_fields_decayed(dt=None, c=None, pt=None, decay_by=None):
     slow group velocities and are absorbed poorly by [PML](Perfectly_Matched_Layer.md).
     """
     if (dt is None) or (c is None) or (pt is None) or (decay_by is None):
-        raise TypeError("stop_when_fields_decayed: dt, c, pt, decay_by must all be specified.")
+        raise ValueError("dt, c, pt, and decay_by are all required.")
 
     closure = {
         'max_abs': 0,
@@ -4436,13 +4436,13 @@ def stop_when_dft_decayed(tol=None, minimum_run_time=0, maximum_run_time=None):
     Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
     or `until_after_sources` parameter, that checks the `Simulation`'s dft objects every `dt`
     timesteps, and stops the simulation once all the field components and frequencies of *every*
-    dft object have decayed by at least some tolerance `tol` (no default value). The optimal `dt`
-    is determined automatically based on the frequency content in the DFT monitors.
+    dft object have decayed by at least some tolerance `tol` (no default value). The time interval
+    `dt` is determined automatically based on the frequency content in the DFT monitors.
     There are two optional parameters: a minimum run time `minimum_run_time` (default: 0) or a
     maximum run time `maximum_run_time` (no default).
     """
     if tol is None:
-        raise TypeError("stop_when_dft_decayed: tol parameter must be specified.")
+        raise ValueError("tol is required.")
 
     # Record data in closure so that we can persistently edit
     closure = {'previous_fields':0, 't0':0, 'dt':0, 'maxchange':0}

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4434,10 +4434,10 @@ def stop_on_interrupt():
 def stop_when_dft_decayed(tol=None, minimum_run_time=0, maximum_run_time=None):
     """
     Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
-    or `until_after_sources` parameter, that checks all of the `Simulation`'s dft objects
-    every `dt` timesteps, and stops the simulation once *all* the field components and frequencies
-    of *every* dft object have decayed by at least some tolerance `tol` (no default value).
-    The optimal `dt` is determined automatically based on the frequency content in the DFT monitors.
+    or `until_after_sources` parameter, that checks the `Simulation`'s dft objects every `dt`
+    timesteps, and stops the simulation once all the field components and frequencies of *every*
+    dft object have decayed by at least some tolerance `tol` (no default value). The optimal `dt`
+    is determined automatically based on the frequency content in the DFT monitors.
     There are two optional parameters: a minimum run time `minimum_run_time` (default: 0) or a
     maximum run time `maximum_run_time` (no default).
     """

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4462,11 +4462,11 @@ def stop_when_dft_decayed(tol=None, minimum_run_time=0, maximum_run_time=None):
             if previous_fields == 0:
                 closure['previous_fields'] = current_fields
                 return False
-            
+
             closure['previous_fields'] = current_fields
             closure['t0'] = _sim.fields.t
-            if mp.verbosity > 0:
-                fmt = "DFT decay(t = {0:1.1f}): {1:0.4e}"
+            if mp.verbosity > 1:
+                fmt = "DFT fields decay(t = {0:0.2f}): {1:0.4e}"
                 print(fmt.format(_sim.meep_time(), np.real(change/closure['maxchange'])))
             return (change/closure['maxchange']) <= tol and _sim.round_time() >= minimum_run_time
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4431,18 +4431,16 @@ def stop_on_interrupt():
 
     return _stop
 
-def stop_when_dft_decayed(tol=None, minimum_run_time=0, maximum_run_time=None):
+def stop_when_dft_decayed(tol=1e-11, minimum_run_time=0, maximum_run_time=None):
     """
     Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
     or `until_after_sources` parameter, that checks the `Simulation`'s dft objects every `dt`
     timesteps, and stops the simulation once all the field components and frequencies of *every*
-    dft object have decayed by at least some tolerance `tol` (no default value). The time interval
+    dft object have decayed by at least some tolerance `tol` (default is 1e-11). The time interval
     `dt` is determined automatically based on the frequency content in the DFT monitors.
     There are two optional parameters: a minimum run time `minimum_run_time` (default: 0) or a
     maximum run time `maximum_run_time` (no default).
     """
-    if tol is None:
-        raise ValueError("tol is required.")
 
     # Record data in closure so that we can persistently edit
     closure = {'previous_fields':0, 't0':0, 'dt':0, 'maxchange':0}


### PR DESCRIPTION
Markdown documentation for `stop_when_dft_decayed` (which was missing from #1740).