### PR TITLE
Fix bug in `get_group_masters`

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -6042,7 +6042,7 @@ def get_group_masters():
 
     # Check if current worker is a group master
     is_group_master = True if mp.my_rank() == 0 else False
-    group_master_idx = np.zeros((num_workers,), dtype=np.bool)
+    group_master_idx = np.zeros((num_workers,), dtype=np.bool_)
 
     # Formulate send and receive packets
     smsg = [np.array([is_group_master]), ([1] * num_workers, [0] * num_workers)]


### PR DESCRIPTION
Fixes a bug in the function `get_group_masters` of `simulation.py` which is recently [causing a failure in the CI](https://github.com/NanoComp/meep/actions/runs/3736895444) (reproduced below). This bug occurs in Numpy 1.24 which [removed a deprecation warning for `np.bool`](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations).

```
Elapsed run time = 0.3249 sERROR: test_divide_parallel_processes (__main__.TestDivideParallelProcesses)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/meep/meep/build/meep-1.26.0-beta/_build/sub/python/../../../python/tests/test_divide_mp\
i_processes.py", line 53, in test_divide_parallel_processes
    tot_fluxes = mp.merge_subgroup_data(tot_flux)
  File "/home/runner/work/meep/meep/build/meep-1.26.0-beta/_build/sub/python/meep/simulation.py", line 6078, in m\
erge_subgroup_data
    group_masters = get_group_masters()
  File "/home/runner/work/meep/meep/build/meep-1.26.0-beta/_build/sub/python/meep/simulation.py", line 6045, in g\
et_group_masters
    group_master_idx = np.zeros((num_workers,), dtype=np.bool)
  File "/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/numpy/__init__.py", line 284, in __ge\
tattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'bool'

```