### PR TITLE
Lower the tolerance in unit tests of adjoint gradient of eigenmode monitor involving an eigenmode source without dispersion

### DIFF
--- a/python/adjoint/optimization_problem.py
+++ b/python/adjoint/optimization_problem.py
@@ -122,7 +122,7 @@ class OptimizationProblem:
         need_value: bool = True,
         need_gradient: bool = True,
         beta: float = None,
-    ) -> Tuple[List[float], List[float]]:
+    ) -> Tuple[List[np.ndarray], List[List[np.ndarray]]]:
         """Evaluate value and/or gradient of objective function."""
         if rho_vector:
             self.update_design(rho_vector=rho_vector, beta=beta)


### PR DESCRIPTION
As demonstrated in #2307, the errors in the adjoint gradient for an objective function of an eigenmode monitor  tend to be larger at the non-center frequencies of a pulsed source compared to its center frequency due to the current limitation of the `EigenModeSource` which uses the mode profile at only the center frequency. Until #2315 provides a permanent fix to this problem, this PR modifies several of the tests in `test_adjoint_solver.py` involving an eigenmode source and the calculation of the adjoint gradient at a single frequency (the center frequency of the pulsed source) by *lowering* the tolerance (relative to the value used for the multifrequency adjoint-gradient calculation) used to validate the result against the finite-difference approximation. In effect, this enforces a tighter tolerance on the "correct" result for the gradient.

Separately (but related to this PR), several type hints are added and corrected.