### PR TITLE
use unique_ptr (C++11) instead of make_unique (C++14)

### DIFF
--- a/src/GDSIIgeom.cpp
+++ b/src/GDSIIgeom.cpp
@@ -144,7 +144,7 @@ geometric_object_list get_GDSII_prisms(material_type material, const char *GDSII
   for (int np = 0; np < num_prisms; np++) {
     dVec polygon = polygons[np];
     int num_vertices = polygon.size() / 2;
-    auto vertices = std::make_unique<vector3[]>(num_vertices);
+    std::unique_ptr<vector3[]> vertices(new vector3[num_vertices]);
     for (int nv = 0; nv < num_vertices; nv++) {
       vertices[nv].x = polygon[2 * nv + 0];
       vertices[nv].y = polygon[2 * nv + 1];
@@ -170,7 +170,7 @@ geometric_object get_GDSII_prism(material_type material, const char *GDSIIFile, 
   dVec polygon = get_polygon(GDSIIFile, Text, Layer);
 
   int num_vertices = polygon.size() / 2;
-  auto vertices = std::make_unique<vector3[]>(num_vertices);
+  std::unique_ptr<vector3[]> vertices(new vector3[num_vertices]);
   for (int nv = 0; nv < num_vertices; nv++) {
     vertices[nv].x = polygon[2 * nv + 0];
     vertices[nv].y = polygon[2 * nv + 1];


### PR DESCRIPTION
Fixes #1843.

We may eventually want to require C++14, but for now it is causing trouble with Apple clang and the C++11 alternative seems fine.