### PR TITLE
suppress output when verbosity is 0

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1915,7 +1915,8 @@ class Simulation(object):
         if self.structure is None:
             raise ValueError("Structure must be initialized before calling dump_structure")
         self.structure.dump(fname, single_parallel_file)
-        print("Dumped structure to file: %s (%s)" % (fname, str(single_parallel_file)))
+        if verbosity.meep > 0:
+            print("Dumped structure to file: %s (%s)" % (fname, str(single_parallel_file)))
 
     def load_structure(self, fname, single_parallel_file=True):
         """
@@ -1924,7 +1925,8 @@ class Simulation(object):
         if self.structure is None:
             raise ValueError("Structure must be initialized before loading structure from file '%s'" % fname)
         self.structure.load(fname, single_parallel_file)
-        print("Loaded structure from file: %s (%s)" % (fname, str(single_parallel_file)))
+        if verbosity.meep > 0:
+            print("Loaded structure from file: %s (%s)" % (fname, str(single_parallel_file)))
 
     def dump_fields(self, fname, single_parallel_file=True):
         """
@@ -1933,7 +1935,8 @@ class Simulation(object):
         if self.fields is None:
             raise ValueError("Fields must be initialized before calling dump_fields")
         self.fields.dump(fname, single_parallel_file)
-        print("Dumped fields to file: %s (%s)" % (fname, str(single_parallel_file)))
+        if verbosity.meep > 0:
+            print("Dumped fields to file: %s (%s)" % (fname, str(single_parallel_file)))
 
     def load_fields(self, fname, single_parallel_file=True):
         """
@@ -1943,7 +1946,8 @@ class Simulation(object):
             raise ValueError("Fields must be initialized before loading fields from file '%s'" % fname)
         self._evaluate_dft_objects()
         self.fields.load(fname, single_parallel_file)
-        print("Loaded fields from file: %s (%s)" % (fname, str(single_parallel_file)))
+        if verbosity.meep > 0:
+            print("Loaded fields from file: %s (%s)" % (fname, str(single_parallel_file)))
 
     def dump_chunk_layout(self, fname):
         """
@@ -2426,10 +2430,11 @@ class Simulation(object):
             harminv = self.run_k_point(t, k)
             freqs = [complex(m.freq, m.decay) for m in harminv.modes]
 
-            print("freqs:, {}, {}, {}, {}, ".format(k_index, k.x, k.y, k.z), end='')
-            print(', '.join([str(f.real) for f in freqs]))
-            print("freqs-im:, {}, {}, {}, {}, ".format(k_index, k.x, k.y, k.z), end='')
-            print(', '.join([str(f.imag) for f in freqs]))
+            if verbosity.meep > 0:
+                print("freqs:, {}, {}, {}, {}, ".format(k_index, k.x, k.y, k.z), end='')
+                print(', '.join([str(f.real) for f in freqs]))
+                print("freqs-im:, {}, {}, {}, {}, ".format(k_index, k.x, k.y, k.z), end='')
+                print(', '.join([str(f.imag) for f in freqs]))
 
             all_freqs.append(freqs)
 
@@ -2678,7 +2683,8 @@ class Simulation(object):
     def _display_energy(self, name, func, energys):
         if energys:
             freqs = get_energy_freqs(energys[0])
-            display_csv(self, "{}-energy".format(name), zip(freqs, *[func(f) for f in energys]))
+            if verbosity.meep > 0:
+                display_csv(self, "{}-energy".format(name), zip(freqs, *[func(f) for f in energys]))
 
     def display_electric_energy(self, *energys):
         """
@@ -2906,7 +2912,8 @@ class Simulation(object):
         subsequent columns are the force spectra.
         """
         force_freqs = get_force_freqs(forces[0])
-        display_csv(self, 'force', zip(force_freqs, *[get_forces(f) for f in forces]))
+        if verbosity.meep > 0:
+            display_csv(self, 'force', zip(force_freqs, *[get_forces(f) for f in forces]))
 
     def load_force(self, fname, force):
         """
@@ -3043,7 +3050,8 @@ class Simulation(object):
         `fcen`/`df`/`nfreq` or `freq`. The first column are the frequencies, and
         subsequent columns are the flux spectra.
         """
-        display_csv(self, 'flux', zip(get_flux_freqs(fluxes[0]), *[get_fluxes(f) for f in fluxes]))
+        if verbosity.meep > 0:
+            display_csv(self, 'flux', zip(get_flux_freqs(fluxes[0]), *[get_fluxes(f) for f in fluxes]))
 
     def load_flux(self, fname, flux):
         """
@@ -4544,7 +4552,7 @@ def stop_when_dft_decayed(tol=1e-11, minimum_run_time=0, maximum_run_time=None):
 
             closure['previous_fields'] = current_fields
             closure['t0'] = _sim.fields.t
-            if mp.verbosity > 1:
+            if verbosity.meep > 1:
                 fmt = "DFT fields decay(t = {0:0.2f}): {1:0.4e}"
                 print(fmt.format(_sim.meep_time(), np.real(change/closure['maxchange'])))
             return (change/closure['maxchange']) <= tol and _sim.round_time() >= minimum_run_time
@@ -4647,7 +4655,8 @@ def display_run_data(sim, data_name, data):
         data_str = [data_to_str(f) for f in data]
     else:
         data_str = [data_to_str(data)]
-    print("{}{}:, {}".format(data_name, sim.run_index, ', '.join(data_str)))
+    if verbosity.meep > 0:
+        print("{}{}:, {}".format(data_name, sim.run_index, ', '.join(data_str)))
 
 
 def convert_h5(rm_h5, convert_cmd, *step_funcs):
@@ -5126,7 +5135,8 @@ def dft_ldos(*args, **kwargs):
             sim.ldos_data = mp._dft_ldos_ldos(ldos)
             sim.ldos_Fdata = mp._dft_ldos_F(ldos)
             sim.ldos_Jdata = mp._dft_ldos_J(ldos)
-            display_csv(sim, 'ldos', zip(mp.get_ldos_freqs(ldos), sim.ldos_data))
+            if verbosity.meep > 0:
+                display_csv(sim, 'ldos', zip(mp.get_ldos_freqs(ldos), sim.ldos_data))
     return _ldos
 
 

--- a/python/solver.py
+++ b/python/solver.py
@@ -12,9 +12,10 @@ import time
 import h5py
 import numpy as np
 import meep as mp
-from . import mode_solver, with_hermitian_epsilon, verbosity
+from . import mode_solver, with_hermitian_epsilon
 from meep.geom import init_do_averaging
 from meep.simulation import get_num_args
+from meep.verbosity_mgr import Verbosity
 try:
     basestring
 except NameError:
@@ -24,6 +25,7 @@ U_MIN = 0
 U_PROD = 1
 U_MEAN = 2
 
+verbosity = Verbosity(mp.cvar, 'meep', 1)
 
 class MPBArray(np.ndarray):
 
@@ -510,7 +512,7 @@ class ModeSolver(object):
         return update_brd(brd, freqs, [])
 
     def output_band_range_data(self, br_data):
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             for tup, band in zip(br_data, range(1, len(br_data) + 1)):
                 fmt = "Band {} range: {} at {} to {} at {}"
                 min_band, max_band = tup
@@ -537,7 +539,7 @@ class ModeSolver(object):
                 else:
                     gap_size = ((200 * (br_rest_min_f - br_cur_max_f)) /
                                 (br_rest_min_f + br_cur_max_f))
-                    if verbosity.mpb >= 1:
+                    if verbosity.mpb > 0:
                         fmt = "Gap from band {} ({}) to band {} ({}), {}%"
                         print(fmt.format(i, br_cur_max_f, i + 1, br_rest_min_f, gap_size))
                     return ogaps(br_rest[0], br_rest[1:], i + 1,
@@ -642,7 +644,7 @@ class ModeSolver(object):
             self.freqs[curfield_band - 1]
         )
         fname = self._create_fname(fname, fname_prefix, True)
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print("Outputting complex scalar field to {}...".format(fname))
 
         with h5py.File(fname, 'w') as f:
@@ -676,7 +678,7 @@ class ModeSolver(object):
         )
 
         fname = self._create_fname(fname, fname_prefix, True)
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print("Outputting fields to {}...".format(fname))
 
         with h5py.File(fname, 'w') as f:
@@ -721,7 +723,7 @@ class ModeSolver(object):
 
         parity_suffix = False if curfield_type in 'mn' else True
         fname = self._create_fname(fname, fname_prefix, parity_suffix)
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print("Outputting {}...".format(fname))
 
         with h5py.File(fname, 'w') as f:
@@ -810,7 +812,7 @@ class ModeSolver(object):
 
     def display_kpoint_data(self, name, data):
         k_index = self.mode_solver.get_kpoint_index()
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print("{}{}:, {}".format(self.parity, name, k_index), end='')
 
             for d in data:
@@ -826,7 +828,7 @@ class ModeSolver(object):
         min_iters = min(self.eigensolver_iters)
         max_iters = max(self.eigensolver_iters)
         mean_iters = np.mean(self.eigensolver_iters)
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             fmt = "eigensolver iterations for {} kpoints: {}-{}, mean = {}"
             print(fmt.format(num_runs, min_iters, max_iters, mean_iters), end='')
 
@@ -834,15 +836,15 @@ class ModeSolver(object):
         idx1 = num_runs // 2
         idx2 = ((num_runs + 1) // 2) - 1
         median_iters = 0.5 * (sorted_iters[idx1] + sorted_iters[idx2])
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print(", median = {}".format(median_iters))
 
         mean_flops = self.eigensolver_flops / (num_runs * mean_iters)
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print("mean flops per iteration = {}".format(mean_flops))
 
         mean_time = self.total_run_time / (mean_iters * num_runs)
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print("mean time per iteration = {} s".format(mean_time))
 
     def _get_grid_size(self):
@@ -896,7 +898,7 @@ class ModeSolver(object):
 
         init_time = time.time()
 
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print("Initializing eigensolver data")
             print("Computing {} bands with {} tolerance".format(self.num_bands, self.tolerance))
 
@@ -905,7 +907,7 @@ class ModeSolver(object):
         if isinstance(reset_fields, basestring):
             self.load_eigenvectors(reset_fields)
 
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print("{} k-points".format(len(self.k_points)))
 
             for kp in self.k_points:
@@ -924,7 +926,7 @@ class ModeSolver(object):
                 solve_kpoint_time = time.time()
                 self.mode_solver.solve_kpoint(k)
                 self.iterations = self.mode_solver.get_iterations()
-                if verbosity.mpb >= 1:
+                if verbosity.mpb > 0:
                     print("elapsed time for k point: {}".format(time.time() - solve_kpoint_time))
                 self.freqs = self.get_freqs()
                 self.all_freqs[i, :] = np.array(self.freqs)
@@ -952,12 +954,12 @@ class ModeSolver(object):
                 self.gap_list = []
 
         end = time.time() - start
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print("total elapsed time for run: {}".format(end))
         self.total_run_time += end
         self.eigensolver_flops = self.mode_solver.get_eigensolver_flops()
         self.parity = self.mode_solver.get_parity_string()
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print("done")
 
     def run(self, *band_functions):
@@ -1024,7 +1026,7 @@ class ModeSolver(object):
                 # First, look in the cached table
                 tab_val = bktab.get((b, k), None)
                 if tab_val:
-                    if verbosity.mpb >= 1:
+                    if verbosity.mpb > 0:
                         print("find-k {} at {}: {} (cached)".format(b, k, tab_val[0]))
                     return tab_val
                 # Otherwise, compute bands and cache results
@@ -1046,7 +1048,7 @@ class ModeSolver(object):
                         bktab[(_b, k)] = (_f - omega, _v)
 
                     fun = self.freqs[-1] - omega
-                    if verbosity.mpb >= 1:
+                    if verbosity.mpb > 0:
                         print("find-k {} at {}: {}".format(b, k, fun))
                     return (fun, v[-1])
 
@@ -1075,7 +1077,7 @@ class ModeSolver(object):
         self.num_bands = num_bands_save
         self.k_points = kpoints_save
         ks = list(reversed(ks))
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             print("{}kvals:, {}, {}, {}".format(self.parity, omega, band_min, band_max), end='')
             for k in korig:
                 print(", {}".format(k), end='')
@@ -1239,7 +1241,7 @@ def output_dpwr_in_objects(output_func, min_energy, objects=[]):
         ms.get_dfield(which_band, False)
         ms.compute_field_energy()
         energy = ms.compute_energy_in_objects(objects)
-        if verbosity.mpb >= 1:
+        if verbosity.mpb > 0:
             fmt = "dpwr:, {}, {}, {} "
             print(fmt.format(which_band, ms.freqs[which_band - 1], energy))
         if energy >= min_energy:

--- a/python/verbosity_mgr.py
+++ b/python/verbosity_mgr.py
@@ -136,7 +136,7 @@ class Verbosity(object):
         """
         Convenience for setting the verbosity level. This lets you set the
         global level by calling the instance like a function. For example, if
-        `verbosity` is an instance of this class, then it's value can be changed
+        `verbosity` is an instance of this class, then its value can be changed
         like this:
 
         ```
@@ -176,4 +176,3 @@ class Verbosity(object):
             self._cvars[name].verbosity = level
 
         setattr(Verbosity, name, property(_getter, _setter))
-


### PR DESCRIPTION
Closes #1799. Closes #1545.

Also fixes a bug in PyMPB in which the output was not being suppressed when `verbosity.mpb = 0`. 

@joamatab