### PR TITLE
Slightly increase tolerance for single-precision check in `test_complex_fields` of `test_adjoint_solver.py`

### DIFF
--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -710,7 +710,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                 unperturbed_grad = np.expand_dims(unperturbed_grad, axis=1)
             adj_dd = (self.dp[None, :] @ unperturbed_grad).flatten()
             fnd_dd = perturbed_val - unperturbed_val
-            tol = 0.02 if mp.is_single_precision() else 0.001
+            tol = 0.025 if mp.is_single_precision() else 0.001
             self.assertClose(adj_dd, fnd_dd, epsilon=tol)
             print(
                 f"PASSED: frequencies={frequencies}"


### PR DESCRIPTION
Fixes an error which recently appeared in the CI for Python 3.10 because of the switch to Numpy 1.24 from 1.23.5.

After this PR and #2349 are merged, we will need to rebase #2348.