### PR TITLE
Check for invalid sources at r=0 in cylindrical coordinates

### DIFF
--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -273,7 +273,7 @@ static void src_vol_chunkloop(fields_chunk *fc, int ichunk, component c, ivec is
     amps_array[idx_vol] = IVEC_LOOP_WEIGHT(s0, s1, e0, e1, 1) * amp * data->A(rel_loc);
 
     // check for invalid sources at r=0 in cylindrical coordinates
-    if (fc->gv.dim == Dcyl && loc.r() == 0 && abs(amps_array[idx_vol]) > 0) {
+    if (fc->gv.dim == Dcyl && loc.r() == 0 && amps_array[idx_vol] != 0.0) {
       if (fc->m == 0 && (component_direction(c) == R || component_direction(c) == P))
         meep::abort("Not possible to place a %s source at r=0 in "
                     "cylindrical coordinates for m = 0.",

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -284,7 +284,8 @@ static void src_vol_chunkloop(fields_chunk *fc, int ichunk, component c, ivec is
                     component_name(c));
       else
         meep::abort("Not possible to place a source at r=0 in "
-                    "cylindrical coordinates for m = %g.", fc->m);
+                    "cylindrical coordinates for m = %g.",
+                    fc->m);
     }
 
     /* for "D" sources, multiply by epsilon.  FIXME: this is not quite

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -278,13 +278,13 @@ static void src_vol_chunkloop(fields_chunk *fc, int ichunk, component c, ivec is
         meep::abort("Not possible to place a %s source at r=0 in "
                     "cylindrical coordinates for m = 0.",
                     component_name(c));
-      else if (fabs(fc->m) == 1.0 && (c == Ez || c == Dz))
+      else if (fabs(fc->m) == 1.0 && component_direction(c) == Z)
         meep::abort("Not possible to place a %s source at r=0 in "
                     "cylindrical coordinates for |m| = 1.0.",
                     component_name(c));
-      else if (fabs(fc->m) > 1.0)
+      else
         meep::abort("Not possible to place a source at r=0 in "
-                    "cylindrical coordinates for |m| > 1.0.");
+                    "cylindrical coordinates for m = %g.", fc->m);
     }
 
     /* for "D" sources, multiply by epsilon.  FIXME: this is not quite

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -454,6 +454,17 @@ void fields::add_volume_source(component c, const src_time &src, const volume &w
     }
   }
 
+  // check for invalid sources at r=0 in cylindrical coordinates
+  if (gv.dim == Dcyl && where.in_direction_min(R) == 0.0) {
+    if (fabs(m) == 1.0 && (c == Ez || c == Dz))
+      meep::abort("Not possible to place a %s source at r=0 in "
+                  "cylindrical coordinates for |m| = 1.0.",
+                  component_name(c));
+    else if (fabs(m) > 1.0)
+      meep::abort("Not possible to place a source at r=0 in "
+                  "cylindrical coordinates for |m| > 1.0.");
+  }
+
   src_vol_chunkloop_data data;
   data.A = A ? A : one;
   data.amp = amp;


### PR DESCRIPTION
Adds a check within ~~`fields::add_volume_source`~~ `src_vol_chunkloop` for ~~two~~ three different types of invalid sources at $r=0$ in cylindrical coordinates.