### PR TITLE
Remove pinning for Numpy in `requirements.txt`

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,7 +3,7 @@ h5py
 jax
 jaxlib
 matplotlib
-numpy<1.24
+numpy
 parameterized
 pytest
 scipy


### PR DESCRIPTION
Reverts the change in #2350 since support for Numpy 1.24 is enabled by #2348, #2349, and #2351.