### PR TITLE
Add function to create nlopt epigraph formulations.

### DIFF
--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -4,7 +4,7 @@ import meep as mp
 import numpy as onp
 from autograd import tensor_jacobian_product
 
-from . import ObjectiveQuantity, OptimizationProblem
+from . import ObjectiveQuantity
 
 # Meep field components used to compute adjoint sensitivities
 _ADJOINT_FIELD_COMPONENTS = [mp.Dx, mp.Dy, mp.Dz]
@@ -250,7 +250,7 @@ def create_adjoint_sources(
 
 
 def get_epigraph_nlopt(
-    mpa_opt: OptimizationProblem,
+    mpa_opt,
     mapping: Callable,
     callback: Callable | None = None,
 ) -> tuple[Callable, Callable]:

--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterable, List, Tuple
+from typing import Callable, Iterable, List, Optional, Tuple
 
 import meep as mp
 import numpy as onp
@@ -252,7 +252,7 @@ def create_adjoint_sources(
 def get_epigraph_nlopt(
     mpa_opt,
     mapping: Callable,
-    callback: Callable | None = None,
+    callback: Optional[Callable] = None,
 ) -> tuple[Callable, Callable]:
     """Helper function to create the NLopt objective and vector constraints for an
     epigraph formulation of a meep adjoint optimization problem.

--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -253,7 +253,7 @@ def get_epigraph_nlopt(
     mpa_opt,
     mapping: Callable,
     callback: Optional[Callable] = None,
-) -> tuple[Callable, Callable]:
+) -> Tuple[Callable, Callable]:
     """Helper function to create the NLopt objective and vector constraints for an
     epigraph formulation of a meep adjoint optimization problem.
 

--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -1,10 +1,10 @@
-from typing import Iterable, List, Tuple
-
-import numpy as onp
+from typing import Callable, Iterable, List, Tuple
 
 import meep as mp
+import numpy as onp
+from autograd import tensor_jacobian_product
 
-from . import ObjectiveQuantity
+from . import ObjectiveQuantity, OptimizationProblem
 
 # Meep field components used to compute adjoint sensitivities
 _ADJOINT_FIELD_COMPONENTS = [mp.Dx, mp.Dy, mp.Dz]
@@ -247,3 +247,74 @@ def create_adjoint_sources(
             adjoint_sources += monitor.place_adjoint_source(dj)
     assert adjoint_sources
     return adjoint_sources
+
+
+def get_epigraph_nlopt(
+    mpa_opt: OptimizationProblem,
+    mapping: Callable,
+    callback: Callable | None = None,
+) -> tuple[Callable, Callable]:
+    """Helper function to create the NLopt objective and vector constraints for an
+    epigraph formulation of a meep adjoint optimization problem.
+
+    Parameters
+    ----------
+    mpa_opt : OptimizationProblem
+        Instance of a meep adjoint optimization problem.
+    mapping : function
+        A Python function that maps the optimization variables to a design
+        distribution. Expects the following signature::
+
+            mapping(x: np.ndarray) -> np.ndarray
+
+        If `mapping` takes additional arguments, you can wrap it in a lambda before
+        passing it to this function.
+    callback : function, optional
+        A function that is called after every evaluation of the constraints, useful for
+        logging during optimization.
+        Expects the following signature::
+
+            callback(t: float, v: np.ndarray, f0: np.ndarray, grad: np.ndarray) -> None
+
+        with the epigraph dummy objective `t`, design weights `v`, the current meep
+        objective values `f0` and the gradients `grad`.
+
+    Returns
+    -------
+    _objective : function
+        The epigraph dummy objective.
+    _constraints: function
+        The epigraph constraints.
+    """
+
+    def _objective(x: onp.ndarray, gd: onp.ndarray) -> float:
+        if gd.size > 0:
+            gd[0] = 1
+            gd[1:] = 0
+        return x[0]
+
+    def _constraints(result: onp.ndarray, x: onp.ndarray, gd: onp.ndarray) -> None:
+        t, v = x[0], x[1:]
+
+        f0, grad = mpa_opt([mapping(v)])
+
+        # f0 -> (obj_funs, wavelengths), grad -> (obj_funs, dofs, wavelengths)
+        f0 = onp.atleast_2d(f0)
+        grad = onp.reshape(grad, (f0.shape[0], -1, f0.shape[-1]))
+
+        f0 = onp.concatenate(f0, axis=0)
+        grad = onp.concatenate(grad, axis=-1)
+
+        for k in range(grad.shape[-1]):
+            grad[:, k] = tensor_jacobian_product(mapping, 0)(v, grad[:, k])
+
+        if gd.size > 0:
+            gd[:, 0] = -1
+            gd[:, 1:] = grad.T
+
+        result[:] = onp.real(f0) - t
+
+        if callback:
+            callback(t, v, f0, grad)
+
+    return _objective, _constraints


### PR DESCRIPTION
This PR adds a convenience function to create nlopt epigraph objectives from meep adjoint optimization problems.
I am using this myself currently and thought it would be a neat feature to have, as nlopt is being used in all the adjoint tutorials/examples anyways and it might make it easier for people to get started with epigraph problems.

I'm not sure if this functionality is out of scope for meep, but at least it doesn't require adding a dependency and should still be general enough to not restrict whatever one is trying to do with nlopt.