### PR TITLE
remove unused `Volume` parameter from _get_gradient

### DIFF
--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -70,7 +70,6 @@ class DesignRegion:
             fields_f[1].swigobj,
             fields_f[2].swigobj,
             sim.gv,
-            vol.swigobj,
             onp.array(frequencies),
             sim.geps,
             finite_difference_step,

--- a/python/meep.i
+++ b/python/meep.i
@@ -844,9 +844,9 @@ meep::volume_list *make_volume_list(const meep::volume &v, int c,
 
 %inline %{
 void _get_gradient(PyObject *grad, double scalegrad,
-                    meep::dft_fields *fields_a_0, meep::dft_fields *fields_a_1, meep::dft_fields *fields_a_2,
-                    meep::dft_fields *fields_f_0, meep::dft_fields *fields_f_1, meep::dft_fields *fields_f_2,
-                   meep::grid_volume *grid_volume, meep::volume *where, PyObject *frequencies,
+                   meep::dft_fields *fields_a_0, meep::dft_fields *fields_a_1, meep::dft_fields *fields_a_2,
+                   meep::dft_fields *fields_f_0, meep::dft_fields *fields_f_1, meep::dft_fields *fields_f_2,
+                   meep::grid_volume *grid_volume, PyObject *frequencies,
                    meep_geom::geom_epsilon *geps, double fd_step) {
 
     // clean the gradient array
@@ -872,7 +872,7 @@ void _get_gradient(PyObject *grad, double scalegrad,
     if (PyArray_DIMS(pao_grad)[0] != nf) meep::abort("Numpy grad array is allocated for %td frequencies; it should be allocated for %td.",PyArray_DIMS(pao_grad)[0],nf);
 
     // calculate the gradient
-    meep_geom::material_grids_addgradient(grad_c,ng,nf,adjoint_fields,forward_fields,frequencies_c,scalegrad,*grid_volume,*where,geps,fd_step);
+    meep_geom::material_grids_addgradient(grad_c,ng,nf,adjoint_fields,forward_fields,frequencies_c,scalegrad,*grid_volume,geps,fd_step);
 
 }
 %}

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2829,8 +2829,8 @@ void material_grids_addgradient_point(double *v, vector3 p, double scalegrad, ge
 void material_grids_addgradient(double *v, size_t ng, size_t nf,
                                 std::vector<meep::dft_fields *> fields_a,
                                 std::vector<meep::dft_fields *> fields_f, double *frequencies,
-                                double scalegrad, meep::grid_volume &gv, meep::volume &where,
-                                geom_epsilon *geps, double du) {
+                                double scalegrad, meep::grid_volume &gv, geom_epsilon *geps,
+                                double du) {
   /* ------------------------------------------------------------ */
   // initialize local gradient array
   /* ------------------------------------------------------------ */

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -292,8 +292,8 @@ geom_box_tree calculate_tree(const meep::volume &v, geometric_object_list g);
 void material_grids_addgradient(double *v, size_t ng, size_t nf,
                                 std::vector<meep::dft_fields *> fields_a,
                                 std::vector<meep::dft_fields *> fields_f, double *frequencies,
-                                double scalegrad, meep::grid_volume &gv, meep::volume &where,
-                                geom_epsilon *geps, double du = 1e-6);
+                                double scalegrad, meep::grid_volume &gv, geom_epsilon *geps,
+                                double du = 1e-6);
 
 /***************************************************************/
 /* routines in GDSIIgeom.cc ************************************/


### PR DESCRIPTION
There is an unused `Volume` parameter of `_get_gradient` of the adjoint solver module which is generating a warning at compile time.