### PR TITLE
Add Meep namespace identifier to prevent conflict with standard library in C++20

### DIFF
--- a/tests/h5test.cpp
+++ b/tests/h5test.cpp
@@ -35,7 +35,7 @@ double funky_eps_3d(const vec &p_) {
 
 symmetry make_identity(const grid_volume &gv) {
   (void)gv; // unused
-  return identity();
+  return meep::identity();
 }
 
 symmetry make_mirrorx(const grid_volume &gv) { return mirror(X, gv); }


### PR DESCRIPTION
Adds a `meep::` namespace identifier to the function `identity` in one of the unit tests to prevent a conflict with [`std::identity`](https://en.cppreference.com/w/cpp/utility/functional/identity) introduced in C++20.