### PR TITLE
Remove unnecessary long-duration source from LED extraction-efficiency tutorial in cylindrical coordinates

### DIFF
--- a/python/examples/extraction_eff_ldos.py
+++ b/python/examples/extraction_eff_ldos.py
@@ -19,12 +19,7 @@ wvl = 1.0  # wavelength (in vacuum)
 
 fcen = 1 / wvl  # center frequency of source/monitor
 
-# source properties (cylindrical)
-df = 0.05 * fcen
-cutoff = 10.0
-src = mp.GaussianSource(fcen, fwidth=df, cutoff=cutoff)
-
-# termination criteria
+# runtime termination criteria
 tol = 1e-8
 
 
@@ -48,7 +43,13 @@ def extraction_eff_cyl(dmat: float, h: float) -> float:
 
     src_cmpt = mp.Er
     src_pt = mp.Vector3(0, 0, -0.5 * sz + h * dmat)
-    sources = [mp.Source(src=src, component=src_cmpt, center=src_pt)]
+    sources = [
+        mp.Source(
+            src=mp.GaussianSource(fcen, fwidth=0.1 * fcen),
+            component=src_cmpt,
+            center=src_pt,
+        )
+    ]
 
     geometry = [
         mp.Block(


### PR DESCRIPTION
#2382 and #2383 fixed two separate bugs related to the $z$-PML at $r=0$ for $m=0, \pm 1$ simulation in cylindrical coordinates. Prior to this bugfix, to ensure that the fields at $r=0$ decayed sufficiently away it was  necessary to use the workaround of a narrow bandwidth source with long cutoff. However, this long-duration source is no longer necessary for these types of calculations. 

This PR updates the tutorial [Extraction Efficiency of a Light-Emitting Diode (LED)](https://meep.readthedocs.io/en/latest/Python_Tutorials/Local_Density_of_States/#extraction-efficiency-of-a-light-emitting-diode-led) to replace this long-duration source with a significantly shorter one.