### PR TITLE
specify default no smoothing for `MaterialGrid` constructor

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -4414,7 +4414,7 @@ def __init__(self,
              medium2,
              weights=None,
              grid_type='U_DEFAULT',
-             do_averaging=True,
+             do_averaging=False,
              beta=0,
              eta=0.5,
              damping=0):

--- a/python/geom.py
+++ b/python/geom.py
@@ -541,7 +541,7 @@ class MaterialGrid(object):
                  medium2,
                  weights=None,
                  grid_type="U_DEFAULT",
-                 do_averaging=True,
+                 do_averaging=False,
                  beta=0,
                  eta=0.5,
                  damping=0):

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -381,7 +381,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@adjsol_grad).flatten()
             fd_grad = Ez2_perturbed-Ez2_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.04 if mp.is_single_precision() else 0.006
+            tol = 0.07 if mp.is_single_precision() else 0.006
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
 
@@ -477,7 +477,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             adj_scale = (dp[None,:]@adjsol_grad).flatten()
             fd_grad = Ez2_perturbed-Ez2_unperturbed
             print("Directional derivative -- adjoint solver: {}, FD: {}".format(adj_scale,fd_grad))
-            tol = 0.012 if mp.is_single_precision() else 0.002
+            tol = 0.018 if mp.is_single_precision() else 0.002
             self.assertClose(adj_scale,fd_grad,epsilon=tol)
 
     def test_damping(self):


### PR DESCRIPTION
#1780 added support for subpixel smoothing of the adjoint gradient and also [set smoothing as the *default* for the `MaterialGrid`](https://github.com/NanoComp/meep/pull/1780/files#diff-1a0db8ede85a5d6c8139da7efb2cf09d1c3273439f2bbf75f9c303bc94abc885R532). (#1886 fixed a bug to permit no smoothing via `do_averaging=False` of the `MaterialGrid`.) Since subpixel smoothing of the adjoint gradients is currently an experimental feature which can, under certain circumstances, significantly slow down the runtime performance of the [`get_gradient`](https://github.com/NanoComp/meep/blob/accaf4fc7bd7008893ae30e7883547a59d30656b/python/adjoint/utils.py#L44-L93) function of the adjoint-solver module (compared to no smoothing), it is probably better to use a default of no smoothing for the `MaterialGrid`. The default setting can be changed once this feature is more mature and the performance is better tested (via e.g. #1855).

(Since forward simulations that do not involve computing the adjoint gradient do benefit from the improved accuracy of subpixel smoothing of the `MaterialGrid` without a noticeable degradation in runtime performance, it could be useful to have a *separate* flag for subpixel smoothing in the adjoint solver. This way, the `do_averaging` property of the `MaterialGrid` can still be `True` by default and overwritten to `False` by the adjoint solver.) 