### PR TITLE
Use `kpoint_func` as initial `k_point` in `fields::get_eigenmode`

### DIFF
--- a/python/tests/test_binary_grating.py
+++ b/python/tests/test_binary_grating.py
@@ -174,10 +174,16 @@ class TestEigCoeffs(unittest.TestCase):
                 print(f"kdiff = ({kdiff.x:.6f}, {kdiff.y:.6f}, {kdiff.z:.6f})")
                 res = sim.get_eigenmode_coefficients(
                     refl_flux,
-                    [1],
+                    bands=[1],
                     kpoint_func=lambda *not_used: kdiff,
                     eig_parity=eig_parity,
                     direction=mp.NO_DIRECTION,
+                    # We must specify the monitor volume to be a single pixel
+                    # in the periodic direction in order for MPB to interpret
+                    # its Bloch wavevector as a planewave wavevector.
+                    eig_vol=mp.Volume(
+                        center=refl_pt, size=mp.Vector3(0, 1 / self.resolution, 0)
+                    ),
                 )
                 R = abs(res.alpha[0, 0, 1]) ** 2 / input_flux[0]
                 print(f"refl-order:, {nm:+d}, {R:.6f}")
@@ -200,10 +206,16 @@ class TestEigCoeffs(unittest.TestCase):
                 kdiff = mp.Vector3(np.sqrt(kx2), ky, 0)
                 res = sim.get_eigenmode_coefficients(
                     tran_flux,
-                    [1],
+                    bands=[1],
                     kpoint_func=lambda *not_used: kdiff,
                     eig_parity=eig_parity,
                     direction=mp.NO_DIRECTION,
+                    # We must specify the monitor volume to be a single pixel
+                    # in the periodic direction in order for MPB to interpret
+                    # its Bloch wavevector as a planewave wavevector.
+                    eig_vol=mp.Volume(
+                        center=tran_pt, size=mp.Vector3(0, 1 / self.resolution, 0)
+                    ),
                 )
                 T = abs(res.alpha[0, 0, 0]) ** 2 / input_flux[0]
                 print(f"tran-order:, {nm:+d}, {T:.6f}")

--- a/python/tests/test_binary_grating.py
+++ b/python/tests/test_binary_grating.py
@@ -175,7 +175,7 @@ class TestEigCoeffs(unittest.TestCase):
                     kpoint_func=lambda *not_used: mp.Vector3(np.sqrt(kx2), ky, 0),
                     eig_parity=eig_parity,
                     direction=mp.NO_DIRECTION,
-                    # We must specify the monitor volume to be a single pixel
+                    # We must specify the length of the line monitor to be ~0
                     # in the periodic direction in order for MPB to interpret
                     # its Bloch wavevector as a planewave wavevector.
                     eig_vol=mp.Volume(center=refl_pt, size=mp.Vector3(0, 1e-7, 0)),
@@ -204,7 +204,7 @@ class TestEigCoeffs(unittest.TestCase):
                     kpoint_func=lambda *not_used: mp.Vector3(np.sqrt(kx2), ky, 0),
                     eig_parity=eig_parity,
                     direction=mp.NO_DIRECTION,
-                    # We must specify the monitor volume to be a single pixel
+                    # We must specify the length of the line monitor to be ~0
                     # in the periodic direction in order for MPB to interpret
                     # its Bloch wavevector as a planewave wavevector.
                     eig_vol=mp.Volume(center=tran_pt, size=mp.Vector3(0, 1e-7, 0)),

--- a/python/tests/test_binary_grating.py
+++ b/python/tests/test_binary_grating.py
@@ -57,9 +57,8 @@ class TestEigCoeffs(unittest.TestCase):
 
     @parameterized.parameterized.expand([(0.0,), (10.7,)])
     def test_binary_grating_oblique(self, theta):
-        """Verifies that the sum of the reflectance and transmittance of all
-        the diffracted orders of a binary grating is equivalent to one.
-        """
+        """Verifies energy conservation."""
+
         if theta == 0:
             symmetries = [mp.Mirror(mp.Y)]
             eig_parity = mp.ODD_Z + mp.EVEN_Y
@@ -170,20 +169,16 @@ class TestEigCoeffs(unittest.TestCase):
             ky = k.y + nm / self.cell_size.y
             kx2 = (self.fcen * self.ng) ** 2 - ky**2
             if kx2 > 0:
-                kdiff = mp.Vector3(np.sqrt(kx2), ky, 0)
-                print(f"kdiff = ({kdiff.x:.6f}, {kdiff.y:.6f}, {kdiff.z:.6f})")
                 res = sim.get_eigenmode_coefficients(
                     refl_flux,
                     bands=[1],
-                    kpoint_func=lambda *not_used: kdiff,
+                    kpoint_func=lambda *not_used: mp.Vector3(np.sqrt(kx2), ky, 0),
                     eig_parity=eig_parity,
                     direction=mp.NO_DIRECTION,
                     # We must specify the monitor volume to be a single pixel
                     # in the periodic direction in order for MPB to interpret
                     # its Bloch wavevector as a planewave wavevector.
-                    eig_vol=mp.Volume(
-                        center=refl_pt, size=mp.Vector3(0, 1 / self.resolution, 0)
-                    ),
+                    eig_vol=mp.Volume(center=refl_pt, size=mp.Vector3(0, 1e-7, 0)),
                 )
                 R = abs(res.alpha[0, 0, 1]) ** 2 / input_flux[0]
                 print(f"refl-order:, {nm:+d}, {R:.6f}")
@@ -203,19 +198,16 @@ class TestEigCoeffs(unittest.TestCase):
             ky = k.y + nm / self.cell_size.y
             kx2 = self.fcen**2 - ky**2
             if kx2 > 0:
-                kdiff = mp.Vector3(np.sqrt(kx2), ky, 0)
                 res = sim.get_eigenmode_coefficients(
                     tran_flux,
                     bands=[1],
-                    kpoint_func=lambda *not_used: kdiff,
+                    kpoint_func=lambda *not_used: mp.Vector3(np.sqrt(kx2), ky, 0),
                     eig_parity=eig_parity,
                     direction=mp.NO_DIRECTION,
                     # We must specify the monitor volume to be a single pixel
                     # in the periodic direction in order for MPB to interpret
                     # its Bloch wavevector as a planewave wavevector.
-                    eig_vol=mp.Volume(
-                        center=tran_pt, size=mp.Vector3(0, 1 / self.resolution, 0)
-                    ),
+                    eig_vol=mp.Volume(center=tran_pt, size=mp.Vector3(0, 1e-7, 0)),
                 )
                 T = abs(res.alpha[0, 0, 0]) ** 2 / input_flux[0]
                 print(f"tran-order:, {nm:+d}, {T:.6f}")

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -340,11 +340,11 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
   else
     eig_gv = vol3d(eig_vol.in_direction(X), eig_vol.in_direction(Y), eig_vol.in_direction(Z), a);
   vec kpoint(_kpoint);
-  LOOP_OVER_DIRECTIONS(v.dim, dd) {
-    if (dd != d && eig_gv.num_direction(dd) == user_volume.num_direction(dd))
-      if (boundaries[High][dd] == Periodic && boundaries[Low][dd] == Periodic)
-        kpoint.set_direction(dd, real(k[dd]));
-  }
+  if (d != NO_DIRECTION) LOOP_OVER_DIRECTIONS(v.dim, dd) {
+      if (dd != d && eig_gv.num_direction(dd) == user_volume.num_direction(dd))
+        if (boundaries[High][dd] == Periodic && boundaries[Low][dd] == Periodic)
+          kpoint.set_direction(dd, real(k[dd]));
+    }
 
   bool empty_dim[3] = {false, false, false};
 

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -340,11 +340,11 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
   else
     eig_gv = vol3d(eig_vol.in_direction(X), eig_vol.in_direction(Y), eig_vol.in_direction(Z), a);
   vec kpoint(_kpoint);
-  if (d != NO_DIRECTION) LOOP_OVER_DIRECTIONS(v.dim, dd) {
-      if (dd != d && eig_gv.num_direction(dd) == user_volume.num_direction(dd))
-        if (boundaries[High][dd] == Periodic && boundaries[Low][dd] == Periodic)
-          kpoint.set_direction(dd, real(k[dd]));
-    }
+  LOOP_OVER_DIRECTIONS(v.dim, dd) {
+    if (dd != d && eig_gv.num_direction(dd) == user_volume.num_direction(dd))
+      if (boundaries[High][dd] == Periodic && boundaries[Low][dd] == Periodic)
+        kpoint.set_direction(dd, real(k[dd]));
+  }
 
   bool empty_dim[3] = {false, false, false};
 
@@ -368,7 +368,7 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
   if (where.dim != gv.dim || eig_vol.dim != gv.dim)
     meep::abort("invalid volume dimensionality in add_eigenmode_source");
 
-  if (!eig_vol.contains(where))
+  if (d != NO_DIRECTION && !eig_vol.contains(where))
     meep::abort("invalid grid_volume in get_eigenmode: "
                 "where must be in eig_vol");
 


### PR DESCRIPTION
As described in the user manual, the parameter `kpoint_func` of [`get_eigenmode_coefficients`](https://meep.readthedocs.io/en/latest/Python_User_Interface/#mode-decomposition) "supplies a rough initial guess for the $\vec{k}$ of band number `n` at frequency $f=\omega/2\pi$." The manual also states that "If `direction` is set to `mp.NO_DIRECTION`, then `kpoint_func` is not only the initial guess and the search direction of the $\vec{k}$ vectors, but is also taken to be the direction of the waveguide."

This PR fixes a bug whereby if `direction = mp.NO_DIRECTION` then the initial $\vec{k}$ which had been set to `kpoint_func` via the argument [`_kpoint` of `fields::get_eigenmode`](https://github.com/NanoComp/meep/blob/5fa12b499d4934ea8b352e3e8033762b34f6eb0c/src/mpb.cpp#L342) was actually being *overwritten* by the components of `k_point` of the `Simulation` object in the periodic directions of the cell for which the mode monitor extends to the cell edge. 

The fix ensures that the initial $\vec{k}$ is set to `kpoint_func` when `direction = mp.NO_DIRECTION` consistent with what is described in the manual.