### PR TITLE
Define what happens when `β=∞` and `u=η`

### DIFF
--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -480,6 +480,7 @@ double material_grid_val(vector3 p, material_data *md) {
 
 static double tanh_projection(double u, double beta, double eta) {
   if (beta == 0) return u;
+  if ((beta == std::numeric_limits<double>::infinity()) && (u == 0.5)) return 1.0; // 0*∞ is undefined, so let's just assign 1 here
   double tanh_beta_eta = tanh(beta*eta);
   return (tanh_beta_eta + tanh(beta*(u-eta))) /
     (tanh_beta_eta + tanh(beta*(1-eta)));

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -480,7 +480,7 @@ double material_grid_val(vector3 p, material_data *md) {
 
 static double tanh_projection(double u, double beta, double eta) {
   if (beta == 0) return u;
-  if ((beta == std::numeric_limits<double>::infinity()) && (u == eta)) return 1.0; // 0*∞ is undefined, so let's just assign 1 here
+  if (u == eta) return 0.5; // avoid NaN when beta is Inf
   double tanh_beta_eta = tanh(beta*eta);
   return (tanh_beta_eta + tanh(beta*(u-eta))) /
     (tanh_beta_eta + tanh(beta*(1-eta)));

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -480,7 +480,7 @@ double material_grid_val(vector3 p, material_data *md) {
 
 static double tanh_projection(double u, double beta, double eta) {
   if (beta == 0) return u;
-  if ((beta == std::numeric_limits<double>::infinity()) && (u == 0.5)) return 1.0; // 0*∞ is undefined, so let's just assign 1 here
+  if ((beta == std::numeric_limits<double>::infinity()) && (u == eta)) return 1.0; // 0*∞ is undefined, so let's just assign 1 here
   double tanh_beta_eta = tanh(beta*eta);
   return (tanh_beta_eta + tanh(beta*(u-eta))) /
     (tanh_beta_eta + tanh(beta*(1-eta)));


### PR DESCRIPTION
#1801 allows us to take gradients when `β=∞`.

Currently, if `β=∞` and `u=η`, `NaN` is returned (as `∞×0` is not defined). 

This PR simply returns a 1 in that case (and thereby defines the default behavior).