### PR TITLE
unit test for MaterialGrid with symmetry

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -34,16 +34,16 @@ else
   WVG_SRC_TEST =
 endif
 
-TESTS =                                   \
+TESTS =                                        \
     $(TEST_DIR)/test_3rd_harm_1d.py            \
     $(TEST_DIR)/test_absorber_1d.py            \
     $(TEST_DIR)/test_adjoint_solver.py         \
-		$(TEST_DIR)/test_adjoint_cyl.py            \
+    $(TEST_DIR)/test_adjoint_cyl.py            \
     $(TEST_DIR)/test_adjoint_jax.py            \
     $(TEST_DIR)/test_antenna_radiation.py      \
     $(TEST_DIR)/test_array_metadata.py         \
     $(TEST_DIR)/test_bend_flux.py              \
-    $(BINARY_GRATING_TEST)                \
+    $(BINARY_GRATING_TEST)                     \
     $(TEST_DIR)/test_cavity_arrayslice.py      \
     $(TEST_DIR)/test_cavity_farfield.py        \
     $(TEST_DIR)/test_chunk_layout.py           \
@@ -51,9 +51,10 @@ TESTS =                                   \
     $(TEST_DIR)/test_cyl_ellipsoid.py          \
     $(TEST_DIR)/test_dft_energy.py             \
     $(TEST_DIR)/test_dft_fields.py             \
-    ${DIFFRACTED_PLANEWAVE_TEST}          \
-    ${DISPERSIVE_EIGENMODE_TEST}          \
+    ${DIFFRACTED_PLANEWAVE_TEST}               \
+    ${DISPERSIVE_EIGENMODE_TEST}               \
     $(TEST_DIR)/test_divide_mpi_processes.py   \
+    $(TEST_DIR)/test_dump_load.py              \
     $(TEST_DIR)/test_eigfreq.py                \
     $(TEST_DIR)/test_faraday_rotation.py       \
     $(TEST_DIR)/test_field_functions.py        \
@@ -66,7 +67,6 @@ TESTS =                                   \
     $(TEST_DIR)/test_holey_wvg_cavity.py       \
     $(KDOM_TEST)                               \
     $(TEST_DIR)/test_ldos.py                   \
-    $(TEST_DIR)/test_dump_load.py              \
     $(MDPYTEST)                                \
     $(TEST_DIR)/test_material_grid.py          \
     $(TEST_DIR)/test_medium_evaluations.py     \

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -24,10 +24,10 @@ boundary_layers = [mp.PML(thickness=dpml)]
 
 eig_parity = mp.EVEN_Y + mp.ODD_Z
 
-design_shape = mp.Vector3(1.5,1.5)
+design_region_size = mp.Vector3(1.5,1.5)
 design_region_resolution = int(2*resolution)
-Nx = int(design_region_resolution*design_shape.x)
-Ny = int(design_region_resolution*design_shape.y)
+Nx = int(design_region_resolution*design_region_size.x)
+Ny = int(design_region_resolution*design_region_size.y)
 
 ## ensure reproducible results
 np.random.seed(9861548)
@@ -60,7 +60,7 @@ def forward_simulation(design_params,mon_type, frequencies=None, use_complex=Fal
                               weights=design_params.reshape(Nx,Ny))
 
     matgrid_geometry = [mp.Block(center=mp.Vector3(),
-                                 size=mp.Vector3(design_shape.x,design_shape.y,0),
+                                 size=mp.Vector3(design_region_size.x,design_region_size.y,0),
                                  material=matgrid)]
 
     geometry = waveguide_geometry + matgrid_geometry
@@ -121,7 +121,7 @@ def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False,
 
     matgrid_region = mpa.DesignRegion(matgrid,
                                       volume=mp.Volume(center=mp.Vector3(),
-                                                       size=mp.Vector3(design_shape.x,design_shape.y,0)))
+                                                       size=mp.Vector3(design_region_size.x,design_region_size.y,0)))
 
     matgrid_geometry = [mp.Block(center=matgrid_region.center,
                                  size=matgrid_region.size,
@@ -179,8 +179,8 @@ def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False,
 def mapping(x,filter_radius,eta,beta):
     filtered_field = mpa.conic_filter(x,
                                       filter_radius,
-                                      design_shape.x,
-                                      design_shape.y,
+                                      design_region_size.x,
+                                      design_region_size.y,
                                       design_region_resolution)
 
     projected_field = mpa.tanh_projection(filtered_field,beta,eta)

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -26,8 +26,8 @@ eig_parity = mp.EVEN_Y + mp.ODD_Z
 
 design_shape = mp.Vector3(1.5,1.5)
 design_region_resolution = int(2*resolution)
-Nx = int(design_region_resolution*design_shape.x) + 1
-Ny = int(design_region_resolution*design_shape.y) + 1
+Nx = int(design_region_resolution*design_shape.x)
+Ny = int(design_region_resolution*design_shape.y)
 
 ## ensure reproducible results
 np.random.seed(9861548)
@@ -179,8 +179,8 @@ def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False,
 def mapping(x,filter_radius,eta,beta):
     filtered_field = mpa.conic_filter(x,
                                       filter_radius,
-                                      design_shape.x+1/design_region_resolution,
-                                      design_shape.y+1/design_region_resolution,
+                                      design_shape.x,
+                                      design_shape.y,
                                       design_region_resolution)
 
     projected_field = mpa.tanh_projection(filtered_field,beta,eta)

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -26,8 +26,8 @@ eig_parity = mp.EVEN_Y + mp.ODD_Z
 
 design_shape = mp.Vector3(1.5,1.5)
 design_region_resolution = int(2*resolution)
-Nx = int(design_region_resolution*design_shape.x)
-Ny = int(design_region_resolution*design_shape.y)
+Nx = int(design_region_resolution*design_shape.x) + 1
+Ny = int(design_region_resolution*design_shape.y) + 1
 
 ## ensure reproducible results
 np.random.seed(9861548)
@@ -53,12 +53,11 @@ sources = [mp.EigenModeSource(src=mp.GaussianSource(fcen,fwidth=df),
                               eig_parity=eig_parity)]
 
 
-def forward_simulation(design_params,mon_type,frequencies=None, use_complex=False, k=False):
+def forward_simulation(design_params,mon_type, frequencies=None, use_complex=False, k=False):
     matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                               mp.air,
                               silicon,
-                              weights=design_params.reshape(Nx,Ny),
-                              grid_type='U_MEAN')
+                              weights=design_params.reshape(Nx,Ny))
 
     matgrid_geometry = [mp.Block(center=mp.Vector3(),
                                  size=mp.Vector3(design_shape.x,design_shape.y,0),
@@ -73,14 +72,17 @@ def forward_simulation(design_params,mon_type,frequencies=None, use_complex=Fals
                         geometry=geometry,
                         force_complex_fields=use_complex,
                         k_point=k)
+
     if not frequencies:
         frequencies = [fcen]
 
     if mon_type.name == 'EIGENMODE':
         mode = sim.add_mode_monitor(frequencies,
-                                    mp.ModeRegion(center=mp.Vector3(0.5*sxy-dpml-0.1),size=mp.Vector3(0,sxy-2*dpml,0)),
+                                    mp.ModeRegion(center=mp.Vector3(0.5*sxy-dpml-0.1),
+                                                  size=mp.Vector3(0,sxy-2*dpml,0)),
                                     yee_grid=True,
-                                    decimation_factor=10)
+                                    decimation_factor=10,
+                                    eig_parity=eig_parity)
 
     elif mon_type.name == 'DFT':
         mode = sim.add_dft_fields([mp.Ez],
@@ -90,17 +92,17 @@ def forward_simulation(design_params,mon_type,frequencies=None, use_complex=Fals
                                   yee_grid=False,
                                   decimation_factor=10)
 
-    sim.run(until_after_sources=50)
+    sim.run(until_after_sources=mp.stop_when_dft_decayed())
 
     if mon_type.name == 'EIGENMODE':
         coeff = sim.get_eigenmode_coefficients(mode,[1],eig_parity).alpha[0,:,0]
-        S12 = abs(coeff)**2
+        S12 = np.power(np.abs(coeff),2)
 
     elif mon_type.name == 'DFT':
         Ez2 = []
         for f in range(len(frequencies)):
             Ez_dft = sim.get_dft_array(mode, mp.Ez, f)
-            Ez2.append(abs(Ez_dft[4,10])**2)
+            Ez2.append(np.power(np.abs(Ez_dft[4,10]),2))
         Ez2 = np.array(Ez2)
 
     sim.reset_meep()
@@ -143,10 +145,11 @@ def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False,
                                              mp.Volume(center=mp.Vector3(0.5*sxy-dpml-0.1),
                                                        size=mp.Vector3(0,sxy-2*dpml,0)),
                                              1,
-                                             decimation_factor=5)]
+                                             decimation_factor=5,
+                                             eig_parity=eig_parity)]
 
         def J(mode_mon):
-            return npa.abs(mode_mon)**2
+            return npa.power(npa.abs(mode_mon),2)
 
     elif mon_type.name == 'DFT':
         obj_list = [mpa.FourierFields(sim,
@@ -156,13 +159,13 @@ def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False,
                                       decimation_factor=5)]
 
         def J(mode_mon):
-            return npa.abs(mode_mon[:,4,10])**2
+            return npa.power(npa.abs(mode_mon[:,4,10]),2)
 
     opt = mpa.OptimizationProblem(
-        simulation = sim,
-        objective_functions = J,
-        objective_arguments = obj_list,
-        design_regions = [matgrid_region],
+        simulation=sim,
+        objective_functions=J,
+        objective_arguments=obj_list,
+        design_regions=[matgrid_region],
         frequencies=frequencies,
         decimation_factor=10)
 
@@ -174,7 +177,11 @@ def adjoint_solver(design_params, mon_type, frequencies=None, use_complex=False,
 
 
 def mapping(x,filter_radius,eta,beta):
-    filtered_field = mpa.conic_filter(x,filter_radius,design_shape.x,design_shape.y,design_region_resolution)
+    filtered_field = mpa.conic_filter(x,
+                                      filter_radius,
+                                      design_shape.x+1/design_region_resolution,
+                                      design_shape.y+1/design_region_resolution,
+                                      design_region_resolution)
 
     projected_field = mpa.tanh_projection(filtered_field,beta,eta)
 
@@ -249,7 +256,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             mapped_p = mapping(p,filter_radius,eta,beta)
 
             ## compute gradient using adjoint solver
-            adjsol_obj, adjsol_grad = adjoint_solver(mapped_p, MonitorObject.EIGENMODE,frequencies)
+            adjsol_obj, adjsol_grad = adjoint_solver(mapped_p, MonitorObject.EIGENMODE, frequencies)
 
             ## backpropagate the gradient
             if len(frequencies) > 1:

--- a/python/tests/test_material_grid.py
+++ b/python/tests/test_material_grid.py
@@ -3,6 +3,7 @@ import numpy as np
 from scipy.ndimage import gaussian_filter
 import unittest
 
+
 def compute_transmittance(use_symmetry=False):
         resolution = 25
 
@@ -25,15 +26,13 @@ def compute_transmittance(use_symmetry=False):
         np.random.seed(2069588)
 
         w = np.random.rand(Nx*Ny)
-        if use_symmetry:
-                weights = w
-        else:
-                weights = 0.5*(w + np.flipud(w))
+        w = w.reshape(Nx,Ny)
+        weights = 0.5 * (w + np.fliplr(w))
 
         matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),
                                   mp.air,
                                   mp.Medium(index=3.5),
-                                  weights=weights.reshape(Nx,Ny),
+                                  weights=weights,
                                   grid_type='U_MEAN')
 
         geometry = [mp.Block(center=mp.Vector3(),
@@ -74,7 +73,11 @@ def compute_transmittance(use_symmetry=False):
 
         mode_coeff = sim.get_eigenmode_coefficients(mode_mon,[1],eig_parity).alpha[0,:,0][0]
 
-        return np.power(np.abs(mode_coeff),2)
+        tran = np.power(np.abs(mode_coeff),2)
+        print('tran:, {}, {}'.format("sym" if use_symmetry else "nosym", tran))
+
+        return tran
+
 
 def compute_resonant_mode(res,default_mat=False):
         cell_size = mp.Vector3(1,1,0)
@@ -163,7 +166,7 @@ class TestMaterialGrid(unittest.TestCase):
     def test_symmetry(self):
             tran_nosym = compute_transmittance(False)
             tran_sym = compute_transmittance(True)
-            self.assertAlmostEqual(tran_nosym, tran_sym, places=5)
+            self.assertAlmostEqual(tran_nosym, tran_sym)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/test_material_grid.py
+++ b/python/tests/test_material_grid.py
@@ -13,11 +13,11 @@ def compute_transmittance(use_symmetry=False):
 
         symmetries = [mp.Mirror(direction=mp.Y,phase=-1)]
 
-        matgrid_shape = mp.Vector3(2,2,0)
+        matgrid_size = mp.Vector3(2,2,0)
         matgrid_resolution = 2*resolution
 
-        Nx = int(matgrid_resolution*matgrid_shape.x)
-        Ny = int(matgrid_resolution*matgrid_shape.y)
+        Nx = int(matgrid_resolution*matgrid_size.x)
+        Ny = int(matgrid_resolution*matgrid_size.y)
 
         ## ensure reproducible results
         np.random.seed(2069588)
@@ -36,12 +36,12 @@ def compute_transmittance(use_symmetry=False):
                              size=mp.Vector3(mp.inf,1.0,mp.inf),
                              material=mp.Medium(index=3.5)),
                     mp.Block(center=mp.Vector3(),
-                             size=mp.Vector3(matgrid_shape.x,matgrid_shape.y,0),
+                             size=mp.Vector3(matgrid_size.x,matgrid_size.y,0),
                              material=matgrid)]
 
         if use_symmetry:
                 geometry.append(mp.Block(center=mp.Vector3(),
-                                         size=mp.Vector3(matgrid_shape.x,matgrid_shape.y,0),
+                                         size=mp.Vector3(matgrid_size.x,matgrid_size.y,0),
                                          material=matgrid,
                                          e2=mp.Vector3(y=-1)))
 
@@ -89,16 +89,16 @@ def compute_resonant_mode(res,default_mat=False):
 
         k_point = mp.Vector3(0.3892,0.1597,0)
 
-        matgrid_shape = mp.Vector3(1,1,0)
+        matgrid_size = mp.Vector3(1,1,0)
         matgrid_resolution = 1200
 
         # for a fixed resolution, compute the number of grid points
         # necessary which are defined on the corners of the voxels
-        Nx = int(matgrid_resolution*matgrid_shape.x) + 1
-        Ny = int(matgrid_resolution*matgrid_shape.y) + 1
+        Nx = int(matgrid_resolution*matgrid_size.x) + 1
+        Ny = int(matgrid_resolution*matgrid_size.y) + 1
 
-        x = np.linspace(-0.5*matgrid_shape.x,0.5*matgrid_shape.x,Nx)
-        y = np.linspace(-0.5*matgrid_shape.y,0.5*matgrid_shape.y,Ny)
+        x = np.linspace(-0.5*matgrid_size.x,0.5*matgrid_size.x,Nx)
+        y = np.linspace(-0.5*matgrid_size.y,0.5*matgrid_size.y,Ny)
         xv, yv = np.meshgrid(x,y)
         weights = np.sqrt(np.square(xv) + np.square(yv)) < rad
         filtered_weights = gaussian_filter(weights,
@@ -114,7 +114,7 @@ def compute_resonant_mode(res,default_mat=False):
                                   eta=0.5)
 
         geometry = [mp.Block(center=mp.Vector3(),
-                             size=mp.Vector3(matgrid_shape.x,matgrid_shape.y,0),
+                             size=mp.Vector3(matgrid_size.x,matgrid_size.y,0),
                              material=matgrid)]
 
         sim = mp.Simulation(resolution=res,

--- a/python/tests/test_material_grid.py
+++ b/python/tests/test_material_grid.py
@@ -11,16 +11,13 @@ def compute_transmittance(use_symmetry=False):
 
         boundary_layers = [mp.PML(thickness=1.0)]
 
-        if use_symmetry:
-                symmetries = [mp.Mirror(direction=mp.Y,phase=-1)]
-        else:
-                symmetries = []
+        symmetries = [mp.Mirror(direction=mp.Y,phase=-1)]
 
         matgrid_shape = mp.Vector3(2,2,0)
         matgrid_resolution = 2*resolution
 
-        Nx = int(matgrid_resolution*matgrid_shape.x) + 1
-        Ny = int(matgrid_resolution*matgrid_shape.y) + 1
+        Nx = int(matgrid_resolution*matgrid_shape.x)
+        Ny = int(matgrid_resolution*matgrid_shape.y)
 
         ## ensure reproducible results
         np.random.seed(2069588)

--- a/python/tests/test_material_grid.py
+++ b/python/tests/test_material_grid.py
@@ -16,14 +16,13 @@ def compute_transmittance(use_symmetry=False):
         matgrid_size = mp.Vector3(2,2,0)
         matgrid_resolution = 2*resolution
 
-        Nx = int(matgrid_resolution*matgrid_size.x)
-        Ny = int(matgrid_resolution*matgrid_size.y)
+        Nx = int(matgrid_resolution*matgrid_size.x) + 1
+        Ny = int(matgrid_resolution*matgrid_size.y) + 1
 
         ## ensure reproducible results
         np.random.seed(2069588)
 
-        w = np.random.rand(Nx*Ny)
-        w = w.reshape(Nx,Ny)
+        w = np.random.rand(Nx,Ny)
         weights = 0.5 * (w + np.fliplr(w))
 
         matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),


### PR DESCRIPTION
Adds a missing unit test for the `MaterialGrid` with (mirror) symmetry. The test involves verifying that the transmittance of a `MaterialGrid` with random weights and mirror symmetry in the *y* direction is equivalent whether or not the `MaterialGrid` itself is defined to be symmetric.

Also includes minor improvements to `test_adjoint_solver.py`.