### PR TITLE
Rebuild Markdown user manual from docstrings

### DIFF
--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -655,6 +655,13 @@ The following step function collects field data from a given point and runs [Har
 * [Harminv class](#Harminv)
 
 
+#### PadeDFT Step Function
+
+The following step function collects field data from a given point or volume and performs spectral extrapolation by computing the [Padé approximant](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.pade.html) of the DFT at every specified spatial point.
+
+* [PadeDFT class](#PadeDFT)
+
+
 ### Step-Function Modifiers
 
 Rather than writing a brand-new step function every time something a bit different is required, the following "modifier" functions take a bunch of step functions and produce *new* step functions with modified behavior. See also [Tutorial/Basics](Python_Tutorials/Basics.md) for examples.
@@ -861,6 +868,8 @@ The following classes are available directly via the `meep` package.
 @@ Animate2D[methods-with-docstrings] @@
 
 @@ Harminv[methods-with-docstrings] @@
+
+@@ PadeDFT[methods-with-docstrings] @@
 
 @@ Verbosity @@
 @@ Verbosity.__init__ @@

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -870,7 +870,7 @@ class PadeDFT:
     which allows it to be used as a step function that collects field data from a given
     point and runs [Padé](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.pade.html)
     on that data to extract an analytic rational function which approximates the frequency response.
-    For more information about the Padé approximant, see: https://en.wikipedia.org/wiki/Padé_approximant.
+    For more information about the Padé approximant, see the [Wikipedia article](https://en.wikipedia.org/wiki/Padé_approximant).
 
     See [`__init__`](#PadeDFT.__init__) for details about constructing a `PadeDFT`.
 
@@ -962,7 +962,7 @@ class PadeDFT:
 
     def __call__(self, sim, todo):
         """
-        Allows a Pade instance to be used as a step function.
+        Allows a PadeDFT instance to be used as a step function.
         """
         self.step_func(sim, todo)
 


### PR DESCRIPTION
Rebuilds the Markdown user manual from the Python docstrings via `make python_api_doc` with some custom edits to `Python_User_Interface.md`. This is in preparation for the v1.27 release next week.