### PR TITLE
Pade approximant based spectral extrapolation

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -4070,6 +4070,13 @@ The following step function collects field data from a given point and runs [Har
 * [Harminv class](#Harminv)
 
 
+#### PadeDFT Step Function
+
+The following step function collects field data from a given point or volume and performs spectral extrapolation by computing the [Pade approximant](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.pade.html) of the DFT at every specified spatial point.
+
+* [PadeDFT class](#PadeDFT)
+
+
 ### Step-Function Modifiers
 
 Rather than writing a brand-new step function every time something a bit different is required, the following "modifier" functions take a bunch of step functions and produce *new* step functions with modified behavior. See also [Tutorial/Basics](Python_Tutorials/Basics.md) for examples.

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -7502,6 +7502,127 @@ search for. Defaults to 100.
 
 
 ---
+<a id="PadeDFT"></a>
+
+### PadeDFT
+
+```python
+class PadeDFT(object):
+```
+
+<div class="class_docstring" markdown="1">
+
+Padé approximant based spectral extrapolation is implemented as a class with a [`__call__`](#PadeDFT.__call__) method,
+which allows it to be used as a step function that collects field data from a given
+point and runs [Padé](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.pade.html)
+on that data to extract an analytic rational function which approximates the frequency response.
+For more information about the Padé approximant, see the [wiki](https://en.wikipedia.org/wiki/Padé_approximant).
+
+See [`__init__`](#PadeDFT.__init__) for details about constructing a `PadeDFT`.
+
+In particular, `PadeDFT` stores the discrete time series $\hat{f}[n]$ corresponding to the given field
+component as a function of time and expresses it as:
+
+$$\hat{f}(\omega) = \sum_n \hat{f}[n] e^{i\omega n \Delta t}$$
+
+The above is a "Taylor-like" polynomial in $n$ with a Fourier basis and
+coefficients which are the sampled field data. We then compute the Padé approximant
+to be the analytic form of this function as:
+
+$$R(f) = R(2 \pi \omega) = \frac{P(f)}{Q(f)}$$
+
+Where $P$ and $Q$ are polynomials of degree $m$ and $n$, and $m + n + 1$ is the
+degree of agreement of the Padé approximant to the analytic function $f(2 \pi \omega)$. This
+function $R$ is stored in the callable method `pade_instance.dft`. Note that the computed polynomials
+$P$ and $Q$ for each spatial point are stored as well in the instance variable `pade_instance.polys`,
+as a spatial array of dicts: `[{"P": P(t), "Q": Q(t)}]` with no spectral extrapolation performed.
+Be sure to save a reference to the `Pade` instance if you wish
+to use the results after the simulation:
+
+```py
+sim = mp.Simulation(...)
+p = mp.PadeDFT(...)
+sim.run(p, until=time)
+# do something with p.dft
+```
+
+</div>
+
+
+<a id="PadeDFT.__call__"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def __call__(self, sim, todo):
+```
+
+<div class="method_docstring" markdown="1">
+
+Allows a PadeDFT instance to be used as a step function.
+
+</div>
+
+</div>
+
+
+<a id="PadeDFT.__init__"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def __init__(
+    self,
+    c: int = None,
+    vol: Volume = None,
+    center: Vector3Type = None,
+    size: Vector3Type = None,
+    m: Optional[int] = None,
+    n: Optional[int] = None,
+    m_frac: float = 0.5,
+    n_frac: Optional[float] = None,
+    sampling_interval: int = 1,
+    start_time: int = 0,
+    stop_time: Optional[int] = None,
+):
+```
+
+<div class="method_docstring" markdown="1">
+
+Construct a Padé DFT object.
+
+A `PadeDFT` is a step function that collects data from the field component `c`
+(e.g. `meep.Ex`, etc.) at the given point `pt` (a `Vector3`). Then, at the end
+of the run, it uses the scipy Padé algorithm to approximate the analytic
+frequency response at the specified point.
+
++ **`c` [`component` constant]** — Specifies the field component to use for extrapolation.
+  No default.
++ **`vol` [`Volume`]** — Specifies the volume over which to accumulate fields
+  (may be 0d, 1d, 2d, or 3d). No default.
++ **`center` [`Vector3` class]** — Alternative method for specifying volume, using a center point
++ **`size` [`Vector3` class]** — Alternative method for specifying volume, using a size vector
++ **`m` [`Optional[int]`]** — Directly pecifies the order of the numerator $P$. If not specified,
+  defaults to the length of aggregated field data times `m_frac`.
++ **`n` [`Optional[int]`]** — Specifies the order of the denominator $Q$. Defaults
+  to length of field data - m - 1.
++ **`m_frac` [`float`]** — Method for specifying `m` as a fraction of
+  field samples to use as order for numerator. Default is 0.5.
++ **`n_frac` [`Optional[float]`]** — Fraction of field samples to use as order for
+  denominator. No default.
++ **`sampling_interval` [`int`]** — Specifies the interval at which to sample the field data.
+  Defaults to 1.
++ **`start_time` [`int`]** — Specifies the time (in increments of dt) at which
+  to start sampling the field data. Default 0 (beginning of simulation).
++ **`stop_time` [`Optional[int]`]** — Specifies the time (in increments of dt) at which
+  to stop sampling the field data. Default is `None` (end of simulation).
+
+</div>
+
+</div>
+
+
+---
 <a id="Verbosity"></a>
 
 ### Verbosity

--- a/python/meep.i
+++ b/python/meep.i
@@ -1723,6 +1723,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         FluxRegion,
         ForceRegion,
         Harminv,
+        Pade,
         Identity,
         Mirror,
         ModeRegion,

--- a/python/meep.i
+++ b/python/meep.i
@@ -1723,7 +1723,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         FluxRegion,
         ForceRegion,
         Harminv,
-        Pade,
+        PadeDFT,
         Identity,
         Mirror,
         ModeRegion,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -925,10 +925,10 @@ class PadeDFT:
         + **`m` [`Optional[float]`]** — Directly pecifies the order of the numerator $P$. If not specified,
          defaults to the length of aggregated field data times `m_frac`.
         + **`n` [`Optional[float]`]** — Specifies the order of the denominator $Q$. Defaults
-         to length of field data - m - 1. 
-        + **`m_frac` [`float`]** — Method for specifying `m` as a fraction of 
-         field samples to use as order for numerator. Default is 0.5. 
-        + **`n_frac` [`Optional[float]`]** — Fraction of field samples to use as order for 
+         to length of field data - m - 1.
+        + **`m_frac` [`float`]** — Method for specifying `m` as a fraction of
+         field samples to use as order for numerator. Default is 0.5.
+        + **`n_frac` [`Optional[float]`]** — Fraction of field samples to use as order for
          denominator. No default.
         + **`sampling_interval` [`int`]** — Specifies the interval at which to sample the field data.
          Defaults to 1.
@@ -979,9 +979,13 @@ class PadeDFT:
 
         # Infer the desired behavior for m and n from the supplied arguments
         if not self.m:
-            self.m = int(len(samples)*self.m_frac)
+            self.m = int(len(samples) * self.m_frac)
         if not self.n:
-            self.n = int(len(samples)-self.m-1) if not self.n_frac else int(len(samples)*self.n_frac)
+            self.n = (
+                int(len(samples) - self.m - 1)
+                if not self.n_frac
+                else int(len(samples) * self.n_frac)
+            )
 
         # Compute the Padé approximant, store the poly1d instances
         self.p, self.q = pade(samples, self.m, self.n)

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -922,9 +922,9 @@ class PadeDFT:
         + **`c` [`component` constant]** — Specifies the field component to use for extrapolation.
          No default.
         + **`pt` [`Vector3`]** — Specifies the location to accumulate fields. No default.
-        + **`m` [`Optional[float]`]** — Directly pecifies the order of the numerator $P$. If not specified,
+        + **`m` [`Optional[int]`]** — Directly pecifies the order of the numerator $P$. If not specified,
          defaults to the length of aggregated field data times `m_frac`.
-        + **`n` [`Optional[float]`]** — Specifies the order of the denominator $Q$. Defaults
+        + **`n` [`Optional[int]`]** — Specifies the order of the denominator $Q$. Defaults
          to length of field data - m - 1.
         + **`m_frac` [`float`]** — Method for specifying `m` as a fraction of
          field samples to use as order for numerator. Default is 0.5.

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -866,26 +866,27 @@ class EigenmodeData:
 
 class Pade:
     """
-    Pade is implemented as a class with a [`__call__`](#Pade.__call__) method,
+    Padé approximant based spectral extrapolation is implemented as a class with a [`__call__`](#Pade.__call__) method,
     which allows it to be used as a step function that collects field data from a given
-    point and runs [Pade](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.pade.html)
-    on that data to extract an analytic rational function which models the frequency response.
+    point and runs [Padé](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.pade.html)
+    on that data to extract an analytic rational function which approximates the frequency response.
+    For more information about the Padé approximant, see: https://en.wikipedia.org/wiki/Padé_approximant.
 
     See [`__init__`](#Pade.__init__) for details about constructing a `Pade`.
 
-    In particular, Pade stores the discrete time series $\\hat{f}[n]$ corresponding to the given field
+    In particular, `Padé` stores the discrete time series $\\hat{f}[n]$ corresponding to the given field
     component as a function of time and expresses it as:
 
     $$\\hat{f}(\\omega) = \\sum_n \\hat{f}[n] e^{i\\omega n \\Delta t}$$
 
     The above is a "Taylor-like" polynomial in $$n$$ with a Fourier basis and
-    coefficients which are the sampled field data. We then compute the Pade approximant
-    to the analytic form of this function as:
+    coefficients which are the sampled field data. We then compute the Padé approximant
+    to be the analytic form of this function as:
 
     $$R(\\omega) = \\frac{P(\\omega)}{Q(\\omega)}$$
 
     Where $$P$$ and $$Q$$ are polynomials of degree $$m$$ and $$n$$, and $$m + n + 1$$ is the
-    degree of agreement of the Pade Approximant to the analytic function $$f(\\omega)$$. This
+    degree of agreement of the Padé approximant to the analytic function $$f(\\omega)$$. This
     function $$R$$ is stored in the callable method `pade_instance.freq_response`.
     Be sure to save a reference to the `Pade` instance if you wish
     to use the results after the simulation:

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -964,18 +964,15 @@ class PadeDFT:
         """
         self.step_func(sim, todo)
 
-    def _collect_pade(self):
-        def _collect1(c, vol, center, size):
-            self.t0 = 0
+    def _collect_pade(self, c, vol, center, size):
+        self.t0 = 0
 
-            def _collect2(sim):
-                self.data_dt = sim.meep_time() - self.t0
-                self.t0 = sim.meep_time()
-                self.data.append(sim.get_array(c, vol, center, size))
+        def _collect(sim):
+            self.data_dt = sim.meep_time() - self.t0
+            self.t0 = sim.meep_time()
+            self.data.append(sim.get_array(c, vol, center, size))
 
-            return _collect2
-
-        return _collect1
+        return _collect
 
     def _analyze_pade(self, sim):
         # Ensure that the field data has dimension (# time steps x (volume dims))
@@ -1035,11 +1032,9 @@ class PadeDFT:
         def _p(sim):
             self.dft = self._analyze_pade(sim)
 
-        f1 = self._collect_pade()
+        f1 = self._collect_pade(self.c, self.vol, self.center, self.size)
 
-        return _combine_step_funcs(
-            at_end(_p), f1(self.c, self.vol, self.center, self.size)
-        )
+        return _combine_step_funcs(at_end(_p), f1)
 
 
 class Harminv:

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -5203,6 +5203,11 @@ def stop_when_dft_decayed(tol=1e-11, minimum_run_time=0, maximum_run_time=None):
 
     return _stop
 
+def compute_pade():
+    pass
+
+def stop_when_pade_converged():
+    pass
 
 def combine_step_funcs(*step_funcs):
     """

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -874,20 +874,20 @@ class Pade:
 
     See [`__init__`](#Pade.__init__) for details about constructing a `Pade`.
 
-    In particular, `Padé` stores the discrete time series $\\hat{f}[n]$ corresponding to the given field
+    In particular, `Pade` stores the discrete time series $\\hat{f}[n]$ corresponding to the given field
     component as a function of time and expresses it as:
 
     $$\\hat{f}(\\omega) = \\sum_n \\hat{f}[n] e^{i\\omega n \\Delta t}$$
 
-    The above is a "Taylor-like" polynomial in $$n$$ with a Fourier basis and
+    The above is a "Taylor-like" polynomial in $n$ with a Fourier basis and
     coefficients which are the sampled field data. We then compute the Padé approximant
     to be the analytic form of this function as:
 
     $$R(\\omega) = \\frac{P(\\omega)}{Q(\\omega)}$$
 
-    Where $$P$$ and $$Q$$ are polynomials of degree $$m$$ and $$n$$, and $$m + n + 1$$ is the
-    degree of agreement of the Padé approximant to the analytic function $$f(\\omega)$$. This
-    function $$R$$ is stored in the callable method `pade_instance.freq_response`.
+    Where $P$ and $Q$ are polynomials of degree $m$ and $n$, and $m + n + 1$ is the
+    degree of agreement of the Padé approximant to the analytic function $f(\\omega)$. This
+    function $R$ is stored in the callable method `pade_instance.freq_response`.
     Be sure to save a reference to the `Pade` instance if you wish
     to use the results after the simulation:
 
@@ -906,18 +906,18 @@ class Pade:
         m: Optional[Union[int, float]] = None,
         n: Optional[Union[int, float]] = None,
         sampling_interval: int = 1,
-        start_time: Optional[int] = 0,
+        start_time: int = 0,
         stop_time: Optional[int] = None,
     ):
         """
         Construct a Padé object.
 
         A `Pade` is a step function that collects data from the field component `c`
-        (e.g. $E_x$, etc.) at the given point `pt` (a `Vector3`). Then, at the end
+        (e.g. `meep.Ex`, etc.) at the given point `pt` (a `Vector3`). Then, at the end
         of the run, it uses the scipy Padé algorithm to approximate the analytic
         frequency response at the specified point.
 
-        + **`c` [`Component`]** — Specifies the field component to use for extrapolation.
+        + **`c` [`component` constant]** — Specifies the field component to use for extrapolation.
          No default.
         + **`pt` [`Vector3`]** — Specifies the location to accumulate fields. No default.
         + **`m` [`Optional[Union[int,float]]`]** — Specifies the order of the numerator $$P$$. Behavior
@@ -928,10 +928,10 @@ class Pade:
          similar behavior to `n`. Defaults to length of sampled data - `m` - 1.
         + **`sampling_interval` [`int`]** — Specifies the interval at which to sample the field data.
          Defaults to 1.
-        + **`start_time` [`Optional[int]`]** — Specifies the time (in increments of dt) at which
+        + **`start_time` [`int`]** — Specifies the time (in increments of dt) at which
          to start sampling the field data. Default 0 (beginning of simulation).
         + **`stop_time` [`Optional[int]`]** — Specifies the time (in increments of dt) at which
-         to stop sampling the field data. Default None (end of simulation).
+         to stop sampling the field data. Default is `None` (end of simulation).
         """
         self.c = c
         self.pt = pt

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -887,7 +887,9 @@ class PadeDFT:
 
     Where $P$ and $Q$ are polynomials of degree $m$ and $n$, and $m + n + 1$ is the
     degree of agreement of the Padé approximant to the analytic function $f(2 \\pi \\omega)$. This
-    function $R$ is stored in the callable method `pade_instance.dft`.
+    function $R$ is stored in the callable method `pade_instance.dft`. Note that the computed polynomials
+    $P$ and $Q$ for each spatial point are stored as well in the instance variable `pade_instance.polys`,
+    as a spatial array of dicts: `[{"P": P(t), "Q": Q(t)}]` with no spectral extrapolation performed.
     Be sure to save a reference to the `Pade` instance if you wish
     to use the results after the simulation:
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -9,6 +9,7 @@ import sys
 import warnings
 from collections import OrderedDict, namedtuple
 from typing import Callable, List, Optional, Tuple, Union
+from scipy.interpolate import pade
 
 try:
     from collections.abc import Sequence, Iterable

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -858,49 +858,39 @@ class EigenmodeData:
     def amplitude(self, point, component):
         swig_point = mp.vec(point.x, point.y, point.z)
         return mp.eigenmode_amplitude(self.swigobj, swig_point, component)
-    
+
+
 class Pade:
     """
-    Pade is implemented as a class with a [`__call__`](#Pade.__call__) method from scipy,
+    Pade is implemented as a class with a [`__call__`](#Pade.__call__) method,
     which allows it to be used as a step function that collects field data from a given
     point and runs [Pade](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.pade.html) 
-    on that data to extract the frequency response
+    on that data to extract an analytic rational function which models the frequency response.
 
     See [`__init__`](#Pade.__init__) for details about constructing a `Pade`.
 
-    In particular, Pade takes the time series $f(t)$ corresponding to the given field
-    component as a function of time and decomposes it (within the specified bandwidth) as:
+    In particular, Pade stores the discrete time series $\\hat{f}[n]$ corresponding to the given field
+    component as a function of time and expresses it as:
 
-    $$f(t) = \\sum_n a_n e^{-i\\omega_n t}$$
+    $$\\hat{f}(\\omega) = \\sum_n \\hat{f}[n] e^{i\\omega n \\Delta t}$$
 
-    The results are stored in the list `Pade.dtft`, which is a list of tuples holding
-    the frequency, amplitude, and error of each frequency component. Given one of these tuples (e.g.,
-    `first_mode = harminv_instance.modes[0]`), you can extract its various components:
+    The above is a "Taylor-like" polynomial in $$n$$ with a Fourier basis and
+    coefficients which are the sampled field data. We then compute the Pade approximant
+    to the analytic form of this function as:
 
-    + **`freq`** — The real part of frequency ω (in the usual Meep 2πc units).
-
-    + **`decay`** — The imaginary part of the frequency ω.
-
-    + **`Q`** — The dimensionless lifetime, or quality factor defined as
-      $-\\mathrm{Re}\\,\\omega / 2 \\mathrm{Im}\\,\\omega$.
-
-    + **`amp`** — The complex amplitude $a$.
-
-    + **`err`** — A crude measure of the error in the frequency (both real and imaginary).
-      If the error is much larger than the imaginary part, for example, then you can't
-      trust the $Q$ to be accurate. Note: this error is only the uncertainty in the signal
-      processing, and tells you nothing about the errors from finite resolution, finite
-      cell size, and so on.
-
-    For example, `[m.freq for m in pade_instance.modes]` gives a list of the real parts
-    of the frequencies. Be sure to save a reference to the `Pade` instance if you wish
+    $$R(\\omega) = \\frac{P(\\omega)}{Q(\\omega)}$$
+    
+    Where $$P$$ and $$Q$$ are polynomials of degree $$m$$ and $$n$$, and $$m + n + 1$$ is the
+    degree of agreement of the Pade Approximant to the analytic function $$f(\\omega)$$. This
+    function $$R$$ is stored in the callable method `pade_instance.freq_response`.
+    Be sure to save a reference to the `Pade` instance if you wish
     to use the results after the simulation:
 
     ```py
     sim = mp.Simulation(...)
-    h = mp.Pade(...)
-    sim.run(mp.after_sources(h))
-    # do something with h.modes
+    p = mp.Pade(...)
+    sim.run(p, until=time)
+    # do something with p.freq_response
     ```
     """
 
@@ -908,35 +898,51 @@ class Pade:
         self,
         c: int = None,
         pt: Vector3Type = None,
+        m: Optional[float] = None,
+        n: Optional[float] = None,
+        m_frac: float = 0.5,
+        n_frac: Optional[float] = None,
         sample_rate: int = 1,
         start_time: Optional[int] = 0,
-        stop_time: Optional[int] = -1,
-        m: Optional[float] = None,
-        n: Optional[float] = None
+        stop_time: Optional[int] = None,
     ):
         """
         Construct a Pade object.
 
         A `Pade` is a step function that collects data from the field component `c`
         (e.g. $E_x$, etc.) at the given point `pt` (a `Vector3`). Then, at the end
-        of the run, it uses Harminv to look for modes in the given frequency range (center
-        `fcen` and width `df`), printing the results to standard output (prefixed by
-        `harminv:`) as comma-delimited text, and also storing them to the variable
-        `Harminv.modes`. The optional argument `mxbands` is the maximum number of modes to
-        search for. Defaults to 100.
+        of the run, it uses the scipy pade algorithm to approximate the analytic
+        frequency response at the specified point. 
         
-        m_frac is the order of the top polynomial with respect to thte bottom polynomial
+        + **`c` [`Component`]** — Specifies the field component to use for extrapolation.
+         No default.
+        + **`pt` [`Vector3`]** — Specifies the location to accumulate fields. No default.
+        + **`m` [`Optional[float]`]** — Specifies the order of the numerator $$P$$. Defaults
+         to half the length of the sampled field data.
+        + **`n` [`Optional[float]`]** — Specifies the order of the denominator $$Q$$. Defaults
+         to length of sample data - m - 2. 
+        + **`m_frac` [`float`]** — Alternative method for specifying `m` as a fraction of 
+         field samples to use as order for numerator. Default 0.5. 
+        + **`n_frac` [`Optional[float]`]** — Fraction of field samples to use as order for 
+         denominator. No default.
+        + **`sample_rate` [`int`]** — Specifies the rate at which to sample the field data. Default 1.
+        + **`start_time` [`Optional[int]`]** — Specifies the time (in increments of dt) at which 
+         to start sampling the field data. Default 0 (beginning of simulation).
+        + **`stop_time` [`Optional[int]`]** — Specifies the time (in increments of dt) at which 
+         to stop sampling the field data. Default None (end of simulation).
         """
         self.c = c
         self.pt = pt
-        self.sample_rate = sample_rate
+        self.m_frac = m_frac
+        self.n_frac = n_frac
         self.m = m
         self.n = n
+        self.sample_rate = sample_rate
         self.start_time = start_time
         self.stop_time = stop_time
         self.data = []
         self.data_dt = 0
-        self.pade_approx: Callable = None
+        self.freq_response: Callable = None
         self.step_func = self._pade()
 
     def __call__(self, sim, todo):
@@ -958,38 +964,33 @@ class Pade:
 
         return _collect1
 
-
     def _analyze_pade(self, sim):
-        # pade_cols = ["frequency", "imag. freq.", "Q", "|amp|", "amplitude", "error"]
-        # display_run_data(sim, "pade", pade_cols)
-
         dt = sim.fields.dt
         
-        print(len(self.data))
         samples = self.data[self.start_time:self.stop_time:self.sample_rate]
-        print(len(samples))
 
-        m = int(len(samples)/2) if not self.m else self.m
-        n = int(len(samples)-m-2) if not self.n else self.n
+        if not self.m:
+            self.m = int(len(samples)/2) if not self.m_frac else int(len(samples)*self.m_frac)
+        if not self.n:
+            self.n = int(len(samples)-self.m-2) if not self.n_frac else int(len(samples)*self.n_frac)
         
-        p,q = pade(samples, m, n)
+        p,q = pade(samples, self.m, self.n)
         
-        #TODO: make compatible with any monitor type (e.g. poynting flux, energy spectra)
-        #TODO: add decimation factor (comes with monitor type)
-        #TODO: print rho, number of zero singular values in SVD
+        # TODO: make compatible with any monitor type (e.g. poynting flux, energy spectra)
+        # TODO: add decimation factor (comes with monitor type)
+        # TODO: include option to use Trefethen SVD-based algorithm
 
         pn = p.coef
         qn = q.coef
 
-        P = lambda w: np.sum([pi * np.exp(1j * w * self.sample_rate*dt * n) for n,pi in enumerate(np.flip(pn))])
-        Q = lambda w: np.sum([qi * np.exp(1j * w * self.sample_rate*dt * n) for n,qi in enumerate(np.flip(qn))])
+        P = lambda w: np.sum([pi * np.exp(1j * w * self.sample_rate*dt * i) for i,pi in enumerate(pn)])
+        Q = lambda w: np.sum([qi * np.exp(1j * w * self.sample_rate*dt * i) for i,qi in enumerate(qn)])
 
         return lambda freq: P(2*np.pi*freq)/Q(2*np.pi*freq)
 
-
     def _pade(self):
         def _p(sim):
-            self.pade_approx = self._analyze_pade(sim)
+            self.freq_response = self._analyze_pade(sim)
 
         f1 = self._collect_pade()
 
@@ -5340,11 +5341,6 @@ def stop_when_dft_decayed(tol=1e-11, minimum_run_time=0, maximum_run_time=None):
 
     return _stop
 
-def compute_pade():
-    pass
-
-def stop_when_pade_converged():
-    pass
 
 def combine_step_funcs(*step_funcs):
     """

--- a/python/tests/test_ring.py
+++ b/python/tests/test_ring.py
@@ -46,7 +46,7 @@ class TestRing(unittest.TestCase):
 
         self.sim.use_output_directory(self.temp_dir)
         self.h = mp.Harminv(mp.Ez, mp.Vector3(r + 0.1), fcen, df)
-        self.p = mp.Pade(mp.Ez, mp.Vector3(r + 0.1), sample_rate=4)
+        self.p = mp.Pade(mp.Ez, mp.Vector3(r + 0.1), sampling_interval=4)
 
     def test_harminv(self):
         self.init()

--- a/python/tests/test_ring.py
+++ b/python/tests/test_ring.py
@@ -46,7 +46,9 @@ class TestRing(unittest.TestCase):
 
         self.sim.use_output_directory(self.temp_dir)
         self.h = mp.Harminv(mp.Ez, mp.Vector3(r + 0.1), fcen, df)
-        self.p = mp.PadeDFT(mp.Ez, mp.Vector3(r + 0.1), sampling_interval=4)
+        self.p = mp.PadeDFT(
+            c=mp.Ez, center=mp.Vector3(r + 0.1), size=mp.Vector3(), sampling_interval=4
+        )
 
     def test_harminv(self):
         self.init()

--- a/python/tests/test_ring.py
+++ b/python/tests/test_ring.py
@@ -46,7 +46,7 @@ class TestRing(unittest.TestCase):
 
         self.sim.use_output_directory(self.temp_dir)
         self.h = mp.Harminv(mp.Ez, mp.Vector3(r + 0.1), fcen, df)
-        self.p = mp.Pade(mp.Ez, mp.Vector3(r + 0.1), sampling_interval=4)
+        self.p = mp.PadeDFT(mp.Ez, mp.Vector3(r + 0.1), sampling_interval=4)
 
     def test_harminv(self):
         self.init()
@@ -86,7 +86,7 @@ class TestRing(unittest.TestCase):
             self.h.fcen - self.h.df / 2, self.h.fcen + self.h.df / 2, 1000
         )
 
-        freq_domain = [self.p.freq_response(freq) for freq in freqs]
+        freq_domain = [self.p.dft(freq) for freq in freqs]
 
         idx = find_peaks(
             np.abs(freq_domain) ** 2 / max(np.abs(freq_domain) ** 2), prominence=1e-4

--- a/python/tests/test_ring.py
+++ b/python/tests/test_ring.py
@@ -77,7 +77,6 @@ class TestRing(unittest.TestCase):
         self.init()
 
         self.sim.run(
-            mp.at_beginning(mp.output_epsilon),
             self.p,
             mp.after_sources(self.h),
             until_after_sources=300,

--- a/python/tests/test_ring.py
+++ b/python/tests/test_ring.py
@@ -6,6 +6,7 @@ import meep as mp
 import numpy as np
 from scipy.signal import find_peaks
 
+
 class TestRing(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -82,12 +83,16 @@ class TestRing(unittest.TestCase):
             until_after_sources=300,
         )
 
-        freqs = np.linspace(self.h.fcen - self.h.df/2, self.h.fcen + self.h.df/2, 1000)
+        freqs = np.linspace(
+            self.h.fcen - self.h.df / 2, self.h.fcen + self.h.df / 2, 1000
+        )
 
         freq_domain = [self.p.freq_response(freq) for freq in freqs]
 
-        idx = find_peaks(np.abs(freq_domain)**2 / max(np.abs(freq_domain)**2), prominence=1e-4)[0]
-        
+        idx = find_peaks(
+            np.abs(freq_domain) ** 2 / max(np.abs(freq_domain) ** 2), prominence=1e-4
+        )[0]
+
         self.assertAlmostEqual(freqs[idx[0]], self.h.modes[0].freq, places=3)
 
 

--- a/python/tests/test_ring.py
+++ b/python/tests/test_ring.py
@@ -3,7 +3,8 @@
 import unittest
 
 import meep as mp
-
+import numpy as np
+from scipy.signal import find_peaks
 
 class TestRing(unittest.TestCase):
     @classmethod
@@ -44,6 +45,7 @@ class TestRing(unittest.TestCase):
 
         self.sim.use_output_directory(self.temp_dir)
         self.h = mp.Harminv(mp.Ez, mp.Vector3(r + 0.1), fcen, df)
+        self.p = mp.Pade(mp.Ez, mp.Vector3(r + 0.1), sample_rate=4)
 
     def test_harminv(self):
         self.init()
@@ -69,6 +71,24 @@ class TestRing(unittest.TestCase):
         places = 5 if mp.is_single_precision() else 7
         self.assertAlmostEqual(ep, 11.559999999999999, places=places)
         self.assertAlmostEqual(fp, -0.08185972142450348, places=places)
+
+    def test_pade(self):
+        self.init()
+
+        self.sim.run(
+            mp.at_beginning(mp.output_epsilon),
+            self.p,
+            mp.after_sources(self.h),
+            until_after_sources=300,
+        )
+
+        freqs = np.linspace(self.h.fcen - self.h.df/2, self.h.fcen + self.h.df/2, 1000)
+
+        freq_domain = [self.p.freq_response(freq) for freq in freqs]
+
+        idx = find_peaks(np.abs(freq_domain)**2 / max(np.abs(freq_domain)**2), prominence=1e-4)[0]
+        
+        self.assertAlmostEqual(freqs[idx[0]], self.h.modes[0].freq, places=3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
After too much delay, this is an initial PR for Pade-approximant based spectral extrapolation, hopefully closing #2192. It essentially works in the same way as `Harminv` (thanks @Alex-Kaylor for help with the initial implementation) by aggregating field and computing an analytic frequency response using the rational Pade Approximant.

Like `Harminv`, `Pade` is constructed as a class that holds as a member variable (`data`) the aggregated field data, parameters for sampling the data, and the computed analytic function. 

To initialize, one need only provide a field component `c` and a point `pt` at which to perform the computation. 

Optional arguments include `sample_rate`, `start_time` and `stop_time`, which sample the collected field data according to `samples = self.data[self.start_time : self.stop_time : self.sample_rate]`. 

Additionally, there are `m` and `n`, which respectively set the orders of the numerator and denominator. Alternatively, one can specify `m_frac` or `n_frac`, which specify `m` and `n` as fractions of the length of the collected time series. If none of these are specified, the default behavior is to use half the length of the time series as the order of the numerator `m`, and `N-m-2` as the order of the denominator.

Speaking of the algorithm, the code is currently implemented by calling the builtin scipy `pade` routine. Separately, I have investigated the behavior of the [Trefethen SVD-based algorithm](https://doi.org/10.1137/110853236) and found it to be much harder to get it to converge (though in theory it is more robust to noise in the input data). Thus, the existing implementation only uses the builtin scipy algorithm, but it would be nice to at least have the option of using either algorithm. The way I have implemented the Trefethen algorithm [here](https://github.com/Arjun-Khurana/series-extrapolation/blob/master/trefethen.py) provides straightforward potential interchange of Trefethen and scipy. 

I have also written a test case that compares the center frequency of a peak in the Pade frequency response to the first Harminv mode, included in `test_ring.py`. This case passes when I run it locally with `python3 -m pytest python/tests/test_ring.py` but fails on my fork's CI workflow, I'm sure I'm doing something incorrectly there. 