### PR TITLE
Run recent version of `clang-format` on source files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,46 +13,46 @@
 # See https://github.com/pre-commit/pre-commit
 
 repos:
-  # Standard hooks
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-      - id: check-yaml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
 
-  # Black, the code formatter, natively supports pre-commit
-  - repo: https://github.com/psf/black
-    rev: "4f1772e2aed8356e57b923eacf45f813ec3324a0"
-    hooks:
-      - id: black
+# Standard hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
 
-  # Automatically upgrade syntax for newer versions of the language.
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
-    hooks:
-      - id: pyupgrade
-        args: [--py37-plus, --keep-runtime-typing]
+# Black, the code formatter, natively supports pre-commit
+- repo: https://github.com/psf/black
+  rev: "4f1772e2aed8356e57b923eacf45f813ec3324a0"
+  hooks:
+    - id: black
 
+# Automatically upgrade syntax for newer versions of the language
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.9.0
+  hooks:
+    - id: pyupgrade
+      args: [--py37-plus, --keep-runtime-typing]
 
-  # A collection of fast, cheap, regex based pre-commit hooks.
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-      - id: python-use-type-annotations
+# Collection of fast, cheap, regex based pre-commit hooks
+- repo: https://github.com/pre-commit/pygrep-hooks
+  rev: v1.10.0
+  hooks:
+    - id: python-use-type-annotations
 
-  # Find common security issues in Python code.
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
-    hooks:
-      - id: bandit
-        args: [--exit-zero]
-        # ignore all tests, not just tests data
-        exclude: ^tests/
+# Find common security issues in Python code
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.7.5
+  hooks:
+    - id: bandit
+      args: [--exit-zero]
+      # ignore all tests, not just tests data
+      exclude: ^python/tests/
 
-  # Widely used C++ formatter.
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.6  # Use the sha / tag you want to point at
-    hooks:
-    -   id: clang-format
-        types: [c++, python]
+# Clang C/C++ formatter
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v16.0.6  # Use the sha / tag you want to point at
+  hooks:
+  - id: clang-format
+    types: [c++]

--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -234,9 +234,9 @@ mode_solver::mode_solver(int num_bands, double resolution[3], lattice lat, doubl
       use_simple_preconditioner(use_simple_preconditioner), grid_size(grid_size), nwork_alloc(0),
       eigensolver_nwork(eigensolver_nwork), eigensolver_block_size(eigensolver_block_size),
       last_parity(-2), iterations(0), eigensolver_flops(flops), geometry_list{},
-      geometry_tree(NULL), vol(0), R{}, G{}, mdata(NULL), mtdata(NULL),
-      curfield_band(0), H{}, Hblock{}, muinvH{}, W{}, freqs(num_bands), verbose(verbose),
-      deterministic(deterministic), kpoint_index(0), curfield(NULL), curfield_type('-'), eps(true) {
+      geometry_tree(NULL), vol(0), R{}, G{}, mdata(NULL), mtdata(NULL), curfield_band(0), H{},
+      Hblock{}, muinvH{}, W{}, freqs(num_bands), verbose(verbose), deterministic(deterministic),
+      kpoint_index(0), curfield(NULL), curfield_type('-'), eps(true) {
 
   // See geom-ctl-io-defaults.c in libctl
   geometry_lattice = lat;

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -687,7 +687,7 @@ void *fields::do_get_array_slice(const volume &where, std::vector<component> com
   }
   if (vslice) {
     memcpy(vslice, vslice_uncollapsed, slice_size * elem_size * sizeof(realnum));
-    delete[](realnum *) vslice_uncollapsed;
+    delete[] (realnum *)vslice_uncollapsed;
   }
   else
     vslice = vslice_uncollapsed;
@@ -772,7 +772,7 @@ complex<realnum> *fields::get_source_slice(const volume &where, component source
 
   if (slice) {
     memcpy(slice, slice_collapsed, 2 * slice_size * sizeof(realnum));
-    delete[](complex<realnum> *) slice_collapsed;
+    delete[] (complex<realnum> *)slice_collapsed;
   }
   else
     slice = slice_collapsed;

--- a/src/fields_dump.cpp
+++ b/src/fields_dump.cpp
@@ -176,7 +176,7 @@ void fields::load_fields_chunk_field(h5file *h5f, bool single_parallel_file,
           size_t n = num_f[(chunk_i * NUM_FIELD_COMPONENTS + c) * 2 + d];
           realnum **f = field_ptr_getter(chunks[i], c, d);
           if (n == 0) {
-            delete[] * f;
+            delete[] *f;
             *f = NULL;
           }
           else {

--- a/src/material_data.cpp
+++ b/src/material_data.cpp
@@ -46,8 +46,8 @@ void medium_struct::check_offdiag_im_zero_or_abort() const {
 
 material_data::material_data()
     : which_subclass(MEDIUM), medium(), user_func(NULL), user_data(NULL), do_averaging(false),
-      epsilon_data(NULL), epsilon_dims{}, grid_size{}, weights(NULL), medium_1(),
-      medium_2(), material_grid_kinds{U_DEFAULT} {}
+      epsilon_data(NULL), epsilon_dims{}, grid_size{}, weights(NULL), medium_1(), medium_2(),
+      material_grid_kinds{U_DEFAULT} {}
 
 void material_data::copy_from(const material_data &from) {
   which_subclass = from.which_subclass;

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -461,7 +461,7 @@ public:
     int dindex;
     char *dataname;
     struct extending_s *next;
-  } * extending;
+  } *extending;
   extending_s *get_extending(const char *dataname) const;
 };
 

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -333,9 +333,9 @@ void structure::add_to_effort_volumes(const grid_volume &new_effort_volume, doub
 }
 
 structure::structure(const structure &s)
-    : num_chunks{s.num_chunks}, shared_chunks{false}, gv(s.gv),
-      user_volume(s.user_volume), a{s.a}, Courant{s.Courant}, dt{s.dt}, v(s.v), S(s.S),
-      outdir(s.outdir), num_effort_volumes{s.num_effort_volumes}, bp(new binary_partition(*s.bp)) {
+    : num_chunks{s.num_chunks}, shared_chunks{false}, gv(s.gv), user_volume(s.user_volume), a{s.a},
+      Courant{s.Courant}, dt{s.dt}, v(s.v), S(s.S), outdir(s.outdir),
+      num_effort_volumes{s.num_effort_volumes}, bp(new binary_partition(*s.bp)) {
   chunks = new structure_chunk_ptr[num_chunks];
   for (int i = 0; i < num_chunks; i++) {
     chunks[i] = new structure_chunk(s.chunks[i]);


### PR DESCRIPTION
Manually running `clang-format` on the source C++ files after updating the `pre-commit` package to use latest version. Also includes some formatting tweaks and minor updates to the `pre-commit` yaml file.

Separately, if we ever do decide to limit the line length to 80 characters for all source files, we just need to add an additional argument to the `black` and `clang-format` pre-commit hooks (e.g., `args: [--line-length=80]`).