### PR TITLE
Add cylindrical coordinates support for `plot2d`

### DIFF
--- a/python/visualization.py
+++ b/python/visualization.py
@@ -571,14 +571,15 @@ def plot_fields(sim, ax=None, fields=None, output_plane=None, field_parameters=N
 
 
     fields = field_parameters['post_process'](fields)
+    fields = np.flipud(fields) if ((sim.dimensions == mp.CYLINDRICAL) or sim.is_cylindrical) else np.rot90(fields)
 
     # Either plot the field, or return the array
     if ax:
         if mp.am_master():
-            ax.imshow(np.flipud(fields), extent=extent, **filter_dict(field_parameters,ax.imshow))
+            ax.imshow(fields, extent=extent, **filter_dict(field_parameters,ax.imshow))
         return ax
     else:
-        return np.flipud(fields)
+        return fields
     return ax
 
 def plot2D(sim, ax=None, output_plane=None, fields=None, labels=False,


### PR DESCRIPTION
Basic support for visualization of cylindrical coordinates.

Example image of (nonoptimized) metalens when plotting with `master` (incorrect)

![image](https://user-images.githubusercontent.com/24902086/147702641-22ce8bd3-15af-4809-8fb0-4d3d1a0101ba.png)

Correct plot using this PR:

![image](https://user-images.githubusercontent.com/24902086/147702541-af944386-8ac6-423d-8d0f-0f294634d316.png)

With fields

![image](https://user-images.githubusercontent.com/24902086/147703021-85be9973-463e-451c-a46f-417f89c627bc.png)

(cc @mochen4) 
