### PR TITLE
pympb ports of of MPB's `compute_symmetries`

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -1725,7 +1725,7 @@ mpb_real mode_solver::get_val(int ix, int iy, int iz, int nx, int ny, int nz, in
 mpb_real mode_solver::interp_val(vector3 p, int nx, int ny, int nz, int last_dim_size,
                                  mpb_real *data, int stride, int conjugate) {
   double ipart;
-  mpb_real rx, ry, rz, dx, dy, dz, v;
+  mpb_real rx, ry, rz, dx, dy, dz;
   int x, y, z, x2, y2, z2;
 
   mpb_real latx = geometry_lattice.size.x == 0 ? 1e-20 : geometry_lattice.size.x;
@@ -1761,13 +1761,12 @@ mpb_real mode_solver::interp_val(vector3 p, int nx, int ny, int nz, int last_dim
 
 #define D(x, y, z) (get_val(x, y, z, nx, ny, nz, last_dim_size, data, stride, conjugate))
 
-     v = (((D(x,y,z)   * (1.0-dx) + D(x2,y,z)   * dx) * (1.0-dy) +
-           (D(x,y2,z)  * (1.0-dx) + D(x2,y2,z)  * dx) * dy         ) * (1.0-dz) +
-          ((D(x,y,z2)  * (1.0-dx) + D(x2,y,z2)  * dx) * (1.0-dy) +
-           (D(x,y2,z2) * (1.0-dx) + D(x2,y2,z2) * dx) * dy         ) * dz);
-
-     mpi_allreduce_1(&v, mpb_real, SCALAR_MPI_TYPE, MPI_SUM, mpb_comm);
-     return v;
+  return (((D(x, y, z) * (1.0 - dx) + D(x2, y, z) * dx) * (1.0 - dy) +
+           (D(x, y2, z) * (1.0 - dx) + D(x2, y2, z) * dx) * dy) *
+              (1.0 - dz) +
+          ((D(x, y, z2) * (1.0 - dx) + D(x2, y, z2) * dx) * (1.0 - dy) +
+           (D(x, y2, z2) * (1.0 - dx) + D(x2, y2, z2) * dx) * dy) *
+              dz);
 
 #undef D
 }

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -175,6 +175,7 @@ struct mode_solver {
   cmatrix3x3 get_epsilon_inverse_tensor_point(vector3 p);
   mpb_real get_energy_point(vector3 p);
   cvector3 get_field_point(vector3 p);
+  void get_bloch_field_point_(scalar_complex field[3], vector3 p);
   cvector3 get_bloch_field_point(vector3 p);
 
   void multiply_bloch_phase(std::complex<double> *cdata = NULL);
@@ -194,6 +195,9 @@ struct mode_solver {
                                  field_integral_energy_func energy_func, void *py_func);
 
   vector3 get_dominant_planewave(int band);
+
+  cnumber transformed_overlap(matrix3x3 W, vector3 w);
+  cnumber compute_symmetry(int which_band, matrix3x3 W, vector3 w);
 
 private:
   int kpoint_index;

--- a/python/solver.py
+++ b/python/solver.py
@@ -1128,6 +1128,18 @@ class ModeSolver(object):
     def get_dominant_planewave(self, band):
         return self.mode_solver.get_dominant_planewave(band)
 
+    def transformed_overlap(self, W, w):
+        return self.mode_solver.transformed_overlap(W, w)
+
+    def compute_symmetry(self, band, W, w):
+        return self.mode_solver.compute_symmetry(band, W, w)
+   
+    def compute_symmetries(self, W, w):
+        symvals = []
+        for band in range(1, self.num_bands+1):
+            symvals.append(self.mode_solver.compute_symmetry(band, W, w))
+        return symvals
+
 
 # Predefined output functions (functions of the band index), for passing to `run`
 

--- a/python/tests/test_mpb.py
+++ b/python/tests/test_mpb.py
@@ -1421,6 +1421,56 @@ class TestModeSolver(unittest.TestCase):
 
         self.check_band_range_data(expected_brd, ms.band_range_data)
 
+    def test_symmetry_overlap(self):
+        ms = mpb.ModeSolver(
+            num_bands=6,
+            k_points         = [mp.Vector3(0.5, 0.5, 0.5),],
+            geometry         = [mp.Sphere(0.25, material=mp.Medium(epsilon=13))],
+            geometry_lattice = mp.Lattice(size=mp.Vector3(1, 1, 1)),
+            resolution       = 32,
+            filename_prefix  = self.filename_prefix,
+            deterministic    = True,
+            tolerance        = 1e-12
+        )
+        ms.run()
+
+        # inversion symmetry
+        W = mp.Matrix([-1,0,0], [0,-1,0], [0,0,-1])
+        w = mp.Vector3(0,0,0)
+        symeigs = ms.compute_symmetries(W, w) 
+        symeigs_expected = [1,1,1,-1,-1,-1]
+        for i in range(0,5):
+            self.assertAlmostEqual(symeigs[i].real, symeigs_expected[i], places=3)
+            self.assertAlmostEqual(symeigs[i].imag, 0, places=3)
+        
+        # check that transformed_overlap agrees when called manually, with a
+        # "preloaded" bfield
+        for i in range(0,5):
+            ms.get_bfield(i+1, bloch_phase=False)
+            symeig_bfield = ms.transformed_overlap(W, w)
+            self.assertAlmostEqual(symeigs[i].real, symeig_bfield.real, places=3)
+            self.assertAlmostEqual(symeigs[i].imag, symeig_bfield.imag, places=3)
+
+            ms.get_dfield(i+1, bloch_phase=False)
+            symeig_dfield = ms.transformed_overlap(W, w)
+            self.assertAlmostEqual(symeigs[i].real, symeig_dfield.real, places=3)
+            self.assertAlmostEqual(symeigs[i].imag, symeig_dfield.imag, places=3)
+
+        # mirror symmetry: compare with run_zeven & run_zodd 
+        ms.k_points = [mp.Vector3(0,0,0)] # must be at Γ cf. https://github.com/NanoComp/mpb/issues/114
+        Wz = mp.Matrix([1,0,0], [0,1,0], [0,0,-1])
+
+        ms.run_zeven()
+        symeigs_zeven = ms.compute_symmetries(Wz, w)
+        for i in range(0,5):
+            self.assertAlmostEqual(symeigs_zeven[i].real, 1, places=3)
+            self.assertAlmostEqual(symeigs_zeven[i].imag, 0, places=3)
+
+        ms.run_zodd()
+        symeigs_zodd = ms.compute_symmetries(Wz, w)
+        for i in range(0,5):
+            self.assertAlmostEqual(symeigs_zodd[i].real, -1, places=3)
+            self.assertAlmostEqual(symeigs_zodd[i].imag,  0, places=3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is essentially just a copy-port of https://github.com/NanoComp/mpb/issues/134, which enables MPB to compute overlap integrals of eigenfields transformed by a space group operation.

I also pulled in [**edit:** a small part of] https://github.com/NanoComp/mpb/issues/100 because https://github.com/NanoComp/mpb/issues/134 depended on parts of that. ~My understanding is that the Python interface to MPB does not currently run under MPI - so it's not clear that it's worth pulling in https://github.com/NanoComp/mpb/issues/100 which was mainly about making `get_val` run under MPI. On the other hand, I figured there wouldn't be any harm in it, in case it ever becomes a priority to make MPI work for MPB's Python interface.~[**edit:** I've left out the MPI parts]

I haven't tried connecting Python and C(++) before, so the PR here is mainly based on reading the current source. Please let me know if I missed anything.

If this gets merged, I'll make a Python-docs PR to the MPB repo as well.