### PR TITLE
allow cylindrical adjoint near2far at r=0

### DIFF
--- a/python/tests/test_adjoint_cyl.py
+++ b/python/tests/test_adjoint_cyl.py
@@ -24,14 +24,14 @@ dpml = 1.0
 boundary_layers = [mp.PML(thickness=dpml)]
 
 design_region_resolution = int(2*resolution)
-design_r = 4.8
+design_r = 5
 design_z = 2
 Nr, Nz = int(design_r*design_region_resolution), int(design_z*design_region_resolution)
 
 fcen = 1/1.55
 width = 0.2
 fwidth = width * fcen
-source_center  = [0.1+design_r/2,0,(sz/2-dpml+design_z/2)/2]
+source_center  = [design_r/2,0,-(sz/2-dpml+design_z/2)/2]
 source_size    = mp.Vector3(design_r,0,0)
 src = mp.GaussianSource(frequency=fcen,fwidth=fwidth)
 source = [mp.Source(src,component=mp.Er,
@@ -51,7 +51,7 @@ def forward_simulation(design_params):
                               Si,
                               weights=design_params.reshape(Nr,1,Nz))
 
-    geometry = [mp.Block(center=mp.Vector3(0.1+design_r/2,0,0),
+    geometry = [mp.Block(center=mp.Vector3(design_r/2,0,0),
                                  size=mp.Vector3(design_r,0,design_z),
                                  material=matgrid)]
 
@@ -67,7 +67,7 @@ def forward_simulation(design_params):
     far_x = [mp.Vector3(5,0,20)]
     mode = sim.add_near2far(
         frequencies,
-        mp.Near2FarRegion(center=mp.Vector3(0.1+design_r/2,0,(sz/2-dpml+design_z/2)/2),
+        mp.Near2FarRegion(center=mp.Vector3(design_r/2,0,(sz/2-dpml+design_z/2)/2),
                           size=mp.Vector3(design_r,0,0),weight=+1))
 
     sim.run(until_after_sources=1200)
@@ -81,7 +81,7 @@ def adjoint_solver(design_params):
 
     design_variables = mp.MaterialGrid(mp.Vector3(Nr,0,Nz),SiO2,Si)
     design_region = mpa.DesignRegion(design_variables,
-                                     volume=mp.Volume(center=mp.Vector3(0.1+design_r/2,0,0),
+                                     volume=mp.Volume(center=mp.Vector3(design_r/2,0,0),
                                                       size=mp.Vector3(design_r,0,design_z)))
     geometry = [mp.Block(center=design_region.center,
                          size=design_region.size,
@@ -96,7 +96,7 @@ def adjoint_solver(design_params):
         m=m)
 
     far_x = [mp.Vector3(5,0,20)]
-    NearRegions = [mp.Near2FarRegion(center=mp.Vector3(0.1+design_r/2,0,(sz/2-dpml+design_z/2)/2),
+    NearRegions = [mp.Near2FarRegion(center=mp.Vector3(design_r/2,0,(sz/2-dpml+design_z/2)/2),
                                      size=mp.Vector3(design_r,0,0),
                                      weight=+1)]
     FarFields = mpa.Near2FarFields(sim, NearRegions ,far_x)

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -697,7 +697,7 @@ std::vector<struct sourcedata> dft_near2far::near_sourcedata(const vec &x_0, dou
           EH0 *= -1;
         EH0 /= f->S.multiplicity(ix0);
         if (x_0.dim == Dcyl){
-          EH0 /= xs.r();
+          if (xs.r() != 0) EH0 /= xs.r();
           //Somehow, a factor of (2pi)r for r of the near2far region was double counted.
           //2pi is canceled out by the integral over design region, where an extra factor of 2pi*r' (r' of the design region) is needed. See meepgeom.cpp
         }


### PR DESCRIPTION
Fixes https://github.com/NanoComp/meep/issues/1974. The test is adjusted accordingly.