### PR TITLE
Add anchor links to section headers in mkdocs manual

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ markdown_extensions:
     - wikilinks
     - toc:
         title: Table of Contents
+        permalink: []
     - attr_list
     - fenced_code
     - md_in_html


### PR DESCRIPTION
Adds [anchor links](https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages) to section headers in the mkdocs manual. This should make it a little easier to link to individual sections of the user manual.