### PR TITLE
Regenerate markdown user manual from docstrings

### DIFF
--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -837,7 +837,9 @@ The following classes are available directly via the `meep` package.
 
 @@ EigenModeSource[methods-with-docstrings] @@
 
-@@ GaussianBeamSource[methods-with-docstrings] @@
+@@ GaussianBeam3DSource[methods-with-docstrings] @@
+
+@@ GaussianBeam2DSource[methods-with-docstrings] @@
 
 @@ ContinuousSource[methods-with-docstrings] @@
 

--- a/python/geom.py
+++ b/python/geom.py
@@ -622,7 +622,8 @@ class MaterialGrid:
         `do_averaging=True`. If you want to use a material grid to define a (nearly) discontinuous,
         piecewise-constant material that is *either* `medium1` or `medium2` almost everywhere, you can
         optionally enable a (smoothed) *projection* feature by setting the parameter `beta` to a
-        positive value. When the projection feature is enabled, the weights $u(x)$ can be thought of as a
+        positive non-zero value. `beta` is `0` by default (no projection). When the projection feature is
+        enabled, the weights $u(x)$ can be thought of as a
         [level-set function](https://en.wikipedia.org/wiki/Level-set_method) defining an interface at
         $u(x)=\\eta$ with a smoothing factor $\\beta$ where $\\beta=+\\infty$ gives an unsmoothed,
         discontinuous interface. The projection operator is $(\\tanh(\\beta\\times\\eta)
@@ -631,7 +632,11 @@ class MaterialGrid:
         ($\\eta$: offset for erosion/dilation). The level set provides a general approach for defining
         a *discontinuous* function from otherwise continuously varying (via the bilinear interpolation)
         grid values. Subpixel smoothing is fast and accurate because it exploits an analytic formulation
-        for level-set functions.
+        for level-set functions. Note that when subpixel smoothing is enabled via `do_averaging=True`,
+        projecting the `weights` is done internally using the (non-zero) `beta` parameter. In this case,
+        do *not* manually project the `weights` yourself outside of `MaterialGrid`. However, visualizing
+        the `weights` used to define the structure does require manually projecting the `weights` yourself.
+        (Alternatively, you can output the actual structure using `plot2D` or `output_epsilon`.)
 
         A nonzero `damping` term creates an artificial conductivity $\\sigma = u(1-u)*$`damping`, which acts as
         dissipation loss that penalizes intermediate pixel values of non-binarized structures. The value of


### PR DESCRIPTION
#2385 applied changes to `Python_User_Interface.md` which is automatically generated from `Python_User_Interface.md.in` using the Python docstrings. Unfortunately, any change to `Python_User_Interface.md` can therefore be overwritten.

This PR applies the changes from #2385 to the docstrings for `MaterialGrid` in `geom.py` with some modifications (mainly for consistency with the rest of the documentation) and also regenerates the entire markdown user manual via `make python_api_doc`. As a result, this PR contains several additional changes to the user manual based on several recently added features (`GaussianBeam2Dsource`, `Simulation.timestep`, etc).