### PR TITLE
add/update type hints for JAX wrapper of adjoint solver

### DIFF
--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -143,7 +143,7 @@ def install_design_region_monitors(
     design_regions: List[DesignRegion],
     frequencies: List[float],
     decimation_factor: int = 0,
-) -> List[mp.DftFields]:
+) -> List[List[mp.DftFields]]:
     """Installs DFT field monitors at the design regions of the simulation."""
     return [
         [

--- a/python/adjoint/wrapper.py
+++ b/python/adjoint/wrapper.py
@@ -46,7 +46,7 @@ def loss(x):
 value, grad = jax.value_and_grad(loss)(x)
 ```
 """
-from typing import Callable, List, Tuple
+from typing import Callable, Iterable, List, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -137,7 +137,9 @@ class MeepJaxWrapper:
         """
         return self._simulate_fn(designs)
 
-    def _run_fwd_simulation(self, design_variables):
+    def _run_fwd_simulation(
+        self, design_variables: Iterable[onp.ndarray]
+    ) -> (jnp.ndarray, List[List[mp.DftFields]]):
         """Runs forward simulation, returning monitor values and design region fields."""
         utils.validate_and_update_design(self.design_regions, design_variables)
         self.simulation.reset_meep()
@@ -161,7 +163,9 @@ class MeepJaxWrapper:
         monitor_values = utils.gather_monitor_values(self.monitors)
         return (jnp.asarray(monitor_values), fwd_design_region_monitors)
 
-    def _run_adjoint_simulation(self, monitor_values_grad):
+    def _run_adjoint_simulation(
+        self, monitor_values_grad: onp.ndarray
+    ) -> List[List[mp.DftFields]]:
         """Runs adjoint simulation, returning design region fields."""
         if not self.design_regions:
             raise RuntimeError(
@@ -195,11 +199,11 @@ class MeepJaxWrapper:
 
     def _calculate_vjps(
         self,
-        fwd_fields,
-        adj_fields,
-        design_variable_shapes,
-        sum_freq_partials=True,
-    ):
+        fwd_fields: List[List[mp.DftFields]],
+        adj_fields: List[List[mp.DftFields]],
+        design_variable_shapes: List[Tuple[int, ...]],
+        sum_freq_partials: bool = True,
+    ) -> List[onp.ndarray]:
         """Calculates the VJP for a given set of forward and adjoint fields."""
         return utils.calculate_vjps(
             self.simulation,

--- a/python/tests/test_adjoint_jax.py
+++ b/python/tests/test_adjoint_jax.py
@@ -9,16 +9,20 @@ from utils import ApproxComparisonTestCase
 
 import meep as mp
 
-# The calculation of finite difference gradients requires that JAX be operated with double precision
+# The calculation of finite-difference gradients
+# requires that JAX be operated with double precision
 jax.config.update("jax_enable_x64", True)
 
-# The step size for the finite difference gradient calculation
+# The step size for the finite-difference
+# gradient calculation
 _FD_STEP = 1e-4
 
-# The tolerance for the adjoint and finite difference gradient comparison
+# The tolerance for the adjoint and finite-difference
+# gradient comparison
 _TOL = 0.1 if mp.is_single_precision() else 0.025
 
-# We expect 3 design region monitor pointers (one for each field component)
+# We expect 3 design region monitor pointers
+# (one for each field component)
 _NUM_DES_REG_MON = 3
 
 mp.verbosity(0)
@@ -257,8 +261,8 @@ class WrapperTest(ApproxComparisonTestCase):
                 frequencies,
             )
             monitor_values = wrapped_meep([x])
-            s1p, s1m, s2m, s2p = monitor_values
-            t = s2m / s1p if excite_port_idx == 0 else s1m / s2p
+            s1p, s1m, s2p, s2m = monitor_values
+            t = s2p / s1p if excite_port_idx == 0 else s1m / s2m
             return jnp.mean(jnp.square(jnp.abs(t)))
 
         value, adjoint_grad = jax.value_and_grad(loss_fn)(


### PR DESCRIPTION
This PR adds new and also updates existing type hints for *all* functions which make up the JAX wrapper of the adjoint solver. Several of these changes are necessary because #1855 modified the API for `meep._get_gradients` replacing the forward and adjoint field arguments of type `numpy.ndarray` with `meep.DftFields`.  

The function `gather_design_region_fields` is removed because it is no longer used.

cc @ianwilliamson 