### PR TITLE
don't require mpb.h in swig code

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -90,6 +90,11 @@ void display_geometric_object_info(int indentby, GEOMETRIC_OBJECT o);
 
 %}
 
+%ignore meep::eigenmode_data::mdata;
+%ignore meep::eigenmode_data::fft_data_H;
+%ignore meep::eigenmode_data::fft_data_E;
+%ignore meep::eigenmode_data::H;
+
 %include "numpy.i"
 %include "std_vector.i"
 


### PR DESCRIPTION
Fixes #2485.

(When #1319 if fixed this `struct` should be further abstracted to completely remove mpb-dependent fields, but removing the getters/setters in Python should fix the immediate issue.)