### PR TITLE
"discrete" option in python/visualization.plot_eps

### DIFF
--- a/python/visualization.py
+++ b/python/visualization.py
@@ -402,7 +402,6 @@ def plot_eps(sim, ax, output_plane=None, eps_parameters=None, frequency=None):
     else:
         raise ValueError("A 2D plane has not been specified...")
 
-    print()
     eps_data = np.rot90(np.real(sim.get_epsilon_grid(xtics, ytics, ztics, eps_parameters['frequency'])))
 
     def threshold_eps(eps_levels, tol=1E-6):

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -50,6 +50,7 @@ default_eps_parameters = {
         'contour':False,
         'contour_linewidth':1,
         'discrete':False,
+        'discrete_eps_levels':None,
         'frequency':None,
         'resolution':None
     }
@@ -426,9 +427,12 @@ def plot_eps(sim, ax, output_plane=None, eps_parameters=None, frequency=None):
         if eps_parameters['contour']:
             ax.contour(eps_data, 0, colors='black', origin='upper', extent=extent, linewidths=eps_parameters['contour_linewidth'])
         elif eps_parameters['discrete']:
-            norm, cmap = discretize_colormap(eps_parameters['discrete_eps_levels'], eps_parameters['cmap'])
-            del eps_parameters['cmap']
-            ax.imshow(eps_data, extent=extent, norm=norm, cmap=cmap, **filter_dict(eps_parameters, ax.imshow))
+            if eps_parameters['discrete_eps_levels'].any() == None:
+                eps_parameters['discrete_eps_levels'] = [np.min(eps_data), np.max(eps_data)]
+            if colors == 
+            norm, eps_parameters['cmap'] = discretize_colormap(eps_parameters['discrete_eps_levels'], eps_parameters['cmap'])
+            #del eps_parameters['cmap']
+            ax.imshow(eps_data, extent=extent, norm=norm, **filter_dict(eps_parameters, ax.imshow))
         else:
             ax.imshow(eps_data, extent=extent, **filter_dict(eps_parameters, ax.imshow))
         ax.set_xlabel(xlabel)


### PR DESCRIPTION
Small PR for support for "discrete" plotting options in python/visualization.plot_eps

This is useful if a geometry has both large and small index contrasts. Below, for instance, we have ncore=3.45, nclad=1.44, and nfibercore=1.4467. ```sim.plot2D()``` with default or ```contour``` options cannot resolve the fiber core:


```
eps_parameters = {}
sim.plot2D(eps_parameters=eps_parameters)
```
![GC_notContour](https://user-images.githubusercontent.com/46427609/147388941-45f71f60-e0de-4829-a0cc-936123591ace.png)

```
eps_parameters = {}
eps_parameters['contour'] = True
sim.plot2D(eps_parameters=eps_parameters)
```

![GC_contour](https://user-images.githubusercontent.com/46427609/147388942-32dbfdec-6ab4-48c3-b0c5-0be22662d6cd.png)

In this PR, the ```eps_parameters``` option ```discrete``` (a boolean like ```contour```) allows plotting of user-provided permittivity ranges in solid colors:

```
# Make an iterable with some permittivities of the simulation geometry
epsilons = []
for item in geometry:
    epsilons.append(item.material.epsilon(1 / 1.55))
epsilons = np.array(epsilons)[:, 0, 0]

eps_parameters = {}
eps_parameters['discrete'] = True
eps_parameters['discrete_eps_levels'] = epsilons
sim.plot2D(eps_parameters=eps_parameters)
```

![GC_discrete](https://user-images.githubusercontent.com/46427609/147389042-8871bb0b-c4b8-4cd7-9e26-30ba034175fe.png)

This is controlled by new optional entries of the ```eps_parameters``` dict:

- ```discrete```: if True (and ```contour``` False), enables this option. Default is False
- ```discrete_eps_levels```: an iterable with the permittivities to highlight. The code actually sets the coloring thresholds at the midpoints of the unique, sorted values of this iterable. If left unset, will use the minimum and maximum of permittivity data across the simulation region, and threshold at the average.
- ```discrete_eps_colors```: an iterable with the colors to use for each permittivity level (sorted in increasing order). Needs to be larger than the iterable corresponding to ```unique(discrete_eps_levels)```, otherwise will throw an ```AssertionError```. If left, unset, will generate ```len(discrete_eps_levels)``` colors equally distributed from the ```cmap``` item, which by default is the ```binary``` matplotlib colormap.

Examples with all options are below. The effect of subpixel averaging can be seen.

Using another colormap:
```
epsilons = []
for item in geometry:
    epsilons.append(item.material.epsilon(1 / 1.55))
epsilons = np.array(epsilons)[:, 0, 0]

eps_parameters = {}
eps_parameters['discrete'] = True
eps_parameters['discrete_eps_levels'] = epsilons
eps_parameters['cmap'] = 'viridis'
sim.plot2D(eps_parameters=eps_parameters)
```
![GC_discrete_viridis](https://user-images.githubusercontent.com/46427609/147389383-a228565f-77fd-4b87-a134-f18b93da7aff.png)

Using an iterable of colors:
```
epsilons = []
for item in geometry:
    epsilons.append(item.material.epsilon(1 / 1.55))
epsilons = np.array(epsilons)[:, 0, 0]

eps_parameters = {}
eps_parameters['discrete'] = True
eps_parameters['discrete_eps_levels'] = epsilons
eps_parameters['discrete_eps_colors'] = ['red', 'blue', 'green', 'yellow']
sim.plot2D(eps_parameters=eps_parameters)
```
![GC_discrete_custom](https://user-images.githubusercontent.com/46427609/147389390-b4e473d1-591e-4e25-ac59-57ba277bf0f6.png)

