### PR TITLE
assign unique name to HDF5 files for MPB output functions 

### DIFF
--- a/python/solver.py
+++ b/python/solver.py
@@ -620,14 +620,11 @@ class ModeSolver(object):
             output_k = [0, 0, 0]
 
         if curfield_type in 'dhbecv':
-            if mp.am_master():
-                self._output_vector_field(curfield_type, fname_prefix, output_k, component)
+            self._output_vector_field(curfield_type, fname_prefix, output_k, component)
         elif curfield_type == 'C':
-            if mp.am_master():
-                self._output_complex_scalar_field(fname_prefix, output_k)
+            self._output_complex_scalar_field(fname_prefix, output_k)
         elif curfield_type in 'DHBnmR':
-            if mp.am_master():
-                self._output_scalar_field(curfield_type, fname_prefix)
+            self._output_scalar_field(curfield_type, fname_prefix)
         else:
             raise ValueError("Unkown field type: {}".format(curfield_type))
 

--- a/python/solver.py
+++ b/python/solver.py
@@ -620,11 +620,14 @@ class ModeSolver(object):
             output_k = [0, 0, 0]
 
         if curfield_type in 'dhbecv':
-            self._output_vector_field(curfield_type, fname_prefix, output_k, component)
+            if mp.am_master():
+                self._output_vector_field(curfield_type, fname_prefix, output_k, component)
         elif curfield_type == 'C':
-            self._output_complex_scalar_field(fname_prefix, output_k)
+            if mp.am_master():
+                self._output_complex_scalar_field(fname_prefix, output_k)
         elif curfield_type in 'DHBnmR':
-            self._output_scalar_field(curfield_type, fname_prefix)
+            if mp.am_master():
+                self._output_scalar_field(curfield_type, fname_prefix)
         else:
             raise ValueError("Unkown field type: {}".format(curfield_type))
 

--- a/python/tests/test_mpb.py
+++ b/python/tests/test_mpb.py
@@ -24,7 +24,7 @@ class TestModeSolver(unittest.TestCase):
     def setUp(self):
         self.start = time.time()
 
-        self.filename_prefix = os.path.join(self.temp_dir, self.id().split('.')[-1])
+        self.filename_prefix = os.path.join(self.temp_dir, self.id().split('.')[-1] + '-' + str(mp.my_rank()))
         print()
         print(self.filename_prefix)
         print('=' * 24)


### PR DESCRIPTION
As described in [#2017 (comment)](https://github.com/NanoComp/meep/pull/2017#issuecomment-1077727121), `test_mpb.py` sometimes fails when writing an HDF5 file to disk during CI. This happens because in 2 out of the 4 CI setup configurations, `test_mpb.py` is run as two independent (and *simultaneous*) MPI processes. Thus when, as part of various MPB output functions (e.g., `output_efield_z`, `output_dpwr`, etc.) used in `test_mpb.py`, both these MPI processes at (nearly) the same instance try to invoke [`h5py.File(fname, 'w')`](https://github.com/NanoComp/meep/blob/cd569b21436d340bfc656c6d372a227af128f016/python/solver.py#L682-L702), one of the two processes is prevented from doing so which causes `h5py` to abort with the error:
```
BlockingIOError: [Errno 11] Unable to create file (unable to lock file, errno = 11, error message = 'Resource temporarily unavailable')
```
Because the Python interface of MPB is (currently) only available for serial MPB via Meep, ~~the fix involves ensuring that the MPB output functions only use a *single* process (the master MPI process) to write the file. This avoids having to assign a unique filename to each test involving an output function for each process~~. 

Note that `test_mpb.py` already assigns a ~~unique~~ filename for each individual test (i.e., [`self.id()`](https://docs.python.org/3/library/unittest.html#unittest.TestCase.id) is a string identifying the test case):

https://github.com/NanoComp/meep/blob/11545a1b859222df2c404370673115666b589c22/python/tests/test_mpb.py#L24-L34