### PR TITLE
pympp: remove `HAVE_MPI`-variation of `XYZ_LOOP`

### DIFF
--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -17,7 +17,7 @@ extern "C" int mpb_verbosity = 2;
 #endif
 
 // xyz_loop.h
-#ifndef HAVE_MPI
+// #ifndef HAVE_MPI
 #define LOOP_XYZ(md)                                                                               \
   {                                                                                                \
     int n1 = md->nx, n2 = md->ny, n3 = md->nz, i1, i2, i3;                                         \
@@ -25,18 +25,18 @@ extern "C" int mpb_verbosity = 2;
       for (i2 = 0; i2 < n2; ++i2)                                                                  \
         for (i3 = 0; i3 < n3; ++i3) {                                                              \
           int xyz_index = ((i1 * n2 + i2) * n3 + i3);
-#else /* HAVE_MPI */
-/* first two dimensions are transposed in MPI output: */
-#define LOOP_XYZ(md)                                                                               \
-  {                                                                                                \
-    int n1 = md->nx, n2 = md->ny, n3 = md->nz, i1, i2_, i3;                                        \
-    int local_n2 = md->local_ny, local_y_start = md->local_y_start;                                \
-    for (i2_ = 0; i2_ < local_n2; ++i2_)                                                           \
-      for (i1 = 0; i1 < n1; ++i1)                                                                  \
-        for (i3 = 0; i3 < n3; ++i3) {                                                              \
-          int i2 = i2_ + local_y_start;                                                            \
-          int xyz_index = ((i2_ * n1 + i1) * n3 + i3);
-#endif /* HAVE_MPI */
+// #else /* HAVE_MPI */
+// /* first two dimensions are transposed in MPI output: */
+// #define LOOP_XYZ(md)                                                                               \
+//   {                                                                                                \
+//     int n1 = md->nx, n2 = md->ny, n3 = md->nz, i1, i2_, i3;                                        \
+//     int local_n2 = md->local_ny, local_y_start = md->local_y_start;                                \
+//     for (i2_ = 0; i2_ < local_n2; ++i2_)                                                           \
+//       for (i1 = 0; i1 < n1; ++i1)                                                                  \
+//         for (i3 = 0; i3 < n3; ++i3) {                                                              \
+//           int i2 = i2_ + local_y_start;                                                            \
+//           int xyz_index = ((i2_ * n1 + i1) * n3 + i3);
+// #endif /* HAVE_MPI */
 
 typedef mpb_real real; // needed for the CASSIGN macros below
 

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -6,15 +6,15 @@ TEST_DIR = tests
 # material_dispersion.py test must be excluded from test suite for MPI build
 if WITH_MPI
   MDPYTEST=
-  MPBPYTEST=
 else
   MDPYTEST=$(TEST_DIR)/test_material_dispersion.py
+endif # WITH_MPI
+
 if WITH_MPB
   MPBPYTEST=$(TEST_DIR)/test_mpb.py
 else
   MPBPYTEST=
 endif # WITH_MPB
-endif # WITH_MPI
 
 if WITH_MPB
   BINARY_GRATING_TEST = $(TEST_DIR)/test_binary_grating.py

--- a/python/tests/test_mpb.py
+++ b/python/tests/test_mpb.py
@@ -1433,9 +1433,9 @@ class TestModeSolver(unittest.TestCase):
         ms.run()
 
         # inversion symmetry
-        W = mp.Matrix([-1,0,0], [0,-1,0], [0,0,-1])
+        Wi = mp.Matrix([-1,0,0], [0,-1,0], [0,0,-1])
         w = mp.Vector3(0,0,0)
-        symeigs = ms.compute_symmetries(W, w) 
+        symeigs = ms.compute_symmetries(Wi, w) 
         symeigs_expected = [1,1,1,-1,-1,-1]
         for i in range(0,5):
             self.assertAlmostEqual(symeigs[i].real, symeigs_expected[i], places=3)
@@ -1445,14 +1445,20 @@ class TestModeSolver(unittest.TestCase):
         # "preloaded" bfield
         for i in range(0,5):
             ms.get_bfield(i+1, bloch_phase=False)
-            symeig_bfield = ms.transformed_overlap(W, w)
+            symeig_bfield = ms.transformed_overlap(Wi, w)
             self.assertAlmostEqual(symeigs[i].real, symeig_bfield.real, places=3)
             self.assertAlmostEqual(symeigs[i].imag, symeig_bfield.imag, places=3)
 
             ms.get_dfield(i+1, bloch_phase=False)
-            symeig_dfield = ms.transformed_overlap(W, w)
+            symeig_dfield = ms.transformed_overlap(Wi, w)
             self.assertAlmostEqual(symeigs[i].real, symeig_dfield.real, places=3)
             self.assertAlmostEqual(symeigs[i].imag, symeig_dfield.imag, places=3)
+
+        # 2-fold symmetry (across MPI xy-transposition dimensions)
+        W2 = mp.Matrix([-1,0,0], [0,1,0], [0,0,-1])
+        symeigs = ms.compute_symmetries(W2, w)
+        self.assertAlmostEqual(sum(symeigs[0:3]), -1+0j, places=3)
+        self.assertAlmostEqual(sum(symeigs[3:6]), -1+0j, places=3)
 
         # mirror symmetry: compare with run_zeven & run_zodd 
         ms.k_points = [mp.Vector3(0,0,0)] # must be at Γ cf. https://github.com/NanoComp/mpb/issues/114


### PR DESCRIPTION
This is split into three commits, the first of which is the main one: 

1. Implements what I suggested in https://github.com/NanoComp/meep/pull/1930#issuecomment-1036999119: i.e., it comments out the `HAVE_MPI`-specific code for `XYZ_LOOP` in pympb.cpp (since the code doesn't match the layout of `mdata`). Fixes https://github.com/NanoComp/meep/pull/1930#issuecomment-1036360784.

2. Adds a test of the symmetry-functionality from #1930 which previously gave the wrong answer when compiled with `--with-mpi`.

3. Tries to reenable Python-MPB tests (originally removed in https://github.com/NanoComp/meep/pull/262). Locally, I saw that there was a single failure (in `test_output_efield_z`) but the margin of error was very small, so figured I'd check if it did the same here (and reenable if it did not).