### PR TITLE
place fourier adjoint sources collectively for each frequency

### DIFF
--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -258,6 +258,7 @@ class FourierFields(ObjectiveQuantity):
         min_max_corners = self.sim.fields.get_corners(self._monitor.swigobj, self.component) # ivec values of the corners
         mon_size = self._dft_monitor_size(min_max_corners)
 
+        dJ = dJ.astype(np.complex128)
         if np.prod(mon_size)*self.num_freq == dJ.size: # The objective function J is a scalar.
             dJ = dJ.flatten()
         elif np.prod(mon_size)*self.num_freq**2 == dJ.size: # The objective function J is a vector. Each component corresponds to a frequency.

--- a/python/adjoint/optimization_problem.py
+++ b/python/adjoint/optimization_problem.py
@@ -312,7 +312,16 @@ class OptimizationProblem(object):
         '''
         if filter is None:
             filter = lambda x: x
-        if num_gradients > self.num_design_params[design_variables_idx]:
+        if num_gradients < self.num_design_params[design_variables_idx]:
+            # randomly choose indices to loop estimate
+            fd_gradient_idx = np.random.choice(
+                self.num_design_params[design_variables_idx],
+                num_gradients,
+                replace=False,
+            )
+        elif num_gradients == self.num_design_params[design_variables_idx]:
+            fd_gradient_idx = range(self.num_design_params[design_variables_idx])
+        else:
             raise ValueError(
                 "The requested number of gradients must be less than or equal to the total number of design parameters."
             )
@@ -323,13 +332,6 @@ class OptimizationProblem(object):
 
         # preallocate result vector
         fd_gradient = []
-
-        # randomly choose indices to loop estimate
-        fd_gradient_idx = np.random.choice(
-            self.num_design_params[design_variables_idx],
-            num_gradients,
-            replace=False,
-        )
 
         for k in fd_gradient_idx:
 

--- a/python/meep.i
+++ b/python/meep.i
@@ -1066,6 +1066,10 @@ void _get_gradient(PyObject *grad, double scalegrad, PyObject *fields_a, PyObjec
     $1 = PyList_Check($input);
 }
 
+%typemap(in) int* thickness_indicator {
+    $1 = (int *)thickness_indicator($input);
+}
+
 %apply int INPLACE_ARRAY1[ANY] { int [3] };
 %apply double INPLACE_ARRAY1[ANY] { double [3] };
 
@@ -1426,6 +1430,10 @@ void _get_gradient(PyObject *grad, double scalegrad, PyObject *fields_a, PyObjec
 
 %typemap(in) double* farpt_list {
     $1 = (double *)array_data($input);
+}
+
+%typemap(in) int* min_max_corners {
+    $1 = (int *)array_data($input);
 }
 
 %exception {

--- a/python/meep.i
+++ b/python/meep.i
@@ -1066,10 +1066,6 @@ void _get_gradient(PyObject *grad, double scalegrad, PyObject *fields_a, PyObjec
     $1 = PyList_Check($input);
 }
 
-%typemap(in) int* thickness_indicator {
-    $1 = (int *)thickness_indicator($input);
-}
-
 %apply int INPLACE_ARRAY1[ANY] { int [3] };
 %apply double INPLACE_ARRAY1[ANY] { double [3] };
 

--- a/python/meep.i
+++ b/python/meep.i
@@ -1432,10 +1432,6 @@ void _get_gradient(PyObject *grad, double scalegrad, PyObject *fields_a, PyObjec
     $1 = (double *)array_data($input);
 }
 
-%typemap(in) int* min_max_corners {
-    $1 = (int *)array_data($input);
-}
-
 %exception {
 #ifdef MEEP_SWIG_PYTHON_DEBUG
   // NOTE: You can do fancier things like timing the calls and using that

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -812,4 +812,14 @@ std::vector<double> fields::get_array_metadata(const volume &where) {
 
 } // get_array_metadata
 
+std::vector<int> fields::indicate_thick_dims(const volume &where) { // indicate which dimensions have sizes larger than 1
+
+  std::vector<int> thickness_indicator = {1, 1, 1};
+  for (int nd = 0; nd < 3; nd++) {
+    direction d = direction(nd);
+    if (where.in_direction(d) == 0.0) thickness_indicator[nd] = 0; // set the entry to 0 if the size of the corresponding dimension is only 1
+  }
+  return thickness_indicator;
+}
+
 } // namespace meep

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -1396,7 +1396,7 @@ std::vector<int> fields::get_corners(dft_fields fdft, component c){ // get the m
   return corners;
 }
 
-std::vector<struct sourcedata> dft_fields::fourier_sourcedata(const volume &where, int* min_max_corners, std::complex<double>* dJ){
+std::vector<struct sourcedata> dft_fields::fourier_sourcedata(const volume &where, const int* min_max_corners, const std::complex<double>* dJ){
   if (!chunks) return std::vector<struct sourcedata>();
   const size_t Nfreq = freq.size();
 

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -1407,7 +1407,6 @@ std::vector<int> fields::dft_monitor_size(dft_fields fdft, const volume &where, 
 }
 
 std::vector<struct sourcedata> dft_fields::fourier_sourcedata(const volume &where, component c, fields &f, const std::complex<double>* dJ){
-  if (!chunks) return std::vector<struct sourcedata>();
   const size_t Nfreq = freq.size();
 
   ivec min_corner, max_corner;
@@ -1420,6 +1419,7 @@ std::vector<struct sourcedata> dft_fields::fourier_sourcedata(const volume &wher
   size_t *dims = f.get_dims(chunklists, 1, c, min_corner, max_corner, array_size, bufsz, rank, dirs);
   size_t *reduced_dims = reduce_array_dimensions(where, rank, reduced_rank, reduced_grid_size, dims, stride, reduced_stride, dirs, reduced_dirs);
   size_t monitor_array[3] = {1, 1, 1}; // lengths of the dft monitor along the three dimensions
+  for (int nd = 0; nd < 3; ++nd) if (nd < reduced_rank) monitor_array[nd] = reduced_dims[nd];
   const size_t monitor_size = monitor_array[0]*monitor_array[1]*monitor_array[2]; // total number of points in the monitor
 
   std::vector<struct sourcedata> temp;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1419,7 +1419,7 @@ public:
   dft_fields(dft_chunk *chunks, double freq_min, double freq_max, int Nfreq, const volume &where);
   dft_fields(dft_chunk *chunks, const std::vector<double> &freq_, const volume &where);
   dft_fields(dft_chunk *chunks, const double *freq_, size_t Nfreq, const volume &where);
-  std::vector<sourcedata> fourier_sourcedata(const volume &where, const int* min_max_corners, const std::complex<double>* dJ);
+  std::vector<sourcedata> fourier_sourcedata(const volume &where, component c, fields &f, const std::complex<double>* dJ);
   void scale_dfts(std::complex<double> scale);
 
   void remove();
@@ -2167,9 +2167,8 @@ public:
   std::complex<double> get_field(int c, const vec &loc, bool parallel = true) const;
   std::complex<double> get_field(component c, const vec &loc, bool parallel = true) const;
   double get_field(derived_component c, const vec &loc, bool parallel = true) const;
-  std::vector<int> get_corners(dft_fields fdft,component c); // get the minimum and maximum ivec values of the dft monitor
-  std::vector<int> indicate_thick_dims(const volume &where); // indicate which dimensions have sizes larger than 1
-  size_t *get_dims(dft_chunk **chunklists, int num_chunklists, component c, ivec *min_corner, ivec *max_corner, size_t *array_size, size_t *bufsz, int *rank, direction *ds, int *array_rank=0, size_t *array_dims=0, direction *array_dirs=0);
+  std::vector<int> dft_monitor_size(dft_fields fdft, const volume &where, component c);
+  size_t *get_dims(dft_chunk **chunklists, int num_chunklists, component c, ivec &min_corner, ivec &max_corner, size_t &array_size, size_t &bufsz, int &rank, direction *ds, int *array_rank=0, size_t *array_dims=0, direction *array_dirs=0);
 
   // energy_and_flux.cpp
   void synchronize_magnetic_fields();

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -2169,6 +2169,7 @@ public:
   double get_field(derived_component c, const vec &loc, bool parallel = true) const;
   std::vector<int> get_corners(dft_fields fdft,component c); // get the minimum and maximum ivec values of the dft monitor
   std::vector<int> indicate_thick_dims(const volume &where); // indicate which dimensions have sizes larger than 1
+  size_t *get_dims(dft_chunk **chunklists, int num_chunklists, component c, ivec *min_corner, ivec *max_corner, size_t *array_size, size_t *bufsz, int *rank, direction *ds, int *array_rank=0, size_t *array_dims=0, direction *array_dirs=0);
 
   // energy_and_flux.cpp
   void synchronize_magnetic_fields();

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1419,7 +1419,7 @@ public:
   dft_fields(dft_chunk *chunks, double freq_min, double freq_max, int Nfreq, const volume &where);
   dft_fields(dft_chunk *chunks, const std::vector<double> &freq_, const volume &where);
   dft_fields(dft_chunk *chunks, const double *freq_, size_t Nfreq, const volume &where);
-
+  std::vector<sourcedata> fourier_sourcedata(const volume &where, int* min_max_corners, std::complex<double>* dJ);
   void scale_dfts(std::complex<double> scale);
 
   void remove();
@@ -2167,6 +2167,8 @@ public:
   std::complex<double> get_field(int c, const vec &loc, bool parallel = true) const;
   std::complex<double> get_field(component c, const vec &loc, bool parallel = true) const;
   double get_field(derived_component c, const vec &loc, bool parallel = true) const;
+  std::vector<int> get_corners(dft_fields fdft,component c); // get the minimum and maximum ivec values of the dft monitor
+  std::vector<int> indicate_thick_dims(const volume &where); // indicate which dimensions have sizes larger than 1
 
   // energy_and_flux.cpp
   void synchronize_magnetic_fields();

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -2168,7 +2168,7 @@ public:
   std::complex<double> get_field(component c, const vec &loc, bool parallel = true) const;
   double get_field(derived_component c, const vec &loc, bool parallel = true) const;
   std::vector<int> dft_monitor_size(dft_fields fdft, const volume &where, component c);
-  size_t *get_dims(dft_chunk **chunklists, int num_chunklists, component c, ivec &min_corner, ivec &max_corner, size_t &array_size, size_t &bufsz, int &rank, direction *ds, int *array_rank=0, size_t *array_dims=0, direction *array_dirs=0);
+  void get_dft_component_dims(dft_chunk **chunklists, int num_chunklists, component c, ivec &min_corner, ivec &max_corner, size_t &array_size, size_t &bufsz, int &rank, direction *ds, size_t *dims, int *array_rank=0, size_t *array_dims=0, direction *array_dirs=0);
 
   // energy_and_flux.cpp
   void synchronize_magnetic_fields();

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1382,7 +1382,7 @@ public:
   int periodic_n[2];
   double periodic_k[2], period[2];
 
-  std::vector<sourcedata> near_sourcedata(const vec &x_0, double* farpt_list, size_t nfar_pts, std::complex<double>* dJ);
+  std::vector<sourcedata> near_sourcedata(const vec &x_0, double* farpt_list, size_t nfar_pts, const std::complex<double>* dJ);
 };
 
 /* Class to compute local-density-of-states spectra: the power spectrum
@@ -1419,7 +1419,7 @@ public:
   dft_fields(dft_chunk *chunks, double freq_min, double freq_max, int Nfreq, const volume &where);
   dft_fields(dft_chunk *chunks, const std::vector<double> &freq_, const volume &where);
   dft_fields(dft_chunk *chunks, const double *freq_, size_t Nfreq, const volume &where);
-  std::vector<sourcedata> fourier_sourcedata(const volume &where, int* min_max_corners, std::complex<double>* dJ);
+  std::vector<sourcedata> fourier_sourcedata(const volume &where, const int* min_max_corners, const std::complex<double>* dJ);
   void scale_dfts(std::complex<double> scale);
 
   void remove();

--- a/src/meep_internals.hpp
+++ b/src/meep_internals.hpp
@@ -19,6 +19,8 @@
 #include <string.h>
 #include "meep.hpp"
 
+using namespace std;
+
 namespace meep {
 
 #define DOCMP for (int cmp = 0; cmp < 2 - is_real; cmp++)
@@ -166,5 +168,11 @@ void green2d(std::complex<double> *EH, const vec &x, double freq, double eps, do
              const vec &x0, component c0, std::complex<double> f0);
 void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, double mu,
               const vec &x0, component c0, std::complex<double> f0, double m, double tol);
+
+// functions in array_slice.cpp:
+
+complex<realnum> *collapse_array(complex<realnum> *array, int *rank, size_t dims[3], direction dirs[3], volume where);
+
+void reduce_array_dimensions(volume where, int full_rank, size_t dims[3], direction dirs[3], size_t stride[3], int &reduced_rank, size_t reduced_dims[3], direction reduced_dirs[3], size_t reduced_stride[3]);
 
 } // namespace meep

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -642,7 +642,7 @@ dft_near2far fields::add_dft_near2far(const volume_list *where, const double *fr
 }
 
 //Modified from farfield_lowlevel
-std::vector<struct sourcedata> dft_near2far::near_sourcedata(const vec &x_0, double* farpt_list, size_t nfar_pts, std::complex<double>* dJ) {
+std::vector<struct sourcedata> dft_near2far::near_sourcedata(const vec &x_0, double* farpt_list, size_t nfar_pts, const std::complex<double>* dJ) {
   if (x_0.dim != D3 && x_0.dim != D2 && x_0.dim != Dcyl)
     meep::abort("only 2d or 3d or cylindrical far-field computation is supported");
   greenfunc green = x_0.dim == D2 ? green2d : green3d;


### PR DESCRIPTION
The main features of this PR are
1. The Fourier adjoint sources at each frequency are placed collectively, while in the current master branch the adjoint sources are placed point by point.
2. The Fourier adjoint solver has 'yee_grid' as a user specified argument, which can be `True` or `False`. The default option is `False`.

This PR passes all the built-in tests except test_adjoint_jax.py, test_binary_partition_utils.py, and test_chunk_balancer.py, as the current master branch does.