### PR TITLE
fix memory leak in array-slice-ll.cpp

### DIFF
--- a/tests/array-slice-ll.cpp
+++ b/tests/array-slice-ll.cpp
@@ -164,6 +164,7 @@ int main(int argc, char *argv[]) {
   geometric_object_list g = {no, objects};
   meep_geom::set_materials_from_geometry(&the_structure, g);
   fields f(&the_structure);
+
   /***************************************************************/
   /* add source and timestep until source has finished (no later)*/
   /***************************************************************/

--- a/tests/array-slice-ll.cpp
+++ b/tests/array-slice-ll.cpp
@@ -164,7 +164,6 @@ int main(int argc, char *argv[]) {
   geometric_object_list g = {no, objects};
   meep_geom::set_materials_from_geometry(&the_structure, g);
   fields f(&the_structure);
-
   /***************************************************************/
   /* add source and timestep until source has finished (no later)*/
   /***************************************************************/
@@ -247,6 +246,10 @@ int main(int argc, char *argv[]) {
     master_printf("2D: rel error %e\n", RelErr2D);
 
   }; // if (write_files) ... else ...
+
+  for (int n = 0; n < no; n++) {
+    geometric_object_destroy(objects[n]);
+  }
 
   return 0;
 }


### PR DESCRIPTION
Fixes a memory leak in one of the C++ unit tests which was [reported by the address sanitizer](https://gist.github.com/ahoenselaar/13d0b764bb38bbab8b579ed414c49592#file-asan-log-for-mep-1e43687-L413).