### PR TITLE
Add environment variables to set verbosity levels on initialization

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -1866,19 +1866,18 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
             print('\n**\n** failed to load python MPI module (mpi4py)\n**', e, '\n**\n')
             pass
         else:
-            # this variable reference is needed for lazy initialization of MPI
-            comm = MPI.COMM_WORLD
-            if am_master():
-                Procs=comm.Get_size()
-                (Major,Minor)=MPI.Get_version()
-                if verbosity.meep > 0:
-                    print('Using MPI version {}.{}, {} processes'.format(Major, Minor, Procs))
-
-            if not am_master():
-                import os
+            import os
+            if not am_master() and os.getenv("MEEP_MPI_SILENCE_WORKERS", "true").lower() in ("true", "1"):
                 import sys
                 saved_stdout = sys.stdout
                 sys.stdout = open(os.devnull, 'w')
+
+            # this variable reference is needed for lazy initialization of MPI
+            comm = MPI.COMM_WORLD
+            Procs = comm.Get_size()
+            Major, Minor = MPI.Get_version()
+            if verbosity.meep > 0:
+                print('Using MPI version {}.{}, {} processes'.format(Major, Minor, Procs))
 
     vacuum = Medium(epsilon=1)
     air = Medium(epsilon=1)

--- a/python/meep.i
+++ b/python/meep.i
@@ -1870,8 +1870,9 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
             comm = MPI.COMM_WORLD
             if am_master():
                 Procs=comm.Get_size()
-                (Major,Minor)=MPI.Get_version();
-                print('Using MPI version {}.{}, {} processes'.format(Major, Minor, Procs));
+                (Major,Minor)=MPI.Get_version()
+                if verbosity.meep > 0:
+                    print('Using MPI version {}.{}, {} processes'.format(Major, Minor, Procs))
 
             if not am_master():
                 import os

--- a/python/mpb.i
+++ b/python/mpb.i
@@ -356,8 +356,9 @@ const int MPB_VERSION_PATCH;
 %pythoncode %{
     __version__ = (_mpb.cvar.MPB_VERSION_MAJOR, _mpb.cvar.MPB_VERSION_MINOR, _mpb.cvar.MPB_VERSION_PATCH)
 
+    import os
     from meep.verbosity_mgr import Verbosity
-    verbosity = Verbosity(_mpb.cvar, 'mpb', 1)
+    verbosity = Verbosity(_mpb.cvar, 'mpb', int(os.getenv("MPB_VERBOSITY_LEVEL", 1)))
 
     from .solver import (
         MPBArray,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -43,7 +43,7 @@ except ImportError:
 
 from matplotlib.axes import Axes
 
-verbosity = Verbosity(mp.cvar, "meep", 1)
+verbosity = Verbosity(mp.cvar, "meep", int(os.getenv("MEEP_VERBOSITY_LEVEL", 1)))
 
 mp.setup()
 


### PR DESCRIPTION
This PR closes #2421 by adding the following environment variables that meep checks for upon initialization:

- `MEEP_VERBOSITY_LEVEL`: Verbosity level of `verbosity.meep` (default = 1).
- `MPB_VERBOSITY_LEVEL`: Verbosity level of `verbosity.mpb` (default = 1).
- `MEEP_MPI_SILENCE_WORKERS`: Whether non-master `stdout` should be overridden or not (default = true).

The defaults are set so that current behavior does not change.

The variable `MEEP_MPI_SILENCE_WORKERS` was not discussed in #2421 but I have found it very helpful while debugging in the past and thought it might go well with this PR.