### PR TITLE
support for single-precision floating point for fields array functions

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -3591,7 +3591,9 @@ current simulation time.
 + `cmplx`: `boolean`; if `True`, return complex-valued data otherwise return
   real-valued data (default).
 
-+ `arr`: optional field to pass a pre-allocated NumPy array of the correct size,
++ `arr`: optional parameter to pass a pre-allocated NumPy array of the correct size and
+  type (either `numpy.float32` or `numpy.float64` depending on the [floating-point precision
+  of the fields and materials](Build_From_Source.md#floating-point-precision-of-the-fields-and-materials-arrays))
   which will be overwritten with the field/material data instead of allocating a
   new array.  Normally, this will be the array returned from a previous call to
   `get_array` for a similar slice, allowing one to re-use `arr` (e.g., when
@@ -3644,7 +3646,8 @@ def get_dft_array(self, dft_obj, component, num_freq):
 
 <div class="method_docstring" markdown="1">
 
-Returns the Fourier-transformed fields as a NumPy array.
+Returns the Fourier-transformed fields as a NumPy array. The type is either `numpy.complex64`
+or `numpy.complex128` depending on the [floating-point precision of the fields](Build_From_Source.md#floating-point-precision-of-the-fields-and-materials-arrays).
 
 **Parameters:**
 
@@ -4401,7 +4404,7 @@ def __init__(self,
              medium2,
              weights=None,
              grid_type='U_DEFAULT',
-             do_averaging=False,
+             do_averaging=True,
              beta=0,
              eta=0.5,
              damping=0):

--- a/python/adjoint/optimization_problem.py
+++ b/python/adjoint/optimization_problem.py
@@ -248,7 +248,7 @@ class OptimizationProblem(object):
 
             # Store adjoint fields for each design set of design variables
             self.D_a.append(utils.gather_design_region_fields(self.sim,self.design_region_monitors,self.frequencies))
-        
+
         # reset the m number
         if utils._check_if_cylindrical(self.sim):
             self.sim.m = -self.sim.m

--- a/python/adjoint/wrapper.py
+++ b/python/adjoint/wrapper.py
@@ -229,7 +229,9 @@ class MeepJaxWrapper:
         def _simulate_rev(res, monitor_values_grad):
             """Runs adjoint simulation, returning VJP of design wrt monitor values."""
             fwd_fields = jax.tree_map(
-                lambda x: onp.asarray(x, dtype=onp.complex128), res[0])
+                lambda x: onp.asarray(x,
+                                      dtype=onp.complex64 if mp.is_single_precision() else onp.complex128),
+                res[0])
             design_variable_shapes = res[1]
             adj_fields = self._run_adjoint_simulation(monitor_values_grad)
             vjps = self._calculate_vjps(fwd_fields, adj_fields,

--- a/python/meep.i
+++ b/python/meep.i
@@ -444,12 +444,12 @@ PyObject *_get_dft_array(meep::fields *f, dft_type dft, meep::component c, int n
     std::complex<meep::realnum> *dft_arr = f->get_dft_array(dft, c, num_freq, &rank, dims);
 
     if (dft_arr == NULL) { // this can happen e.g. if component c vanishes by symmetry
-         std::complex<meep::realnum> d[1] = {std::complex<meep::realnum>(0,0)};
-         return PyArray_SimpleNewFromData(0, 0, sizeof(meep::realnum) == sizeof(float) ? NPY_CFLOAT : NPY_CDOUBLE, d);
+      std::complex<double> d[1] = {std::complex<double>(0,0)};
+      return PyArray_SimpleNewFromData(0, 0, sizeof(meep::realnum) == sizeof(float) ? NPY_CFLOAT : NPY_CDOUBLE, d);
     }
 
     if (rank == 0) // singleton results
-         return PyArray_SimpleNewFromData(0, 0, sizeof(meep::realnum) == sizeof(float) ? NPY_CFLOAT : NPY_CDOUBLE, dft_arr);
+      return PyArray_SimpleNewFromData(0, 0, sizeof(meep::realnum) == sizeof(float) ? NPY_CFLOAT : NPY_CDOUBLE, dft_arr);
 
     size_t length = 1;
     npy_intp *arr_dims = new npy_intp[rank];
@@ -1025,7 +1025,7 @@ void _get_gradient(PyObject *grad, double scalegrad, PyObject *fields_a, PyObjec
     $1 = (size_t *)array_data($input);
 }
 
-%typecheck(SWIG_TYPECHECK_POINTER, fragment="NumPy_Fragments") double* slice {
+%typecheck(SWIG_TYPECHECK_POINTER, fragment="NumPy_Fragments") meep::realnum* slice {
     $1 = is_array($input);
 }
 
@@ -1033,7 +1033,7 @@ void _get_gradient(PyObject *grad, double scalegrad, PyObject *fields_a, PyObjec
     $1 = (meep::realnum *)array_data($input);
 }
 
-%typecheck(SWIG_TYPECHECK_POINTER, fragment="NumPy_Fragments") std::complex<double>* slice {
+%typecheck(SWIG_TYPECHECK_POINTER, fragment="NumPy_Fragments") std::complex<meep::realnum>* slice {
     $1 = is_array($input);
 }
 
@@ -1558,11 +1558,6 @@ void _get_gradient(PyObject *grad, double scalegrad, PyObject *fields_a, PyObjec
 %template(DoubleVector) std::vector<double>;
 
 // use NumPy arrays for returning common std::vector types:
-%typemap(out) std::vector<float> {
-    npy_intp vec_len = (npy_intp) $1.size();
-    $result = PyArray_SimpleNew(1, &vec_len, NPY_FLOAT);
-    memcpy(PyArray_DATA((PyArrayObject*) $result), &$1[0], vec_len * sizeof(float));
-}
 %typemap(out) std::vector<double> {
     npy_intp vec_len = (npy_intp) $1.size();
     $result = PyArray_SimpleNew(1, &vec_len, NPY_DOUBLE);
@@ -1585,12 +1580,6 @@ void _get_gradient(PyObject *grad, double scalegrad, PyObject *fields_a, PyObjec
 
 %include "std_complex.i"
 %template(ComplexVector) std::vector<std::complex<double> >;
-
-%typemap(out) std::vector<std::complex<float> > {
-    npy_intp vec_len = (npy_intp) $1.size();
-    $result = PyArray_SimpleNew(1, &vec_len, NPY_COMPLEX64);
-    memcpy(PyArray_DATA((PyArrayObject*) $result), &$1[0], vec_len * sizeof(float) * 2);
-}
 
 %typemap(out) std::vector<std::complex<double> > {
     npy_intp vec_len = (npy_intp) $1.size();

--- a/python/meep.i
+++ b/python/meep.i
@@ -150,9 +150,9 @@ static std::complex<double> py_amp_func_wrap(const meep::vec &v) {
     return ret;
 }
 
-static std::complex<double> py_field_func_wrap(const std::complex<double> *fields,
-                                               const meep::vec &loc,
-                                               void *data_) {
+static std::complex<meep::realnum> py_field_func_wrap(const std::complex<meep::realnum> *fields,
+                                                      const meep::vec &loc,
+                                                      void *data_) {
     SWIG_PYTHON_THREAD_SCOPED_BLOCK;
     PyObject *pyv = vec2py(loc);
 
@@ -175,7 +175,7 @@ static std::complex<double> py_field_func_wrap(const std::complex<double> *field
 
     double real = PyComplex_RealAsDouble(pyret);
     double imag = PyComplex_ImagAsDouble(pyret);
-    std::complex<double> ret(real, imag);
+    std::complex<meep::realnum> ret(real, imag);
     Py_DECREF(pyv);
     Py_DECREF(pyret);
     Py_DECREF(py_args);

--- a/python/meep.i
+++ b/python/meep.i
@@ -844,8 +844,8 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 
 %inline %{
 void _get_gradient(PyObject *grad, double scalegrad, PyObject *fields_a, PyObject *fields_f, 
-    meep::grid_volume *grid_volume, meep::volume *where, PyObject *frequencies, 
-    meep_geom::geom_epsilon *geps, PyObject *fields_shapes, double fd_step) {
+                   meep::grid_volume *grid_volume, meep::volume *where, PyObject *frequencies,
+                   meep_geom::geom_epsilon *geps, PyObject *fields_shapes, double fd_step) {
     // clean the gradient array
     PyArrayObject *pao_grad = (PyArrayObject *)grad;
     if (!PyArray_Check(pao_grad)) meep::abort("grad parameter must be numpy array.");
@@ -859,14 +859,14 @@ void _get_gradient(PyObject *grad, double scalegrad, PyObject *fields_a, PyObjec
     if (!PyArray_Check(pao_fields_a)) meep::abort("adjoint fields parameter must be numpy array.");
     if (!PyArray_ISCARRAY(pao_fields_a)) meep::abort("Numpy adjoint fields array must be C-style contiguous.");
     if (PyArray_NDIM(pao_fields_a) !=1) {meep::abort("Numpy adjoint fields array must have 1 dimension.");}
-    std::complex<double> *fields_a_c = (std::complex<double> *)PyArray_DATA(pao_fields_a);
+    std::complex<meep::realnum> *fields_a_c = (std::complex<meep::realnum> *)PyArray_DATA(pao_fields_a);
 
     // clean the forward fields array
     PyArrayObject *pao_fields_f = (PyArrayObject *)fields_f;
     if (!PyArray_Check(pao_fields_f)) meep::abort("forward fields parameter must be numpy array.");
     if (!PyArray_ISCARRAY(pao_fields_f)) meep::abort("Numpy forward fields array must be C-style contiguous.");
     if (PyArray_NDIM(pao_fields_f) !=1) {meep::abort("Numpy forward fields array must have 1 dimension.");}
-    std::complex<double> *fields_f_c = (std::complex<double> *)PyArray_DATA(pao_fields_f);
+    std::complex<meep::realnum> *fields_f_c = (std::complex<meep::realnum> *)PyArray_DATA(pao_fields_f);
 
     // clean shapes array
     PyArrayObject *pao_fields_shapes = (PyArrayObject *)fields_shapes;

--- a/python/meep.i
+++ b/python/meep.i
@@ -150,9 +150,9 @@ static std::complex<double> py_amp_func_wrap(const meep::vec &v) {
     return ret;
 }
 
-static std::complex<meep::realnum> py_field_func_wrap(const std::complex<meep::realnum> *fields,
-                                                      const meep::vec &loc,
-                                                      void *data_) {
+static std::complex<double> py_field_func_wrap(const std::complex<meep::realnum> *fields,
+                                               const meep::vec &loc,
+                                               void *data_) {
     SWIG_PYTHON_THREAD_SCOPED_BLOCK;
     PyObject *pyv = vec2py(loc);
 
@@ -175,7 +175,7 @@ static std::complex<meep::realnum> py_field_func_wrap(const std::complex<meep::r
 
     double real = PyComplex_RealAsDouble(pyret);
     double imag = PyComplex_ImagAsDouble(pyret);
-    std::complex<meep::realnum> ret(real, imag);
+    std::complex<double> ret(real, imag);
     Py_DECREF(pyv);
     Py_DECREF(pyret);
     Py_DECREF(py_args);

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3405,7 +3405,10 @@ class Simulation(object):
             arr = np.require(arr, requirements=['C', 'W'])
 
         else:
-            arr = np.zeros(dims, dtype=np.complex128 if cmplx else np.float64)
+            if mp.is_single_precision():
+                arr = np.zeros(dims, dtype=np.complex64 if cmplx else np.float32)
+            else:
+                arr = np.zeros(dims, dtype=np.complex128 if cmplx else np.float64)
 
         if np.iscomplexobj(arr):
             self.fields.get_complex_array_slice(v, component, arr, frequency, snap)

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3335,7 +3335,9 @@ class Simulation(object):
         + `cmplx`: `boolean`; if `True`, return complex-valued data otherwise return
           real-valued data (default).
 
-        + `arr`: optional field to pass a pre-allocated NumPy array of the correct size,
+        + `arr`: optional parameter to pass a pre-allocated NumPy array of the correct size and
+          type (either `numpy.float32` or `numpy.float64` depending on the [floating-point precision
+          of the fields and materials](Build_From_Source.md#floating-point-precision-of-the-fields-and-materials-arrays))
           which will be overwritten with the field/material data instead of allocating a
           new array.  Normally, this will be the array returned from a previous call to
           `get_array` for a similar slice, allowing one to re-use `arr` (e.g., when
@@ -3419,7 +3421,8 @@ class Simulation(object):
 
     def get_dft_array(self, dft_obj, component, num_freq):
         """
-        Returns the Fourier-transformed fields as a NumPy array.
+        Returns the Fourier-transformed fields as a NumPy array. The type is either `numpy.complex64`
+        or `numpy.complex128` depending on the [floating-point precision of the fields](Build_From_Source.md#floating-point-precision-of-the-fields-and-materials-arrays).
 
         **Parameters:**
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3465,7 +3465,7 @@ class Simulation(object):
         dim_sizes = np.zeros(3, dtype=np.uintp)
         mp._get_array_slice_dimensions(self.fields, v, dim_sizes, True, False)
         dims = [s for s in dim_sizes if s != 0]
-        arr = np.zeros(dims, dtype=np.complex128)
+        arr = np.zeros(dims, dtype=np.complex64 if mp.is_single_precision() else np.complex128)
         self.fields.get_source_slice(v, component, arr)
         return arr
 

--- a/python/tests/test_adjoint_jax.py
+++ b/python/tests/test_adjoint_jax.py
@@ -175,7 +175,8 @@ class UtilsTest(unittest.TestCase):
         for value in design_region_fields[0]:
             self.assertIsInstance(value, onp.ndarray)
             self.assertEqual(value.ndim, 4)  # dims: freq, x, y, pad
-            self.assertEqual(value.dtype, onp.complex128)
+            self.assertEqual(value.dtype,
+                             onp.complex64 if mp.is_single_precision() else onp.complex128)
 
 
 class WrapperTest(ApproxComparisonTestCase):

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -507,7 +507,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.13 if mp.is_single_precision() else 0.03
+            tol = 0.06 if mp.is_single_precision() else 0.03
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
     def test_offdiagonal(self):
@@ -534,7 +534,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.06 if mp.is_single_precision() else 0.04
+            tol = 0.05 if mp.is_single_precision() else 0.04
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -467,8 +467,6 @@ class TestAdjointSolver(ApproxComparisonTestCase):
 
             ## compute unperturbed |Ez|^2
             Ez2_unperturbed = forward_simulation_complex_fields(p, frequencies)
-            self.assertEqual(Ez2_unperturbed.dtype,
-                             np.float32 if mp.is_single_precision() else np.float64)
 
             ## compare objective results
             print("Ez2 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,Ez2_unperturbed))

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -15,7 +15,8 @@ MonitorObject = Enum('MonitorObject', 'EIGENMODE DFT')
 resolution = 30
 
 silicon = mp.Medium(epsilon=12)
-sapphire = mp.Medium(epsilon_diag=(10.225,10.225,9.95),epsilon_offdiag=(-0.825,-0.55*np.sqrt(3/2),0.55*np.sqrt(3/2)))
+sapphire = mp.Medium(epsilon_diag=(10.225,10.225,9.95),
+                     epsilon_offdiag=(-0.825,-0.55*np.sqrt(3/2),0.55*np.sqrt(3/2)))
 
 sxy = 5.0
 cell_size = mp.Vector3(sxy,sxy,0)
@@ -469,7 +470,8 @@ class TestAdjointSolver(ApproxComparisonTestCase):
 
             ## compare objective results
             print("Ez2 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,Ez2_unperturbed))
-            self.assertClose(adjsol_obj,Ez2_unperturbed,epsilon=1e-8)
+            tol = 1e-7 if mp.is_single_precision() else 1e-8
+            self.assertClose(adjsol_obj,Ez2_unperturbed,epsilon=tol)
 
             ## compute perturbed |Ez|^2
             Ez2_perturbed = forward_simulation_complex_fields(p+dp, frequencies)

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -467,11 +467,12 @@ class TestAdjointSolver(ApproxComparisonTestCase):
 
             ## compute unperturbed |Ez|^2
             Ez2_unperturbed = forward_simulation_complex_fields(p, frequencies)
+            self.assertEqual(Ez2_unperturbed.dtype,
+                             np.float32 if mp.is_single_precision() else np.float64)
 
             ## compare objective results
             print("Ez2 -- adjoint solver: {}, traditional simulation: {}".format(adjsol_obj,Ez2_unperturbed))
-            tol = 1e-7 if mp.is_single_precision() else 1e-8
-            self.assertClose(adjsol_obj,Ez2_unperturbed,epsilon=tol)
+            self.assertClose(adjsol_obj,Ez2_unperturbed,epsilon=1e-6)
 
             ## compute perturbed |Ez|^2
             Ez2_perturbed = forward_simulation_complex_fields(p+dp, frequencies)
@@ -508,7 +509,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.06 if mp.is_single_precision() else 0.03
+            tol = 0.13 if mp.is_single_precision() else 0.03
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
     def test_offdiagonal(self):
@@ -535,7 +536,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@adjsol_grad).flatten()
             fd_grad = S12_perturbed-S12_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.04
+            tol = 0.06 if mp.is_single_precision() else 0.04
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 if __name__ == '__main__':
     unittest.main()

--- a/python/tests/test_cavity_arrayslice.py
+++ b/python/tests/test_cavity_arrayslice.py
@@ -70,7 +70,7 @@ class TestCavityArraySlice(ApproxComparisonTestCase):
 
     def test_1d_slice_user_array(self):
         self.sim.run(until_after_sources=0)
-        arr = np.zeros(126, dtype=np.float64)
+        arr = np.zeros(126, dtype=np.float32 if mp.is_single_precision() else np.float64)
         vol = mp.Volume(center=self.center_1d, size=self.size_1d)
         self.sim.get_array(mp.Hz, vol, arr=arr)
         tol = 1e-5 if mp.is_single_precision() else 1e-8
@@ -78,7 +78,7 @@ class TestCavityArraySlice(ApproxComparisonTestCase):
 
     def test_2d_slice_user_array(self):
         self.sim.run(until_after_sources=0)
-        arr = np.zeros((126, 38), dtype=np.float64)
+        arr = np.zeros((126, 38), dtype=np.float32 if mp.is_single_precision() else np.float64)
         vol = mp.Volume(center=self.center_2d, size=self.size_2d)
         self.sim.get_array(mp.Hz, vol, arr=arr)
         tol = 1e-5 if mp.is_single_precision() else 1e-8
@@ -106,14 +106,14 @@ class TestCavityArraySlice(ApproxComparisonTestCase):
         self.sim.run(until_after_sources=0)
         vol = mp.Volume(center=self.center_1d, size=self.size_1d)
         hl_slice1d = self.sim.get_array(mp.Hz, vol, cmplx=True)
-        self.assertTrue(hl_slice1d.dtype == np.complex128)
+        self.assertTrue(hl_slice1d.dtype == np.complex64 if mp.is_single_precision() else np.complex128)
         self.assertTrue(hl_slice1d.shape[0] == 126)
 
     def test_2d_complex_slice(self):
         self.sim.run(until_after_sources=0)
         vol = mp.Volume(center=self.center_2d, size=self.size_2d)
         hl_slice2d = self.sim.get_array(mp.Hz, vol, cmplx=True)
-        self.assertTrue(hl_slice2d.dtype == np.complex128)
+        self.assertTrue(hl_slice2d.dtype == np.complex64 if mp.is_single_precision() else np.complex128)
         self.assertTrue(hl_slice2d.shape[0] == 126 and hl_slice2d.shape[1] == 38)
 
 

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -33,9 +33,9 @@ static inline std::complex<double> my_complex_func2(double t, void *f) {
 }
 
 typedef struct { SCM func; int nf; } my_field_func_data;
-static inline std::complex<meep::realnum> my_field_func(const std::complex<meep::realnum> *fields,
-                                                        const meep::vec &loc,
-                                                        void *data_) {
+static inline std::complex<double> my_field_func(const std::complex<meep::realnum> *fields,
+                                                 const meep::vec &loc,
+                                                 void *data_) {
   my_field_func_data *data = (my_field_func_data *) data_;
   int num_items = data->nf;
   cnumber *items = new cnumber[num_items];
@@ -46,7 +46,7 @@ static inline std::complex<meep::realnum> my_field_func(const std::complex<meep:
 			      make_cnumber_list(num_items, items)));
   delete[] items;
   cnumber cret = ctl_convert_cnumber_to_c(ret);
-  return std::complex<meep::realnum>(cret.re, cret.im);
+  return std::complex<double>(cret.re, cret.im);
 }
 
 /* Unfortunately, this is not re-entrant.  Damn dynamic scoping.

--- a/scheme/meep.i
+++ b/scheme/meep.i
@@ -33,9 +33,9 @@ static inline std::complex<double> my_complex_func2(double t, void *f) {
 }
 
 typedef struct { SCM func; int nf; } my_field_func_data;
-static inline std::complex<double> my_field_func(const std::complex<double> *fields,
-					    const meep::vec &loc,
-					    void *data_) {
+static inline std::complex<meep::realnum> my_field_func(const std::complex<meep::realnum> *fields,
+                                                        const meep::vec &loc,
+                                                        void *data_) {
   my_field_func_data *data = (my_field_func_data *) data_;
   int num_items = data->nf;
   cnumber *items = new cnumber[num_items];
@@ -46,7 +46,7 @@ static inline std::complex<double> my_field_func(const std::complex<double> *fie
 			      make_cnumber_list(num_items, items)));
   delete[] items;
   cnumber cret = ctl_convert_cnumber_to_c(ret);
-  return std::complex<double>(cret.re, cret.im);
+  return std::complex<meep::realnum>(cret.re, cret.im);
 }
 
 /* Unfortunately, this is not re-entrant.  Damn dynamic scoping.

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -43,7 +43,7 @@ constexpr size_t ARRAY_TO_ALL_BUFSIZE = 1 << 16; // Use (64k * 8 bytes) of buffe
 /* repeatedly call sum_to_all to consolidate all entries of    */
 /* an array on all cores.                                      */
 /* array: in/out ptr to the data                               */
-/* array_size: data size in multiples of sizeof(double)        */
+/* array_size: data size in multiples of sizeof(realnum)       */
 /***************************************************************/
 realnum *array_to_all(realnum *array, size_t array_size) {
 #ifdef HAVE_MPI

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -101,7 +101,7 @@ typedef struct {
   // temporary internal storage buffers
   component *cS;
   complex<double> *ph;
-  complex<double> *fields;
+  complex<realnum> *fields;
   ptrdiff_t *offsets;
 
   double frequency;
@@ -119,13 +119,13 @@ typedef struct {
 } array_slice_data;
 
 /* passthrough field function equivalent to component_fun in h5fields.cpp */
-static complex<double> default_field_func(const complex<double> *fields, const vec &loc, void *data_) {
+static complex<realnum> default_field_func(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc;   // unused
   (void)data_; // unused
   return fields[0];
 }
 
-static double default_field_rfunc(const complex<double> *fields, const vec &loc, void *data_) {
+static realnum default_field_rfunc(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc;   // unused
   (void)data_; // unused
   return real(fields[0]);
@@ -310,18 +310,19 @@ static void get_array_slice_chunkloop(fields_chunk *fc, int ichnk, component cgr
   // Otherwise proceed to compute the function of field components to be   //
   // tabulated on the slice, exactly as in fields::integrate.              //
   //-----------------------------------------------------------------------//
-  double *slice = 0;
-  complex<double> *zslice = 0;
+  realnum *slice = 0;
+  complex<realnum> *zslice = 0;
   bool complex_data = (data->rfun == 0);
   if (complex_data)
-    zslice = (complex<double> *)data->vslice;
+    zslice = (complex<realnum> *)data->vslice;
   else
-    slice = (double *)data->vslice;
+    slice = (realnum *)data->vslice;
 
   ptrdiff_t *off = data->offsets;
   component *cS = data->cS;
   double frequency = data->frequency;
-  complex<double> *fields = data->fields, *ph = data->ph;
+  complex<realnum> *fields = data->fields;
+  complex<double> *ph = data->ph;
   const component *iecs = data->inveps_cs;
   const direction *ieds = data->inveps_ds;
   ptrdiff_t ieos[6];
@@ -619,7 +620,7 @@ void *fields::do_get_array_slice(const volume &where, std::vector<component> com
   int num_components = components.size();
   data.cS = new component[num_components];
   data.ph = new complex<double>[num_components];
-  data.fields = new complex<double>[num_components];
+  data.fields = new complex<realnum>[num_components];
   data.offsets = new ptrdiff_t[2 * num_components];
   memset(data.offsets, 0, 2 * num_components * sizeof(ptrdiff_t));
   data.empty_dim[0] = data.empty_dim[1] = data.empty_dim[2] = data.empty_dim[3] =

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -72,6 +72,14 @@ complex<realnum> *array_to_all(complex<realnum> *array, size_t array_size) {
 
 /***************************************************************************/
 
+std::complex<double> cdouble(std::complex<float> z) {
+  return std::complex<double>(real(z), imag(z));
+}
+
+std::complex<double> cdouble(std::complex<double> z) {
+  return z;
+}
+
 typedef struct {
 
   // information related to the volume covered by the
@@ -119,16 +127,16 @@ typedef struct {
 } array_slice_data;
 
 /* passthrough field function equivalent to component_fun in h5fields.cpp */
-static complex<realnum> default_field_func(const complex<realnum> *fields, const vec &loc, void *data_) {
+static complex<double> default_field_func(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc;   // unused
   (void)data_; // unused
-  return fields[0];
+  return cdouble(fields[0]);
 }
 
-static realnum default_field_rfunc(const complex<realnum> *fields, const vec &loc, void *data_) {
+static double default_field_rfunc(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc;   // unused
   (void)data_; // unused
-  return real(fields[0]);
+  return real(cdouble(fields[0]));
 }
 
 /***************************************************************/

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -859,11 +859,11 @@ dft_fields fields::add_dft_fields(component *components, int num_components, con
 /***************************************************************/
 /* chunk-level processing for fields::process_dft_component.   */
 /***************************************************************/
-complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corner, ivec max_corner,
-                                                 int num_freq, h5file *file, double *buffer, int reim,
-                                                 complex<double> *field_array, void *mode1_data, void *mode2_data,
-                                                 int ic_conjugate, bool retain_interp_weights,
-                                                 fields *parent) {
+complex<realnum> dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corner, ivec max_corner,
+                                                  int num_freq, h5file *file, realnum *buffer, int reim,
+                                                  complex<realnum> *field_array, void *mode1_data, void *mode2_data,
+                                                  int ic_conjugate, bool retain_interp_weights,
+                                                  fields *parent) {
 
   if ((num_freq < 0) || (num_freq > static_cast<int>(omega.size())-1))
     meep::abort("process_dft_component: frequency index %d is outside the range of the frequency array of size %lu",num_freq,omega.size());
@@ -923,7 +923,7 @@ complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec m
   /***************************************************************/
   vec rshift(shift * (0.5 * fc->gv.inva));
   int chunk_idx = 0;
-  complex<double> integral = 0.0;
+  complex<realnum> integral = 0.0;
   component c_conjugate = (component)(ic_conjugate >= 0 ? ic_conjugate : -ic_conjugate);
   LOOP_OVER_IVECS(fc->gv, is, ie, idx) {
     IVEC_LOOP_LOC(fc->gv, loc);

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -859,11 +859,11 @@ dft_fields fields::add_dft_fields(component *components, int num_components, con
 /***************************************************************/
 /* chunk-level processing for fields::process_dft_component.   */
 /***************************************************************/
-complex<realnum> dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corner, ivec max_corner,
-                                                  int num_freq, h5file *file, realnum *buffer, int reim,
-                                                  complex<realnum> *field_array, void *mode1_data, void *mode2_data,
-                                                  int ic_conjugate, bool retain_interp_weights,
-                                                  fields *parent) {
+complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec min_corner, ivec max_corner,
+                                                 int num_freq, h5file *file, realnum *buffer, int reim,
+                                                 complex<realnum> *field_array, void *mode1_data, void *mode2_data,
+                                                 int ic_conjugate, bool retain_interp_weights,
+                                                 fields *parent) {
 
   if ((num_freq < 0) || (num_freq > static_cast<int>(omega.size())-1))
     meep::abort("process_dft_component: frequency index %d is outside the range of the frequency array of size %lu",num_freq,omega.size());
@@ -923,7 +923,7 @@ complex<realnum> dft_chunk::process_dft_component(int rank, direction *ds, ivec 
   /***************************************************************/
   vec rshift(shift * (0.5 * fc->gv.inva));
   int chunk_idx = 0;
-  complex<realnum> integral = 0.0;
+  complex<double> integral = 0.0;
   component c_conjugate = (component)(ic_conjugate >= 0 ? ic_conjugate : -ic_conjugate);
   LOOP_OVER_IVECS(fc->gv, is, ie, idx) {
     IVEC_LOOP_LOC(fc->gv, loc);
@@ -1025,11 +1025,11 @@ complex<realnum> dft_chunk::process_dft_component(int rank, direction *ds, ivec 
 /* if where is non-null, only field components inside *where   */
 /* are processed.                                              */
 /***************************************************************/
-complex<realnum> fields::process_dft_component(dft_chunk **chunklists, int num_chunklists, int num_freq,
-                                               component c, const char *HDF5FileName, complex<realnum> **pfield_array,
-                                               int *array_rank, size_t *array_dims, direction *array_dirs,
-                                               void *mode1_data, void *mode2_data, component c_conjugate,
-                                               bool *first_component, bool retain_interp_weights) {
+complex<double> fields::process_dft_component(dft_chunk **chunklists, int num_chunklists, int num_freq,
+                                              component c, const char *HDF5FileName, complex<realnum> **pfield_array,
+                                              int *array_rank, size_t *array_dims, direction *array_dirs,
+                                              void *mode1_data, void *mode2_data, component c_conjugate,
+                                              bool *first_component, bool retain_interp_weights) {
 
   /***************************************************************/
   /***************************************************************/
@@ -1109,7 +1109,7 @@ complex<realnum> fields::process_dft_component(dft_chunk **chunklists, int num_c
   else if (pfield_array)
     *pfield_array = field_array = (array_size ? new complex<realnum>[array_size] : 0);
 
-  complex<realnum> overlap = 0.0;
+  complex<double> overlap = 0.0;
   for (int reim = 0; reim <= reim_max; reim++) {
     h5file *file = 0;
     if (HDF5FileName) {

--- a/src/energy_and_flux.cpp
+++ b/src/energy_and_flux.cpp
@@ -58,10 +58,10 @@ double fields::field_energy_in_box(const volume &where) {
   return electric_energy_in_box(where) + cur_step_magnetic_energy;
 }
 
-static complex<realnum> dot_integrand(const complex<realnum> *fields, const vec &loc, void *data_) {
+static complex<double> dot_integrand(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc;
   (void)data_; // unused;
-  return real(conj(fields[0]) * fields[1]);
+  return real(conj(cdouble(fields[0])) * cdouble(fields[1]));
 }
 
 double fields::field_energy_in_box(component c, const volume &where) {
@@ -249,12 +249,13 @@ flux_vol *fields::add_flux_plane(const vec &p1, const vec &p2) {
    is more expensive and requires us to know the boundary orientation, and
    does not seem worth the trouble at this point. */
 
-static complex<realnum> dot3_max_integrand(const complex<realnum> *fields, const vec &loc,
-                                           void *data_) {
+static complex<double> dot3_max_integrand(const complex<realnum> *fields, const vec &loc,
+                                          void *data_) {
   (void)loc;
   (void)data_; // unused;
-  return (real(conj(fields[0]) * fields[3]) + real(conj(fields[1]) * fields[4]) +
-          real(conj(fields[2]) * fields[5]));
+  return (real(conj(cdouble(fields[0])) * cdouble(fields[3])) +
+          real(conj(cdouble(fields[1])) * cdouble(fields[4])) +
+          real(conj(cdouble(fields[2])) * cdouble(fields[5])));
 }
 
 double fields::electric_energy_max_in_box(const volume &where) {
@@ -294,10 +295,10 @@ double fields::modal_volume_in_box(const volume &where) {
 
 typedef double (*fx_func)(const vec &);
 
-static complex<realnum> dot_fx_integrand(const complex<realnum> *fields, const vec &loc,
-                                         void *data_) {
+static complex<double> dot_fx_integrand(const complex<realnum> *fields, const vec &loc,
+                                        void *data_) {
   fx_func fx = (fx_func)data_;
-  return (real(conj(fields[0]) * fields[1]) * fx(loc));
+  return (real(conj(cdouble(fields[0])) * cdouble(fields[1])) * fx(loc));
 }
 
 /* computes integral of f(x) * |E|^2 / integral epsilon*|E|^2 */

--- a/src/energy_and_flux.cpp
+++ b/src/energy_and_flux.cpp
@@ -58,7 +58,7 @@ double fields::field_energy_in_box(const volume &where) {
   return electric_energy_in_box(where) + cur_step_magnetic_energy;
 }
 
-static complex<double> dot_integrand(const complex<double> *fields, const vec &loc, void *data_) {
+static complex<realnum> dot_integrand(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc;
   (void)data_; // unused;
   return real(conj(fields[0]) * fields[1]);
@@ -249,8 +249,8 @@ flux_vol *fields::add_flux_plane(const vec &p1, const vec &p2) {
    is more expensive and requires us to know the boundary orientation, and
    does not seem worth the trouble at this point. */
 
-static complex<double> dot3_max_integrand(const complex<double> *fields, const vec &loc,
-                                          void *data_) {
+static complex<realnum> dot3_max_integrand(const complex<realnum> *fields, const vec &loc,
+                                           void *data_) {
   (void)loc;
   (void)data_; // unused;
   return (real(conj(fields[0]) * fields[3]) + real(conj(fields[1]) * fields[4]) +
@@ -294,8 +294,8 @@ double fields::modal_volume_in_box(const volume &where) {
 
 typedef double (*fx_func)(const vec &);
 
-static complex<double> dot_fx_integrand(const complex<double> *fields, const vec &loc,
-                                        void *data_) {
+static complex<realnum> dot_fx_integrand(const complex<realnum> *fields, const vec &loc,
+                                         void *data_) {
   fx_func fx = (fx_func)data_;
   return (real(conj(fields[0]) * fields[1]) * fx(loc));
 }

--- a/src/h5fields.cpp
+++ b/src/h5fields.cpp
@@ -48,7 +48,7 @@ typedef struct {
   const component *components;
   component *cS;
   complex<double> *ph;
-  complex<double> *fields;
+  complex<realnum> *fields;
   ptrdiff_t *offsets;
   double frequency;
   int ninveps;
@@ -143,7 +143,8 @@ static void h5_output_chunkloop(fields_chunk *fc, int ichnk, component cgrid, iv
 
   ptrdiff_t *off = data->offsets;
   component *cS = data->cS;
-  complex<double> *fields = data->fields, *ph = data->ph;
+  complex<realnum> *fields = data->fields;
+  complex<double> *ph = data->ph;
   double frequency = data->frequency;
   const component *iecs = data->inveps_cs;
   const direction *ieds = data->inveps_ds;
@@ -267,7 +268,7 @@ void fields::output_hdf5(h5file *file, const char *dataname, int num_fields,
   data.components = components;
   data.cS = new component[num_fields];
   data.ph = new complex<double>[num_fields];
-  data.fields = new complex<double>[num_fields];
+  data.fields = new complex<realnum>[num_fields];
   data.fun = fun;
   data.fun_data_ = fun_data_;
 
@@ -351,7 +352,7 @@ typedef struct {
   void *fun_data_;
 } rintegrand_data;
 
-static complex<double> rintegrand_fun(const complex<double> *fields, const vec &loc, void *data_) {
+static complex<realnum> rintegrand_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
   rintegrand_data *data = (rintegrand_data *)data_;
   return data->fun(fields, loc, data->fun_data_);
 }
@@ -374,7 +375,7 @@ void fields::output_hdf5(const char *dataname, int num_fields, const component *
 
 /***************************************************************************/
 
-static complex<double> component_fun(const complex<double> *fields, const vec &loc, void *data_) {
+static complex<realnum> component_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc;   // unused
   (void)data_; // unused
   return fields[0];

--- a/src/h5fields.cpp
+++ b/src/h5fields.cpp
@@ -352,7 +352,7 @@ typedef struct {
   void *fun_data_;
 } rintegrand_data;
 
-static complex<realnum> rintegrand_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
+static complex<double> rintegrand_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
   rintegrand_data *data = (rintegrand_data *)data_;
   return data->fun(fields, loc, data->fun_data_);
 }
@@ -375,10 +375,10 @@ void fields::output_hdf5(const char *dataname, int num_fields, const component *
 
 /***************************************************************************/
 
-static complex<realnum> component_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
+static complex<double> component_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc;   // unused
   (void)data_; // unused
-  return fields[0];
+  return cdouble(fields[0]);
 }
 
 void fields::output_hdf5(component c, const volume &where, h5file *file, bool append_data,

--- a/src/integrate.cpp
+++ b/src/integrate.cpp
@@ -37,7 +37,7 @@ struct integrate_data {
   int ninvmu;
   component invmu_cs[3];
   direction invmu_ds[3];
-  complex<long double> sum;
+  complex<double> sum;
   double maxabs;
   field_function integrand;
   void *integrand_data_;
@@ -197,7 +197,7 @@ complex<double> fields::integrate(int num_fvals, const component *components,
   if (maxabs) *maxabs = max_to_all(data.maxabs);
   data.sum = sum_to_all(data.sum);
 
-  return complex<double>(real(data.sum), imag(data.sum));
+  return cdouble(data.sum);
 }
 
 typedef struct {
@@ -205,7 +205,7 @@ typedef struct {
   void *integrand_data;
 } rfun_wrap_data;
 
-static complex<realnum> rfun_wrap(const complex<realnum> *fvals, const vec &loc, void *data_) {
+static complex<double> rfun_wrap(const complex<realnum> *fvals, const vec &loc, void *data_) {
   rfun_wrap_data *data = (rfun_wrap_data *)data_;
   return data->integrand(fvals, loc, data->integrand_data);
 }
@@ -233,11 +233,11 @@ double fields::max_abs(int num_fvals, const component *components, field_rfuncti
   return max_abs(num_fvals, components, rfun_wrap, &data, where);
 }
 
-static complex<realnum> return_the_field(const complex<realnum> *fields, const vec &loc,
+static complex<double> return_the_field(const complex<realnum> *fields, const vec &loc,
                                          void *integrand_data_) {
   (void)integrand_data_;
   (void)loc; // unused
-  return fields[0];
+  return cdouble(fields[0]);
 }
 
 double fields::max_abs(int c, const volume &where) {

--- a/src/integrate.cpp
+++ b/src/integrate.cpp
@@ -29,7 +29,7 @@ struct integrate_data {
   const component *components;
   component *cS;
   complex<double> *ph;
-  complex<double> *fvals;
+  complex<realnum> *fvals;
   ptrdiff_t *offsets;
   int ninveps;
   component inveps_cs[3];
@@ -51,7 +51,8 @@ static void integrate_chunkloop(fields_chunk *fc, int ichunk, component cgrid, i
   integrate_data *data = (integrate_data *)data_;
   ptrdiff_t *off = data->offsets;
   component *cS = data->cS;
-  complex<double> *fvals = data->fvals, *ph = data->ph;
+  complex<realnum> *fvals = data->fvals;
+  complex<double> *ph = data->ph;
   complex<long double> sum = 0.0;
   double maxabs = 0;
   const component *iecs = data->inveps_cs;
@@ -146,7 +147,7 @@ complex<double> fields::integrate(int num_fvals, const component *components,
   data.components = components;
   data.cS = new component[num_fvals];
   data.ph = new complex<double>[num_fvals];
-  data.fvals = new complex<double>[num_fvals];
+  data.fvals = new complex<realnum>[num_fvals];
   data.sum = 0;
   data.maxabs = 0;
   data.integrand = integrand;
@@ -203,7 +204,8 @@ typedef struct {
   field_rfunction integrand;
   void *integrand_data;
 } rfun_wrap_data;
-static complex<double> rfun_wrap(const complex<double> *fvals, const vec &loc, void *data_) {
+
+static complex<realnum> rfun_wrap(const complex<realnum> *fvals, const vec &loc, void *data_) {
   rfun_wrap_data *data = (rfun_wrap_data *)data_;
   return data->integrand(fvals, loc, data->integrand_data);
 }
@@ -231,8 +233,8 @@ double fields::max_abs(int num_fvals, const component *components, field_rfuncti
   return max_abs(num_fvals, components, rfun_wrap, &data, where);
 }
 
-static complex<double> return_the_field(const complex<double> *fields, const vec &loc,
-                                        void *integrand_data_) {
+static complex<realnum> return_the_field(const complex<realnum> *fields, const vec &loc,
+                                         void *integrand_data_) {
   (void)integrand_data_;
   (void)loc; // unused
   return fields[0];

--- a/src/integrate2.cpp
+++ b/src/integrate2.cpp
@@ -35,7 +35,7 @@ struct integrate_data {
   const component *components2;
   component *cS;
   complex<double> *ph;
-  complex<double> *fvals;
+  complex<realnum> *fvals;
   ptrdiff_t *offsets;
   int ninveps;
   component inveps_cs[3];
@@ -57,7 +57,8 @@ static void integrate_chunkloop(fields_chunk *fc, int ichunk, component cgrid, i
   integrate_data *data = (integrate_data *)data_;
   ptrdiff_t *off = data->offsets;
   component *cS = data->cS;
-  complex<double> *fvals = data->fvals, *ph = data->ph;
+  complex<realnum> *fvals = data->fvals;
+  complex<double> *ph = data->ph;
   complex<long double> sum = 0.0;
   double maxabs = 0;
   const component *iecs = data->inveps_cs;
@@ -223,7 +224,7 @@ complex<double> fields::integrate2(const fields &fields2, int num_fvals1,
   data.components2 = components2;
   data.cS = new component[num_fvals1 + num_fvals2];
   data.ph = new complex<double>[num_fvals1 + num_fvals2];
-  data.fvals = new complex<double>[num_fvals1 + num_fvals2];
+  data.fvals = new complex<realnum>[num_fvals1 + num_fvals2];
   data.sum = 0;
   data.maxabs = 0;
   data.integrand = integrand;
@@ -292,7 +293,8 @@ typedef struct {
   field_rfunction integrand;
   void *integrand_data;
 } rfun_wrap_data;
-static complex<double> rfun_wrap(const complex<double> *fields, const vec &loc, void *data_) {
+
+static complex<realnum> rfun_wrap(const complex<realnum> *fields, const vec &loc, void *data_) {
   rfun_wrap_data *data = (rfun_wrap_data *)data_;
   return data->integrand(fields, loc, data->integrand_data);
 }

--- a/src/integrate2.cpp
+++ b/src/integrate2.cpp
@@ -43,7 +43,7 @@ struct integrate_data {
   int ninvmu;
   component invmu_cs[3];
   direction invmu_ds[3];
-  complex<long double> sum;
+  complex<double> sum;
   double maxabs;
   field_function integrand;
   void *integrand_data_;
@@ -286,7 +286,7 @@ complex<double> fields::integrate2(const fields &fields2, int num_fvals1,
   if (maxabs) *maxabs = max_to_all(data.maxabs);
   data.sum = sum_to_all(data.sum);
 
-  return complex<double>(real(data.sum), imag(data.sum));
+  return cdouble(data.sum);
 }
 
 typedef struct {
@@ -294,7 +294,7 @@ typedef struct {
   void *integrand_data;
 } rfun_wrap_data;
 
-static complex<realnum> rfun_wrap(const complex<realnum> *fields, const vec &loc, void *data_) {
+static complex<double> rfun_wrap(const complex<realnum> *fields, const vec &loc, void *data_) {
   rfun_wrap_data *data = (rfun_wrap_data *)data_;
   return data->integrand(fields, loc, data->integrand_data);
 }

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1126,7 +1126,7 @@ public:
   // fields::process_dft_component
   std::complex<realnum> process_dft_component(int rank, direction *ds, ivec min_corner,
                                               ivec max_corner, int num_freq, h5file *file,
-                                              double *buffer, int reim,
+                                              realnum *buffer, int reim,
                                               std::complex<realnum> *field_array, void *mode1_data,
                                               void *mode2_data, int ic_conjugate,
                                               bool retain_interp_weights, fields *parent);
@@ -1812,33 +1812,33 @@ public:
   // of the correct size.
   // otherwise, a new buffer is allocated and returned; it
   // must eventually be caller-deallocated via delete[].
-  double *get_array_slice(const volume &where, std::vector<component> components,
-                          field_rfunction rfun, void *fun_data, double *slice = 0,
-                          double frequency = 0,
-                          bool snap = false);
+  realnum *get_array_slice(const volume &where, std::vector<component> components,
+                           field_rfunction rfun, void *fun_data, realnum *slice = 0,
+                           double frequency = 0,
+                           bool snap = false);
 
-  std::complex<double> *get_complex_array_slice(const volume &where,
-                                                std::vector<component> components,
-                                                field_function fun, void *fun_data,
-                                                std::complex<double> *slice = 0,
-                                                double frequency = 0,
-                                                bool snap = false);
+  std::complex<realnum> *get_complex_array_slice(const volume &where,
+                                                 std::vector<component> components,
+                                                 field_function fun, void *fun_data,
+                                                 std::complex<realnum> *slice = 0,
+                                                 double frequency = 0,
+                                                 bool snap = false);
 
   // alternative entry points for when you have no field
   // function, i.e. you want just a single component or
   // derived component.)
-  double *get_array_slice(const volume &where, component c, double *slice = 0,
-                          double frequency = 0, bool snap = false);
-  double *get_array_slice(const volume &where, derived_component c, double *slice = 0,
-                          double frequency = 0, bool snap = false);
-  std::complex<double> *get_complex_array_slice(const volume &where, component c,
-                                                std::complex<double> *slice = 0,
-                                                double frequency = 0,
-                                                bool snap = false);
+  realnum *get_array_slice(const volume &where, component c, realnum *slice = 0,
+                           double frequency = 0, bool snap = false);
+  realnum *get_array_slice(const volume &where, derived_component c, realnum *slice = 0,
+                           double frequency = 0, bool snap = false);
+  std::complex<realnum> *get_complex_array_slice(const volume &where, component c,
+                                                 std::complex<realnum> *slice = 0,
+                                                 double frequency = 0,
+                                                 bool snap = false);
 
   // like get_array_slice, but for *sources* instead of fields
-  std::complex<double> *get_source_slice(const volume &where, component source_slice_component,
-                                         std::complex<double> *slice = 0);
+  std::complex<realnum> *get_source_slice(const volume &where, component source_slice_component,
+                                          std::complex<realnum> *slice = 0);
 
   // master routine for all above entry points
   void *do_get_array_slice(const volume &where, std::vector<component> components,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1627,10 +1627,10 @@ typedef void (*field_chunkloop)(fields_chunk *fc, int ichunk, component cgrid, i
                                 vec s0, vec s1, vec e0, vec e1, double dV0, double dV1, ivec shift,
                                 std::complex<double> shift_phase, const symmetry &S, int sn,
                                 void *chunkloop_data);
-typedef std::complex<double> (*field_function)(const std::complex<double> *fields, const vec &loc,
-                                               void *integrand_data_);
-typedef double (*field_rfunction)(const std::complex<double> *fields, const vec &loc,
-                                  void *integrand_data_);
+typedef std::complex<realnum> (*field_function)(const std::complex<realnum> *fields, const vec &loc,
+                                                void *integrand_data_);
+typedef realnum (*field_rfunction)(const std::complex<realnum> *fields, const vec &loc,
+                                   void *integrand_data_);
 
 field_rfunction derived_component_func(derived_component c, const grid_volume &gv, int &nfields,
                                        component cs[12]);

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -60,6 +60,10 @@ const double nan = NAN;
 const double nan = -7.0415659787563146e103; // ideally, a value never encountered in practice
 #endif
 
+// Defined in array_slice.cpp
+std::complex<double> cdouble(std::complex<float> z);
+std::complex<double> cdouble(std::complex<double> z);
+
 class h5file;
 
 // Defined in monitor.cpp
@@ -1627,10 +1631,10 @@ typedef void (*field_chunkloop)(fields_chunk *fc, int ichunk, component cgrid, i
                                 vec s0, vec s1, vec e0, vec e1, double dV0, double dV1, ivec shift,
                                 std::complex<double> shift_phase, const symmetry &S, int sn,
                                 void *chunkloop_data);
-typedef std::complex<realnum> (*field_function)(const std::complex<realnum> *fields, const vec &loc,
-                                                void *integrand_data_);
-typedef realnum (*field_rfunction)(const std::complex<realnum> *fields, const vec &loc,
-                                   void *integrand_data_);
+typedef std::complex<double> (*field_function)(const std::complex<realnum> *fields, const vec &loc,
+                                               void *integrand_data_);
+typedef double (*field_rfunction)(const std::complex<realnum> *fields, const vec &loc,
+                                  void *integrand_data_);
 
 field_rfunction derived_component_func(derived_component c, const grid_volume &gv, int &nfields,
                                        component cs[12]);

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1128,12 +1128,12 @@ public:
 
   // chunk-by-chunk helper routine called by
   // fields::process_dft_component
-  std::complex<realnum> process_dft_component(int rank, direction *ds, ivec min_corner,
-                                              ivec max_corner, int num_freq, h5file *file,
-                                              realnum *buffer, int reim,
-                                              std::complex<realnum> *field_array, void *mode1_data,
-                                              void *mode2_data, int ic_conjugate,
-                                              bool retain_interp_weights, fields *parent);
+  std::complex<double> process_dft_component(int rank, direction *ds, ivec min_corner,
+                                             ivec max_corner, int num_freq, h5file *file,
+                                             realnum *buffer, int reim,
+                                             std::complex<realnum> *field_array, void *mode1_data,
+                                             void *mode2_data, int ic_conjugate,
+                                             bool retain_interp_weights, fields *parent);
 
   int get_decimation_factor() const { return decimation_factor; };
 
@@ -2081,13 +2081,13 @@ public:
   /* of DFT fields, and  evaluating overlap integrals     */
   /* flux and mode fields.)                               */
   /********************************************************/
-  std::complex<realnum> process_dft_component(dft_chunk **chunklists, int num_chunklists,
-                                              int num_freq, component c, const char *HDF5FileName,
-                                              std::complex<realnum> **field_array = 0, int *rank = 0,
-                                              size_t *dims = 0, direction *dirs = 0,
-                                              void *mode1_data = 0, void *mode2_data = 0,
-                                              component c_conjugate = Ex, bool *first_component = 0,
-                                              bool retain_interp_weights = true);
+  std::complex<double> process_dft_component(dft_chunk **chunklists, int num_chunklists,
+                                             int num_freq, component c, const char *HDF5FileName,
+                                             std::complex<realnum> **field_array = 0, int *rank = 0,
+                                             size_t *dims = 0, direction *dirs = 0,
+                                             void *mode1_data = 0, void *mode2_data = 0,
+                                             component c_conjugate = Ex, bool *first_component = 0,
+                                             bool retain_interp_weights = true);
 
   // output DFT fields to HDF5 file
   void output_dft_components(dft_chunk **chunklists, int num_chunklists, volume dft_volume,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1124,12 +1124,12 @@ public:
 
   // chunk-by-chunk helper routine called by
   // fields::process_dft_component
-  std::complex<double> process_dft_component(int rank, direction *ds, ivec min_corner,
-                                             ivec max_corner, int num_freq, h5file *file,
-                                             double *buffer, int reim,
-                                             std::complex<double> *field_array, void *mode1_data,
-                                             void *mode2_data, int ic_conjugate,
-                                             bool retain_interp_weights, fields *parent);
+  std::complex<realnum> process_dft_component(int rank, direction *ds, ivec min_corner,
+                                              ivec max_corner, int num_freq, h5file *file,
+                                              double *buffer, int reim,
+                                              std::complex<realnum> *field_array, void *mode1_data,
+                                              void *mode2_data, int ic_conjugate,
+                                              bool retain_interp_weights, fields *parent);
 
   int get_decimation_factor() const { return decimation_factor; };
 
@@ -2077,13 +2077,13 @@ public:
   /* of DFT fields, and  evaluating overlap integrals     */
   /* flux and mode fields.)                               */
   /********************************************************/
-  std::complex<double> process_dft_component(dft_chunk **chunklists, int num_chunklists,
-                                             int num_freq, component c, const char *HDF5FileName,
-                                             std::complex<double> **field_array = 0, int *rank = 0,
-                                             size_t *dims = 0, direction *dirs = 0,
-                                             void *mode1_data = 0, void *mode2_data = 0,
-                                             component c_conjugate = Ex, bool *first_component = 0,
-                                             bool retain_interp_weights = true);
+  std::complex<realnum> process_dft_component(dft_chunk **chunklists, int num_chunklists,
+                                              int num_freq, component c, const char *HDF5FileName,
+                                              std::complex<realnum> **field_array = 0, int *rank = 0,
+                                              size_t *dims = 0, direction *dirs = 0,
+                                              void *mode1_data = 0, void *mode2_data = 0,
+                                              component c_conjugate = Ex, bool *first_component = 0,
+                                              bool retain_interp_weights = true);
 
   // output DFT fields to HDF5 file
   void output_dft_components(dft_chunk **chunklists, int num_chunklists, volume dft_volume,
@@ -2095,14 +2095,14 @@ public:
   void output_dft(dft_fields fdft, const char *HDF5FileName);
 
   // get array of DFT field values
-  std::complex<double> *get_dft_array(dft_flux flux, component c, int num_freq, int *rank,
-                                      size_t dims[3]);
-  std::complex<double> *get_dft_array(dft_fields fdft, component c, int num_freq, int *rank,
-                                      size_t dims[3]);
-  std::complex<double> *get_dft_array(dft_force force, component c, int num_freq, int *rank,
-                                      size_t dims[3]);
-  std::complex<double> *get_dft_array(dft_near2far n2f, component c, int num_freq, int *rank,
-                                      size_t dims[3]);
+  std::complex<realnum> *get_dft_array(dft_flux flux, component c, int num_freq, int *rank,
+                                       size_t dims[3]);
+  std::complex<realnum> *get_dft_array(dft_fields fdft, component c, int num_freq, int *rank,
+                                       size_t dims[3]);
+  std::complex<realnum> *get_dft_array(dft_force force, component c, int num_freq, int *rank,
+                                       size_t dims[3]);
+  std::complex<realnum> *get_dft_array(dft_near2far n2f, component c, int num_freq, int *rank,
+                                       size_t dims[3]);
 
   // overlap integrals between eigenmode fields and DFT flux fields
   void get_overlap(void *mode1_data, void *mode2_data, dft_flux flux, int num_freq,

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -87,7 +87,6 @@ void sum_to_all(const std::complex<float> *in, std::complex<float> *out, int siz
 void sum_to_master(const std::complex<float> *in, std::complex<float> *out, int size);
 void sum_to_master(const std::complex<double> *in, std::complex<double> *out, int size);
 long double sum_to_all(long double);
-std::complex<float> sum_to_all(std::complex<float> in);
 std::complex<double> sum_to_all(std::complex<double> in);
 std::complex<long double> sum_to_all(std::complex<long double> in);
 int sum_to_all(int);

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -76,15 +76,18 @@ int min_to_all(int);
 float sum_to_master(float);   // Only returns the correct value to proc 0.
 double sum_to_master(double); // Only returns the correct value to proc 0.
 double sum_to_all(double);
+void sum_to_all(const float *in, float *out, int size);
 void sum_to_all(const double *in, double *out, int size);
 void sum_to_master(const float *in, float *out, int size);
 void sum_to_master(const double *in, double *out, int size);
 void sum_to_all(const float *in, double *out, int size);
 void sum_to_all(const std::complex<float> *in, std::complex<double> *out, int size);
 void sum_to_all(const std::complex<double> *in, std::complex<double> *out, int size);
+void sum_to_all(const std::complex<float> *in, std::complex<float> *out, int size);
 void sum_to_master(const std::complex<float> *in, std::complex<float> *out, int size);
 void sum_to_master(const std::complex<double> *in, std::complex<double> *out, int size);
 long double sum_to_all(long double);
+std::complex<float> sum_to_all(std::complex<float> in);
 std::complex<double> sum_to_all(std::complex<double> in);
 std::complex<long double> sum_to_all(std::complex<long double> in);
 int sum_to_all(int);

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2770,7 +2770,7 @@ in row-major order (the order used by HDF5): */
 void material_grids_addgradient_point(double *v, vector3 p, double scalegrad, geom_epsilon *geps,
                                       meep::component adjoint_c, meep::component forward_c,
                                       std::complex<double> fwd, std::complex<double> adj,
-                                      double freq, meep::grid_volume &gv, double tol                                      
+                                      double freq, meep::grid_volume &gv, double tol
                                       ) {
   geom_box_tree tp;
   int oi, ois;
@@ -2852,15 +2852,15 @@ void material_grids_addgradient_point(double *v, vector3 p, double scalegrad, ge
 /*              Some gradient helper routines             */
 /**********************************************************/
 
-#define LOOP_OVER_DIRECTIONS_BACKWARDS(dim, d)                                                               \
-  for (meep::direction d = (meep::direction)(meep::stop_at_direction(dim)-1),                                          \
-                       loop_stop_directi = meep::start_at_direction(dim);                           \
+#define LOOP_OVER_DIRECTIONS_BACKWARDS(dim, d)                                     \
+  for (meep::direction d = (meep::direction)(meep::stop_at_direction(dim)-1),      \
+                       loop_stop_directi = meep::start_at_direction(dim);          \
        d >= loop_stop_directi; d = (meep::direction)(d - 1))
 
 void set_strides(meep::ndim dim, ptrdiff_t *the_stride,const meep::ivec c1,const meep::ivec c2) {
   FOR_DIRECTIONS(d) { the_stride[d] = 1;}
   meep::ivec n_s = (c2 - c1)/2 + 1;
-  LOOP_OVER_DIRECTIONS_BACKWARDS(dim,d) { 
+  LOOP_OVER_DIRECTIONS_BACKWARDS(dim,d) {
     ptrdiff_t current_stride = 1;
     LOOP_OVER_DIRECTIONS_BACKWARDS(dim,d_i) {
       if (d_i==d){
@@ -2869,7 +2869,7 @@ void set_strides(meep::ndim dim, ptrdiff_t *the_stride,const meep::ivec c1,const
       }
       current_stride *= n_s.in_direction(d_i);
     }
-  } 
+  }
 }
 
 ptrdiff_t get_idx_from_ivec(meep::ndim dim, meep::ivec c1, ptrdiff_t *the_stride, meep::ivec v){
@@ -2885,7 +2885,7 @@ void material_grids_addgradient(double *v, size_t ng, std::complex<double> *fiel
                                 std::complex<double> *fields_f, size_t fields_shapes[12], double *frequencies,
                                 double scalegrad, meep::grid_volume &gv,
                                 meep::volume &where, geom_epsilon *geps, double du) {
-  
+
 // only loop over field components relevant to our simulation (in the proper order)
 #define FOR_MY_COMPONENTS(c1) FOR_ELECTRIC_COMPONENTS(c1) if (!coordinate_mismatch(gv.dim, component_direction(c1)))
 
@@ -2912,10 +2912,10 @@ void material_grids_addgradient(double *v, size_t ng, std::complex<double> *fiel
     }
   }
   size_t c_start[3];
-  c_start[0] = 0; 
-  c_start[1] = nf*stride_row[0]; 
+  c_start[0] = 0;
+  c_start[1] = nf*stride_row[0];
   c_start[2] = nf*(stride_row[0]+stride_row[1]);
-  
+
 // fields dimensions are (components, nfreqs, x, y, z)
 #define GET_FIELDS(fields,comp,freq,idx) fields[c_start[comp] + freq*stride_row[comp] + idx]
 
@@ -2923,7 +2923,7 @@ void material_grids_addgradient(double *v, size_t ng, std::complex<double> *fiel
   // loop over frequency
   for (size_t f_i = 0; f_i < nf; ++f_i) {
     int ci_adjoint = 0;
-    FOR_MY_COMPONENTS(adjoint_c) { 
+    FOR_MY_COMPONENTS(adjoint_c) {
       LOOP_OVER_IVECS(gv, is[ci_adjoint], ie[ci_adjoint], idx) {
         size_t idx_fields = IVEC_LOOP_COUNTER;
         meep::ivec ip = gv.iloc(adjoint_c,idx);
@@ -2937,8 +2937,8 @@ void material_grids_addgradient(double *v, size_t ng, std::complex<double> *fiel
         double cyl_scale;
         int ci_forward = 0;
         FOR_MY_COMPONENTS(forward_c) {
-          /* we need to calculate the bounds of 
-          the forward fields (in space) so that we 
+          /* we need to calculate the bounds of
+          the forward fields (in space) so that we
           can properly index into the fields array
           later */
           meep::ivec isf = is[ci_forward];
@@ -2966,10 +2966,10 @@ void material_grids_addgradient(double *v, size_t ng, std::complex<double> *fiel
           }else{
             /* we need to restrict the adjoint fields to
             the two nodes of interest (which requires a factor
-            of 0.5 to scale), and interpolate the forward fields 
-            to the same two nodes (which requires another factor of 0.5). 
+            of 0.5 to scale), and interpolate the forward fields
+            to the same two nodes (which requires another factor of 0.5).
             Then we perform our inner product at these nodes.
-            */            
+            */
             std::complex<double> fwd_avg, fwd1, fwd2, prod;
             ptrdiff_t fwd1_idx, fwd2_idx;
 
@@ -2982,7 +2982,7 @@ void material_grids_addgradient(double *v, size_t ng, std::complex<double> *fiel
             meep::ivec fwd_pa  = (fwd_p + unit_a*2);
             meep::ivec fwd_pf  = (fwd_p - unit_f*2);
             meep::ivec fwd_paf = (fwd_p + unit_a*2 - unit_f*2);
-            
+
             //identify the two eps points
             meep::ivec ieps1 = (fwd_p + fwd_pf) / 2;
             meep::ivec ieps2 = (fwd_pa + fwd_paf) / 2;
@@ -2998,7 +2998,7 @@ void material_grids_addgradient(double *v, size_t ng, std::complex<double> *fiel
             material_grids_addgradient_point(
               v+ng*f_i, vec_to_vector3(eps1), scalegrad*cyl_scale, geps,
               adjoint_c, forward_c, fwd_avg, 0.5*adj, frequencies[f_i], gv, du);
-            
+
             //operate on the second eps node
             fwd1_idx = get_idx_from_ivec(gv.dim, start_ivec, the_stride, fwd_pa);
             fwd1 = 0.5 * GET_FIELDS(fields_f,ci_forward,f_i,fwd1_idx);

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -295,10 +295,10 @@ meep::vec material_grid_grad(vector3 p, material_data *md, const geometric_objec
 double matgrid_val(vector3 p, geom_box_tree tp, int oi, material_data *md);
 double material_grid_val(vector3 p, material_data *md);
 geom_box_tree calculate_tree(const meep::volume &v, geometric_object_list g);
-void material_grids_addgradient(double *v, size_t ng, std::complex<double> *fields_a,
-                                std::complex<double> *fields_f, size_t fields_shapes[12],
-                                double *frequencies, double scalegrad,
-                                meep::grid_volume &gv, meep::volume &where, geom_epsilon *geps,double du=1e-6);
+void material_grids_addgradient(double *v, size_t ng, std::complex<meep::realnum> *fields_a,
+                                std::complex<meep::realnum> *fields_f, size_t fields_shapes[12],
+                                double *frequencies, double scalegrad, meep::grid_volume &gv,
+                                meep::volume &where, geom_epsilon *geps, double du = 1e-6);
 
 /***************************************************************/
 /* routines in GDSIIgeom.cc ************************************/

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -441,6 +441,14 @@ double sum_to_all(double in) {
   return out;
 }
 
+void sum_to_all(const float *in, float *out, int size) {
+#ifdef HAVE_MPI
+  MPI_Allreduce((void *)in, out, size, MPI_FLOAT, MPI_SUM, mycomm);
+#else
+  memcpy(out, in, sizeof(float) * size);
+#endif
+}
+
 void sum_to_all(const double *in, double *out, int size) {
 #ifdef HAVE_MPI
   MPI_Allreduce((void *)in, out, size, MPI_DOUBLE, MPI_SUM, mycomm);
@@ -479,6 +487,10 @@ void sum_to_all(const complex<double> *in, complex<double> *out, int size) {
 
 void sum_to_all(const complex<float> *in, complex<double> *out, int size) {
   sum_to_all((const float *)in, (double *)out, 2 * size);
+}
+
+void sum_to_all(const complex<float> *in, complex<float> *out, int size) {
+  sum_to_all((const float *)in, (float *)out, 2 * size);
 }
 
 void sum_to_master(const complex<float> *in, complex<float> *out, int size) {
@@ -548,6 +560,14 @@ size_t partial_sum_to_all(size_t in) {
 #ifdef HAVE_MPI
   MPI_Scan(&in, &out, 1, sizeof(size_t) == 4 ? MPI_UNSIGNED : MPI_UNSIGNED_LONG_LONG, MPI_SUM,
            mycomm);
+#endif
+  return out;
+}
+
+complex<float> sum_to_all(complex<float> in) {
+  complex<float> out = in;
+#ifdef HAVE_MPI
+  MPI_Allreduce(&in, &out, 2, MPI_FLOAT, MPI_SUM, mycomm);
 #endif
   return out;
 }

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -564,14 +564,6 @@ size_t partial_sum_to_all(size_t in) {
   return out;
 }
 
-complex<float> sum_to_all(complex<float> in) {
-  complex<float> out = in;
-#ifdef HAVE_MPI
-  MPI_Allreduce(&in, &out, 2, MPI_FLOAT, MPI_SUM, mycomm);
-#endif
-  return out;
-}
-
 complex<double> sum_to_all(complex<double> in) {
   complex<double> out = in;
 #ifdef HAVE_MPI

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1479,13 +1479,13 @@ volume_list *symmetry::reduce(const volume_list *gl) const {
 
 /***************************************************************************/
 
-static double poynting_fun(const complex<double> *fields, const vec &loc, void *data_) {
+static realnum poynting_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc;   // unused
   (void)data_; // unused
   return (real(conj(fields[0]) * fields[1]) - real(conj(fields[2]) * fields[3]));
 }
 
-static double energy_fun(const complex<double> *fields, const vec &loc, void *data_) {
+static realnum energy_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc; // unused
   int nfields = *((int *)data_) / 2;
   double sum = 0;

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1479,18 +1479,19 @@ volume_list *symmetry::reduce(const volume_list *gl) const {
 
 /***************************************************************************/
 
-static realnum poynting_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
+static double poynting_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc;   // unused
   (void)data_; // unused
-  return (real(conj(fields[0]) * fields[1]) - real(conj(fields[2]) * fields[3]));
+  return (real(conj(cdouble(fields[0])) * cdouble(fields[1])) -
+          real(conj(cdouble(fields[2])) * cdouble(fields[3])));
 }
 
-static realnum energy_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
+static double energy_fun(const complex<realnum> *fields, const vec &loc, void *data_) {
   (void)loc; // unused
   int nfields = *((int *)data_) / 2;
   double sum = 0;
   for (int k = 0; k < nfields; ++k)
-    sum += real(conj(fields[2 * k]) * fields[2 * k + 1]);
+    sum += real(conj(cdouble(fields[2 * k])) * cdouble(fields[2 * k + 1]));
   return sum * 0.5;
 }
 

--- a/tests/array-slice-ll.cpp
+++ b/tests/array-slice-ll.cpp
@@ -230,7 +230,7 @@ int main(int argc, char *argv[]) {
     //
     rank = f.get_array_slice_dimensions(v1d, dims1D, dirs1D, true, false);
     if (rank != 1 || dims1D[0] != NX) meep::abort("incorrect dimensions for 1D slice");
-    std::unique_ptr<std::complex<double> []> slice1d(f.get_complex_array_slice(v1d, Hz, 0, 0, true));
+    std::unique_ptr<std::complex<realnum> []> slice1d(f.get_complex_array_slice(v1d, Hz, 0, 0, true));
     std::vector<std::complex<realnum>> slice1d_realnum;
     for (int i = 0; i < NX; ++i)
       slice1d_realnum.emplace_back(slice1d[i]);
@@ -239,7 +239,7 @@ int main(int argc, char *argv[]) {
 
     rank = f.get_array_slice_dimensions(v2d, dims2D, dirs2D, true, false);
     if (rank != 2 || dims2D[0] != NX || dims2D[1] != NY) meep::abort("incorrect dimensions for 2D slice");
-    std::unique_ptr<double []> slice2d(f.get_array_slice(v2d, Sy, 0, 0, true));
+    std::unique_ptr<realnum []> slice2d(f.get_array_slice(v2d, Sy, 0, 0, true));
     std::unique_ptr<realnum[]> slice2d_realnum(new realnum[NX * NY]);
     for (int i = 0; i < NX * NY; ++i)
       slice2d_realnum[i] = static_cast<realnum>(slice2d[i]);

--- a/tests/dft-fields.cpp
+++ b/tests/dft-fields.cpp
@@ -15,8 +15,6 @@
 
 using namespace meep;
 
-typedef std::complex<realnum> cdouble;
-
 vector3 v3(double x, double y = 0.0, double z = 0.0) {
   vector3 v;
   v.x = x;
@@ -35,7 +33,7 @@ double dummy_eps(const vec &) { return 1.0; }
 /***************************************************************/
 /***************************************************************/
 /***************************************************************/
-void Run(bool Pulse, double resolution, cdouble **field_array = 0, int *array_rank = 0,
+void Run(bool Pulse, double resolution, std::complex<meep::realnum> **field_array = 0, int *array_rank = 0,
          size_t *array_dims = 0) {
   /***************************************************************/
   /* initialize geometry                                         */
@@ -104,7 +102,7 @@ void Run(bool Pulse, double resolution, cdouble **field_array = 0, int *array_ra
 /***************************************************************/
 /* return L2 norm of error normalized by average of L2 norms   */
 /***************************************************************/
-double compare_array_to_dataset(cdouble *field_array, int array_rank, size_t *array_dims,
+double compare_array_to_dataset(std::complex<meep::realnum> *field_array, int array_rank, size_t *array_dims,
                                 const char *file, const char *name) {
   int file_rank;
   size_t file_dims[3];
@@ -121,8 +119,8 @@ double compare_array_to_dataset(cdouble *field_array, int array_rank, size_t *ar
 
   double NormArray = 0.0, NormFile = 0.0, NormDelta = 0.0;
   for (size_t n = 0; n < file_dims[0] * file_dims[1]; n++) {
-    cdouble zArray = field_array[n];
-    cdouble zFile = cdouble(rdata[n], idata[n]);
+    std::complex<double> zArray = field_array[n];
+    std::complex<double> zFile = std::complex<double>(rdata[n], idata[n]);
     NormArray += norm(zArray);
     NormFile += norm(zFile);
     NormDelta += norm(zArray - zFile);
@@ -178,15 +176,15 @@ double compare_complex_hdf5_datasets(const char *file1, const char *name1, const
   for (int d = 1; d < rank1; d++)
     length *= dims1[d];
 
-  realnum max_abs1 = 0.0, max_abs2 = 0.0;
-  realnum max_arg1 = 0.0, max_arg2 = 0.0;
+  double max_abs1 = 0.0, max_abs2 = 0.0;
+  double max_arg1 = 0.0, max_arg2 = 0.0;
   for (size_t n = 0; n < length; n++) {
-    cdouble z1 = cdouble(rdata1[n], idata1[n]);
+    std::complex<double> z1 = std::complex<double>(rdata1[n], idata1[n]);
     if (abs(z1) > max_abs1) {
       max_abs1 = abs(z1);
       max_arg1 = arg(z1);
     }
-    cdouble z2 = cdouble(rdata2[n], idata2[n]);
+    std::complex<double> z2 = std::complex<double>(rdata2[n], idata2[n]);
     if (abs(z2) > max_abs2) {
       max_abs2 = abs(z2);
       max_arg2 = arg(z2);
@@ -196,11 +194,11 @@ double compare_complex_hdf5_datasets(const char *file1, const char *name1, const
 
   // second pass to get L2 norm of difference between normalized data sets
   double norm1 = 0.0, norm2 = 0.0, normdiff = 0.0;
-  cdouble phase1 = exp(-cdouble(0, 1) * max_arg1);
-  cdouble phase2 = exp(-cdouble(0, 1) * max_arg2);
+  std::complex<double> phase1 = exp(-std::complex<double>(0, 1) * max_arg1);
+  std::complex<double> phase2 = exp(-std::complex<double>(0, 1) * max_arg2);
   for (size_t n = 0; n < length; n++) {
-    cdouble z1 = phase1 * cdouble(rdata1[n], idata1[n]) / max_abs1;
-    cdouble z2 = phase2 * cdouble(rdata2[n], idata2[n]) / max_abs2;
+    std::complex<double> z1 = phase1 * std::complex<double>(rdata1[n], idata1[n]) / max_abs1;
+    std::complex<double> z2 = phase2 * std::complex<double>(rdata2[n], idata2[n]) / max_abs2;
     norm1 += norm(z1);
     norm2 += norm(z2);
     normdiff += norm(z1 - z2);
@@ -235,7 +233,7 @@ int main(int argc, char *argv[]) {
       meep::abort("unknown argument %s", argv[narg]);
   }
 
-  cdouble *field_array = 0;
+  std::complex<meep::realnum> *field_array = 0;
   int array_rank;
   size_t array_dims[3];
   Run(true, resolution, &field_array, &array_rank, array_dims);

--- a/tests/dft-fields.cpp
+++ b/tests/dft-fields.cpp
@@ -15,7 +15,7 @@
 
 using namespace meep;
 
-typedef std::complex<double> cdouble;
+typedef std::complex<realnum> cdouble;
 
 vector3 v3(double x, double y = 0.0, double z = 0.0) {
   vector3 v;
@@ -178,8 +178,8 @@ double compare_complex_hdf5_datasets(const char *file1, const char *name1, const
   for (int d = 1; d < rank1; d++)
     length *= dims1[d];
 
-  double max_abs1 = 0.0, max_abs2 = 0.0;
-  double max_arg1 = 0.0, max_arg2 = 0.0;
+  realnum max_abs1 = 0.0, max_abs2 = 0.0;
+  realnum max_arg1 = 0.0, max_arg2 = 0.0;
   for (size_t n = 0; n < length; n++) {
     cdouble z1 = cdouble(rdata1[n], idata1[n]);
     if (abs(z1) > max_abs1) {

--- a/tests/integrate.cpp
+++ b/tests/integrate.cpp
@@ -189,8 +189,7 @@ void check_integral(fields &f, linear_integrand_data &d, const volume &v, compon
                   d.ay, d.az, d.axy, d.ayz, d.axz, d.axyz);
 
   double sum = real(f.integrate(0, 0, linear_integrand, (void *)&d, v));
-  double tol = sizeof(meep::realnum) == sizeof(float) ? 1e-7 : 1e-9;
-  if (fabs(sum - correct_integral(v, d)) > tol * fabs(sum))
+  if (fabs(sum - correct_integral(v, d)) > 1e-9 * fabs(sum))
     meep::abort("FAILED: %0.16g instead of %0.16g\n", sum, correct_integral(v, d));
   master_printf("...PASSED.\n");
 }

--- a/tests/integrate.cpp
+++ b/tests/integrate.cpp
@@ -41,8 +41,8 @@ typedef struct {
 } linear_integrand_data;
 
 /* integrand for integrating c + ax*x + ay*y + az*z. */
-static complex<realnum> linear_integrand(const complex<realnum> *fields, const vec &loc,
-                                         void *data_) {
+static complex<double> linear_integrand(const complex<realnum> *fields, const vec &loc,
+                                        void *data_) {
   linear_integrand_data *data = (linear_integrand_data *)data_;
 
   (void)fields; // unused

--- a/tests/integrate.cpp
+++ b/tests/integrate.cpp
@@ -41,8 +41,8 @@ typedef struct {
 } linear_integrand_data;
 
 /* integrand for integrating c + ax*x + ay*y + az*z. */
-static complex<double> linear_integrand(const complex<double> *fields, const vec &loc,
-                                        void *data_) {
+static complex<realnum> linear_integrand(const complex<realnum> *fields, const vec &loc,
+                                         void *data_) {
   linear_integrand_data *data = (linear_integrand_data *)data_;
 
   (void)fields; // unused
@@ -189,8 +189,9 @@ void check_integral(fields &f, linear_integrand_data &d, const volume &v, compon
                   d.ay, d.az, d.axy, d.ayz, d.axz, d.axyz);
 
   double sum = real(f.integrate(0, 0, linear_integrand, (void *)&d, v));
-  if (fabs(sum - correct_integral(v, d)) > 1e-9 * fabs(sum))
-    meep::abort("FAILED: %0.16g instead of %0.16g\n", (double)sum, correct_integral(v, d));
+  double tol = sizeof(meep::realnum) == sizeof(float) ? 1e-7 : 1e-9;
+  if (fabs(sum - correct_integral(v, d)) > tol * fabs(sum))
+    meep::abort("FAILED: %0.16g instead of %0.16g\n", sum, correct_integral(v, d));
   master_printf("...PASSED.\n");
 }
 

--- a/tests/pw-source-ll.cpp
+++ b/tests/pw-source-ll.cpp
@@ -22,8 +22,6 @@
 
 using namespace meep;
 
-typedef std::complex<double> cdouble;
-
 /***************************************************************/
 /*
 ; pw-amp is a function that returns the amplitude exp(ik(x+x0)) at a
@@ -40,12 +38,12 @@ typedef struct pw_amp_data {
   vec x0;
 } pw_amp_data;
 
-cdouble pw_amp(vec x, void *UserData) {
+std::complex<double> pw_amp(vec x, void *UserData) {
   pw_amp_data *data = (pw_amp_data *)UserData;
   vec k = data->k;
   vec x0 = data->x0;
 
-  const cdouble II(0.0, 1.0);
+  const std::complex<double> II(0.0, 1.0);
   return exp(II * (k & (x + x0)));
 }
 
@@ -56,10 +54,10 @@ cdouble pw_amp(vec x, void *UserData) {
 /* amplitude functions and global variables.                   */
 /***************************************************************/
 pw_amp_data pw_amp_data_left;
-cdouble pw_amp_left(const vec &x) { return pw_amp(x, (void *)&pw_amp_data_left); }
+std::complex<double> pw_amp_left(const vec &x) { return pw_amp(x, (void *)&pw_amp_data_left); }
 
 pw_amp_data pw_amp_data_bottom;
-cdouble pw_amp_bottom(const vec &x) { return pw_amp(x, (void *)&pw_amp_data_bottom); }
+std::complex<double> pw_amp_bottom(const vec &x) { return pw_amp(x, (void *)&pw_amp_data_bottom); }
 
 /***************************************************************/
 /* dummy material function needed to pass to structure( )      */

--- a/tests/ring-ll.cpp
+++ b/tests/ring-ll.cpp
@@ -21,8 +21,6 @@
 
 using namespace meep;
 
-typedef std::complex<double> cdouble;
-
 vector3 v3(double x, double y = 0.0, double z = 0.0) {
   vector3 v;
   v.x = x;
@@ -109,7 +107,7 @@ int main(int argc, char *argv[]) {
 
   double T = 300.0;
   double stop_time = f.round_time() + T;
-  std::vector<cdouble> fieldData;
+  std::vector<std::complex<double>> fieldData;
   vec eval_pt(r + 0.1, 0.0);
   while (f.round_time() < stop_time) {
     f.step();
@@ -117,7 +115,7 @@ int main(int argc, char *argv[]) {
   };
 
 #define MAXBANDS 100
-  cdouble amp[MAXBANDS];
+  std::complex<double> amp[MAXBANDS];
   double freq_re[MAXBANDS];
   double freq_im[MAXBANDS];
   double err[MAXBANDS];
@@ -137,8 +135,8 @@ int main(int argc, char *argv[]) {
   int ref_bands = 3;
   double ref_freq_re[3] = {1.1807e-01, 1.4716e-01, 1.7525e-01};
   double ref_freq_im[3] = {-7.6133e-04, -2.1156e-04, -5.2215e-05};
-  cdouble ref_amp[3] = {cdouble(-8.28e-04, -1.34e-03), cdouble(1.23e-03, -1.25e-02),
-                        cdouble(2.83e-03, -6.52e-04)};
+  std::complex<double> ref_amp[3] = {std::complex<double>(-8.28e-04, -1.34e-03), std::complex<double>(1.23e-03, -1.25e-02),
+                        std::complex<double>(2.83e-03, -6.52e-04)};
   if (bands != 3) meep::abort("harminv found only %i/%i bands\n", bands, ref_bands);
   for (int nb = 0; nb < bands; nb++)
     if (fabs(freq_re[nb] - ref_freq_re[nb]) > 1.0e-2 * fabs(ref_freq_re[nb]) ||


### PR DESCRIPTION
#1544 and #1675 added support for the single-precision floating point type for the time-domain and DFT fields. However, the fields array *functions* such as `fields::get_array_slice` and `fields::get_dft_array` only use double precision which unfortunately exacerbates the memory bottleneck described in #1797. This PR modifies all of the array functions to support single precision.