### PR TITLE
remove unicode whitespace character

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -398,7 +398,7 @@ CPPFLAGS="$CPPFLAGS $GUILE_CPPFLAGS"
 
 AC_MSG_CHECKING([for libctl dir])
 if test x != x"$LIBCTL_DIR" -a -r "$LIBCTL_DIR/share/libctl/base/ctl.scm"; then
-￼	LIBCTL_DIR="$LIBCTL_DIR/share/libctl"
+	LIBCTL_DIR="$LIBCTL_DIR/share/libctl"
 fi
 if test x != x"$LIBCTL_DIR" -a ! -r "$LIBCTL_DIR/base/ctl.scm"; then
 	LIBCTL_DIR=""


### PR DESCRIPTION
Removes the unicode whitespace character (the object replacement character U+FFFC which has byte code 0xEFBFBC (hex) and \357\277\274 (octal) in UTF-8) that is hidden at the beginning of a tab-indented line in configure.ac. This character causes an error when the installation configure script evaluates its line (which only happens occasionally due to the if statement around it).

I think this solves https://github.com/NanoComp/meep/issues/1819.