### PR TITLE
Create a duplicate of the dictionary for the default colorbar parameters of `plot2D`

### DIFF
--- a/python/visualization.py
+++ b/python/visualization.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 import warnings
+import copy
 
 from time import sleep
 
@@ -472,7 +473,7 @@ def _add_colorbar(
     from mpl_toolkits.axes_grid1 import make_axes_locatable
 
     if colorbar_parameters is None:
-        colorbar_parameters = default_colorbar_parameters
+        colorbar_parameters = copy.deepcopy(default_colorbar_parameters)
     else:
         colorbar_parameters = dict(default_colorbar_parameters, **colorbar_parameters)
 
@@ -486,13 +487,17 @@ def _add_colorbar(
         norm=mpl.colors.Normalize(vmin, vmax),
         cmap=mpl.cm.get_cmap(cmap),
     )
+
     # Pop specific values out of colorbar params so user can add any kwargs to plt.colorbar
-    cax = make_axes_locatable(ax).append_axes(
+    # ref: https://matplotlib.org/stable/gallery/axes_grid1/demo_colorbar_with_axes_divider.html#colorbar-with-axesdivider
+    ax_divider = make_axes_locatable(ax)
+    cax = ax_divider.append_axes(
         pad=colorbar_parameters.pop("pad"),
         size=colorbar_parameters.pop("size"),
         position=colorbar_parameters.pop("position"),
     )
-    plt.colorbar(mappable=sm, cax=cax, **colorbar_parameters)
+    fig = ax.get_figure()
+    fig.colorbar(mappable=sm, cax=cax, **colorbar_parameters)
 
 
 def plot_eps(
@@ -881,7 +886,6 @@ def plot_fields(
         ax.imshow(field_data, extent=extent, **filter_dict(field_parameters, ax.imshow))
 
         if field_parameters["colorbar"]:
-
             _add_colorbar(
                 ax=ax,
                 cmap=field_parameters["cmap"],


### PR DESCRIPTION
The colorbar feature for `plot2D` added in #2289 produces an error when trying to add colorbars to more than one subplots of a single `matplotlib.figure` object. This is because the dictionary of default parameters for the colorbar ([`default_colorbar_parametrs`](https://github.com/NanoComp/meep/blob/f448ebd98e5c56a2a64fc80dd9a1db7db2d224d9/python/visualization.py#L65-L72) of `visualization.py`) is passed by reference and the use of `pop` to retrieve its parameters when adding the colorbar to the first subplot removes them from the dictionary. Subsequent calls to retrieve the same parameters in turn triggers an error. The fix involves simply creating a duplicate of the dictionary.

Here is an example which demonstrates this bug:
```py
""                                                                                                               
Plots the fields for an Er point source at r=z=0 in vacuum.                                                       
"""

import meep as mp
import numpy as np
import matplotlib
matplotlib.use('agg')
import matplotlib.pyplot as plt


res = 50
dpml = 1.0
s = 5.0
m = -1
fcen = 1.

cell_size = mp.Vector3(s+dpml,0,s+2*dpml)

pml_layers = [
    mp.PML(dpml, direction=mp.R),
    mp.PML(dpml, direction=mp.Z),
]

sources = [
    mp.Source(
	src=mp.ContinuousSource(fcen),
        center=mp.Vector3(2.3),
        component=mp.Er,
    ),
]

sim = mp.Simulation(
    resolution=res,
    cell_size=cell_size,
    dimensions=mp.CYLINDRICAL,
    m=m,
    sources=sources,
    boundary_layers=pml_layers,
)

sim.run(until=26.5)

fig, ax = plt.subplots(ncols=2)
fig.subplots_adjust(wspace=0.7)

sim.plot2D(
    ax=ax[0],
    fields=mp.Er,
    field_parameters={
	'colorbar':True,
        'cmap':'inferno',
        'post_process':lambda x: np.log10(np.abs(np.real(x))),
    },
)
ax[0].set_title("$|\Re(E_r)|$")

sim.plot2D(
    ax=ax[1],
    fields=mp.Er,
    field_parameters={
        'colorbar':True,
        'cmap':'inferno',
	'post_process':lambda x: np.log10(np.abs(np.imag(x))),
    },
)
ax[1].set_title("$|\Im(E_r)|$")

if mp.am_master():
    plt.savefig(
        f'cyl_er_real_imag.png',
        dpi=150,
        bbox_inches='tight'
    )
```

Executing this script using the current master branch triggers an error related to a missing `pad` key entry in the dictionary when trying to add a colorbar to the second subplot:
```
Traceback (most recent call last):
  File "bug_colorbar.py", line 58, in <module>
    sim.plot2D(
  File "/meep/python/meep/simulation.py", line 4680, in plot2D
    return vis.plot2D(
  File "/meep/python/meep/visualization.py", line 977, in plot2D
    ax = plot_fields(
  File "/meep/python/meep/visualization.py", line 885, in plot_fields
    _add_colorbar(
  File "/meep/python/meep/visualization.py", line 491, in _add_colorbar
    pad=colorbar_parameters.pop("pad"),
KeyError: 'pad'
``` 

With the fix in this PR, colorbars are correctly added to both subplots as shown in the following image:

![cyl_er_real_imag](https://user-images.githubusercontent.com/7152530/213949778-73520b4d-b0da-46b8-a32b-7fcad63e905e.png)

cc @thomasdorch 