### PR TITLE
Fix memory leaks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Robin Dunn <robin@alldunn.com>
 Ian Williamson <iwill@google.com>
 Andreas Hoenselaar <ahoens@google.com>
 Ben Bartlett <benbartlett@stanford.edu>
+Krishna Gadepalli <kkg4theweb@gmail.com>

--- a/src/GDSIIgeom.cpp
+++ b/src/GDSIIgeom.cpp
@@ -144,7 +144,7 @@ geometric_object_list get_GDSII_prisms(material_type material, const char *GDSII
   for (int np = 0; np < num_prisms; np++) {
     dVec polygon = polygons[np];
     int num_vertices = polygon.size() / 2;
-    vector3 *vertices = new vector3[num_vertices];
+    auto vertices = std::make_unique<vector3[]>(num_vertices);
     for (int nv = 0; nv < num_vertices; nv++) {
       vertices[nv].x = polygon[2 * nv + 0];
       vertices[nv].y = polygon[2 * nv + 1];
@@ -152,7 +152,8 @@ geometric_object_list get_GDSII_prisms(material_type material, const char *GDSII
     }
     double height = zmax - zmin;
     vector3 zaxis = {0, 0, 1};
-    prisms.items[np] = make_prism(material, vertices, num_vertices, height, zaxis);
+    prisms.items[np] =
+        make_prism(material, vertices.get(), num_vertices, height, zaxis);
   }
   return prisms;
 }
@@ -169,7 +170,7 @@ geometric_object get_GDSII_prism(material_type material, const char *GDSIIFile, 
   dVec polygon = get_polygon(GDSIIFile, Text, Layer);
 
   int num_vertices = polygon.size() / 2;
-  vector3 *vertices = new vector3[num_vertices];
+  auto vertices = std::make_unique<vector3[]>(num_vertices);
   for (int nv = 0; nv < num_vertices; nv++) {
     vertices[nv].x = polygon[2 * nv + 0];
     vertices[nv].y = polygon[2 * nv + 1];
@@ -178,7 +179,7 @@ geometric_object get_GDSII_prism(material_type material, const char *GDSIIFile, 
 
   double height = zmax - zmin;
   vector3 zaxis = {0, 0, 1};
-  return make_prism(material, vertices, num_vertices, height, zaxis);
+  return make_prism(material, vertices.get(), num_vertices, height, zaxis);
 }
 
 geometric_object get_GDSII_prism(material_type material, const char *GDSIIFile, int Layer,

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -716,7 +716,8 @@ geom_epsilon::geom_epsilon(const geom_epsilon &geps1) {
 geom_epsilon::~geom_epsilon() {
   int length = geometry.num_items;
   for (int i = 0; i < length; i++){
-    delete geometry.items[i].material;
+    material_free((material_type)geometry.items[i].material);
+    geometric_object_destroy(geometry.items[i]);
   }
   delete[] geometry.items;
   unset_volume();


### PR DESCRIPTION
Fix memory leaks introduced with recent changes to geom_epsilon::geom_epsilon (8dd39f7946f1ab3ec8fe59db3cf3bbfc19184375)

Also fix existing memory leaks in GDSIIgeom.cpp