### PR TITLE
Prepare for 1.26 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # Meep Release Notes
 
+## Meep 1.26.0
+
+3/9/2023
+
+* Improved Gaussian beam source in 2D ([#2333]).
+
+* Support for returning the number of timesteps elapsed in simulation ([#2337]).
+
+* Bug fix for fields update in cylindrical coordinates ([#2382]).
+
+* Bug fix for PMLs in cylindrical coordinates ([#2383]).
+
+* Bug fix in amplitude function of eigenmode source ([#2394]).
+
+* Various improvements and minor bug fixes ([#2321], [#2349], [#2371], [#2380], [#2390], [#2413]), and additional unit tests and documentation ([#2314], [#2360], [#2364], [#2365], [#2387], [#2395], [#2402]).
+
 ## Meep 1.25.0
 
 11/17/2022

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([meep],[m4_esyscmd(./version.sh 1.26.0-beta)])
+AC_INIT([meep],[m4_esyscmd(./version.sh 1.26.0)])
 AC_CONFIG_SRCDIR(src/step.cpp)
 
 # Shared-library version number; indicates api compatibility, and is
 # not the same as the "public" version number.  (Don't worry about this
 # except for public releases.) Note that any change to a C++ class
 # definition (in the .hpp file) generally breaks binary compatibility.
-SHARED_VERSION_INFO="30:0:0" # CURRENT:REVISION:AGE
+SHARED_VERSION_INFO="31:0:0" # CURRENT:REVISION:AGE
 
 AM_INIT_AUTOMAKE([foreign color-tests parallel-tests silent-rules 1.11])
 AM_SILENT_RULES(yes)


### PR DESCRIPTION
The next tarball release is tentatively scheduled for Thursday March 9, 2023.