### PR TITLE
updates and fixes to examples/solve-cw.py

### DIFF
--- a/python/examples/solve-cw.py
+++ b/python/examples/solve-cw.py
@@ -1,31 +1,47 @@
+"""
+Verifies that the relative error in the fields of a resonant mode
+of a 2d ring resonator is monotonically decreasing with decreasing
+tolerance of the CW solver. Also visualizes the fields of the resonant
+mode in the time and frequency domains.
+"""
+
+import matplotlib
+
+matplotlib.use("agg")
 import matplotlib.pyplot as plt
 import numpy as np
-from numpy import linalg as LA
-
 import meep as mp
 
-n = 3.4
-w = 1
-r = 1
-pad = 4
-dpml = 2
+resolution = 20  # pixels/μm
+n = 3.4  # refractive index of ring
+w = 1  # width of ring
+r = 1  # inner radius of ring
+pad = 4  # padding between outer ring and PML
+dpml = 2  # PML thickness
 
 sxy = 2 * (r + w + pad + dpml)
 cell_size = mp.Vector3(sxy, sxy)
 
 pml_layers = [mp.PML(dpml)]
 
-nonpml_vol = mp.Volume(mp.Vector3(), size=mp.Vector3(sxy - 2 * dpml, sxy - 2 * dpml))
+nonpml_vol = mp.Volume(
+    center=mp.Vector3(),
+    size=mp.Vector3(sxy - 2 * dpml, sxy - 2 * dpml),
+)
 
 geometry = [
     mp.Cylinder(radius=r + w, material=mp.Medium(index=n)),
     mp.Cylinder(radius=r),
 ]
 
-fcen = 0.118
+fcen = 0.118  # frequency of resonant mode
 
 src = [
-    mp.Source(mp.ContinuousSource(fcen), component=mp.Ez, center=mp.Vector3(r + 0.1)),
+    mp.Source(
+        mp.ContinuousSource(fcen),
+        component=mp.Ez,
+        center=mp.Vector3(r + 0.1),
+    ),
     mp.Source(
         mp.ContinuousSource(fcen),
         component=mp.Ez,
@@ -34,61 +50,93 @@ src = [
     ),
 ]
 
-symmetries = [mp.Mirror(mp.X, phase=-1), mp.Mirror(mp.Y, phase=+1)]
+symmetries = [
+    mp.Mirror(mp.X, phase=-1),
+    mp.Mirror(mp.Y, phase=+1),
+]
 
 sim = mp.Simulation(
+    resolution=resolution,
     cell_size=cell_size,
     geometry=geometry,
     sources=src,
-    resolution=10,
     force_complex_fields=True,
     symmetries=symmetries,
     boundary_layers=pml_layers,
 )
 
+# CW solver convergence properties
+maxiters = 10000
+L = 10
 num_tols = 5
-tols = np.power(10, np.arange(-8.0, -8.0 - num_tols, -1.0))
-ez_dat = np.zeros((122, 122, num_tols), dtype=np.complex_)
+tols = np.logspace(-8, -8.0 - num_tols + 1, num_tols)
+
+ez_dat = np.zeros(
+    (
+        int(nonpml_vol.size.x * resolution) + 2,
+        int(nonpml_vol.size.y * resolution) + 2,
+        num_tols,
+    ),
+    dtype=np.complex_,
+)
 
 for i in range(num_tols):
     sim.init_sim()
-    sim.solve_cw(tols[i], 10000, 10)
+    sim.solve_cw(tols[i], maxiters, L)
     ez_dat[:, :, i] = sim.get_array(vol=nonpml_vol, component=mp.Ez)
 
 err_dat = np.zeros(num_tols - 1)
 for i in range(num_tols - 1):
-    err_dat[i] = LA.norm(ez_dat[:, :, i] - ez_dat[:, :, num_tols - 1])
+    err_dat[i] = np.linalg.norm(ez_dat[:, :, i] - ez_dat[:, :, -1]) / np.linalg.norm(
+        ez_dat[:, :, -1]
+    )
+    print(f"err:, {tols[i]}, {err_dat[i]}")
 
 plt.figure(dpi=150)
 plt.loglog(tols[: num_tols - 1], err_dat, "bo-")
 plt.xlabel("frequency-domain solver tolerance")
-plt.ylabel("L2 norm of error in fields")
-plt.show()
+plt.ylabel("relative error in fields of resonant mode")
+plt.title("2d ring resonator")
+plt.savefig("ring_err.png", dpi=150, bbox_inches="tight")
 
 eps_data = sim.get_array(vol=nonpml_vol, component=mp.Dielectric)
 ez_data = np.real(ez_dat[:, :, num_tols - 1])
 
 plt.figure()
-plt.imshow(eps_data.transpose(), interpolation="spline36", cmap="binary")
-plt.imshow(ez_data.transpose(), interpolation="spline36", cmap="RdBu", alpha=0.9)
+plt.imshow(
+    eps_data.transpose(),
+    interpolation="spline36",
+    cmap="binary",
+)
+plt.imshow(
+    ez_data.transpose(),
+    interpolation="spline36",
+    cmap="RdBu",
+    alpha=0.9,
+)
+plt.title("time-domain fields ($E_z$)")
 plt.axis("off")
-plt.show()
+plt.savefig("ring_ez.png", dpi=150, bbox_inches="tight")
 
 if np.all(np.diff(err_dat) < 0):
     print(
-        "PASSED solve_cw test: error in the fields is decreasing with increasing resolution"
+        "PASSED solve_cw test: error in the fields is "
+        "decreasing with increasing resolution."
     )
 else:
     print(
-        "FAILED solve_cw test: error in the fields is NOT decreasing with increasing resolution"
+        "FAILED solve_cw test: error in the fields is "
+        "NOT decreasing with increasing resolution."
     )
 
 sim.reset_meep()
 
-df = 0.08
+df = 0.08  # frequency width of pulsed source
 src = [
     mp.Source(
-        mp.GaussianSource(fcen, fwidth=df), component=mp.Ez, center=mp.Vector3(r + 0.1)
+        mp.GaussianSource(fcen, fwidth=df),
+        component=mp.Ez,
+        center=mp.Vector3(r + 0.1),
     ),
     mp.Source(
         mp.GaussianSource(fcen, fwidth=df),
@@ -99,23 +147,40 @@ src = [
 ]
 
 sim = mp.Simulation(
+    resolution=resolution,
     cell_size=mp.Vector3(sxy, sxy),
     geometry=geometry,
     sources=src,
-    resolution=10,
     symmetries=symmetries,
     boundary_layers=pml_layers,
 )
 
 dft_obj = sim.add_dft_fields([mp.Ez], fcen, 0, 1, where=nonpml_vol)
 
-sim.run(until_after_sources=100)
+sim.run(
+    until_after_sources=mp.stop_when_fields_decayed(
+        50,
+        mp.Ez,
+        mp.Vector3(r + 0.1523),
+        1e-8,
+    )
+)
 
 eps_data = sim.get_array(vol=nonpml_vol, component=mp.Dielectric)
 ez_data = np.real(sim.get_dft_array(dft_obj, mp.Ez, 0))
 
 plt.figure()
-plt.imshow(eps_data.transpose(), interpolation="spline36", cmap="binary")
-plt.imshow(ez_data.transpose(), interpolation="spline36", cmap="RdBu", alpha=0.9)
+plt.imshow(
+    eps_data.transpose(),
+    interpolation="spline36",
+    cmap="binary",
+)
+plt.imshow(
+    ez_data.transpose(),
+    interpolation="spline36",
+    cmap="RdBu",
+    alpha=0.9,
+)
+plt.title("DFT fields ($E_z$)")
 plt.axis("off")
-plt.show()
+plt.savefig("ring_ez_dft.png", dpi=150, bbox_inches="tight")


### PR DESCRIPTION
Various updates and fixes to `examples/solve-cw.py` which seemed to have bitrotted somewhat. 

With these changes, this example script produces the correct output which are shown in the three figures.

![ring_err](https://user-images.githubusercontent.com/7152530/210024390-9a31562d-c005-4274-a804-d0f2e81b0738.png)

![ring_ez](https://user-images.githubusercontent.com/7152530/210024393-0443bff8-d30c-47bd-962c-360b3fcb6175.png)

![ring_ez_dft](https://user-images.githubusercontent.com/7152530/210024396-58618d4a-3a47-4cd7-935e-d56659bf2b3f.png)
