### PR TITLE
Ensure sim.plot2D() contour option plots all levels

### DIFF
--- a/python/visualization.py
+++ b/python/visualization.py
@@ -402,7 +402,7 @@ def plot_eps(sim, ax, output_plane=None, eps_parameters=None, frequency=None):
 
     if mp.am_master():
         if eps_parameters['contour']:
-            ax.contour(eps_data, 0, colors='black', origin='upper', extent=extent, linewidths=eps_parameters['contour_linewidth'])
+            ax.contour(eps_data, 0, levels=np.unique(eps_data), colors='black', origin='upper', extent=extent, linewidths=eps_parameters['contour_linewidth'])
         else:
             ax.imshow(eps_data, extent=extent, **filter_dict(eps_parameters, ax.imshow))
         ax.set_xlabel(xlabel)


### PR DESCRIPTION
The default ```matplotlib.pyplot.contour``` function does not always choose levels appropriately if there are both small and large contrasts. See for instance the example from [#1827](https://github.com/NanoComp/meep/pull/1827) ([comment](https://github.com/NanoComp/meep/pull/1827#issuecomment-972430404)) :

![plot2D_test](https://user-images.githubusercontent.com/46427609/147419489-571029e4-7cd6-43b3-9247-170943944f45.png)

![plot2D_test_contour](https://user-images.githubusercontent.com/46427609/147419491-b6ce41b2-45da-4ff2-ba11-26ee5720abd7.png)

While the user can always provide the appropriate ```levels``` options, we can ensure the desired behaviour by hardcoding the ```levels``` parameter to look up the unique epsilon values from the geometry (which are used for plotting instead of a multitude of subpixel-averaged values as of [#1827](https://github.com/NanoComp/meep/pull/1827)):

![plot2D_test_contour_levels](https://user-images.githubusercontent.com/46427609/147419499-0d5710ec-e99a-4d1f-9610-10f6bdb895c4.png)
