### PR TITLE
Correct the weights for dipole sources in cylindrical coordinates

### DIFF
--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1524,6 +1524,10 @@ public:
   }
 
   double last_source_time();
+
+  // sources.cpp
+  std::complex<double> sum_sources(field_type ft);
+
   // monitor.cpp
   std::complex<double> get_field(component, const ivec &) const;
 
@@ -1760,6 +1764,9 @@ public:
   void log(const char *prefix = "");
   void change_m(double new_m);
   bool has_nonlinearities(bool parallel = true) const;
+
+  // sources.coo
+  std::complex<double> sum_sources(field_type ft);
 
   // time.cpp
   std::vector<double> time_spent_on(time_sink sink);

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -271,6 +271,7 @@ static void src_vol_chunkloop(fields_chunk *fc, int ichunk, component c, ivec is
 
     vec rel_loc = loc - data->center;
 
+    // in cylindrical coordinates, we need to account for the r term in the integral.
     if (fc->gv.dim == Dcyl)
       amps_array[idx_vol] =
           IVEC_LOOP_WEIGHT(s0, s1, e0, e1, dV0 + dV1 * loop_i2) * amp * data->A(rel_loc);
@@ -483,9 +484,16 @@ void fields::add_volume_source(component c, const src_time &src, const volume &w
   src_vol_chunkloop_data data;
   data.A = A ? A : one;
   data.amp = amp;
+  // correct units for J delta-function amplitude
   LOOP_OVER_DIRECTIONS(gv.dim, d) {
-    if (gv.dim != Dcyl && where.in_direction(d) == 0.0 && !nosize_direction(d)) // delta-fun
-      data.amp *= gv.a; // correct units for J delta-function amplitude
+    if (where.in_direction(d) == 0.0 && !nosize_direction(d)) { // delta-fun
+      if (d == R && where.center().in_direction(d) > 0)
+        // in cylindrical coordinates, we need to scale by $r$ for a dipole.
+        data.amp *= 1.0 / where.center().in_direction(d);
+      else if (gv.dim != Dcyl)
+        // we handle the resolution scaling at the chunk level for cylindrical coordinates.
+        data.amp *= gv.a;
+    }
   }
   sources = src.add_to(sources, &data.src);
   data.center = (where.get_min_corner() + where.get_max_corner()) * 0.5;
@@ -760,6 +768,11 @@ diffractedplanewave::diffractedplanewave(int g_[3], double axis_[3], std::comple
   p = p_;
 };
 
+/*
+Occasionally, it's useful to check the sum of all the actual source amplitudes
+(e.g. to ensure that the boundary weights are being computed properly).
+`sum_sources()` provides a convenient interface to do just that.
+*/
 std::complex<double> fields::sum_sources(field_type ft) {
   std::complex<double> total_sources = 0.0;
 


### PR DESCRIPTION
As discussed, it's challenging to get the weights just right for a dipole source in cylindrical coordinates. This PR attempts to address that.

First, I modified `sources.cpp` to include the `r` factor from the `dV0` and `dV1` weight factors, just like what's implemented when processing DFT fields. Previously, this factor was completely omitted.

Second, for dipole sources, I include the `1/r` term that is necessary for a proper delta function in cylindrical coordinates.

Finally, I added some convenience functions that sum up all the source amplitudes (i.e. perform a sort of "integration") to check if what we're doing is right.

Using these three changes, we should be able to confirm that for a dipole source, it's integral should always be 1 (modulo the resolution scale factor) even for dipoles that lie between grid points. Previously, that wasn't the case. Now, it is. I ran a [simple experiment](https://gist.github.com/smartalecH/6bbd9ced25a18fb29c0a9798e159ee24) that sweeps a dipole between two grid points and sum up the corresponding weights. Indeed, it sums to 1 for all values of $r$ (there's some ambiguity here at $r=0$).

![weights](https://user-images.githubusercontent.com/24902086/233453084-3e629722-6073-4ac9-831a-a449dbfffdd8.png).

Currently, some of the tests are failing. This could be due to a few different factors. Before we tackle that, I want to ensure we get the weight formulation down first.
