### PR TITLE
Add test_verbosity_mgr.py to `make check` suite

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -95,6 +95,7 @@ TESTS =                                        \
     $(TEST_DIR)/test_source.py                 \
     $(TEST_DIR)/test_timing_measurements.py    \
     $(TEST_DIR)/test_user_defined_material.py  \
+    $(TEST_DIR)/test_verbosity_mgr.py          \
     $(TEST_DIR)/test_visualization.py          \
     $(WVG_SRC_TEST)
 


### PR DESCRIPTION
The PR adds the unit test [python/tests/test_verbosity_mgr.py](https://github.com/NanoComp/meep/blob/master/python/tests/test_verbosity_mgr.py) to the `make check` suite. This was likely omitted by accident in #1388.