### PR TITLE
allow construction of `Matrix` from `numpy.array`s

### DIFF
--- a/python/geom.py
+++ b/python/geom.py
@@ -1247,10 +1247,10 @@ class Matrix(object):
         self.c1 = Vector3(*c1)
         self.c2 = Vector3(*c2)
         self.c3 = Vector3(*c3)
-        if c1 == c2 == c3 == Vector3():
-            self.c1 = Vector3(diag.x,offdiag.x,offdiag.y)
-            self.c2 = Vector3(np.conj(offdiag.x),diag.y,offdiag.z)
-            self.c3 = Vector3(np.conj(offdiag.y),np.conj(offdiag.z),diag.z)
+        if np.all(c1 == c2) and np.all(c2 == c3) and np.all(c3 == Vector3()):
+            self.c1 = Vector3(diag[0], offdiag[0], offdiag[1])
+            self.c2 = Vector3(np.conj(offdiag[0]), diag[1], offdiag[2])
+            self.c3 = Vector3(np.conj(offdiag[1]), np.conj(offdiag[2]), diag[2])
 
     def __getitem__(self, i):
         return self.row(i)


### PR DESCRIPTION
I was trying to use the Python interface via PyCall in Julia and wanted to construct a `meep.Matrix` like so
```jl
using PyCall
mp = pyimport("meep")
mp.Matrix([1,2,3], [4,5,6], [7,8,9])
```
and noticed that it errored because the Julia vectors are converted to numpy arrays, which didn't like the chained comparison (throwing `ValueError('The truth value of an array with more than one element is ambiguous. [...]`).
This fixes that.

PS. I know I could just do `mp.Matrix(mp.Vector3(1,2,3), mp.Vector3(4,5,6), mp.Vector3(7,8,9))` - so this is just intended to make it a little bit more ergonomic.