### PR TITLE
Conic Filters off by 1 in the Dimension

### DIFF
--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -229,8 +229,8 @@ def conic_filter(x, radius, Lx, Ly, resolution, symmetries=[]):
     density-based topology optimization. Archive of Applied Mechanics, 86(1-2), 189-218.
     '''
     # Get 2d parameter space shape
-    Nx = int(Lx * resolution) + 1
-    Ny = int(Ly * resolution) + 1
+    Nx = int(Lx * resolution) 
+    Ny = int(Ly * resolution) 
 
     # Formulate grid over entire design region
     xv, yv = np.meshgrid(np.linspace(-Lx / 2, Lx / 2, Nx),


### PR DESCRIPTION
When I was doing the tutorials for the meep adjoint solver module, every time the conic_filter function gets called, the Nx and Ny is off by 1, so I don't think that there should be an extra one added in lines 232 and 233 in filters.py.