### PR TITLE
use RandomState instead of seed

### DIFF
--- a/python/tests/test_adjoint_cyl.py
+++ b/python/tests/test_adjoint_cyl.py
@@ -10,7 +10,7 @@ import unittest
 from enum import Enum
 from utils import ApproxComparisonTestCase
 
-np.random.seed(2)
+rng = np.random.RandomState(2)
 resolution = 20
 dimensions = mp.CYLINDRICAL
 m=0
@@ -40,10 +40,10 @@ source = [mp.Source(src,component=mp.Er,
                     size=source_size)]
 
 ## random design region
-p = np.random.rand(Nr*Nz)
+p = rng.rand(Nr*Nz)
 ## random epsilon perturbation for design region
 deps = 1e-5
-dp = deps*np.random.rand(Nr*Nz)
+dp = deps*rng.rand(Nr*Nz)
 
 
 def forward_simulation(design_params):

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -31,14 +31,14 @@ Nx = int(design_region_resolution*design_region_size.x) + 1
 Ny = int(design_region_resolution*design_region_size.y) + 1
 
 ## ensure reproducible results
-np.random.seed(9861548)
+rng = np.random.RandomState(9861548)
 
 ## random design region
-p = np.random.rand(Nx*Ny)
+p = rng.rand(Nx*Ny)
 
 ## random epsilon perturbation for design region
 deps = 1e-5
-dp = deps*np.random.rand(Nx*Ny)
+dp = deps*rng.rand(Nx*Ny)
 
 w = 1.0
 waveguide_geometry = [mp.Block(material=silicon,

--- a/python/tests/test_material_grid.py
+++ b/python/tests/test_material_grid.py
@@ -20,9 +20,9 @@ def compute_transmittance(use_symmetry=False):
         Ny = int(matgrid_resolution*matgrid_size.y) + 1
 
         ## ensure reproducible results
-        np.random.seed(2069588)
+        rng = np.random.RandomState(2069588)
 
-        w = np.random.rand(Nx,Ny)
+        w = rng.rand(Nx,Ny)
         weights = 0.5 * (w + np.fliplr(w))
 
         matgrid = mp.MaterialGrid(mp.Vector3(Nx,Ny),


### PR DESCRIPTION
As described in [NEP 19](https://numpy.org/neps/nep-0019-rng-policy.html), Numpy no longer guarantees that random streams will be reproducible across versions for `np.random.rand`, even if you set the seed.   If we need reproducible random numbers, we need to use [`np.random.RandomState`](https://numpy.org/doc/stable/reference/random/legacy.html#numpy.random.RandomState) instead.