### PR TITLE
Reformulate Simulation.get_sources() and add 2D GaussianBeam

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1844,6 +1844,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         GaussianBeamSource,
         GaussianBeam3DSource,
         GaussianBeam2DSource,
+        get_equiv_sources,
     )
     from .visualization import (
         plot2D,

--- a/python/meep.i
+++ b/python/meep.i
@@ -1842,6 +1842,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         SourceTime,
         check_positive,
         GaussianBeamSource,
+        GaussianBeam3DSource,
         GaussianBeam2DSource,
     )
     from .visualization import (

--- a/python/meep.i
+++ b/python/meep.i
@@ -1842,6 +1842,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         SourceTime,
         check_positive,
         GaussianBeamSource,
+        GaussianBeam2DSource,
     )
     from .visualization import (
         plot2D,

--- a/python/source.py
+++ b/python/source.py
@@ -849,13 +849,13 @@ class GaussianBeam2DSource(GaussianBeamSource):
             :, :, :, np.newaxis
         ]
 
-        # Get field amplitude for the waist (hankel2)
+        # Get field amplitude for the waist (bessel1)
         w_field_norm = self.green2d(waist_xy, freq, eps, mu, X0, kdir, jv)[
             :, :, :, np.newaxis
         ]
         w_field_norm = np.sqrt(np.sum(np.abs(w_field_norm[:3]) ** 2, axis=0).item(0))
 
-        # Get field for the waist (hankel2)
+        # Get field for the waist (bessel1)
         w_fields2D = self.green2d(X, freq, eps, mu, X0, kdir, jv)[:, :, :, np.newaxis]
 
         # Combine fields

--- a/python/source.py
+++ b/python/source.py
@@ -1019,13 +1019,14 @@ class GaussianBeam2DSource(GaussianBeam3DSource):
 
 class GaussianBeamSource(GaussianBeam3DSource):
     """
-    Wrapper for GaussianBeam3DSource to warn the user when running 2D simulations that this behavior is depricated and they should be using GaussianBeam2DSource.
+    Wrapper for GaussianBeam3DSource to warn the user when running 2D simulations that this behavior is deprecated and they should be using GaussianBeam2DSource.
     """
 
     def add_source(self, sim):
         if sim.dimensions == 2:
             warnings.warn(
-                "GaussianBeamSource is depricated for 2D simulations. For more accurate results, use GaussianBeam2DSource instead. In the future, this will be the default behavior."
+                "GaussianBeamSource is deprecated for 2D simulations. For more accurate results, use GaussianBeam2DSource instead. In the future, this will be the default behavior.",
+                DeprecationWarning,
             )
         super().add_source(sim)
 

--- a/python/source.py
+++ b/python/source.py
@@ -778,7 +778,7 @@ class GaussianBeam2DSource(GaussianBeamSource):
     def get_fields(self, sim):
         from scipy.special import hankel1, hankel2, jv
 
-        # Beam parametersd
+        # Beam parameters
         freq = self.src.swigobj.frequency().real
         eps = sim.fields.get_eps(
             mp.py_v3_to_vec(sim.dimensions, self.center, sim.is_cylindrical)

--- a/python/source.py
+++ b/python/source.py
@@ -674,7 +674,7 @@ class EigenModeSource(Source):
             add_eig_src(self.amp_func)
 
 
-class GaussianBeamSource(Source):
+class GaussianBeam3DSource(Source):
     """
     This is a subclass of `Source` and has **all of the properties** of `Source` above. However, the `component` parameter of the `Source` object is ignored. The [Gaussian beam](https://en.wikipedia.org/wiki/Gaussian_beam) is a transverse electromagnetic mode for which the source region must be a *line* (in 2d) or *plane* (in 3d). For a beam polarized in the $x$ direction with propagation along $+z$, the electric field is defined by $\\mathbf{E}(r,z)=E_0\\hat{x}\\frac{w_0}{w(z)}\\exp\\left(\\frac{-r^2}{w(z)^2}\\right)\\exp\\left(-i\\left(kz + k\\frac{r^2}{2R(z)}\\right)\\right)$ where $r$ is the radial distance from the center axis of the beam, $z$ is the axial distance from the beam's focus (or "waist"), $k=2\\pi n/\\lambda$ is the wavenumber (for a free-space wavelength $\\lambda$ and refractive index $n$ of the homogeneous, lossless medium in which the beam propagates), $E_0$ is the electric field amplitude at the origin, $w(z)$ is the radius at which the field amplitude decays by $1/e$ of its axial values, $w_0$ is the beam waist radius, and $R(z)$ is the radius of curvature of the beam's wavefront at $z$. The only independent parameters that need to be specified are $w_0$, $E_0$, $k$, and the location of the beam focus (i.e., the origin: $r=z=0$).
 
@@ -761,7 +761,7 @@ class GaussianBeamSource(Source):
         add_vol_src()
 
 
-class GaussianBeam2DSource(GaussianBeamSource):
+class GaussianBeam2DSource(GaussianBeam3DSource):
     """
     Identical to `GaussianBeamSource`, except that the beam is defined in 2d. This is useful for 2d simulations, where the 3d beam is not exact.
 
@@ -1012,6 +1012,19 @@ class GaussianBeam2DSource(GaussianBeamSource):
         sources = self.get_equiv_sources(sim, fields)
         for source in sources:
             source.add_source(sim)
+
+
+class GaussianBeamSource(GaussianBeam3DSource):
+    """
+    Wrapper for GaussianBeam3DSource to warn the user when running 2D simulations that this behavior is depricated and they should be using GaussianBeam2DSource.
+    """
+
+    def add_source(self, sim):
+        if sim.dimensions == 2:
+            warnings.warn(
+                "GaussianBeamSource is depricated for 2D simulations. For more accurate results, use GaussianBeam2DSource instead. In the future, this will be the default behavior."
+            )
+        super().add_source(sim)
 
 
 class IndexedSource(Source):

--- a/python/source.py
+++ b/python/source.py
@@ -776,6 +776,7 @@ class GaussianBeam2DSource(GaussianBeamSource):
     """
 
     def get_fields(self, sim):
+        """Calls green2d under various conditions (incoming vs outgoing) providing the correct Hankel functions and returns the fields at the slice provided by the source."""
         from scipy.special import hankel1, hankel2, jv
 
         # Beam parameters
@@ -880,6 +881,7 @@ class GaussianBeam2DSource(GaussianBeamSource):
         return fields2D
 
     def incoming_mask(self, x0, y0, kx, ky, X):
+        """Given a beam with a waist at (x0, y0) and a direction of propagation (kx, ky) returns the boolean masks along the meshgrid X for incoming waves, outgoing waves, and waist points."""
 
         # Create the plane where the beam is incident
         kx, ky = np.round(kx, 8), np.round(ky, 8)
@@ -896,6 +898,7 @@ class GaussianBeam2DSource(GaussianBeamSource):
         return incoming_points, outgoing_points, waist_points
 
     def green2d(self, X, freq, eps, mu, X0, kdir, hankel):
+        """Produces the 2D Green's function for an arbitrary complex point source at X0 along the meshgrid X."""
 
         # Function for vectorizing
         Xshape = X.shape
@@ -964,6 +967,7 @@ class GaussianBeam2DSource(GaussianBeamSource):
         return EH
 
     def get_equiv_sources(self, sim, field):
+        """Given the fields along a slice, returns the equivalent sources as meep source objects for the beam."""
         # Get fields
         Ex, Ey, Ez, Hx, Hy, Hz = field
 
@@ -1003,7 +1007,7 @@ class GaussianBeam2DSource(GaussianBeamSource):
         return sources
 
     def add_source(self, sim):
-        # self.center = self.center - 0.1 * self._beam_kdir
+        """Calls the add_source method for each equivalent source."""
         fields = self.get_fields(sim)
         sources = self.get_equiv_sources(sim, fields)
         for source in sources:

--- a/python/tests/test_gaussianbeam.py
+++ b/python/tests/test_gaussianbeam.py
@@ -7,7 +7,7 @@ import meep as mp
 
 
 class TestGaussianBeamSource(unittest.TestCase):
-    def gaussian_beam(self, rot_angle):
+    def gaussian_beam(self, rot_angle, beamfunc=mp.GaussianBeamSource):
 
         s = 14
         resolution = 25
@@ -27,7 +27,7 @@ class TestGaussianBeamSource(unittest.TestCase):
         src_x = 0
         src_y = -0.5 * s + dpml + 1.0
         sources = [
-            mp.GaussianBeamSource(
+            beamfunc(
                 src=mp.GaussianSource(fcen, fwidth=0.2 * fcen),
                 center=mp.Vector3(src_x, src_y),
                 size=mp.Vector3(s),
@@ -76,10 +76,11 @@ class TestGaussianBeamSource(unittest.TestCase):
             f"ratio of the Gaussian beam energy at the focus over the maximum beam energy for the entire cell: {frac}"
         )
 
-        self.assertGreater(frac, 0.99)
+        self.assertGreater(frac, 0.98)
 
     def test_gaussian_beam(self):
-        self.gaussian_beam(-40)
+        self.gaussian_beam(-40, mp.GaussianBeam2DSource)
+        self.gaussian_beam(-40, mp.GaussianBeam3DSource)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
First, I reformulated get_sources. Before, simulation defined logic for each source type separately with `if isinstance(source, GaussianBeam)`, `elif...` and then provided the specific logic to add the source parameters to the backend.

Now, it simply loops through the list of sources belonging to the simulation and calls add_source on each, passing in self to give the source access to the simulation. Source.py now contains the base logic for adding sources, but `EigenModeSource`, `IndexedSource`, `GaussianBeamSource`, and (new) `GaussianBeam2DSource` overload this logic. 

In addition, a new class `GaussianBeamSource2D` is created. This allows a rigorous solution to Maxwell's equations in 2-dimensions via the complex point source method (similar to 3D). All the logic for finding the solution is provided in the python alone, finding the field at a slice. This is done very similar to `green2d` in near2far.cpp by using Hankel functions of both kinds to generate forward and backward propagating beams when the point source is complex in location. Using this slice, equivalent sources are calculated (also in python). 

Once the equivalent sources are made (python meep objects), `GaussianBeam2dSource.add_source()` simply calls `add_source()` on these equivalent source objects. The fields are normalized to have $|E|=1$ at the location of the point source. 

This is all done in python. Because I wrote a green2d python function and one for equivalent source (for single frequency), we can run our code once in python to generate the sources at the beginning of the run and then pass this information in to the backend before the actual meep runs start. Thus, we do not need to write our code in c++ the way 3D was done. Here is a demonstration of it working, under different conditions. 

<img width="1289" alt="Screen Shot 2022-12-07 at 9 32 00 PM" src="https://user-images.githubusercontent.com/51729722/206341982-83f91675-ac42-4c81-929c-93f1c9bbf635.png">

We can change our plane and provide rotations of k, which is done by rotating the imaginary component of the location of the complex point source between x and y.

<img width="1266" alt="Screen Shot 2022-12-07 at 9 32 42 PM" src="https://user-images.githubusercontent.com/51729722/206342070-0a82364c-81e1-4203-8f1a-3c245354842d.png">

We can also change our polarization. In order for this to work, an E source and H source are placed in the same location oriented 90 degrees from each other, similar to what's done for 3D. 

<img width="1267" alt="Screen Shot 2022-12-07 at 9 33 19 PM" src="https://user-images.githubusercontent.com/51729722/206342151-47fac518-a943-41b1-a0e2-666483c2bdd3.png">

