### PR TITLE
be a little less aggressive with periodic-design test

### DIFF
--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -958,7 +958,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
         eta_d = 1 - eta_e
         beta, eta = 10, 0.5
         radius, c = 0.3, 400
-        places = 18
+        places = 16
         threshold_f = lambda x: mpa.tanh_projection(x, beta, eta)
 
         for selected_filter in (


### PR DESCRIPTION
The values are on the order of 1e-4, so places=16 checks 12 digits, which should suffice.  places=18 checks 14 digits, which is a bit dangerously close to the level of roundoff errors.