### PR TITLE
Update integration weights to account for cylindrical coordinates

### DIFF
--- a/python/tests/test_cyl_weights.py
+++ b/python/tests/test_cyl_weights.py
@@ -1,0 +1,145 @@
+"""Tests that the integration weights are computed properly in cylindrical coordinates.
+
+"""
+
+import unittest
+from typing import Tuple
+import meep as mp
+import numpy as np
+
+
+resolution = 80  # pixels/μm
+n = 2.4  # refractive index of dielectric layer
+wvl = 1.0  # wavelength (in vacuum)
+fcen = 1 / wvl  # center frequency of source/monitor
+
+
+def led_flux(dmat: float, h: float, rpos: float, m: int) -> Tuple[float, float]:
+    """Computes the radiated and total flux of a point source embedded
+       within a dielectric layer above a lossless ground plane.
+
+    Args:
+       dmat: thickness of dielectric layer.
+       h: height of dipole above ground plane as a fraction of dmat.
+       rpos: position of source in radial direction.
+       m: angular φ dependence of the fields exp(imφ).
+
+    Returns:
+       The radiated and total flux as a 2-Tuple.
+    """
+    L = 20  # length of non-PML region in radial direction
+    dair = 1.0  # thickness of air padding
+    dpml = 1.0  # PML thickness
+    sr = L + dpml
+    sz = dmat + dair + dpml
+    cell_size = mp.Vector3(sr, 0, sz)
+
+    boundary_layers = [
+        mp.PML(dpml, direction=mp.R),
+        mp.PML(dpml, direction=mp.Z, side=mp.High),
+    ]
+
+    src_pt = mp.Vector3(rpos, 0, -0.5 * sz + h * dmat)
+    sources = [
+        mp.Source(
+            src=mp.GaussianSource(fcen, fwidth=0.1 * fcen),
+            component=mp.Er,
+            center=src_pt,
+        ),
+    ]
+
+    geometry = [
+        mp.Block(
+            material=mp.Medium(index=n),
+            center=mp.Vector3(0, 0, -0.5 * sz + 0.5 * dmat),
+            size=mp.Vector3(mp.inf, mp.inf, dmat),
+        )
+    ]
+
+    sim = mp.Simulation(
+        resolution=resolution,
+        cell_size=cell_size,
+        dimensions=mp.CYLINDRICAL,
+        m=m,
+        boundary_layers=boundary_layers,
+        sources=sources,
+        geometry=geometry,
+    )
+
+    flux_air_mon = sim.add_flux(
+        fcen,
+        0,
+        1,
+        mp.FluxRegion(
+            center=mp.Vector3(0.5 * L, 0, 0.5 * sz - dpml),
+            size=mp.Vector3(L, 0, 0),
+        ),
+        mp.FluxRegion(
+            center=mp.Vector3(L, 0, 0.5 * sz - dpml - 0.5 * dair),
+            size=mp.Vector3(0, 0, dair),
+        ),
+    )
+
+    sim.run(
+        mp.dft_ldos(fcen, 0, 1),
+        until_after_sources=mp.stop_when_fields_decayed(
+            50.0,
+            mp.Er,
+            src_pt,
+            1e-8,
+        ),
+    )
+
+    flux_air = mp.get_fluxes(flux_air_mon)[0]
+
+    if rpos == 0:
+        dV = np.pi / (resolution**3)
+    else:
+        dV = 2 * np.pi * rpos / (resolution**2)
+
+    # total flux from point source via LDOS
+    flux_src = -np.real(sim.ldos_Fdata[0] * np.conj(sim.ldos_Jdata[0])) * dV
+
+    print(f"flux-cyl:, {rpos:.2f}, {m:3d}, {flux_src:.6f}, {flux_air:.6f}")
+
+    return flux_air, flux_src
+
+class TestCylWeights(unittest.TestCase):
+    def test_weights(self):
+        layer_thickness = 0.7 * wvl / n
+        dipole_height = 0.5
+
+        rpos = [0.5, 1.5]
+        flux_tol = 1e-5  # threshold flux to determine when to truncate expansion
+        normalized_flux = []
+        for rp in rpos:
+            # analytic upper bound on m based on coupling to free-space modes
+            # in light cone of source medium
+            cutoff_M = int(rp * 2 * np.pi * fcen * n)
+            ms = range(cutoff_M + 1)
+            flux_src_tot = 0
+            flux_air_tot = 0
+            flux_air_max = 0
+            for m in ms:
+                flux_air, flux_src = led_flux(
+                    layer_thickness,
+                    dipole_height,
+                    rp,
+                    m,
+                )
+                flux_air_tot += flux_air if m == 0 else 2 * flux_air
+                flux_src_tot += flux_src if m == 0 else 2 * flux_src
+                if flux_air > flux_air_max:
+                    flux_air_max = flux_air
+                if m > 0 and (flux_air / flux_air_max) < flux_tol:
+                    break
+            
+            normalized_flux.append(flux_air_tot / rp**2)
+        
+        print("--------------------------")
+        print(normalized_flux)
+        # TODO
+        # check for equivalence
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
closes #2467.

This PR attempts to compute the proper integration weights for $r$ in cylindrical coordinates. There are a few things to be aware of:

1. @oskooi I don't think this fixes the issue with dipoles near $r=0$. Primarily because the interpolation formula for a dipole in cylindrical coordinates appears to be the *same* as Cartesian (at least according to the in-repo notes). So while this PR should help with some of the edge elements of monitors, it's not the fix we're looking for.
2. I added an `abort` if the user attempts to place a source or monitor that spans $r<0$. Physically, I don't even know what this means (a double source/monitor?) and it's a pain to deal with in the code (as described in the notes). So we punt.
3. Dealing with the weights right at $r=0$ is tricky. We don't want to divide by zero, so I include the `dV` term in the weight itself here. This required some additional modification to the `loop_in_chunks()` function, but doesn't seem to affect the `IVEC_LOOP_WEIGHT` macro (contrary to what the notes suggest) so I left that alone
4. Getting the indexing and resolution just right is a bookkeeping nightmare... so we should double check this.
5. The current test isn't a suitable test, since this doesn't fix that issue (plus it takes far too long to run with all of the `m` simulations sequentially, even for just two points relatively close to $r=0$.

I think this PR is more in the noise floor when it comes to comparing accuracy of a cylindrical simulation and a true 3D simulation with dipole sources.

@stevengj, since the issue isn't with source grid weights themselves, can you think of any other factors that would impact a dipole source in cylindrical coordinates?