### PR TITLE
fix _fit_volume_to_simulation_for_cylindrical for cylindrical coordinates

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1378,6 +1378,9 @@ class Simulation:
     # on the settings in the Simulation instance. This method must be called on
     # any user-defined Volume before passing it to meep via its `swigobj`.
     def _fit_volume_to_simulation(self, vol: Volume) -> Volume:
+        if self.dimensions == mp.CYLINDRICAL:
+            self.dimensions = 2
+            self.is_cylindrical = True
         return Volume(
             vol.center,
             vol.size,


### PR DESCRIPTION
As discussed in #2195, the function `_fit_volume_to_simulation_for_cylindrical` does not apply to cylindrical coordinates. This small PR fixes the issue.

Fixes #2195.