### PR TITLE
switch type from double to realnum for monitor-related functions

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -281,46 +281,46 @@ double py_pml_profile(double u, void *f) {
 }
 
 PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, int maxbands,
-                     double spectral_density, double Q_thresh, double rel_err_thresh,
-                     double err_thresh, double rel_amp_thresh, double amp_thresh) {
+                        double spectral_density, double Q_thresh, double rel_err_thresh,
+                        double err_thresh, double rel_amp_thresh, double amp_thresh) {
     // Return value: New reference
 
-    std::complex<double> *amp = new std::complex<double>[maxbands];
-    double *freq_re = new double[maxbands];
-    double *freq_im = new double[maxbands];
-    double *freq_err = new double[maxbands];
+  std::complex<meep::realnum> *amp = new std::complex<meep::realnum>[maxbands];
+  double *freq_re = new double[maxbands];
+  double *freq_im = new double[maxbands];
+  double *freq_err = new double[maxbands];
 
-    Py_ssize_t n = PyList_Size(vals);
-    std::complex<double> *items = new std::complex<double>[n];
+  Py_ssize_t n = PyList_Size(vals);
+  std::complex<meep::realnum> *items = new std::complex<meep::realnum>[n];
 
-    for(int i = 0; i < n; i++) {
-        Py_complex py_c = PyComplex_AsCComplex(PyList_GetItem(vals, i));
-        std::complex<double> c(py_c.real, py_c.imag);
-        items[i] = c;
-    }
+  for(int i = 0; i < n; i++) {
+    Py_complex py_c = PyComplex_AsCComplex(PyList_GetItem(vals, i));
+    std::complex<meep::realnum> c(py_c.real, py_c.imag);
+    items[i] = c;
+  }
 
-    maxbands = do_harminv(items, n, dt, f_min, f_max, maxbands, amp,
-                          freq_re, freq_im, freq_err, spectral_density, Q_thresh,
-                          rel_err_thresh, err_thresh, rel_amp_thresh, amp_thresh);
+  maxbands = do_harminv(items, n, dt, f_min, f_max, maxbands, amp,
+                        freq_re, freq_im, freq_err, spectral_density, Q_thresh,
+                        rel_err_thresh, err_thresh, rel_amp_thresh, amp_thresh);
 
-    PyObject *res = PyList_New(maxbands);
+  PyObject *res = PyList_New(maxbands);
 
-    for(int i = 0; i < maxbands; i++) {
-        Py_complex pyfreq = {freq_re[i], freq_im[i]};
-        Py_complex pyamp = {amp[i].real(), amp[i].imag()};
-        Py_complex pyfreq_err = {freq_err[i], 0};
+  for(int i = 0; i < maxbands; i++) {
+    Py_complex pyfreq = {freq_re[i], freq_im[i]};
+    Py_complex pyamp = {amp[i].real(), amp[i].imag()};
+    Py_complex pyfreq_err = {freq_err[i], 0};
 
-        PyObject *pyobj = Py_BuildValue("(DDD)", &pyfreq, &pyamp, &pyfreq_err);
-        PyList_SetItem(res, i, pyobj);
-    }
+    PyObject *pyobj = Py_BuildValue("(DDD)", &pyfreq, &pyamp, &pyfreq_err);
+    PyList_SetItem(res, i, pyobj);
+  }
 
-    delete[] freq_err;
-    delete[] freq_im;
-    delete[] freq_re;
-    delete[] amp;
-    delete[] items;
+  delete[] freq_err;
+  delete[] freq_im;
+  delete[] freq_re;
+  delete[] amp;
+  delete[] items;
 
-    return res;
+  return res;
 }
 
 // Wrapper around meep::dft_near2far::farfield

--- a/python/meep.i
+++ b/python/meep.i
@@ -285,17 +285,17 @@ PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, i
                         double err_thresh, double rel_amp_thresh, double amp_thresh) {
     // Return value: New reference
 
-  std::complex<meep::realnum> *amp = new std::complex<meep::realnum>[maxbands];
+  std::complex<double> *amp = new std::complex<double>[maxbands];
   double *freq_re = new double[maxbands];
   double *freq_im = new double[maxbands];
   double *freq_err = new double[maxbands];
 
   Py_ssize_t n = PyList_Size(vals);
-  std::complex<meep::realnum> *items = new std::complex<meep::realnum>[n];
+  std::complex<double> *items = new std::complex<double>[n];
 
   for(int i = 0; i < n; i++) {
     Py_complex py_c = PyComplex_AsCComplex(PyList_GetItem(vals, i));
-    std::complex<meep::realnum> c(py_c.real, py_c.imag);
+    std::complex<double> c(py_c.real, py_c.imag);
     items[i] = c;
   }
 
@@ -654,8 +654,8 @@ void set_ctl_printf_callback(void (*callback)(const char *s));
 void set_mpb_printf_callback(void (*callback)(const char *s));
 
 PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, int maxbands,
-                     double spectral_density, double Q_thresh, double rel_err_thresh,
-                     double err_thresh, double rel_amp_thresh, double amp_thresh);
+                        double spectral_density, double Q_thresh, double rel_err_thresh,
+                        double err_thresh, double rel_amp_thresh, double amp_thresh);
 
 PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v);
 PyObject *_get_farfields_array(meep::dft_near2far *n2f, const meep::volume &where, double resolution);

--- a/python/tests/test_get_epsilon_grid.py
+++ b/python/tests/test_get_epsilon_grid.py
@@ -66,8 +66,9 @@ class TestGetEpsilonGrid(unittest.TestCase):
                                              freq)
         eps_pt = self.sim.get_epsilon_point(pt, freq)
         print("eps:, ({},{}), {}, {}".format(pt.x,pt.y,eps_grid,eps_pt))
-        self.assertAlmostEqual(np.real(eps_grid), np.real(eps_pt), places=6)
-        self.assertAlmostEqual(np.imag(eps_grid), np.imag(eps_pt), places=6)
+        tol = 2 if mp.is_single_precision() else 6
+        self.assertAlmostEqual(np.real(eps_grid), np.real(eps_pt), places=tol)
+        self.assertAlmostEqual(np.imag(eps_grid), np.imag(eps_pt), places=tol)
 
 
 if __name__ == '__main__':

--- a/python/tests/test_mode_coeffs.py
+++ b/python/tests/test_mode_coeffs.py
@@ -116,7 +116,7 @@ class TestModeCoeffs(unittest.TestCase):
         ex_at_eval_point = emdata.amplitude(eval_point, mp.Ex)
         hz_at_eval_point = emdata.amplitude(eval_point, mp.Hz)
 
-        places = 5 if mp.is_single_precision() else 7
+        places = 4 if mp.is_single_precision() else 7
         self.assertAlmostEqual(ex_at_eval_point, 0.4887779638178009+0.484240145324284j, places=places)
         self.assertAlmostEqual(hz_at_eval_point, 3.4249236584603495-3.455974863884166j, places=places)
 

--- a/python/tests/test_special_kz.py
+++ b/python/tests/test_special_kz.py
@@ -145,8 +145,9 @@ class TestSpecialKz(unittest.TestCase):
         ez2 = sim.get_field_point(mp.Ez, mp.Vector3(2.3,-5.7,4.8+d))
         ratio_ez = ez2/ez1
         phase_diff = cmath.exp(1j*2*cmath.pi*kz*d)
-        self.assertAlmostEqual(ratio_ez.real,phase_diff.real,places=10)
-        self.assertAlmostEqual(ratio_ez.imag,phase_diff.imag,places=10)
+        tol = 6 if mp.is_single_precision() else 10
+        self.assertAlmostEqual(ratio_ez.real,phase_diff.real,places=tol)
+        self.assertAlmostEqual(ratio_ez.imag,phase_diff.imag,places=tol)
 
     def test_eigsrc_kz(self):
         self.eigsrc_kz("complex")

--- a/python/tests/test_wvg_src.py
+++ b/python/tests/test_wvg_src.py
@@ -43,7 +43,7 @@ class TestWvgSrc(unittest.TestCase):
         flux2 = self.sim.flux_in_box(mp.X, mp.Volume(center=mp.Vector3(6.0), size=mp.Vector3(1.8, 6)))
 
         self.assertAlmostEqual(flux1, -1.775216564842667e-03)
-        places = 6 if mp.is_single_precision() else 7
+        places = 5 if mp.is_single_precision() else 7
         self.assertAlmostEqual(flux2, 7.215785537102116, places=places)
 
 if __name__ == '__main__':

--- a/scheme/meep.cpp
+++ b/scheme/meep.cpp
@@ -30,11 +30,11 @@ ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt, double fmin
                                 int maxbands, double spectral_density, double Q_thresh,
                                 double rel_err_thresh, double err_thresh, double rel_amp_thresh,
                                 double amp_thresh) {
-  complex<meep::realnum> *amp = new complex<meep::realnum>[maxbands];
+  complex<double> *amp = new complex<double>[maxbands];
   double *freq_re = new double[maxbands];
   double *freq_im = new double[maxbands];
   double *freq_err = new double[maxbands];
-  maxbands = do_harminv(reinterpret_cast<complex<meep::realnum> *>(vals.items), vals.num_items, dt, fmin,
+  maxbands = do_harminv(reinterpret_cast<complex<double> *>(vals.items), vals.num_items, dt, fmin,
                         fmax, maxbands, amp, freq_re, freq_im, freq_err, spectral_density, Q_thresh,
                         rel_err_thresh, err_thresh, rel_amp_thresh, amp_thresh);
   ctlio::cvector3_list res;

--- a/scheme/meep.cpp
+++ b/scheme/meep.cpp
@@ -30,11 +30,11 @@ ctlio::cvector3_list do_harminv(ctlio::cnumber_list vals, double dt, double fmin
                                 int maxbands, double spectral_density, double Q_thresh,
                                 double rel_err_thresh, double err_thresh, double rel_amp_thresh,
                                 double amp_thresh) {
-  complex<double> *amp = new complex<double>[maxbands];
+  complex<meep::realnum> *amp = new complex<meep::realnum>[maxbands];
   double *freq_re = new double[maxbands];
   double *freq_im = new double[maxbands];
   double *freq_err = new double[maxbands];
-  maxbands = do_harminv(reinterpret_cast<complex<double> *>(vals.items), vals.num_items, dt, fmin,
+  maxbands = do_harminv(reinterpret_cast<complex<meep::realnum> *>(vals.items), vals.num_items, dt, fmin,
                         fmax, maxbands, amp, freq_re, freq_im, freq_err, spectral_density, Q_thresh,
                         rel_err_thresh, err_thresh, rel_amp_thresh, amp_thresh);
   ctlio::cvector3_list res;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -67,7 +67,7 @@ std::complex<double> cdouble(std::complex<double> z);
 class h5file;
 
 // Defined in monitor.cpp
-void matrix_invert(std::complex<double> (&Vinv)[9], std::complex<double> (&V)[9]);
+void matrix_invert(std::complex<realnum> (&Vinv)[9], std::complex<realnum> (&V)[9]);
 
 // Defined in dft.cpp
 std::vector<double> linspace(double freq_min, double freq_max, size_t Nfreq);
@@ -1107,7 +1107,7 @@ public:
                          int *numout, double fmin = 0.0, double fmax = 0.0, int maxbands = 100);
   // harminv works much like fourier_transform, except that it is not yet
   // implemented.
-  void harminv(component w, std::complex<realnum> **a, std::complex<realnum> **f, int *numout,
+  void harminv(component w, std::complex<double> **a, std::complex<double> **f, int *numout,
                double fmin, double fmax, int maxbands);
 };
 
@@ -2337,8 +2337,8 @@ void trash_output_directory(const char *dirname);
 void delete_directory(const char *path);
 FILE *create_output_file(const char *dirname, const char *fname);
 
-int do_harminv(std::complex<realnum> *data, int n, double dt, double fmin, double fmax, int maxbands,
-               std::complex<realnum> *amps, double *freq_re, double *freq_im, double *errors = NULL,
+int do_harminv(std::complex<double> *data, int n, double dt, double fmin, double fmax, int maxbands,
+               std::complex<double> *amps, double *freq_re, double *freq_im, double *errors = NULL,
                double spectral_density = 1.1, double Q_thresh = 50, double rel_err_thresh = 1e20,
                double err_thresh = 0.01, double rel_amp_thresh = -1, double amp_thresh = -1);
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -625,11 +625,11 @@ public:
   void remove_susceptibilities();
 
   // monitor.cpp
-  std::complex<double> get_chi1inv_at_pt(component, direction, int idx, double frequency = 0) const;
-  std::complex<double> get_chi1inv(component, direction, const ivec &iloc,
-                                   double frequency = 0) const;
-  std::complex<double> get_inveps(component c, direction d, const ivec &iloc,
-                                  double frequency = 0) const {
+  std::complex<realnum> get_chi1inv_at_pt(component, direction, int idx, double frequency = 0) const;
+  std::complex<realnum> get_chi1inv(component, direction, const ivec &iloc,
+                                    double frequency = 0) const;
+  std::complex<realnum> get_inveps(component c, direction d, const ivec &iloc,
+                                   double frequency = 0) const {
     return get_chi1inv(c, d, iloc, frequency);
   }
   double max_eps() const;
@@ -877,20 +877,20 @@ public:
                          boundary_region &br);
 
   // monitor.cpp
-  std::complex<double> get_chi1inv(component, direction, const ivec &origloc, double frequency = 0,
-                                   bool parallel = true) const;
-  std::complex<double> get_chi1inv(component, direction, const vec &loc, double frequency = 0,
-                                   bool parallel = true) const;
-  std::complex<double> get_inveps(component c, direction d, const ivec &origloc,
-                                  double frequency = 0) const {
+  std::complex<realnum> get_chi1inv(component, direction, const ivec &origloc, double frequency = 0,
+                                    bool parallel = true) const;
+  std::complex<realnum> get_chi1inv(component, direction, const vec &loc, double frequency = 0,
+                                    bool parallel = true) const;
+  std::complex<realnum> get_inveps(component c, direction d, const ivec &origloc,
+                                   double frequency = 0) const {
     return get_chi1inv(c, d, origloc, frequency);
   }
-  std::complex<double> get_inveps(component c, direction d, const vec &loc,
-                                  double frequency = 0) const {
+  std::complex<realnum> get_inveps(component c, direction d, const vec &loc,
+                                   double frequency = 0) const {
     return get_chi1inv(c, d, loc, frequency);
   }
-  std::complex<double> get_eps(const vec &loc, double frequency = 0) const;
-  std::complex<double> get_mu(const vec &loc, double frequency = 0) const;
+  std::complex<realnum> get_eps(const vec &loc, double frequency = 0) const;
+  std::complex<realnum> get_mu(const vec &loc, double frequency = 0) const;
   double max_eps() const;
   double estimated_cost(int process = my_rank());
   // Returns the binary partition that was used to partition the volume into chunks. The returned
@@ -1087,12 +1087,12 @@ public:
   ~monitor_point();
   vec loc;
   double t;
-  std::complex<double> f[NUM_FIELD_COMPONENTS];
+  std::complex<realnum> f[NUM_FIELD_COMPONENTS];
   monitor_point *next;
 
-  std::complex<double> get_component(component);
-  double poynting_in_direction(direction d);
-  double poynting_in_direction(vec direction_v);
+  std::complex<realnum> get_component(component);
+  realnum poynting_in_direction(direction d);
+  realnum poynting_in_direction(vec direction_v);
 
   // When called with only its first four arguments, fourier_transform
   // performs an FFT on its monitor points, putting the frequencies in f
@@ -1103,11 +1103,11 @@ public:
   //
   // Note that in either case, fourier_transform assumes that the monitor
   // points are all equally spaced in time.
-  void fourier_transform(component w, std::complex<double> **a, std::complex<double> **f,
+  void fourier_transform(component w, std::complex<realnum> **a, std::complex<realnum> **f,
                          int *numout, double fmin = 0.0, double fmax = 0.0, int maxbands = 100);
   // harminv works much like fourier_transform, except that it is not yet
   // implemented.
-  void harminv(component w, std::complex<double> **a, std::complex<double> **f, int *numout,
+  void harminv(component w, std::complex<realnum> **a, std::complex<realnum> **f, int *numout,
                double fmin, double fmax, int maxbands);
 };
 
@@ -1506,10 +1506,10 @@ public:
 
   double last_source_time();
   // monitor.cpp
-  std::complex<double> get_field(component, const ivec &) const;
+  std::complex<realnum> get_field(component, const ivec &) const;
 
-  std::complex<double> get_chi1inv(component, direction, const ivec &iloc,
-                                   double frequency = 0) const;
+  std::complex<realnum> get_chi1inv(component, direction, const ivec &iloc,
+                                    double frequency = 0) const;
   // Returns the vector of sources volumes for field type `ft`.
   const std::vector<src_vol> &get_sources(field_type ft) const { return sources[ft]; }
   // Adds a source volume of field type `ft` and takes ownership of `src`.
@@ -2153,19 +2153,19 @@ public:
   dft_near2far add_dft_near2far(const volume_list *where, const double *freq, size_t Nfreq,
                                 int decimation_factor = 0, int Nperiods = 1);
   // monitor.cpp
-  std::complex<double> get_chi1inv(component, direction, const vec &loc, double frequency = 0,
-                                   bool parallel = true) const;
-  std::complex<double> get_inveps(component c, direction d, const vec &loc,
-                                  double frequency = 0) const {
+  std::complex<realnum> get_chi1inv(component, direction, const vec &loc, double frequency = 0,
+                                    bool parallel = true) const;
+  std::complex<realnum> get_inveps(component c, direction d, const vec &loc,
+                                   double frequency = 0) const {
     return get_chi1inv(c, d, loc, frequency);
   }
-  std::complex<double> get_eps(const vec &loc, double frequency = 0) const;
-  std::complex<double> get_mu(const vec &loc, double frequency = 0) const;
+  std::complex<realnum> get_eps(const vec &loc, double frequency = 0) const;
+  std::complex<realnum> get_mu(const vec &loc, double frequency = 0) const;
   void get_point(monitor_point *p, const vec &) const;
   monitor_point *get_new_point(const vec &, monitor_point *p = NULL) const;
 
-  std::complex<double> get_field(int c, const vec &loc, bool parallel = true) const;
-  std::complex<double> get_field(component c, const vec &loc, bool parallel = true) const;
+  std::complex<realnum> get_field(int c, const vec &loc, bool parallel = true) const;
+  std::complex<realnum> get_field(component c, const vec &loc, bool parallel = true) const;
   double get_field(derived_component c, const vec &loc, bool parallel = true) const;
 
   // energy_and_flux.cpp
@@ -2252,9 +2252,9 @@ private:
 
 public:
   // monitor.cpp
-  std::complex<double> get_field(component c, const ivec &iloc, bool parallel = true) const;
-  std::complex<double> get_chi1inv(component, direction, const ivec &iloc, double frequency = 0,
-                                   bool parallel = true) const;
+  std::complex<realnum> get_field(component c, const ivec &iloc, bool parallel = true) const;
+  std::complex<realnum> get_chi1inv(component, direction, const ivec &iloc, double frequency = 0,
+                                    bool parallel = true) const;
   // boundaries.cpp
   bool locate_component_point(component *, ivec *, std::complex<double> *) const;
   // time.cpp
@@ -2337,8 +2337,8 @@ void trash_output_directory(const char *dirname);
 void delete_directory(const char *path);
 FILE *create_output_file(const char *dirname, const char *fname);
 
-int do_harminv(std::complex<double> *data, int n, double dt, double fmin, double fmax, int maxbands,
-               std::complex<double> *amps, double *freq_re, double *freq_im, double *errors = NULL,
+int do_harminv(std::complex<realnum> *data, int n, double dt, double fmin, double fmax, int maxbands,
+               std::complex<realnum> *amps, double *freq_re, double *freq_im, double *errors = NULL,
                double spectral_density = 1.1, double Q_thresh = 50, double rel_err_thresh = 1e20,
                double err_thresh = 0.01, double rel_amp_thresh = -1, double amp_thresh = -1);
 

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -87,6 +87,7 @@ void sum_to_all(const std::complex<float> *in, std::complex<float> *out, int siz
 void sum_to_master(const std::complex<float> *in, std::complex<float> *out, int size);
 void sum_to_master(const std::complex<double> *in, std::complex<double> *out, int size);
 long double sum_to_all(long double);
+std::complex<float> sum_to_all(std::complex<float> in);
 std::complex<double> sum_to_all(std::complex<double> in);
 std::complex<long double> sum_to_all(std::complex<long double> in);
 int sum_to_all(int);

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -48,8 +48,8 @@ monitor_point::~monitor_point() {
   if (next) delete next;
 }
 
-inline complex<realnum> getcm(const realnum *const f[2], size_t i) {
-  return complex<realnum>(f[0][i], f[1][i]);
+inline std::complex<realnum> getcm(const realnum *const f[2], size_t i) {
+  return std::complex<realnum>(f[0][i], f[1][i]);
 }
 
 void fields::get_point(monitor_point *pt, const vec &loc) const {
@@ -63,7 +63,7 @@ void fields::get_point(monitor_point *pt, const vec &loc) const {
   }
 }
 
-complex<realnum> fields::get_field(int c, const vec &loc, bool parallel) const {
+std::complex<realnum> fields::get_field(int c, const vec &loc, bool parallel) const {
   return (is_derived(c) ? get_field(derived_component(c), loc, parallel)
                         : get_field(component(c), loc, parallel));
 }
@@ -124,7 +124,7 @@ double fields::get_field(derived_component c, const vec &loc, bool parallel) con
   }
 }
 
-complex<realnum> fields::get_field(component c, const vec &loc, bool parallel) const {
+std::complex<realnum> fields::get_field(component c, const vec &loc, bool parallel) const {
   switch (c) {
     case Dielectric: return get_eps(loc);
     case Permeability: return get_mu(loc);
@@ -132,7 +132,7 @@ complex<realnum> fields::get_field(component c, const vec &loc, bool parallel) c
     default:
       ivec ilocs[8];
       double w[8];
-      complex<realnum> res = 0.0;
+      std::complex<realnum> res = 0.0;
       gv.interpolate(c, loc, ilocs, w);
       for (int argh = 0; argh < 8 && w[argh]; argh++)
         res += realnum(w[argh]) * get_field(c, ilocs[argh], false);
@@ -142,7 +142,7 @@ complex<realnum> fields::get_field(component c, const vec &loc, bool parallel) c
   }
 }
 
-complex<realnum> fields::get_field(component c, const ivec &origloc, bool parallel) const {
+std::complex<realnum> fields::get_field(component c, const ivec &origloc, bool parallel) const {
   ivec iloc = origloc;
   complex<double> kphase = 1.0;
   locate_point_in_user_volume(&iloc, &kphase);
@@ -150,22 +150,22 @@ complex<realnum> fields::get_field(component c, const ivec &origloc, bool parall
     for (int i = 0; i < num_chunks; i++)
       if (chunks[i]->gv.owns(S.transform(iloc, sn))) {
         complex<double> ps = S.phase_shift(c, sn);
-        complex<realnum> val = complex<realnum>(real(ps),imag(ps)) * complex<realnum>(real(kphase),imag(kphase)) *
+        std::complex<realnum> val = std::complex<realnum>(real(ps),imag(ps)) * std::complex<realnum>(real(kphase),imag(kphase)) *
                                chunks[i]->get_field(S.transform(c, sn), S.transform(iloc, sn));
         return parallel ? sum_to_all(val) : val;
       }
   return 0.0;
 }
 
-complex<realnum> fields_chunk::get_field(component c, const ivec &iloc) const {
+std::complex<realnum> fields_chunk::get_field(component c, const ivec &iloc) const {
   if (is_mine())
     return f[c][0] ? (f[c][1] ? getcm(f[c], gv.index(c, iloc)) : f[c][0][gv.index(c, iloc)]) : 0.0;
   else
     return 0.0;
 }
 
-complex<realnum> fields::get_chi1inv(component c, direction d, const ivec &origloc, double frequency,
-                                     bool parallel) const {
+std::complex<realnum> fields::get_chi1inv(component c, direction d, const ivec &origloc, double frequency,
+                                          bool parallel) const {
   ivec iloc = origloc;
   complex<double> aaack = 1.0;
   locate_point_in_user_volume(&iloc, &aaack);
@@ -173,33 +173,33 @@ complex<realnum> fields::get_chi1inv(component c, direction d, const ivec &origl
     for (int i = 0; i < num_chunks; i++)
       if (chunks[i]->gv.owns(S.transform(iloc, sn))) {
         signed_direction ds = S.transform(d, sn);
-        complex<realnum> val =
+        std::complex<realnum> val =
             chunks[i]->get_chi1inv(S.transform(c, sn), ds.d, S.transform(iloc, sn), frequency) *
-            complex<realnum>(ds.flipped ^ S.transform(component_direction(c), sn).flipped ? -1 : 1,
+            std::complex<realnum>(ds.flipped ^ S.transform(component_direction(c), sn).flipped ? -1 : 1,
                             0);
         return parallel ? sum_to_all(val) : val;
       }
   return d == component_direction(c) ? 1.0 : 0; // default to vacuum outside computational cell
 }
 
-complex<realnum> fields_chunk::get_chi1inv(component c, direction d, const ivec &iloc,
-                                           double frequency) const {
+std::complex<realnum> fields_chunk::get_chi1inv(component c, direction d, const ivec &iloc,
+                                                double frequency) const {
   return s->get_chi1inv(c, d, iloc, frequency);
 }
 
-complex<realnum> fields::get_chi1inv(component c, direction d, const vec &loc, double frequency,
-                                     bool parallel) const {
+std::complex<realnum> fields::get_chi1inv(component c, direction d, const vec &loc, double frequency,
+                                          bool parallel) const {
   ivec ilocs[8];
   double w[8];
-  complex<realnum> res(0.0, 0.0);
+  std::complex<realnum> res(0.0, 0.0);
   gv.interpolate(c, loc, ilocs, w);
   for (int argh = 0; argh < 8 && w[argh] != 0; argh++)
     res += realnum(w[argh]) * get_chi1inv(c, d, ilocs[argh], frequency, false);
   return parallel ? sum_to_all(res) : res;
 }
 
-complex<realnum> fields::get_eps(const vec &loc, double frequency) const {
-  complex<realnum> tr(0.0, 0.0);
+std::complex<realnum> fields::get_eps(const vec &loc, double frequency) const {
+  std::complex<realnum> tr(0.0, 0.0);
   int nc = 0;
   FOR_ELECTRIC_COMPONENTS(c) {
     if (gv.has_field(c)) {
@@ -207,11 +207,11 @@ complex<realnum> fields::get_eps(const vec &loc, double frequency) const {
       ++nc;
     }
   }
-  return complex<realnum>(nc, 0) / sum_to_all(tr);
+  return std::complex<realnum>(nc, 0) / sum_to_all(tr);
 }
 
-complex<realnum> fields::get_mu(const vec &loc, double frequency) const {
-  complex<realnum> tr(0.0, 0.0);
+std::complex<realnum> fields::get_mu(const vec &loc, double frequency) const {
+  std::complex<realnum> tr(0.0, 0.0);
   int nc = 0;
   FOR_MAGNETIC_COMPONENTS(c) {
     if (gv.has_field(c)) {
@@ -219,19 +219,19 @@ complex<realnum> fields::get_mu(const vec &loc, double frequency) const {
       ++nc;
     }
   }
-  return complex<realnum>(nc, 0) / sum_to_all(tr);
+  return std::complex<realnum>(nc, 0) / sum_to_all(tr);
 }
 
-complex<realnum> structure::get_chi1inv(component c, direction d, const ivec &origloc,
-                                        double frequency, bool parallel) const {
+std::complex<realnum> structure::get_chi1inv(component c, direction d, const ivec &origloc,
+                                             double frequency, bool parallel) const {
   ivec iloc = origloc;
   for (int sn = 0; sn < S.multiplicity(); sn++)
     for (int i = 0; i < num_chunks; i++)
       if (chunks[i]->gv.owns(S.transform(iloc, sn))) {
         signed_direction ds = S.transform(d, sn);
-        complex<realnum> val =
+        std::complex<realnum> val =
             chunks[i]->get_chi1inv(S.transform(c, sn), ds.d, S.transform(iloc, sn), frequency) *
-            complex<realnum>((ds.flipped ^ S.transform(component_direction(c), sn).flipped ? -1 : 1),
+            std::complex<realnum>((ds.flipped ^ S.transform(component_direction(c), sn).flipped ? -1 : 1),
                             0);
         return parallel ? sum_to_all(val) : val;
       }
@@ -259,9 +259,9 @@ void matrix_invert(std::complex<realnum> (&Vinv)[9], std::complex<realnum> (&V)[
   Vinv[2 + 3 * 2] = realnum(1.0) / det * (V[0 + 3 * 0] * V[1 + 3 * 1] - V[0 + 3 * 1] * V[1 + 3 * 0]);
 }
 
-complex<realnum> structure_chunk::get_chi1inv_at_pt(component c, direction d, int idx,
-                                                    double frequency) const {
-  complex<realnum> res(0.0, 0.0);
+std::complex<realnum> structure_chunk::get_chi1inv_at_pt(component c, direction d, int idx,
+                                                         double frequency) const {
+  std::complex<realnum> res(0.0, 0.0);
   if (is_mine()) {
     if (frequency == 0)
       return chi1inv[c][d] ? chi1inv[c][d][idx] : (d == component_direction(c) ? 1.0 : 0);
@@ -355,24 +355,24 @@ complex<realnum> structure_chunk::get_chi1inv_at_pt(component c, direction d, in
   return res;
 }
 
-complex<realnum> structure_chunk::get_chi1inv(component c, direction d, const ivec &iloc,
-                                              double frequency) const {
+std::complex<realnum> structure_chunk::get_chi1inv(component c, direction d, const ivec &iloc,
+                                                   double frequency) const {
   return get_chi1inv_at_pt(c, d, gv.index(c, iloc), frequency);
 }
 
-complex<realnum> structure::get_chi1inv(component c, direction d, const vec &loc, double frequency,
-                                        bool parallel) const {
+std::complex<realnum> structure::get_chi1inv(component c, direction d, const vec &loc, double frequency,
+                                             bool parallel) const {
   ivec ilocs[8];
   double w[8];
-  complex<realnum> res(0.0, 0.0);
+  std::complex<realnum> res(0.0, 0.0);
   gv.interpolate(c, loc, ilocs, w);
   for (int argh = 0; argh < 8 && w[argh] != 0; argh++)
     res += realnum(w[argh]) * get_chi1inv(c, d, ilocs[argh], frequency, false);
   return parallel ? sum_to_all(res) : res;
 }
 
-complex<realnum> structure::get_eps(const vec &loc, double frequency) const {
-  complex<realnum> tr(0.0, 0.0);
+std::complex<realnum> structure::get_eps(const vec &loc, double frequency) const {
+  std::complex<realnum> tr(0.0, 0.0);
   int nc = 0;
   FOR_ELECTRIC_COMPONENTS(c) {
     if (gv.has_field(c)) {
@@ -380,11 +380,11 @@ complex<realnum> structure::get_eps(const vec &loc, double frequency) const {
       ++nc;
     }
   }
-  return complex<realnum>(nc, 0) / sum_to_all(tr);
+  return std::complex<realnum>(nc, 0) / sum_to_all(tr);
 }
 
-complex<realnum> structure::get_mu(const vec &loc, double frequency) const {
-  complex<realnum> tr(0.0, 0.0);
+std::complex<realnum> structure::get_mu(const vec &loc, double frequency) const {
+  std::complex<realnum> tr(0.0, 0.0);
   int nc = 0;
   FOR_MAGNETIC_COMPONENTS(c) {
     if (gv.has_field(c)) {
@@ -392,7 +392,7 @@ complex<realnum> structure::get_mu(const vec &loc, double frequency) const {
       ++nc;
     }
   }
-  return complex<realnum>(nc, 0) / sum_to_all(tr);
+  return std::complex<realnum>(nc, 0) / sum_to_all(tr);
 }
 
 monitor_point *fields::get_new_point(const vec &loc, monitor_point *the_list) const {
@@ -402,17 +402,17 @@ monitor_point *fields::get_new_point(const vec &loc, monitor_point *the_list) co
   return p;
 }
 
-complex<realnum> monitor_point::get_component(component w) { return f[w]; }
+std::complex<realnum> monitor_point::get_component(component w) { return f[w]; }
 
 realnum monitor_point::poynting_in_direction(direction d) {
   direction d1 = cycle_direction(loc.dim, d, 1);
   direction d2 = cycle_direction(loc.dim, d, 2);
 
   // below Ex and Hx are used just to say that we want electric or magnetic component
-  complex<realnum> E1 = get_component(direction_component(Ex, d1));
-  complex<realnum> E2 = get_component(direction_component(Ex, d2));
-  complex<realnum> H1 = get_component(direction_component(Hx, d1));
-  complex<realnum> H2 = get_component(direction_component(Hx, d2));
+  std::complex<realnum> E1 = get_component(direction_component(Ex, d1));
+  std::complex<realnum> E2 = get_component(direction_component(Ex, d2));
+  std::complex<realnum> H1 = get_component(direction_component(Hx, d1));
+  std::complex<realnum> H2 = get_component(direction_component(Hx, d2));
 
   return (real(E1) * real(H2) - real(E2) * real(H1)) + (imag(E1) * imag(H2) - imag(E2) * imag(H1));
 }
@@ -425,7 +425,7 @@ realnum monitor_point::poynting_in_direction(vec dir) {
   return result;
 }
 
-void monitor_point::fourier_transform(component w, complex<realnum> **a, complex<realnum> **f,
+void monitor_point::fourier_transform(component w, std::complex<realnum> **a, std::complex<realnum> **f,
                                       int *numout, double fmin, double fmax, int maxbands) {
   int n = 1;
   monitor_point *p = next;
@@ -437,12 +437,12 @@ void monitor_point::fourier_transform(component w, complex<realnum> **a, complex
     p = p->next;
   }
   p = this;
-  complex<realnum> *d = new complex<realnum>[n];
+  std::complex<realnum> *d = new std::complex<realnum>[n];
   for (int i = 0; i < n; i++, p = p->next) {
     d[i] = p->get_component(w);
   }
   if (fmin > 0.0) { // Get rid of any static fields_chunk!
-    complex<realnum> mean = 0.0;
+    std::complex<realnum> mean = 0.0;
     for (int i = 0; i < n; i++)
       mean += d[i];
     mean /= n;
@@ -458,8 +458,8 @@ void monitor_point::fourier_transform(component w, complex<realnum> **a, complex
     fmax = (n - 1) * (1.0 / (tmax - tmin));
   }
 #endif
-    *a = new complex<realnum>[maxbands];
-    *f = new complex<realnum>[maxbands];
+    *a = new std::complex<realnum>[maxbands];
+    *f = new std::complex<realnum>[maxbands];
     *numout = maxbands;
     delete[] d;
     for (int i = 0; i < maxbands; i++) {
@@ -469,7 +469,7 @@ void monitor_point::fourier_transform(component w, complex<realnum> **a, complex
       p = this;
       while (p) {
         double inside = 2 * pi * real((*f)[i]) * p->t;
-        (*a)[i] += p->get_component(w) * complex<realnum>(cos(inside), sin(inside));
+        (*a)[i] += p->get_component(w) * std::complex<realnum>(cos(inside), sin(inside));
         p = p->next;
       }
       (*a)[i] /= (tmax - tmin);
@@ -478,7 +478,7 @@ void monitor_point::fourier_transform(component w, complex<realnum> **a, complex
   }
   else {
     *numout = n;
-    *a = new complex<realnum>[n];
+    *a = new std::complex<realnum>[n];
     *f = d;
     fftw_complex *in = (fftw_complex *)d, *out = (fftw_complex *)*a;
     fftw_plan p;
@@ -500,7 +500,7 @@ void monitor_point::fourier_transform(component w, complex<realnum> **a, complex
 #endif
 }
 
-void monitor_point::harminv(component w, complex<realnum> **a, complex<realnum> **f, int *numout,
+void monitor_point::harminv(component w, complex<double> **a, complex<double> **f, int *numout,
                             double fmin, double fmax, int maxbands) {
   int n = 1;
   monitor_point *p = next;
@@ -512,17 +512,17 @@ void monitor_point::harminv(component w, complex<realnum> **a, complex<realnum> 
     p = p->next;
   }
   p = this;
-  complex<realnum> *d = new complex<realnum>[n];
+  complex<double> *d = new complex<double>[n];
   for (int i = 0; i < n; i++, p = p->next) {
     d[i] = p->get_component(w);
   }
-  *a = new complex<realnum>[n];
+  *a = new complex<double>[n];
   double *f_re = new double[n];
   double *f_im = new double[n];
   *numout = do_harminv(d, n, (tmax - tmin) / (n - 1), fmin, fmax, maxbands, *a, f_re, f_im, NULL);
-  *f = new complex<realnum>[*numout];
+  *f = new complex<double>[*numout];
   for (int i = 0; i < *numout; i++)
-    (*f)[i] = complex<realnum>(f_re[i], f_im[i]);
+    (*f)[i] = complex<double>(f_re[i], f_im[i]);
   delete[] f_re;
   delete[] f_im;
   delete[] d;

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -564,6 +564,14 @@ size_t partial_sum_to_all(size_t in) {
   return out;
 }
 
+complex<float> sum_to_all(complex<float> in) {
+  complex<float> out = in;
+#ifdef HAVE_MPI
+  MPI_Allreduce(&in, &out, 2, MPI_FLOAT, MPI_SUM, mycomm);
+#endif
+  return out;
+}
+
 complex<double> sum_to_all(complex<double> in) {
   complex<double> out = in;
 #ifdef HAVE_MPI

--- a/tests/cylindrical.cpp
+++ b/tests/cylindrical.cpp
@@ -149,7 +149,9 @@ int test_simple_metallic(double eps(const vec &), int splitting) {
   return 1;
 }
 
-static bool issmall(std::complex<double> x) { return abs(x) < 1e-16; }
+static bool issmall(std::complex<realnum> x) {
+  return abs(x) < (sizeof(realnum) == sizeof(float) ? 1e-8 : 1e-16);
+}
 
 int test_r_equals_zero(double eps(const vec &)) {
   double a = 10.0;

--- a/tests/h5test.cpp
+++ b/tests/h5test.cpp
@@ -148,7 +148,7 @@ bool check_2d(double eps(const vec &), double a, int splitting, symfunc Sf, doub
           vec loc2(f.S.transform(loc, sn));
           int cs2 = f.S.transform(file_c, sn);
           complex<double> ph2 = f.S.phase_shift(cs2, -sn);
-          double diff2 = fabs(get_reim(f.get_field(cs2, loc2) * ph2, reim) - h5data[idx]);
+          double diff2 = fabs(get_reim(cdouble(f.get_field(cs2, loc2)) * ph2, reim) - h5data[idx]);
           if (diff2 < diff) {
             loc = loc2;
             cs = cs2;
@@ -158,7 +158,7 @@ bool check_2d(double eps(const vec &), double a, int splitting, symfunc Sf, doub
         }
 
         double err =
-            compare(h5data[idx], get_reim(f.get_field(cs, loc) * ph, reim), name, i0, i1, 0);
+          compare(h5data[idx], get_reim(cdouble(f.get_field(cs, loc)) * ph, reim), name, i0, i1, 0);
         err_max = max<double>(err, err_max);
         data_min = min<double>(data_min, h5data[idx]);
         data_max = max<double>(data_max, h5data[idx]);
@@ -259,7 +259,7 @@ bool check_3d(double eps(const vec &), double a, int splitting, symfunc Sf, comp
             vec loc2(f.S.transform(loc, sn));
             int cs2 = f.S.transform(file_c, sn);
             complex<double> ph2 = f.S.phase_shift(cs2, -sn);
-            double diff2 = fabs(get_reim(f.get_field(cs2, loc2) * ph2, reim) - h5data[idx]);
+            double diff2 = fabs(get_reim(cdouble(f.get_field(cs2, loc2)) * ph2, reim) - h5data[idx]);
             if (diff2 < diff) {
               loc = loc2;
               cs = cs2;
@@ -269,7 +269,7 @@ bool check_3d(double eps(const vec &), double a, int splitting, symfunc Sf, comp
           }
 
           double err =
-              compare(h5data[idx], get_reim(f.get_field(cs, loc) * ph, reim), name, i0, i1, i2);
+            compare(h5data[idx], get_reim(cdouble(f.get_field(cs, loc)) * ph, reim), name, i0, i1, i2);
           err_max = max(err, err_max);
           data_min = min<double>(data_min, h5data[idx]);
           data_max = max<double>(data_max, h5data[idx]);

--- a/tests/harmonics.cpp
+++ b/tests/harmonics.cpp
@@ -52,17 +52,17 @@ void harmonics(double freq, double chi2, double chi3, double J, double &A2, doub
   dft_flux d3 = f.add_dft_flux(Z, volume(fpt), 3 * freq, 3 * freq, 1, true, true,
                                1 /* decimation_factor */);
 
-  double emax = 0;
+  realnum emax = 0;
 
   while (f.time() < f.last_source_time()) {
     emax = max(emax, abs(f.get_field(Ex, fpt)));
     f.step();
   }
   do {
-    double emaxcur = 0;
+    realnum emaxcur = 0;
     double T = f.time() + 50;
     while (f.time() < T) {
-      double e = abs(f.get_field(Ex, fpt));
+      realnum e = abs(f.get_field(Ex, fpt));
       emax = max(emax, e);
       emaxcur = max(emaxcur, e);
       f.step();

--- a/tests/near2far.cpp
+++ b/tests/near2far.cpp
@@ -55,7 +55,7 @@ int check_cyl(double sr, double sz, double a) {
   for (int i = 0; i < N; ++i) {
     double rr = dr * i;
     vec x = veccyl(rr, 0.5 * sz);
-    F[i] = f.get_field(c, x) * phase;
+    F[i] = cdouble(f.get_field(c, x)) * phase;
     greencyl(EH, x, w, 2.0, 1.0, x0, c0, 1.0, m, 1e-6);
     F0[i] = EH[EHcomp[c]] * 2.0 * pi * x0.r(); // Ey = Ep for \phi = 0 (rz = xz) plane
     double d = abs(F0[i] - F[i]);
@@ -150,7 +150,7 @@ int check_2d_3d(ndim dim, const double xmax, double a, component c0, component c
       for (int i = 0; i < N; ++i) {
         double s = xmax / 4 + dx * i;
         vec x = dim == D2 ? vec(s, 0.5 * s) : vec(s, 0.5 * s, 0.3 * s);
-        F[i] = f.get_field(c, x) * phase;
+        F[i] = cdouble(f.get_field(c, x)) * phase;
         (dim == D2 ? green2d : green3d)(EH, x, w, 2.0, 1.0, x0, c0, 1.0);
         F0[i] = EH[EHcomp[c]];
         if (c1 != NO_COMPONENT) {


### PR DESCRIPTION
This PR switches the type from `double` to `realnum` of all the functions defined in `montior.cpp`. None of these functions are performance critical since they are not typically called at every time step. The benefit of switching their type is for consistency with the rest of the API. Note, however, that the fields array input to Harminv is still in double precision since this change would have required modifying the Harminv library to also support single precision which is probably not necessary.

Unfortunately, `make` is failing so this PR is not yet ready to be merged. For some reason, the modified function `matrix_invert` of `monitor.cpp` is not being SWIG-wrapped properly which is causing `make` to fail. However, if the SWIG wrappers for Scheme and Python are modified by hand to force the correct type conversion for this function then `make` and `make check` both pass.