### PR TITLE
Add colorbars for plot2D

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -41,6 +41,8 @@ try:
 except ImportError:
     do_progress = False
 
+from matplotlib.axes import Axes
+
 verbosity = Verbosity(mp.cvar, "meep", 1)
 
 mp.setup()
@@ -4656,23 +4658,24 @@ class Simulation:
 
     def plot2D(
         self,
-        ax=None,
-        output_plane=None,
-        fields=None,
-        labels=False,
-        eps_parameters=None,
-        boundary_parameters=None,
-        source_parameters=None,
-        monitor_parameters=None,
-        field_parameters=None,
+        ax: Optional[Axes] = None,
+        output_plane: Optional[Volume] = None,
+        fields: Optional = None,
+        labels: Optional[bool] = False,
+        eps_parameters: Optional[dict] = None,
+        boundary_parameters: Optional[dict] = None,
+        source_parameters: Optional[dict] = None,
+        monitor_parameters: Optional[dict] = None,
+        field_parameters: Optional[dict] = None,
         colorbar_parameters: Optional[dict] = None,
-        frequency=None,
-        plot_eps_flag=True,
-        plot_sources_flag=True,
-        plot_monitors_flag=True,
-        plot_boundaries_flag=True,
+        frequency: Optional[float] = None,
+        plot_eps_flag: bool = True,
+        plot_sources_flag: bool = True,
+        plot_monitors_flag: bool = True,
+        plot_boundaries_flag: bool = True,
+        nb: bool = False,
         **kwargs,
-    ):
+    ) -> None:
         """
         Plots a 2D cross section of the simulation domain using `matplotlib`. The plot
         includes the geometry, boundary layers, sources, and monitors. Fields can also be
@@ -4774,6 +4777,8 @@ class Simulation:
             - `position='right'`: position of the colorbar with respect to the Axes
             - `size='5%'`: size of the colorbar in the dimension perpendicular to its `orientation`
             - `pad='2%'`: fraction of original axes between colorbar and image axes
+        * `nb`: set this to True if plotting in a Jupyter notebook to use ipympl for plotting. Note: this requires
+        ipympl to be installed.
         """
         import meep.visualization as vis
 
@@ -4794,6 +4799,7 @@ class Simulation:
             plot_sources_flag=plot_sources_flag,
             plot_monitors_flag=plot_monitors_flag,
             plot_boundaries_flag=plot_boundaries_flag,
+            nb=nb,
             **kwargs,
         )
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4665,6 +4665,7 @@ class Simulation:
         source_parameters=None,
         monitor_parameters=None,
         field_parameters=None,
+        colorbar_parameters: Optional[dict] = None,
         frequency=None,
         plot_eps_flag=True,
         plot_sources_flag=True,
@@ -4723,6 +4724,7 @@ class Simulation:
               plot. Defaults to the `frequency` parameter of the [Source](#source) object.
             - `resolution=None`: the resolution of the $\\varepsilon$ grid. Defaults to the
               `resolution` of the `Simulation` object.
+            - `colorbar=False`: whether to add a colorbar to the plot's parent Figure based on epsilon values.
         * `boundary_parameters`: a `dict` of optional plotting parameters that override
           the default parameters for the boundary layers.
             - `alpha=1.0`: transparency of boundary layers
@@ -4759,6 +4761,19 @@ class Simulation:
             - `alpha=0.6`: transparency of fields
             - `post_process=np.real`: post processing function to apply to fields (must be
               a function object)
+            - `colorbar=False`: whether to add a colorbar to the plot's parent Figure based on field values.
+        * `colorbar_parameters`:  a `dict` of optional plotting parameters that override the default parameters for
+          the colorbar.
+            - `label=None`: an optional label for the colorbar, defaults to '$\\epsilon_r$' for epsilon and
+            'field values' for fields.
+            - `orientation='vertical'`: the orientation of the colorbar gradient
+            - `extend=None`: make pointed end(s) for out-of-range values. Allowed values are:
+            ['neither', 'both', 'min', 'max']
+            - `format=None`: formatter for tick labels. Can be an fstring (i.e. "{x:.2e}") or a
+            [matplotlib.ticker.ScalarFormatter](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.ScalarFormatter).
+            - `position='right'`: position of the colorbar with respect to the Axes
+            - `size='5%'`: size of the colorbar in the dimension perpendicular to its `orientation`
+            - `pad='2%'`: fraction of original axes between colorbar and image axes
         """
         import meep.visualization as vis
 
@@ -4773,6 +4788,7 @@ class Simulation:
             source_parameters=source_parameters,
             monitor_parameters=monitor_parameters,
             field_parameters=field_parameters,
+            colorbar_parameters=colorbar_parameters,
             frequency=frequency,
             plot_eps_flag=plot_eps_flag,
             plot_sources_flag=plot_sources_flag,

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -14,7 +14,7 @@ from meep.simulation import Simulation, Volume
 ## Typing imports
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
-from typing import Callable, Union, Any, Tuple, List
+from typing import Callable, Union, Any, Tuple, List, Optional
 
 # ------------------------------------------------------- #
 # Visualization
@@ -117,7 +117,7 @@ def place_label(
     y: float,
     centerx: float,
     centery: float,
-    label_parameters: dict = None,
+    label_parameters: Optional[dict] = None,
 ) -> Axes:
 
     if label_parameters is None:
@@ -292,9 +292,9 @@ def plot_volume(
     sim: Simulation,
     ax: Axes,
     volume: Volume,
-    output_plane: Volume = None,
-    plotting_parameters: dict = None,
-    label: str = None,
+    output_plane: Optional[Volume] = None,
+    plotting_parameters: Optional[dict] = None,
+    label: Optional[str] = None,
 ) -> Axes:
     import matplotlib.patches as patches
     from matplotlib import pyplot as plt
@@ -477,10 +477,10 @@ def _add_colorbar(
 
 def plot_eps(
     sim: Simulation,
-    ax: Axes = None,
-    output_plane: Volume = None,
-    eps_parameters: dict = None,
-    frequency: float = None,
+    ax: Optional[Axes] = None,
+    output_plane: Optional[Volume] = None,
+    eps_parameters: Optional[dict] = None,
+    frequency: Optional[float] = None,
 ) -> Union[Axes, Any]:
     # consolidate plotting parameters
     if eps_parameters is None:
@@ -596,8 +596,8 @@ def plot_eps(
 def plot_boundaries(
     sim: Simulation,
     ax: Axes,
-    output_plane: Volume = None,
-    boundary_parameters: dict = None,
+    output_plane: Optional[Volume] = None,
+    boundary_parameters: Optional[dict] = None,
 ) -> Axes:
     # consolidate plotting parameters
     if boundary_parameters is None:
@@ -712,9 +712,9 @@ def plot_boundaries(
 def plot_sources(
     sim: Simulation,
     ax: Axes,
-    output_plane: Volume = None,
+    output_plane: Optional[Volume] = None,
     labels: bool = False,
-    source_parameters: dict = None,
+    source_parameters: Optional[dict] = None,
 ) -> Axes:
     # consolidate plotting parameters
     if source_parameters is None:
@@ -740,9 +740,9 @@ def plot_sources(
 def plot_monitors(
     sim: Simulation,
     ax: Axes,
-    output_plane: Volume = None,
+    output_plane: Optional[Volume] = None,
     labels: bool = False,
-    monitor_parameters: dict = None,
+    monitor_parameters: Optional[dict] = None,
 ) -> Axes:
     # consolidate plotting parameters
     if monitor_parameters is None:
@@ -768,10 +768,10 @@ def plot_monitors(
 
 def plot_fields(
     sim: Simulation,
-    ax: Axes = None,
-    fields=None,
-    output_plane: Volume = None,
-    field_parameters: dict = None,
+    ax: Optional[Axes] = None,
+    fields: Optional = None,
+    output_plane: Optional[Volume] = None,
+    field_parameters: Optional[dict] = None,
 ) -> Union[Axes, Any]:
     components = {
         mp.Ex,
@@ -871,16 +871,16 @@ def plot_fields(
 
 def plot2D(
     sim: Simulation,
-    ax: Axes = None,
-    output_plane: Volume = None,
-    fields=None,
-    labels: bool = False,
-    eps_parameters: dict = None,
-    boundary_parameters: dict = None,
-    source_parameters: dict = None,
-    monitor_parameters: dict = None,
-    field_parameters: dict = None,
-    frequency: float = None,
+    ax: Optional[Axes] = None,
+    output_plane: Optional[Volume] = None,
+    fields: Optional = None,
+    labels: Optional[bool] = False,
+    eps_parameters: Optional[dict] = None,
+    boundary_parameters: Optional[dict] = None,
+    source_parameters: Optional[dict] = None,
+    monitor_parameters: Optional[dict] = None,
+    field_parameters: Optional[dict] = None,
+    frequency: Optional[float] = None,
     plot_eps_flag: bool = True,
     plot_sources_flag: bool = True,
     plot_monitors_flag: bool = True,
@@ -1162,12 +1162,12 @@ class Animate2D:
 
     def __init__(
         self,
-        sim: Simulation = None,
-        fields=None,
-        f: Figure = None,
+        sim: Optional[Simulation] = None,
+        fields: Optional = None,
+        f: Optional[Figure] = None,
         realtime: bool = False,
         normalize: bool = False,
-        plot_modifiers: list = None,
+        plot_modifiers: Optional[list] = None,
         update_epsilon: bool = False,
         nb: bool = False,
         **customization_args

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -562,35 +562,35 @@ def plot_eps(
     )
 
     if mp.am_master():
-        if ax:
-            if eps_parameters["contour"]:
-                ax.contour(
-                    eps_data,
-                    0,
-                    levels=np.unique(eps_data),
-                    colors="black",
-                    origin="upper",
-                    extent=extent,
-                    linewidths=eps_parameters["contour_linewidth"],
-                )
-            else:
-                ax.imshow(
-                    eps_data, extent=extent, **filter_dict(eps_parameters, ax.imshow)
-                )
+        # If Axes was not provided, just return the eps_data, otherwise plot
+        if not ax:
+            return eps_data
 
-            if eps_parameters["colorbar"]:
-                _add_colorbar(
-                    ax=ax,
-                    cmap=eps_parameters["cmap"],
-                    vmin=np.amin(eps_data),
-                    vmax=np.amax(eps_data),
-                    label=r"$\epsilon_r$",
-                )
+        if eps_parameters["contour"]:
+            ax.contour(
+                eps_data,
+                0,
+                levels=np.unique(eps_data),
+                colors="black",
+                origin="upper",
+                extent=extent,
+                linewidths=eps_parameters["contour_linewidth"],
+            )
+        else:
+            ax.imshow(eps_data, extent=extent, **filter_dict(eps_parameters, ax.imshow))
 
-            ax.set_xlabel(xlabel)
-            ax.set_ylabel(ylabel)
-            return ax
-        return eps_data
+        if eps_parameters["colorbar"]:
+            _add_colorbar(
+                ax=ax,
+                cmap=eps_parameters["cmap"],
+                vmin=np.amin(eps_data),
+                vmax=np.amax(eps_data),
+                label=r"$\epsilon_r$",
+            )
+
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel(ylabel)
+        return ax
 
 
 def plot_boundaries(


### PR DESCRIPTION
This PR:
- Adds colorbars for `plot2D` (both in `plot_epsilon` and `plot_fields`) (#2286)
- Adds additional field components (and derived components) to `plot_fields` (#2267)

I think there's more room to improve the look of the colorbars, so let me know if I should make any adjustments!

So far fields look like this:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/53101766/198534668-61653ac3-b2ce-492e-8938-d1b13b7762d3.png">
and epsilon looks like this:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/53101766/198534880-df9c4a24-5e91-40f7-a91b-c759d8272d46.png">


@smartalecH 
@joamatab 
@SkandanC 