### PR TITLE
Add configuration file for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+   install:
+   - requirements: doc/requirements.txt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,10 +26,6 @@ markdown_extensions:
 extra_javascript:
  - 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML'
 
-formats:
-  - epub
-  - pdf
-
 nav:
 - 'Manual': 'index.md'
 - 'Introduction': 'Introduction.md'


### PR DESCRIPTION
Adds a [configuration file](https://docs.readthedocs.io/en/stable/config-file/index.html) for readthedocs to the source tree. This should [improve reproducibility of the build environments](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html) which hopefully fixes the random [build failures](https://docs.readthedocs.io/en/stable/faq.html#why-does-my-project-have-status-failing) we experience occasionally (such as the current failure). Note that the YAML file must have a `.yaml` rather than `.yml` extension (even though the other YAML files in the source tree use `.yml`).

Also, as described in [#1734 (comment)](https://github.com/NanoComp/meep/issues/1734#issuecomment-1537042784), `mkdocs` does *not* support building `pdf` or `epub` versions of the docs (only `html` is supported) and so the `formats` option is removed from `mkdocs.yml` because it does not do anything.