### PR TITLE
resolve multiplication bug in Prism

### DIFF
--- a/python/geom.py
+++ b/python/geom.py
@@ -1189,7 +1189,7 @@ class Prism(GeometricObject):
         """
 
         centroid = sum(vertices, Vector3(0)) * (1.0 / len(vertices)) # centroid of floor polygon
-        original_center = centroid + (0.5*height)*axis               # center as computed from vertices, height, axis
+        original_center = centroid + axis*(0.5*height)               # center as computed from vertices, height, axis
         if center is not None and len(vertices):
             center = Vector3(*center)
             # translate vertices to center prism at requested center


### PR DESCRIPTION
I wasn't being able to initiate a Prism. Turns out performing the operation Vector3*scalar returns Vector3, while scalar*Vector3 doesn't. 
I'm not sure the latter could work anyway, but in the meanwhile this change allows the Prism to work.