### PR TITLE
Make contraint functions for periodic designs compatible with autograd

### DIFF
--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -853,7 +853,9 @@ def indicator_solid(x, c, filter_f, threshold_f, resolution, periodic_axes=None)
             filtered_field = npa.tile(filtered_field, (3, 1))
         if 1 in periodic_axes:
             filtered_field = npa.tile(filtered_field, (1, 3))
-        gradient_filtered_field = _centered(npa.array(npa.gradient(filtered_field)), (2,) + x.shape)
+        gradient_filtered_field = _centered(
+            npa.array(npa.gradient(filtered_field)), (2,) + x.shape
+        )
 
     grad_mag = (gradient_filtered_field[0] * resolution) ** 2 + (
         gradient_filtered_field[1] * resolution
@@ -953,7 +955,9 @@ def indicator_void(x, c, filter_f, threshold_f, resolution, periodic_axes=None):
             filtered_field = npa.tile(filtered_field, (3, 1))
         if 1 in periodic_axes:
             filtered_field = npa.tile(filtered_field, (1, 3))
-        gradient_filtered_field = _centered(npa.array(npa.gradient(filtered_field)), (2,) + x.shape)
+        gradient_filtered_field = _centered(
+            npa.array(npa.gradient(filtered_field)), (2,) + x.shape
+        )
 
     grad_mag = (gradient_filtered_field[0] * resolution) ** 2 + (
         gradient_filtered_field[1] * resolution

--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -853,9 +853,7 @@ def indicator_solid(x, c, filter_f, threshold_f, resolution, periodic_axes=None)
             filtered_field = npa.tile(filtered_field, (3, 1))
         if 1 in periodic_axes:
             filtered_field = npa.tile(filtered_field, (1, 3))
-        gradient_filtered_field = npa.gradient(filtered_field)
-        gradient_filtered_field[0] = _centered(gradient_filtered_field[0], x.shape)
-        gradient_filtered_field[1] = _centered(gradient_filtered_field[1], x.shape)
+        gradient_filtered_field = _centered(npa.array(npa.gradient(filtered_field)), (2,) + x.shape)
 
     grad_mag = (gradient_filtered_field[0] * resolution) ** 2 + (
         gradient_filtered_field[1] * resolution
@@ -944,7 +942,7 @@ def indicator_void(x, c, filter_f, threshold_f, resolution, periodic_axes=None):
     geometric constraints. Computer Methods in Applied Mechanics and Engineering, 293, 266-282.
     """
 
-    filtered_field = filter_f(x).reshape(x.shape)
+    filtered_field = filter_f(x)
     design_field = threshold_f(filtered_field)
 
     if periodic_axes is None:
@@ -955,9 +953,7 @@ def indicator_void(x, c, filter_f, threshold_f, resolution, periodic_axes=None):
             filtered_field = npa.tile(filtered_field, (3, 1))
         if 1 in periodic_axes:
             filtered_field = npa.tile(filtered_field, (1, 3))
-        gradient_filtered_field = npa.gradient(filtered_field)
-        gradient_filtered_field[0] = _centered(gradient_filtered_field[0], x.shape)
-        gradient_filtered_field[1] = _centered(gradient_filtered_field[1], x.shape)
+        gradient_filtered_field = _centered(npa.array(npa.gradient(filtered_field)), (2,) + x.shape)
 
     grad_mag = (gradient_filtered_field[0] * resolution) ** 2 + (
         gradient_filtered_field[1] * resolution

--- a/python/tests/test_adjoint_solver.py
+++ b/python/tests/test_adjoint_solver.py
@@ -1056,9 +1056,11 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                         self.design_region_resolution,
                         periodic_axes,
                     )
-                    solid_grad_row_shift = np.vstack((solid_grad[idx_row_shift:, :], solid_grad[0:idx_row_shift, :]))
+                    solid_grad_row_shift = np.vstack(
+                        (solid_grad[idx_row_shift:, :], solid_grad[0:idx_row_shift, :])
+                    )
                     self.assertAlmostEqual(
-                        np.sum(abs(solid_grad_row_shift-solid_row_shift_grad)),
+                        np.sum(abs(solid_grad_row_shift - solid_row_shift_grad)),
                         0,
                         places=places,
                     )
@@ -1072,9 +1074,11 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                         self.design_region_resolution,
                         periodic_axes,
                     )
-                    void_grad_row_shift = np.vstack((void_grad[idx_row_shift:, :], void_grad[0:idx_row_shift, :]))
+                    void_grad_row_shift = np.vstack(
+                        (void_grad[idx_row_shift:, :], void_grad[0:idx_row_shift, :])
+                    )
                     self.assertAlmostEqual(
-                        np.sum(abs(void_grad_row_shift-void_row_shift_grad)),
+                        np.sum(abs(void_grad_row_shift - void_row_shift_grad)),
                         0,
                         places=places,
                     )
@@ -1119,9 +1123,11 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                         self.design_region_resolution,
                         periodic_axes,
                     )
-                    solid_grad_col_shift = np.hstack((solid_grad[:, idx_col_shift:], solid_grad[:, 0:idx_col_shift]))
+                    solid_grad_col_shift = np.hstack(
+                        (solid_grad[:, idx_col_shift:], solid_grad[:, 0:idx_col_shift])
+                    )
                     self.assertAlmostEqual(
-                        np.sum(abs(solid_grad_col_shift-solid_col_shift_grad)),
+                        np.sum(abs(solid_grad_col_shift - solid_col_shift_grad)),
                         0,
                         places=places,
                     )
@@ -1135,9 +1141,11 @@ class TestAdjointSolver(ApproxComparisonTestCase):
                         self.design_region_resolution,
                         periodic_axes,
                     )
-                    void_grad_col_shift = np.hstack((void_grad[:, idx_col_shift:], void_grad[:, 0:idx_col_shift]))
+                    void_grad_col_shift = np.hstack(
+                        (void_grad[:, idx_col_shift:], void_grad[:, 0:idx_col_shift])
+                    )
                     self.assertAlmostEqual(
-                        np.sum(abs(void_grad_col_shift-void_col_shift_grad)),
+                        np.sum(abs(void_grad_col_shift - void_col_shift_grad)),
                         0,
                         places=places,
                     )


### PR DESCRIPTION
PR #2465 introduced a bug that made constraint functions incompatible with `autograd`, although the forward run of those constraint functions does not fail. This PR fixes the bug and add some tests to check the gradients of the constraint functions also observe periodicity. 