### PR TITLE
Prepare for 1.27 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # Meep Release Notes
 
+## Meep 1.27.0
+
+5/25/2023
+
+* Support for spectral extrapolation using Padé approximants ([#2440]).
+
+* Support for periodic design regions of adjoint solver ([#2465], [#2518]).
+
+* Support for "unfiltering" a given set of design weights for adjoint optimization ([#2462]).
+
+* MPB is no longer a required dependency ([#2486]).
+
+* Bug fix for sources at $r = 0$ in cylindrical coordinates ([#2459]).
+
+* Additional unit tests and documentation ([#2428], [#2433], [#2452], [#2474]) and various improvements and minor bug fixes ([#2499], [#2504]).
+
 ## Meep 1.26.0
 
 3/9/2023

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([meep],[m4_esyscmd(./version.sh 1.27.0-beta)])
+AC_INIT([meep],[m4_esyscmd(./version.sh 1.27.0)])
 AC_CONFIG_SRCDIR(src/step.cpp)
 
 # Shared-library version number; indicates api compatibility, and is
 # not the same as the "public" version number.  (Don't worry about this
 # except for public releases.) Note that any change to a C++ class
 # definition (in the .hpp file) generally breaks binary compatibility.
-SHARED_VERSION_INFO="31:0:0" # CURRENT:REVISION:AGE
+SHARED_VERSION_INFO="32:0:0" # CURRENT:REVISION:AGE
 
 AM_INIT_AUTOMAKE([foreign color-tests parallel-tests silent-rules 1.11])
 AM_SILENT_RULES(yes)


### PR DESCRIPTION
The next tarball release is tentatively scheduled for Thursday May 25, 2023.