### PR TITLE
fix two memory leaks in geom_epsilon class

### DIFF
--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -43,6 +43,13 @@ void set_default_material(material_type _default_material) {
   }
 }
 
+void unset_default_material(void) {
+  if (default_material != NULL) {
+    material_free((material_type)default_material);
+    default_material = NULL;
+  }
+}
+
 bool susceptibility_equal(const susceptibility &s1, const susceptibility &s2) {
   return (vector3_equal(s1.sigma_diag, s2.sigma_diag) &&
           vector3_equal(s1.sigma_offdiag, s2.sigma_offdiag) && vector3_equal(s1.bias, s2.bias) &&

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -726,6 +726,10 @@ geom_epsilon::~geom_epsilon() {
   FOR_DIRECTIONS(d) FOR_SIDES(b) {
     if (cond[d][b].prof) delete[] cond[d][b].prof;
   }
+  if (default_material != NULL) {
+    material_free((material_type)default_material);
+    default_material = NULL;
+  }
 }
 
 void geom_epsilon::set_cond_profile(meep::direction dir, meep::boundary_side side, double L,
@@ -761,7 +765,8 @@ void geom_epsilon::set_volume(const meep::volume &v) {
   unset_volume();
 
   geom_box box = gv2box(v);
-  restricted_tree = create_geom_box_tree0(geometry, box);
+  if (!restricted_tree)
+    restricted_tree = create_geom_box_tree0(geometry, box);
 }
 
 static void material_epsmu(meep::field_type ft, material_type material, symm_matrix *epsmu,
@@ -1918,8 +1923,8 @@ void add_absorbing_layer(absorber_list alist, double thickness, int direction, i
 /* create a geom_epsilon object that can persist
 if needed */
 geom_epsilon* make_geom_epsilon(meep::structure *s, geometric_object_list *g, vector3 center,
-                                 bool _ensure_periodicity, material_type _default_material,
-                                 material_type_list extra_materials) {
+                                bool _ensure_periodicity, material_type _default_material,
+                                material_type_list extra_materials) {
   // set global variables in libctlgeom based on data fields in s
   geom_initialize();
   geometry_center = center;
@@ -1980,17 +1985,17 @@ void set_materials_from_geometry(meep::structure *s, geometric_object_list g, ve
                                  bool _ensure_periodicity, material_type _default_material,
                                  absorber_list alist, material_type_list extra_materials) {
   meep_geom::geom_epsilon *geps = meep_geom::make_geom_epsilon(s, &g, center, _ensure_periodicity,
-                                  _default_material, extra_materials);
+                                                               _default_material, extra_materials);
   set_materials_from_geom_epsilon(s, geps, use_anisotropic_averaging, tol,
-                                 maxeval, alist);
+                                  maxeval, alist);
   delete geps;
 }
 
 /* from a previously created geom_epsilon object,
 set the materials as specified */
 void set_materials_from_geom_epsilon(meep::structure *s, geom_epsilon *geps,
-                                 bool use_anisotropic_averaging,
-                                 double tol, int maxeval, absorber_list alist) {
+                                     bool use_anisotropic_averaging,
+                                     double tol, int maxeval, absorber_list alist) {
 
   // store for later use in gradient calculations
   geps->tol = tol;
@@ -2007,7 +2012,7 @@ void set_materials_from_geom_epsilon(meep::structure *s, geom_epsilon *geps,
           mythunk.func = layer->pml_profile;
           mythunk.func_data = layer->pml_profile_data;
           geps->set_cond_profile(d, b, layer->thickness, gv.inva * 0.5, pml_profile_wrapper,
-                                (void *)&mythunk, layer->R_asymptotic);
+                                 (void *)&mythunk, layer->R_asymptotic);
         }
       }
     }

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -726,10 +726,6 @@ geom_epsilon::~geom_epsilon() {
   FOR_DIRECTIONS(d) FOR_SIDES(b) {
     if (cond[d][b].prof) delete[] cond[d][b].prof;
   }
-  if (default_material != NULL) {
-    material_free((material_type)default_material);
-    default_material = NULL;
-  }
 }
 
 void geom_epsilon::set_cond_profile(meep::direction dir, meep::boundary_side side, double L,

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -253,6 +253,7 @@ vector3 vec_to_vector3(const meep::vec &pt);
 meep::vec vector3_to_vec(const vector3 v3);
 
 void set_default_material(material_type _default_material);
+void unset_default_material(void);
 void epsilon_material_grid(material_data *md, double u);
 void epsilon_file_material(material_data *md, vector3 p);
 bool susceptibility_equal(const susceptibility &s1, const susceptibility &s2);

--- a/tests/array-slice-ll.cpp
+++ b/tests/array-slice-ll.cpp
@@ -251,10 +251,7 @@ int main(int argc, char *argv[]) {
   for (int n = 0; n < no; n++) {
     geometric_object_destroy(objects[n]);
   }
-  if (default_material != NULL) {
-    meep_geom::material_free((meep_geom::material_type)default_material);
-    default_material = NULL;
-  }
+  meep_geom::unset_default_material();
 
   return 0;
 }

--- a/tests/array-slice-ll.cpp
+++ b/tests/array-slice-ll.cpp
@@ -251,6 +251,10 @@ int main(int argc, char *argv[]) {
   for (int n = 0; n < no; n++) {
     geometric_object_destroy(objects[n]);
   }
+  if (default_material != NULL) {
+    meep_geom::material_free((meep_geom::material_type)default_material);
+    default_material = NULL;
+  }
 
   return 0;
 }

--- a/tests/cyl-ellipsoid-ll.cpp
+++ b/tests/cyl-ellipsoid-ll.cpp
@@ -198,10 +198,7 @@ int main(int argc, char *argv[]) {
   for (int n = 0; n < 2; n++) {
     geometric_object_destroy(objects[n]);
   }
-  if (default_material != NULL) {
-    meep_geom::material_free((meep_geom::material_type)default_material);
-    default_material = NULL;
-  }
+  meep_geom::unset_default_material();
 
   return 0;
 }

--- a/tests/cyl-ellipsoid-ll.cpp
+++ b/tests/cyl-ellipsoid-ll.cpp
@@ -198,6 +198,10 @@ int main(int argc, char *argv[]) {
   for (int n = 0; n < 2; n++) {
     geometric_object_destroy(objects[n]);
   }
+  if (default_material != NULL) {
+    meep_geom::material_free((meep_geom::material_type)default_material);
+    default_material = NULL;
+  }
 
   return 0;
 }


### PR DESCRIPTION
This PR fixes a couple of memory leaks in the `geom_epsilon` class. The first is a simple check to avoid duplicating the `restricted_tree` object in `geom_epsilon::set_volume`. The second is manually deleting the global variable `default_material` (which is a pointer to `material_data`) by calling a new function `meep_geom::unset_default_material()` at the end of two C++ unit tests (`array-slice-ll.cpp` and `cyl-ellipsoid-ll.cpp`).

With these two fixes, the address sanitizer in the GitHub Actions CI passes and can thus be enabled by default for all subsequent PRs.