### PR TITLE
Pin CI sanitizer builds to Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-san.yml
+++ b/.github/workflows/build-san.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: "Test C++ with ${{ matrix.name-suffix }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The default version of [GitHub Actions](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) for `ubuntu-latest` was recently changed from 20.04 to 22.04 (see actions/runner-images#6399). As part of this upgrade, Clang was updated from version 10.0.0 to 12.* which seems to be causing the [memory sanitizer](https://github.com/NanoComp/meep/actions/runs/3810053615) (MSAN) of the CI to fail.

Until we figure out how to fix this, a stop-gap measure is simply to force the CI sanitizer builds to use Ubuntu 20.04. This change only affects the sanitizer builds. The [CI unit tests](https://github.com/NanoComp/meep/blob/9c56cf1a6e34bb03553068ab3abc2e9489d4978f/.github/workflows/build-ci.yml#L13) are using `ubuntu-latest`.