### PR TITLE
compute adjoint gradient using restriction/interpolation only when anisotropic materials are present

### DIFF
--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2965,8 +2965,14 @@ void material_grids_addgradient(double *v, size_t ng, std::complex<meep::realnum
             material_grids_addgradient_point(
                 v+ng*f_i, vec_to_vector3(p), scalegrad*cyl_scale, geps,
                 adjoint_c, forward_c, fwd, adj, frequencies[f_i], gv, du);
-          /* more complicated case requires interpolation/restriction */
-          } else if (md->do_averaging) {
+          /* anisotropic materials require interpolation/restriction */
+          } else if (md->do_averaging ||
+                     md->medium_1.epsilon_offdiag.x.re != 0 ||
+                     md->medium_1.epsilon_offdiag.y.re != 0 ||
+                     md->medium_1.epsilon_offdiag.z.re != 0 ||
+                     md->medium_2.epsilon_offdiag.x.re != 0 ||
+                     md->medium_2.epsilon_offdiag.y.re != 0 ||
+                     md->medium_2.epsilon_offdiag.z.re != 0) {
             /* we need to restrict the adjoint fields to
             the two nodes of interest (which requires a factor
             of 0.5 to scale), and interpolate the forward fields

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2959,7 +2959,7 @@ void material_grids_addgradient(double *v, size_t ng, std::complex<meep::realnum
           /********* compute -λᵀAᵤx *************/
 
           /* trivial case, no interpolation/restriction needed        */
-          if (forward_c == adjoint_c) {
+          if (forward_c == adjoint_c || !md->do_averaging) {
             std::complex<double> fwd = GET_FIELDS(fields_f, ci_forward, f_i, idx_fields);
             cyl_scale = (gv.dim == meep::Dcyl) ? 2*p.r() : 1; // the pi is already factored in near2far.cpp
             material_grids_addgradient_point(

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2959,14 +2959,14 @@ void material_grids_addgradient(double *v, size_t ng, std::complex<meep::realnum
           /********* compute -λᵀAᵤx *************/
 
           /* trivial case, no interpolation/restriction needed        */
-          if (forward_c == adjoint_c || !md->do_averaging) {
+          if (forward_c == adjoint_c) {
             std::complex<double> fwd = GET_FIELDS(fields_f, ci_forward, f_i, idx_fields);
             cyl_scale = (gv.dim == meep::Dcyl) ? 2*p.r() : 1; // the pi is already factored in near2far.cpp
             material_grids_addgradient_point(
                 v+ng*f_i, vec_to_vector3(p), scalegrad*cyl_scale, geps,
                 adjoint_c, forward_c, fwd, adj, frequencies[f_i], gv, du);
           /* more complicated case requires interpolation/restriction */
-          } else {
+          } else if (md->do_averaging) {
             /* we need to restrict the adjoint fields to
             the two nodes of interest (which requires a factor
             of 0.5 to scale), and interpolate the forward fields


### PR DESCRIPTION
#1780 added support for subpixel smoothing of the adjoint gradients in which ε is an anisotropic tensor. However, in the current implementation of `material_grids_addgradient` of `meepgeom.cpp`, regardless of the value of the `do_averaging` property of the `MaterialGrid` object, the adjoint gradient is *always* computed for the off-diagonal components of ε which is a bug. Also, as reported in #1861, computing these off-diagonal elements involves a memory violation in which the array for the forward fields is read outside of its bounds. The memory violation issue is exacerbated by the fact that `do_averaging=True` is the default setting in `MaterialGrid`:

https://github.com/NanoComp/meep/blob/efe3b4b1fff538cf1b1ad2e34bb47c7a3ddfb28a/python/geom.py#L538-L547

This PR provides a small fix to `material_grids_addgradient` to ensure that when `do_averaging=False` only the diagonal ε elements are computed (and the memory violation is therefore avoided).