### PR TITLE
pin Numpy version in requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,7 +3,7 @@ h5py
 jax
 jaxlib
 matplotlib
-numpy
+numpy<1.24
 parameterized
 pytest
 scipy


### PR DESCRIPTION
Fixes a recent failure in the CI for Python 3.10 related to Numpy 1.24 which [raises a `TypeError` in ufuncs due to an expired deprecation](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations).