### PR TITLE
Replace deprecated `set-output` command in Github Actions CI configuration

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -112,7 +112,7 @@ jobs:
       id: pip-cache
       run: |
         python -m pip install --upgrade pip wheel
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "name=dir::$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: pip cache
       uses: actions/cache@v3

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -112,7 +112,7 @@ jobs:
       id: pip-cache
       run: |
         python -m pip install --upgrade pip wheel
-        echo "name=dir::$(pip cache dir)" >> $GITHUB_OUTPUT
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: pip cache
       uses: actions/cache@v3


### PR DESCRIPTION
Replaces the `set-output` workflow command in the Github Actions CI configuration as suggested in this [Github blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).