### PR TITLE
Fixes and tweaks for tutorial on phase of mode coefficients

### DIFF
--- a/doc/docs/Python_Tutorials/Mode_Decomposition.md
+++ b/doc/docs/Python_Tutorials/Mode_Decomposition.md
@@ -146,17 +146,17 @@ In the reflected-flux calculation, we apply our usual trick of first performing 
 Phase of a Total Internal Reflected Mode
 ----------------------------------------
 
-For certain applications, such as [physically based ray tracing](https://pbr-book.org/), the phase of the reflection/transmission coefficient of a surface interface (flat or textured) is an important parameter used for modeling coherent effects (i.e., constructive or destructive interference from a collection of intersecting rays scattered off the surface). This tutorial demonstrates how to use mode decomposition to compute the phase of the reflection coefficient of a [total internal reflected](https://en.wikipedia.org/wiki/Total_internal_reflection) (TIR) mode. The simulated results are verified using the [Fresnel equations](https://en.wikipedia.org/wiki/Total_internal_reflection#Phase_shifts).
+For certain applications, such as [physically based ray tracing](https://pbr-book.org/), the phase of the reflection/transmission coefficient of a surface interface (flat or textured) is an important parameter used for modeling coherent effects (i.e., constructive or destructive interference from a collection of intersecting rays scattered off the surface). This tutorial demonstrates how to use mode decomposition to compute the phase of the reflection coefficient of a [total internal reflected](https://en.wikipedia.org/wiki/Total_internal_reflection) (TIR) mode. The simulated results are validated using the [Fresnel equations](https://en.wikipedia.org/wiki/Total_internal_reflection#Phase_shifts).
 
 The example involves a 2d simulation of a flat interface of two lossless media with $n_1=1.5$ and $n_2=1.0$. The [critical angle](https://en.wikipedia.org/wiki/Total_internal_reflection#Critical_angle) for this interface is $\theta_c = 41.8^\circ$. The source is an incident planewave with linear polarization ($S$ or $P$). The 2d cell is periodic in $y$ with PML in the $x$ direction. The cell size does not affect the results and is therefore arbitrary. A schematic of the simulation layout is shown below.
 
-The key item to consider in these types of calculations is the *location of the mode monitor relative to the interface*. The mode monitor is a line extending the entire length of the cell in the $y$ direction. In order to compare the result with the Fresnel equations, the phase of the reflection coefficient must be computed *exactly* at the interface. However, it is problematic to measure the reflection coefficient exactly at the interface because the amplitude of the left-going wave drops discontinuously to zero across the interface. For this reason, the mode monitor must be positioned away from the interface (somewhere within the $n_1$ medium) and the measured phase must be corrected in post processing to account for this offset.
-
 ![](../images/refl_coeff_flat_interface.png#center)
+
+The key item to consider in these types of calculations is the *location of the mode monitor relative to the interface*. The mode monitor is a line extending the entire length of the cell in the $y$ direction. In order to compare the result with the Fresnel equations, the phase of the reflection coefficient must be computed *exactly* at the interface. However, it is problematic to measure the reflection coefficient exactly at the interface because the amplitude of the left-going wave drops discontinuously to zero across the interface. For this reason, the mode monitor must be positioned away from the interface (somewhere within the $n_1$ medium) and the measured phase must be corrected in post processing to account for this offset.
 
 The calculation of the reflection coefficient requires two separate runs: (1) a normalization run involving just the source medium ($n_1$) to obtain the incident fields, and (2) the main run including the interface whereby the incident fields from (1) are first subtracted from the monitor to obtain only the reflected fields. The mode coefficient in (2) divided by (1) is, by definition, the reflection coefficient.
 
-The phase of the reflection coefficient needs to be corrected for the offset of the mode monitor relative to the interface &mdash; labeled $L$ in the schematic above &mdash; using the formula $\exp(i 2\pi k_x 2L)$, where $k_x$ is the $x$ component of the planewave's wavevector (`k` in the script). The $2\pi$ factor is necessary because `k` does *not* include this factor (per convention in Meep). The factor 2 in front of the $L$ is necessary because the phase needs to be corrected for the monitors in the normalization and main runs separately. The correction factor is just the phase accumulated as the wave propagates in the surface-normal direction for a distance $L$ in a medium with index $n_1$.
+The phase of the reflection coefficient needs to be corrected for the offset of the mode monitor relative to the interface &mdash; labeled $L$ in the schematic above &mdash; using the formula $\exp(i 2\pi k_x 2L)$, where $k_x$ is the $x$ component of the planewave's wavevector (`k` in the script). The $2\pi$ factor is necessary because `k` does *not* include this factor (per convention in Meep). The factor 2 in front of the $L$ is necessary because the phase needs to be corrected for the monitors in the normalization and main runs separately. The correction factor is just the phase accumulated as the wave propagates in the surface-normal direction for a distance $L$ in a medium with index $n_1$. (A transmitted mode would involve a correction factor for a medium with index $n_2$.)
 
 With this setup, we measure the phase of the reflection coefficient for two different source configurations (polarization and angle) and compare the result with the Fresnel equations. The location of the mode monitor is also varied in the two test configurations. Results are shown in the two tables below. There is good agreement between the simulation and theory. (As additional validation, we note that the magnitude of the reflection coefficient of a TIR mode must be one which is indeed the case.)
 
@@ -189,15 +189,18 @@ n2 = 1.0
 
 
 def refl_coeff_meep(pol: Polarization, theta: float, L: float) -> complex:
-    """Computes the reflection coefficient of a TIR mode using mode
-       decomposition.
+    """Returns the complex reflection coefficient of a TIR mode computed
+       using mode decomposition.
 
     Args:
         pol: polarization of the incident planewave (S or P).
         theta: angle of the incident planewave (radians).
-        L: position of the mode monitor relative to the flat interface. 0 is
-            interface position.
+        L: position of the mode monitor relative to the flat interface.
     """
+    if theta < math.asin(n2 / n1):
+        raise ValueError(f"incident angle of {math.degrees(theta):.2f}° is "
+                         f"not a total internal reflected mode.")
+
     resolution = 50.0
 
     # cell size is arbitrary
@@ -207,18 +210,17 @@ def refl_coeff_meep(pol: Polarization, theta: float, L: float) -> complex:
     cell_size = mp.Vector3(sx + 2 * dpml, sy, 0)
     pml_layers = [mp.PML(dpml, direction=mp.X)]
 
-    fcen = 1.0  # center frequency
+    fcen = 1.0  # source/monitor frequency
     df = 0.1 * fcen
 
     # k (in source medium) with correct length
     # plane of incidence is xy
     k = mp.Vector3(n1 * fcen, 0, 0).rotate(mp.Vector3(0, 0, 1), theta)
 
-    # planewave amplitude function (for source)
+    # planewave amplitude function (for line source)
     def pw_amp(k, x0):
         def _pw_amp(x):
             return cmath.exp(1j * 2 * math.pi * k.dot(x + x0))
-
         return _pw_amp
 
     src_pt = mp.Vector3(-0.5 * sx, 0, 0)
@@ -322,7 +324,7 @@ def refl_coeff_meep(pol: Polarization, theta: float, L: float) -> complex:
     sim.run(
         until_after_sources=mp.stop_when_fields_decayed(
             50,
-            mp.Ez,
+            src_cmpt,
             mp.Vector3(-L, 0, 0),
             1e-6,
         ),
@@ -349,12 +351,12 @@ def refl_coeff_meep(pol: Polarization, theta: float, L: float) -> complex:
 
 
 def refl_coeff_Fresnel(pol: Polarization, theta: float) -> complex:
-    """Computes the reflection coefficient of a TIR mode using the Fresnel
-       equations.
+    """Returns the complex reflection coefficient of a TIR mode computed
+       using the Fresnel equations.
 
     Args:
         pol: polarization of the incident planewave (S or P).
-        theta: angle of the incident planewave (degrees).
+        theta: angle of the incident planewave (radians).
     """
     if pol.name == "S":
         refl_coeff = (
@@ -373,31 +375,42 @@ def refl_coeff_Fresnel(pol: Polarization, theta: float) -> complex:
 
 
 if __name__ == "__main__":
-    thetas = [54.3, 48.5] # angle of incident planewave (degrees)
-    Ls = [0.4, 1.2] # position of mode monitor relative to flat interface
-    pols = [Polarization.S, Polarization.P] # polarization of incident planewave
+    # angle of incident planewave (degrees)
+    thetas = [54.3, 48.5]
+
+    # position of mode monitor relative to flat interface
+    Ls = [0.4, 1.2]
+
+    # polarization of incident planewave
+    pols = [Polarization.S, Polarization.P]
 
     for pol, theta, L in zip(pols, thetas, Ls):
         theta_rad = np.radians(theta)
-        rc_m = refl_coeff_meep(pol, theta_rad, L)
-        rc_f = refl_coeff_Fresnel(pol, theta_rad)
+        R_meep = refl_coeff_meep(pol, theta_rad, L)
+        R_fres = refl_coeff_Fresnel(pol, theta_rad)
 
-        rc_m_str = f"{rc_m.real:.5f}{rc_m.imag:+.5f}j"
-        rc_f_str = f"{rc_f.real:.5f}{rc_f.imag:+.5f}j"
-        print(f"refl-coeff:, {pol.name}, {theta}, {rc_m_str} (Meep), "
-              f"{rc_f_str} (Fresnel)")
+        complex_to_str = lambda cnum: f"{cnum.real:.5f}{cnum.imag:+.5f}j"
+        print(
+            f"refl-coeff:, {pol.name}, {theta}, "
+            f"{complex_to_str(R_meep)} (Meep), "
+            f"{complex_to_str(R_fres)} (Fresnel)"
+        )
 
-        mag_m = abs(rc_m)
-        mag_f = abs(rc_f)
-        err_mag = abs(mag_m - mag_f) / mag_f
-        print(f"magnitude:, {mag_m:.5f} (Meep), {mag_f:.5f} (Fresnel), "
-              f"{err_mag:.5f} (error)")
+        mag_meep = abs(R_meep)
+        mag_fres = abs(R_fres)
+        err_mag = abs(mag_meep - mag_fres) / mag_fres
+        print(
+            f"magnitude:, {mag_meep:.5f} (Meep), {mag_fres:.5f} (Fresnel), "
+            f"{err_mag:.5f} (error)"
+        )
 
-        phase_m = cmath.phase(rc_m)
-        phase_f = cmath.phase(rc_f)
-        err_phase = abs(phase_m - phase_f) / abs(phase_f)
-        print(f"phase:, {phase_m:.5f} (Meep), {phase_f:.5f} (Fresnel), "
-              f"{err_phase:.5f} (error)")
+        phase_meep = cmath.phase(R_meep)
+        phase_fres = cmath.phase(R_fres)
+        err_phase = abs(phase_meep - phase_fres) / abs(phase_fres)
+        print(
+            f"phase:, {phase_meep:.5f} (Meep), {phase_fres:.5f} (Fresnel), "
+            f"{err_phase:.5f} (error)"
+        )
 ```
 
 


### PR DESCRIPTION
Fixes a bug in the tutorial [Phase of a Total Internal Reflected Mode](https://meep.readthedocs.io/en/latest/Python_Tutorials/Mode_Decomposition/#phase-of-a-total-internal-reflected-mode) whereby the `stop_when_fields_decayed` termination criteria was using a fixed field component (`mp.Ez`) which is invalid for the test case involving the $H_z$ polarization.

Also includes some additional tweaks.