### PR TITLE
Fix the shapes of 2d filters

### DIFF
--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -26,7 +26,7 @@ def _proper_pad(arr, pad_to):
 
     Parameters
     ----------
-    arr : 2d input array.
+    arr : 2d input array representing the nonnegative-coordinate ≈1/4 of a filter kernel.
     pad_to : 1d array composed of two integers indicating the total size to be padded to.
     """
 

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -20,32 +20,37 @@ def _centered(arr, newshape):
     myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
     return arr[tuple(myslice)]
 
+
 def _proper_pad(arr, pad_to):
-    '''
+    """
     Parameters
     ----------
     arr : 2d input array.
     pad_to : 1d array composed of two integers indicating the total size to be padded to.
-    '''
+    """
 
-    pad_size = pad_to-2*np.array(arr.shape)+1
+    pad_size = pad_to - 2 * np.array(arr.shape) + 1
 
-    top = np.zeros((pad_size[0],arr.shape[1]))
-    bottom = np.zeros((pad_size[0],arr.shape[1]-1))
-    middle = np.zeros((pad_to[0],pad_size[1]))
+    top = np.zeros((pad_size[0], arr.shape[1]))
+    bottom = np.zeros((pad_size[0], arr.shape[1] - 1))
+    middle = np.zeros((pad_to[0], pad_size[1]))
 
-    top_left = arr[:,:]
-    top_right = npa.flipud(arr[1:,:])
-    bottom_left = npa.fliplr(arr[:,1:])
-    bottom_right = npa.flipud(npa.fliplr(arr[1:,1:])) # equivalent to flip, but flip is incompatible with autograd
+    top_left = arr[:, :]
+    top_right = npa.flipud(arr[1:, :])
+    bottom_left = npa.fliplr(arr[:, 1:])
+    bottom_right = npa.flipud(
+        npa.fliplr(arr[1:, 1:])
+    ) # equivalent to flip, but flip is incompatible with autograd
 
     return npa.concatenate(
         (
-            npa.concatenate((top_left, top, top_right)), middle,
+            npa.concatenate((top_left, top, top_right)),
+            middle,
             npa.concatenate((bottom_left, bottom, bottom_right)),
         ),
         axis=1,
     )
+
 
 def _edge_pad(arr, pad):
 
@@ -91,7 +96,7 @@ def simple_2d_filter(x, h):
         The output of the 2d convolution.
     """
     (kx, ky) = x.shape
-    h = _proper_pad(x,3*np.array([kx, ky]))
+    h = _proper_pad(h, 3 * np.array([kx, ky]))
     h = h / npa.sum(h)  # Normalize the kernel
     x = _edge_pad(x, ((kx, kx), (ky, ky)))
 
@@ -134,10 +139,10 @@ def cylindrical_filter(x, radius, Lx, Ly, resolution):
     yv = np.arange(0, Ly / 2, 1 / resolution)
 
     X, Y = np.meshgrid(xv, yv, sparse=True, indexing='ij')
-    kernel = np.where(X**2 + Y**2 < radius**2, 1, 0)
+    h = np.where(X**2 + Y**2 < radius**2, 1, 0)
 
     # Filter the response
-    return simple_2d_filter(x, kernel)
+    return simple_2d_filter(x, h)
 
 
 def conic_filter(x, radius, Lx, Ly, resolution):
@@ -174,11 +179,12 @@ def conic_filter(x, radius, Lx, Ly, resolution):
     yv = np.arange(0, Ly / 2, 1 / resolution)
 
     X, Y = np.meshgrid(xv, yv, sparse=True, indexing='ij')
-    kernel = np.where(X**2 + Y**2 < radius**2,
-                      (1 - np.sqrt(abs(xv**2 + yv**2)) / radius), 0)
+    h = np.where(
+        X**2 + Y**2 < radius**2, (1 - np.sqrt(abs(X**2 + Y**2)) / radius), 0
+    )
 
     # Filter the response
-    return simple_2d_filter(x, kernel)
+    return simple_2d_filter(x, h)
 
 
 def gaussian_filter(x, sigma, Lx, Ly, resolution):
@@ -215,10 +221,10 @@ def gaussian_filter(x, sigma, Lx, Ly, resolution):
     yv = np.arange(0, Ly / 2, 1 / resolution)
 
     X, Y = np.meshgrid(xv, yv, sparse=True, indexing='ij')
-    kernel = np.exp(-(X**2 + Y**2) / sigma**2)
+    h = np.exp(-(X**2 + Y**2) / sigma**2)
 
     # Filter the response
-    return simple_2d_filter(x, kernel)
+    return simple_2d_filter(x, h)
 
 
 """

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -40,7 +40,7 @@ def _proper_pad(arr, pad_to):
     bottom_left = npa.fliplr(arr[:, 1:])
     bottom_right = npa.flipud(
         npa.fliplr(arr[1:, 1:])
-    ) # equivalent to flip, but flip is incompatible with autograd
+    )  # equivalent to flip, but flip is incompatible with autograd
 
     return npa.concatenate(
         (
@@ -138,7 +138,7 @@ def cylindrical_filter(x, radius, Lx, Ly, resolution):
     xv = np.arange(0, Lx / 2, 1 / resolution)
     yv = np.arange(0, Ly / 2, 1 / resolution)
 
-    X, Y = np.meshgrid(xv, yv, sparse=True, indexing='ij')
+    X, Y = np.meshgrid(xv, yv, sparse=True, indexing="ij")
     h = np.where(X**2 + Y**2 < radius**2, 1, 0)
 
     # Filter the response
@@ -178,7 +178,7 @@ def conic_filter(x, radius, Lx, Ly, resolution):
     xv = np.arange(0, Lx / 2, 1 / resolution)
     yv = np.arange(0, Ly / 2, 1 / resolution)
 
-    X, Y = np.meshgrid(xv, yv, sparse=True, indexing='ij')
+    X, Y = np.meshgrid(xv, yv, sparse=True, indexing="ij")
     h = np.where(
         X**2 + Y**2 < radius**2, (1 - np.sqrt(abs(X**2 + Y**2)) / radius), 0
     )
@@ -220,7 +220,7 @@ def gaussian_filter(x, sigma, Lx, Ly, resolution):
     xv = np.arange(0, Lx / 2, 1 / resolution)
     yv = np.arange(0, Ly / 2, 1 / resolution)
 
-    X, Y = np.meshgrid(xv, yv, sparse=True, indexing='ij')
+    X, Y = np.meshgrid(xv, yv, sparse=True, indexing="ij")
     h = np.exp(-(X**2 + Y**2) / sigma**2)
 
     # Filter the response

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -92,8 +92,9 @@ def simple_2d_filter(x, h):
     """
     (kx, ky) = x.shape
     h = _proper_pad(x,3*np.array([kx, ky]))
-    print("h shape = ",h.shape, ", h = ",h)
+    h = h / npa.sum(h)  # Normalize the kernel
     x = _edge_pad(x, ((kx, kx), (ky, ky)))
+
     return _centered(
         npa.real(npa.fft.ifft2(npa.fft.fft2(x) * npa.fft.fft2(h))), (kx, ky)
     )
@@ -133,13 +134,10 @@ def cylindrical_filter(x, radius, Lx, Ly, resolution):
     yv = np.arange(0, Ly / 2, 1 / resolution)
 
     X, Y = np.meshgrid(xv, yv, sparse=True, indexing='ij')
-    h = X**2+Y**2 < radius**2
-
-    # Normalize kernel
-    h = h / np.sum(h.flatten())  # Normalize the filter
+    kernel = np.where(X**2 + Y**2 < radius**2, 1, 0)
 
     # Filter the response
-    return simple_2d_filter(x, h)
+    return simple_2d_filter(x, kernel)
 
 
 def conic_filter(x, radius, Lx, Ly, resolution):
@@ -176,13 +174,11 @@ def conic_filter(x, radius, Lx, Ly, resolution):
     yv = np.arange(0, Ly / 2, 1 / resolution)
 
     X, Y = np.meshgrid(xv, yv, sparse=True, indexing='ij')
-    h = X**2+Y**2 < radius**2
-
-    # Normalize kernel
-    h = h / np.sum(h.flatten())  # Normalize the filter
+    kernel = np.where(X**2 + Y**2 < radius**2,
+                      (1 - np.sqrt(abs(xv**2 + yv**2)) / radius), 0)
 
     # Filter the response
-    return simple_2d_filter(x, h)
+    return simple_2d_filter(x, kernel)
 
 
 def gaussian_filter(x, sigma, Lx, Ly, resolution):
@@ -219,13 +215,10 @@ def gaussian_filter(x, sigma, Lx, Ly, resolution):
     yv = np.arange(0, Ly / 2, 1 / resolution)
 
     X, Y = np.meshgrid(xv, yv, sparse=True, indexing='ij')
-    h = X**2+Y**2 < radius**2
-
-    # Normalize kernel
-    h = h / np.sum(h.flatten())  # Normalize the filter
+    kernel = np.exp(-(X**2 + Y**2) / sigma**2)
 
     # Filter the response
-    return simple_2d_filter(x, h)
+    return simple_2d_filter(x, kernel)
 
 
 """

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -22,7 +22,8 @@ def _centered(arr, newshape):
 
 
 def _proper_pad(arr, pad_to):
-    """
+    """Return a zero-padded/expanded version of filter arr (≈1/4 of kernel) to size pad_to, for convolution.
+
     Parameters
     ----------
     arr : 2d input array.

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -678,7 +678,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
             # non-center frequencies of a multifrequency simulation
             # are expected to be less accurate than the center frequency
             if nfrq == 1 and frequencies[0] == self.fcen:
-                tol = 2e-4 if mp.is_single_precision() else 5e-6
+                tol = 2.1e-4 if mp.is_single_precision() else 5e-6
             else:
                 tol = 0.005 if mp.is_single_precision() else 0.002
 

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -39,8 +39,8 @@ class TestAdjointSolver(ApproxComparisonTestCase):
 
         cls.design_region_size = mp.Vector3(1.5, 1.5)
         cls.design_region_resolution = int(2 * cls.resolution)
-        cls.Nx = int(cls.design_region_size.x * cls.design_region_resolution)
-        cls.Ny = int(cls.design_region_size.y * cls.design_region_resolution)
+        cls.Nx = int(round(cls.design_region_size.x * cls.design_region_resolution))
+        cls.Ny = int(round(cls.design_region_size.y * cls.design_region_resolution))
 
         # ensure reproducible results
         rng = np.random.RandomState(9861548)

--- a/python/tests/test_adjoint_utils.py
+++ b/python/tests/test_adjoint_utils.py
@@ -41,7 +41,7 @@ class TestAdjointUtils(ApproxComparisonTestCase):
     def test_filter_offset(self, test_name, Lx, Ly, resolution, radius, filter_func):
         """ensure that the filters are indeed zero-phase"""
         print("Testing ", test_name)
-        Nx, Ny = int(resolution * Lx), int(resolution * Ly)
+        Nx, Ny = int(round(resolution * Lx)), int(round(resolution * Ly))
         x = np.random.rand(Nx, Ny)
         x = x + np.fliplr(x)
         x = x + np.flipud(x)


### PR DESCRIPTION
As mentioned [here](https://github.com/NanoComp/meep/pull/2016#issuecomment-1368121521), the 2d filters in `filters.py` should have kernels with circular boundaries, but these boundaries are rectangular in the current master branch. This PR makes them circular. In addition, this PR adds a `round` operation preceding each `int` operation in `filters.py` to avoid unexpected results, as mentioned [here](https://github.com/NanoComp/meep/discussions/2240#discussioncomment-4003077).