### PR TITLE
Fix bug in step-db update equations in cylindrical coordinates for `m=±1`

### DIFF
--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -329,7 +329,7 @@ bool fields_chunk::step_db(field_type ft) {
         realnum *fu = siginvu && f_u[cc][cmp] ? f[cc][cmp] : 0;
         realnum *the_f = fu ? f_u[cc][cmp] : f[cc][cmp];
         int sd = ft == D_stuff ? +1 : -1;
-        realnum f_m_mult = ft == D_stuff ? 2 : (1 - 2 * cmp);
+        realnum f_m_mult = ft == D_stuff ? 2 : (1 - 2 * cmp) * m;
 
         for (int iz = (ft == D_stuff); iz < nz + (ft == D_stuff); ++iz) {
           realnum df;


### PR DESCRIPTION
Fixes a bug in the field update equations in cylindrical coordinates for `m = ±1` described in [#2108 (comment)](https://github.com/NanoComp/meep/issues/2108#issuecomment-1402345898).

Also includes a new unit test which verifies that the radiated flux from a point source is the same for simulations with `m = ±1`. This is based on the discussion in [#2108 (comment)](https://github.com/NanoComp/meep/issues/2108#issuecomment-1402482090).

Since this bug fix also fixes the $z$-PML at $r=0$ which previously required using a large `cutoff` value for the `GaussianSource` as described in [#2148 (comment)](https://github.com/NanoComp/meep/issues/2148#issuecomment-1200546285), the existing unit test in `test_ldos_ext_eff` of `test_ldos.py` is also updated to remove the large `cutoff` parameter from the source.

