### PR TITLE
Restore PML plotting with cartesian coordinates

### DIFF
--- a/python/visualization.py
+++ b/python/visualization.py
@@ -477,20 +477,20 @@ def plot_boundaries(sim, ax, output_plane=None, boundary_parameters=None):
             else:
                 raise ValueError("Invalid simulation dimensions")
             for permutation in itertools.product(dims, [mp.Low, mp.High]):
-                if (permutation[0] == mp.X) and (permutation[1] == mp.Low):
+                if ((permutation[0] == mp.X) and (permutation[1] == mp.Low)) and (sim.dimensions == mp.CYLINDRICAL or sim.is_cylindrical):
                     continue
                 vol = get_boundary_volumes(boundary.thickness,*permutation)
                 ax = plot_volume(sim,ax,vol,output_plane,plotting_parameters=boundary_parameters)
         # two sides are the same
         elif boundary.side == mp.ALL:
             for side in [mp.Low, mp.High]:
-                if (boundary.direction == mp.X) and (side == mp.Low):
+                if ((boundary.direction == mp.X) and (side == mp.Low)) and (sim.dimensions == mp.CYLINDRICAL or sim.is_cylindrical):
                     continue
                 vol = get_boundary_volumes(boundary.thickness,boundary.direction,side)
                 ax = plot_volume(sim,ax,vol,output_plane,plotting_parameters=boundary_parameters)
         # only one side
         else:                
-            if (boundary.direction == mp.X) and (boundary.side == mp.Low):
+            if ((boundary.direction == mp.X) and (boundary.side == mp.Low)) and (sim.dimensions == mp.CYLINDRICAL or sim.is_cylindrical):
                 continue
             vol = get_boundary_volumes(boundary.thickness,boundary.direction,boundary.side)
             ax = plot_volume(sim,ax,vol,output_plane,plotting_parameters=boundary_parameters)


### PR DESCRIPTION
Fixes #1880.

Cartesian:

![image](https://user-images.githubusercontent.com/24902086/148149965-9ca28b53-85ce-401d-a935-6301f5e70d66.png)

![image](https://user-images.githubusercontent.com/24902086/148149990-441b0ea8-2fa6-4681-a9f9-34d07689770c.png)
