### PR TITLE
Fix bug when specifying array of boolean values for `weights` parameter of `MaterialGrid`

### DIFF
--- a/python/geom.py
+++ b/python/geom.py
@@ -610,6 +610,7 @@ class MaterialGrid:
         ![](images/material_grid.png#center)
 
         Elements of the `weights` array must be in the range [0,1] where 0 is `medium1` and 1 is `medium2`.
+        An array of boolean values `False` and `True` will be converted to 0 and 1, respectively.
         The `weights` array is used to define a linear interpolation from `medium1` to `medium2`.
         Two material types are supported: (1) frequency-independent isotropic $\\varepsilon$ (`epsilon_diag`
         and `epsilon_offdiag` are interpolated) and (2) `LorentzianSusceptibility` (`sigma` and `sigma_offdiag`
@@ -671,7 +672,7 @@ class MaterialGrid:
                 )
             )
         else:
-            self.weights = self.check_weights(weights).flatten().astype(np.float64)
+            self.weights = self.check_weights(weights.flatten().astype(np.float64))
 
         grid_type_dict = {"U_MIN": 0, "U_PROD": 1, "U_MEAN": 2, "U_DEFAULT": 3}
         if grid_type not in grid_type_dict:

--- a/python/tests/test_get_epsilon_grid.py
+++ b/python/tests/test_get_epsilon_grid.py
@@ -26,7 +26,6 @@ class TestGetEpsilonGrid(unittest.TestCase):
         weights = np.logical_and(
             np.sqrt(np.square(xv) + np.square(yv)) > rad,
             np.sqrt(np.square(xv) + np.square(yv)) < rad + w,
-            dtype=np.double,
         )
 
         matgrid = mp.MaterialGrid(


### PR DESCRIPTION
Fixes a bug which is recently [causing a failure in the CI for Python 3.10](https://github.com/NanoComp/meep/actions/runs/3736895444) (reproduced below) related to passing an array of boolean values for the `weights` parameter of the `MaterialGrid`. The fix involves ensuring that during initialization of the `MaterialGrid` class object the elements of the `weights` array passed in by the user are cast correctly to `numpy.float64`.

```
ERROR: test_get_epsilon_grid_0 (__main__.TestGetEpsilonGrid)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/meep/meep/build/meep-1.26.0-beta/_build/sub/python/../../../python/tests/test_get_epsil\
on_grid.py", line 26, in setUp
    weights = np.logical_and(
TypeError: No loop matching the specified signature and casting was found for ufunc logical_and
```