### PR TITLE
Replace custom loops for im/r update of `step_db.cpp` with `LOOP_OVER_VOL_OWNED0`

### DIFF
--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -171,105 +171,96 @@ bool fields_chunk::step_db(field_type ft) {
         const int dku = gv.iyee_shift(cc).in_direction(dsigu);
         const realnum the_m =
             m * (1 - 2 * cmp) * (1 - 2 * (ft == B_stuff)) * (1 - 2 * (d_c == R)) * Courant;
-        const realnum ir0 = gv.origin_r() * gv.a + 0.5 * gv.iyee_shift(cc).in_direction(R);
-        int sr = gv.nz() + 1;
+        const ivec is = gv.little_owned_corner0(cc);
 
         // 8 special cases of the same loop (sigh):
         if (siginv) {    // PML in f update
           if (siginvu) { // PML + fu
             if (cndinv)  // PML + fu + conductivity
               //////////////////// MOST GENERAL CASE //////////////////////
-              for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                realnum rinv = the_m / (ir + ir0);
-                for (int iz = 0; iz <= gv.nz(); ++iz) {
-                  ptrdiff_t idx = ir * sr + iz;
-                  int k = dk + 2 * (dsig == Z ? iz : ir);
-                  int ku = dku + 2 * (dsigu == Z ? iz : ir);
-                  realnum df, dfcnd = rinv * g[idx] * cndinv[idx];
-                  fcnd[idx] += dfcnd;
-                  fu[idx] += (df = dfcnd * siginv[k]);
-                  the_f[idx] += siginvu[ku] * df;
-                }
+              LOOP_OVER_VOL_OWNED0(gv, cc, i) {
+                const ptrdiff_t ir = loop_i2;
+                realnum rinv = the_m / ir;
+                KSTRIDE_DEF(dsig, k, is, gv);
+                DEF_k;
+                KSTRIDE_DEF(dsigu, ku, is, gv);
+                DEF_ku;
+                realnum df, dfcnd = rinv * g[i] * cndinv[i];
+                fcnd[i] += dfcnd;
+                fu[i] += (df = dfcnd * siginv[k]);
+                the_f[i] += siginvu[ku] * df;
               }
             /////////////////////////////////////////////////////////////
             else // PML + fu - conductivity
-              for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                realnum rinv = the_m / (ir + ir0);
-                for (int iz = 0; iz <= gv.nz(); ++iz) {
-                  ptrdiff_t idx = ir * sr + iz;
-                  int k = dk + 2 * (dsig == Z ? iz : ir);
-                  int ku = dku + 2 * (dsigu == Z ? iz : ir);
-                  realnum df, dfcnd = rinv * g[idx];
-                  fu[idx] += (df = dfcnd * siginv[k]);
-                  the_f[idx] += siginvu[ku] * df;
-                }
+              LOOP_OVER_VOL_OWNED0(gv, cc, i) {
+                const ptrdiff_t ir = loop_i2;
+                realnum rinv = the_m / ir;
+                KSTRIDE_DEF(dsig, k, is, gv);
+                DEF_k;
+                KSTRIDE_DEF(dsigu, ku, is, gv);
+                DEF_ku;
+                realnum df, dfcnd = rinv * g[i];
+                fu[i] += (df = dfcnd * siginv[k]);
+                the_f[i] += siginvu[ku] * df;
               }
           }
           else {        // PML - fu
             if (cndinv) // PML - fu + conductivity
-              for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                realnum rinv = the_m / (ir + ir0);
-                for (int iz = 0; iz <= gv.nz(); ++iz) {
-                  ptrdiff_t idx = ir * sr + iz;
-                  int k = dk + 2 * (dsig == Z ? iz : ir);
-                  realnum dfcnd = rinv * g[idx] * cndinv[idx];
-                  fcnd[idx] += dfcnd;
-                  the_f[idx] += dfcnd * siginv[k];
-                }
+              LOOP_OVER_VOL_OWNED0(gv, cc, i) {
+                const ptrdiff_t ir = loop_i2;
+                realnum rinv = the_m / ir;
+                KSTRIDE_DEF(dsig, k, is, gv);
+                DEF_k;
+                realnum dfcnd = rinv * g[i] * cndinv[i];
+                fcnd[i] += dfcnd;
+                the_f[i] += dfcnd * siginv[k];
               }
             else // PML - fu - conductivity
-              for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                realnum rinv = the_m / (ir + ir0);
-                for (int iz = 0; iz <= gv.nz(); ++iz) {
-                  ptrdiff_t idx = ir * sr + iz;
-                  int k = dk + 2 * (dsig == Z ? iz : ir);
-                  realnum dfcnd = rinv * g[idx];
-                  the_f[idx] += dfcnd * siginv[k];
-                }
+              LOOP_OVER_VOL_OWNED0(gv, cc, i) {
+                const ptrdiff_t ir = loop_i2;
+                realnum rinv = the_m / ir;
+                KSTRIDE_DEF(dsig, k, is, gv);
+                DEF_k;
+                realnum dfcnd = rinv * g[i];
+                the_f[i] += dfcnd * siginv[k];
               }
           }
         }
         else {           // no PML in f update
           if (siginvu) { // no PML + fu
             if (cndinv)  // no PML + fu + conductivity
-              for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                realnum rinv = the_m / (ir + ir0);
-                for (int iz = 0; iz <= gv.nz(); ++iz) {
-                  ptrdiff_t idx = ir * sr + iz;
-                  int ku = dku + 2 * (dsigu == Z ? iz : ir);
-                  realnum df = rinv * g[idx] * cndinv[idx];
-                  fu[idx] += df;
-                  the_f[idx] += siginvu[ku] * df;
-                }
+              LOOP_OVER_VOL_OWNED0(gv, cc, i) {
+                const ptrdiff_t ir = loop_i2;
+                realnum rinv = the_m / ir;
+                KSTRIDE_DEF(dsigu, ku, is, gv);
+                DEF_ku;
+                realnum df = rinv * g[i] * cndinv[i];
+                fu[i] += df;
+                the_f[i] += siginvu[ku] * df;
               }
             else // no PML + fu - conductivity
-              for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                realnum rinv = the_m / (ir + ir0);
-                for (int iz = 0; iz <= gv.nz(); ++iz) {
-                  ptrdiff_t idx = ir * sr + iz;
-                  int ku = dku + 2 * (dsigu == Z ? iz : ir);
-                  realnum df = rinv * g[idx];
-                  fu[idx] += df;
-                  the_f[idx] += siginvu[ku] * df;
-                }
+              LOOP_OVER_VOL_OWNED0(gv, cc, i) {
+                const ptrdiff_t ir = loop_i2;
+                realnum rinv = the_m / ir;
+                KSTRIDE_DEF(dsigu, ku, is, gv);
+                DEF_ku;
+                realnum df = rinv * g[i];
+                fu[i] += df;
+                the_f[i] += siginvu[ku] * df;
               }
           }
           else {        // no PML - fu
             if (cndinv) // no PML - fu + conductivity
-              for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                realnum rinv = the_m / (ir + ir0);
-                for (int iz = 0; iz <= gv.nz(); ++iz) {
-                  ptrdiff_t idx = ir * sr + iz;
-                  the_f[idx] += rinv * g[idx] * cndinv[idx];
-                }
+              LOOP_OVER_VOL_OWNED0(gv, cc, i) {
+                const ptrdiff_t ir = loop_i2;
+                realnum rinv = the_m / ir;
+                the_f[i] += rinv * g[i] * cndinv[i];
               }
             else // no PML - fu - conductivity
-              for (int ir = ir0 == 0; ir <= gv.nr(); ++ir) {
-                realnum rinv = the_m / (ir + ir0);
-                for (int iz = 0; iz <= gv.nz(); ++iz) {
-                  ptrdiff_t idx = ir * sr + iz;
-                  the_f[idx] += rinv * g[idx];
-                }
+              LOOP_OVER_VOL_OWNED0(gv, cc, i) {
+                const ptrdiff_t ir = loop_i2;
+                realnum rinv = the_m / ir;
+                the_f[i] += rinv * g[i];
               }
           }
         }

--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -171,7 +171,8 @@ bool fields_chunk::step_db(field_type ft) {
         const int dku = gv.iyee_shift(cc).in_direction(dsigu);
         const ivec is = gv.little_owned_corner0(cc);
 
-        // Factor of 2 is necessary because in LOOP_OVER_VOL_OWNED0 macro each
+        // Constant factor for the i*m component of the i*m/r term.
+        // A factor of 2 is included because in LOOP_OVER_VOL_OWNED0 each
         // increment of the array index in the grid_volume in the R direction
         // corresponds to a change of 0.5*Δr in real space.
         const realnum the_m =

--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -171,6 +171,7 @@ bool fields_chunk::step_db(field_type ft) {
         const int dku = gv.iyee_shift(cc).in_direction(dsigu);
         const realnum the_m =
             m * (1 - 2 * cmp) * (1 - 2 * (ft == B_stuff)) * (1 - 2 * (d_c == R)) * Courant;
+        const realnum ir0 = gv.origin_r() * gv.a + 0.5 * gv.iyee_shift(cc).in_direction(R);
         const ivec is = gv.little_owned_corner0(cc);
 
         // 8 special cases of the same loop (sigh):
@@ -180,7 +181,7 @@ bool fields_chunk::step_db(field_type ft) {
               //////////////////// MOST GENERAL CASE //////////////////////
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
                 const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / ir;
+                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
                 KSTRIDE_DEF(dsig, k, is, gv);
                 DEF_k;
                 KSTRIDE_DEF(dsigu, ku, is, gv);
@@ -194,7 +195,7 @@ bool fields_chunk::step_db(field_type ft) {
             else // PML + fu - conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
                 const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / ir;
+                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
                 KSTRIDE_DEF(dsig, k, is, gv);
                 DEF_k;
                 KSTRIDE_DEF(dsigu, ku, is, gv);
@@ -208,7 +209,7 @@ bool fields_chunk::step_db(field_type ft) {
             if (cndinv) // PML - fu + conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
                 const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / ir;
+                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
                 KSTRIDE_DEF(dsig, k, is, gv);
                 DEF_k;
                 realnum dfcnd = rinv * g[i] * cndinv[i];
@@ -218,7 +219,7 @@ bool fields_chunk::step_db(field_type ft) {
             else // PML - fu - conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
                 const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / ir;
+                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
                 KSTRIDE_DEF(dsig, k, is, gv);
                 DEF_k;
                 realnum dfcnd = rinv * g[i];
@@ -231,7 +232,7 @@ bool fields_chunk::step_db(field_type ft) {
             if (cndinv)  // no PML + fu + conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
                 const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / ir;
+                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
                 KSTRIDE_DEF(dsigu, ku, is, gv);
                 DEF_ku;
                 realnum df = rinv * g[i] * cndinv[i];
@@ -241,7 +242,7 @@ bool fields_chunk::step_db(field_type ft) {
             else // no PML + fu - conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
                 const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / ir;
+                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
                 KSTRIDE_DEF(dsigu, ku, is, gv);
                 DEF_ku;
                 realnum df = rinv * g[i];
@@ -253,13 +254,13 @@ bool fields_chunk::step_db(field_type ft) {
             if (cndinv) // no PML - fu + conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
                 const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / ir;
+                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
                 the_f[i] += rinv * g[i] * cndinv[i];
               }
             else // no PML - fu - conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
                 const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / ir;
+                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
                 the_f[i] += rinv * g[i];
               }
           }

--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -171,7 +171,6 @@ bool fields_chunk::step_db(field_type ft) {
         const int dku = gv.iyee_shift(cc).in_direction(dsigu);
         const realnum the_m =
             m * (1 - 2 * cmp) * (1 - 2 * (ft == B_stuff)) * (1 - 2 * (d_c == R)) * Courant;
-        const realnum ir0 = gv.origin_r() * gv.a + 0.5 * gv.iyee_shift(cc).in_direction(R);
         const ivec is = gv.little_owned_corner0(cc);
 
         // 8 special cases of the same loop (sigh):
@@ -180,8 +179,8 @@ bool fields_chunk::step_db(field_type ft) {
             if (cndinv)  // PML + fu + conductivity
               //////////////////// MOST GENERAL CASE //////////////////////
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
+                IVEC_LOOP_ILOC(gv, here);
+                realnum rinv = the_m / here.r();
                 KSTRIDE_DEF(dsig, k, is, gv);
                 DEF_k;
                 KSTRIDE_DEF(dsigu, ku, is, gv);
@@ -194,8 +193,8 @@ bool fields_chunk::step_db(field_type ft) {
             /////////////////////////////////////////////////////////////
             else // PML + fu - conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
+                IVEC_LOOP_ILOC(gv, here);
+                realnum rinv = the_m / here.r();
                 KSTRIDE_DEF(dsig, k, is, gv);
                 DEF_k;
                 KSTRIDE_DEF(dsigu, ku, is, gv);
@@ -208,8 +207,8 @@ bool fields_chunk::step_db(field_type ft) {
           else {        // PML - fu
             if (cndinv) // PML - fu + conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
+                IVEC_LOOP_ILOC(gv, here);
+                realnum rinv = the_m / here.r();
                 KSTRIDE_DEF(dsig, k, is, gv);
                 DEF_k;
                 realnum dfcnd = rinv * g[i] * cndinv[i];
@@ -218,8 +217,8 @@ bool fields_chunk::step_db(field_type ft) {
               }
             else // PML - fu - conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
+                IVEC_LOOP_ILOC(gv, here);
+                realnum rinv = the_m / here.r();
                 KSTRIDE_DEF(dsig, k, is, gv);
                 DEF_k;
                 realnum dfcnd = rinv * g[i];
@@ -231,8 +230,8 @@ bool fields_chunk::step_db(field_type ft) {
           if (siginvu) { // no PML + fu
             if (cndinv)  // no PML + fu + conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
+                IVEC_LOOP_ILOC(gv, here);
+                realnum rinv = the_m / here.r();
                 KSTRIDE_DEF(dsigu, ku, is, gv);
                 DEF_ku;
                 realnum df = rinv * g[i] * cndinv[i];
@@ -241,8 +240,8 @@ bool fields_chunk::step_db(field_type ft) {
               }
             else // no PML + fu - conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
+                IVEC_LOOP_ILOC(gv, here);
+                realnum rinv = the_m / here.r();
                 KSTRIDE_DEF(dsigu, ku, is, gv);
                 DEF_ku;
                 realnum df = rinv * g[i];
@@ -253,14 +252,14 @@ bool fields_chunk::step_db(field_type ft) {
           else {        // no PML - fu
             if (cndinv) // no PML - fu + conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
+                IVEC_LOOP_ILOC(gv, here);
+                realnum rinv = the_m / here.r();
                 the_f[i] += rinv * g[i] * cndinv[i];
               }
             else // no PML - fu - conductivity
               LOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                const ptrdiff_t ir = loop_i2;
-                realnum rinv = the_m / (ir == 0 ? (ir0 == 0 ? 1 : ir0) : (ir + ir0));
+                IVEC_LOOP_ILOC(gv, here);
+                realnum rinv = the_m / here.r();
                 the_f[i] += rinv * g[i];
               }
           }

--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -169,9 +169,13 @@ bool fields_chunk::step_db(field_type ft) {
         const direction dsigu = cycle_direction(gv.dim, d_c, 2);
         const realnum *siginvu = s->sigsize[dsigu] > 1 ? s->siginv[dsigu] : 0;
         const int dku = gv.iyee_shift(cc).in_direction(dsigu);
-        const realnum the_m =
-            m * (1 - 2 * cmp) * (1 - 2 * (ft == B_stuff)) * (1 - 2 * (d_c == R)) * Courant;
         const ivec is = gv.little_owned_corner0(cc);
+
+        // Factor of 2 is necessary because in LOOP_OVER_VOL_OWNED0 macro each
+        // increment of the array index in the grid_volume in the R direction
+        // corresponds to a change of 0.5*Δr in real space.
+        const realnum the_m =
+            2 * m * (1 - 2 * cmp) * (1 - 2 * (ft == B_stuff)) * (1 - 2 * (d_c == R)) * Courant;
 
         // 8 special cases of the same loop (sigh):
         if (siginv) {    // PML in f update


### PR DESCRIPTION
Following a suggestion by @stevengj in [#2538 (comment)](https://github.com/NanoComp/meep/pull/2538#issuecomment-1634805342) which had #2583 as a prerequisite, this PR replaces the eight separate custom loops for the $+im/r$ update of `step_db.cpp` with `LOOP_OVER_VOL_OWNED0`.