### PR TITLE
Fix adjoint gradient segfault

### DIFF
--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -3022,7 +3022,7 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf, std::vector<mee
   
   // clear all the dft data structures
   for (int i=0;i<3;i++){
-    for (int ii=0;i<adjoint_dft_chunks[i].size();i++){
+    for (int ii=0;ii<adjoint_dft_chunks[i].size();ii++){
       delete adjoint_dft_chunks[i][ii];
       delete forward_dft_chunks[i][ii];
     }


### PR DESCRIPTION
Fixes #2055.

I ran @mawc2019's test case ([here](https://github.com/NanoComp/meep/pull/1855#issuecomment-1103429038)) and @oskooi 's test case ([here](https://github.com/NanoComp/meep/issues/2055#issue-1223531778)) and they both seem to pass now.

The issue was a copy/paste bug within a nested for-loop.