### PR TITLE
Add note in docs for array slices that output is always centered on the Yee cell

### DIFF
--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -585,6 +585,7 @@ The output functions described above write the data for the fields and materials
 @@ Simulation.get_array @@
 @@ Simulation.get_dft_array @@
 
+Note that although the various field components are stored at different places in the [Yee lattice](Yee_Lattice.md), internally the DFT fields are all linearly interpolated to the same grid: to the points at the *centers* of the Yee cells, i.e. $(i+0.5,j+0.5,k+0.5)\cdotΔ$ in 3d. Additionally, `get_array` interpolates all fields to the center of the Yee cell. In summary, the output of `get_array` and `get_dft_array` is always centered on the Yee cell.
 
 #### Array Metadata
 


### PR DESCRIPTION
In the documentation for [`output_dft`](https://meep.readthedocs.io/en/latest/Python_User_Interface/#output-functions), it is mentioned that:

```
Note that although the various field components are stored at different places in
the Yee lattice, when they are outputted they are all linearly interpolated to the 
same grid: to the points at the centers of the Yee cells, i.e. (i+0.5,j+0.5,k+0.5)⋅Δ
in 3d.
```

However, there is no such description for the array-slice routines `get_array` and `get_dft_array`. This interpolation feature is an important part of Meep's design philosophy of ensuring (for the user) an [illusion of continuity](https://meep.readthedocs.io/en/latest/Introduction/#the-illusion-of-continuity).