### PR TITLE
Add label for geometrical object

### DIFF
--- a/python/geom.py
+++ b/python/geom.py
@@ -1067,7 +1067,7 @@ class GeometricObject:
     ```
     """
 
-    def __init__(self, material=Medium(), center=Vector3(), epsilon_func=None):
+    def __init__(self, material=Medium(), center=Vector3(), epsilon_func=None, label=None):
         """
         Construct a `GeometricObject`.
 
@@ -1095,6 +1095,7 @@ class GeometricObject:
             epsilon_func.eps = True
             material = epsilon_func
 
+        self.label = label
         self.material = material
         self.center = Vector3(*center)
 

--- a/python/geom.py
+++ b/python/geom.py
@@ -1067,7 +1067,9 @@ class GeometricObject:
     ```
     """
 
-    def __init__(self, material=Medium(), center=Vector3(), epsilon_func=None, label=None):
+    def __init__(
+        self, material=Medium(), center=Vector3(), epsilon_func=None, label=None
+    ):
         """
         Construct a `GeometricObject`.
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4874,7 +4874,7 @@ class Simulation:
             output_plane=output_plane,
             fields=fields,
             labels=labels,
-            label_geometry = label_geometry,
+            label_geometry=label_geometry,
             eps_parameters=eps_parameters,
             boundary_parameters=boundary_parameters,
             source_parameters=source_parameters,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4745,6 +4745,7 @@ class Simulation:
         output_plane: Optional[Volume] = None,
         fields: Optional = None,
         labels: bool = False,
+        label_geometry: bool = False,
         eps_parameters: Optional[dict] = None,
         boundary_parameters: Optional[dict] = None,
         source_parameters: Optional[dict] = None,
@@ -4796,6 +4797,8 @@ class Simulation:
           `mp.Hz`) to superimpose over the simulation geometry. Default is `None`, where
           no fields are superimposed.
         * `labels`: if `True`, then labels will appear over each of the simulation
+          elements. Defaults to `False`.
+        * `label_geometry`: if `True`, then labels will appear over each of the geometry
           elements. Defaults to `False`.
         * `eps_parameters`: a `dict` of optional plotting parameters that override the
           default parameters for the geometry.
@@ -4871,6 +4874,7 @@ class Simulation:
             output_plane=output_plane,
             fields=fields,
             labels=labels,
+            label_geometry = label_geometry,
             eps_parameters=eps_parameters,
             boundary_parameters=boundary_parameters,
             source_parameters=source_parameters,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4745,7 +4745,7 @@ class Simulation:
         output_plane: Optional[Volume] = None,
         fields: Optional = None,
         labels: bool = False,
-        label_geometry: bool = False,
+        label_geometry: bool = True,
         eps_parameters: Optional[dict] = None,
         boundary_parameters: Optional[dict] = None,
         source_parameters: Optional[dict] = None,
@@ -4799,7 +4799,7 @@ class Simulation:
         * `labels`: if `True`, then labels will appear over each of the simulation
           elements. Defaults to `False`.
         * `label_geometry`: if `True`, then labels will appear over each of the geometry
-          elements. Defaults to `False`.
+          elements. Defaults to `True`.
         * `eps_parameters`: a `dict` of optional plotting parameters that override the
           default parameters for the geometry.
             - `interpolation='spline36'`: interpolation algorithm used to upsample the pixels.

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -92,7 +92,12 @@ default_volume_parameters = {
 
 default_label_parameters = {"label_color": "r", "offset": 20, "label_alpha": 0.3}
 
-default_label_geometry_parameters = {"label_color": "w", "arrow_color": "r", "offset": 20, "label_alpha": 0.8}
+default_label_geometry_parameters = {
+    "label_color": "w",
+    "arrow_color": "r",
+    "offset": 20,
+    "label_alpha": 0.8,
+}
 
 # Used to remove the elements of a dictionary (dict_to_filter) that
 # don't correspond to the keyword arguments of a particular
@@ -162,7 +167,9 @@ def place_label(
         ha="center",
         va="bottom",
         bbox=dict(boxstyle="round,pad=0.2", fc=color, alpha=alpha),
-        arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.5", color=arrow_color),
+        arrowprops=dict(
+            arrowstyle="->", connectionstyle="arc3,rad=0.5", color=arrow_color
+        ),
     )
     return ax
 
@@ -622,7 +629,6 @@ def plot_eps(
                 colorbar_parameters=colorbar_parameters,
             )
 
-
         if label_geometry:
             for el in sim.geometry:
                 if sim_size.x == 0:
@@ -647,10 +653,8 @@ def plot_eps(
                     center_second,
                     sim_first,
                     sim_second,
-                    label_parameters = default_label_geometry_parameters,
+                    label_parameters=default_label_geometry_parameters,
                 )
-
-
 
         ax.set_xlabel(xlabel)
         ax.set_ylabel(ylabel)

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -637,9 +637,9 @@ def plot_eps(
                     sim_first = sim_center.y
                     sim_second = sim_center.z
                 elif sim_size.y == 0:
-                    center_first = el.center.y
+                    center_first = el.center.x
                     center_second = el.center.z
-                    sim_first = sim_center.y
+                    sim_first = sim_center.x
                     sim_second = sim_center.z
                 elif sim_size.z == 0:
                     center_first = el.center.x

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -92,6 +92,8 @@ default_volume_parameters = {
 
 default_label_parameters = {"label_color": "r", "offset": 20, "label_alpha": 0.3}
 
+default_label_geometry_parameters = {"label_color": "w", "arrow_color": "r", "offset": 20, "label_alpha": 0.8}
+
 # Used to remove the elements of a dictionary (dict_to_filter) that
 # don't correspond to the keyword arguments of a particular
 # function (func_with_kwargs.)
@@ -138,6 +140,10 @@ def place_label(
     offset = label_parameters["offset"]
     alpha = label_parameters["label_alpha"]
     color = label_parameters["label_color"]
+    if "arrow_color" in label_parameters:
+        arrow_color = label_parameters["arrow_color"]
+    else:
+        arrow_color = color
 
     if x > centerx:
         xtext = -offset
@@ -156,7 +162,7 @@ def place_label(
         ha="center",
         va="bottom",
         bbox=dict(boxstyle="round,pad=0.2", fc=color, alpha=alpha),
-        arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.5", color=color),
+        arrowprops=dict(arrowstyle="->", connectionstyle="arc3,rad=0.5", color=arrow_color),
     )
     return ax
 
@@ -507,6 +513,7 @@ def plot_eps(
     eps_parameters: Optional[dict] = None,
     colorbar_parameters: Optional[dict] = None,
     frequency: Optional[float] = None,
+    label_geometry: bool = False,
 ) -> Union[Axes, Any]:
     # consolidate plotting parameters
     if eps_parameters is None:
@@ -614,6 +621,36 @@ def plot_eps(
                 default_label=r"$\epsilon_r$",
                 colorbar_parameters=colorbar_parameters,
             )
+
+
+        if label_geometry:
+            for el in sim.geometry:
+                if sim_size.x == 0:
+                    center_first = el.center.y
+                    center_second = el.center.z
+                    sim_first = sim_center.y
+                    sim_second = sim_center.z
+                elif sim_size.y == 0:
+                    center_first = el.center.y
+                    center_second = el.center.z
+                    sim_first = sim_center.y
+                    sim_second = sim_center.z
+                elif sim_size.z == 0:
+                    center_first = el.center.x
+                    center_second = el.center.y
+                    sim_first = sim_center.x
+                    sim_second = sim_center.y
+                ax = place_label(
+                    ax,
+                    el.label,
+                    center_first,
+                    center_second,
+                    sim_first,
+                    sim_second,
+                    label_parameters = default_label_geometry_parameters,
+                )
+
+
 
         ax.set_xlabel(xlabel)
         ax.set_ylabel(ylabel)
@@ -903,6 +940,7 @@ def plot2D(
     output_plane: Optional[Volume] = None,
     fields: Optional = None,
     labels: bool = False,
+    label_geometry: bool = False,
     eps_parameters: Optional[dict] = None,
     boundary_parameters: Optional[dict] = None,
     source_parameters: Optional[dict] = None,
@@ -945,6 +983,7 @@ def plot2D(
             eps_parameters=eps_parameters,
             colorbar_parameters=colorbar_parameters,
             frequency=frequency,
+            label_geometry=label_geometry,
         )
 
     # Plot boundaries

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -646,15 +646,16 @@ def plot_eps(
                     center_second = el.center.y
                     sim_first = sim_center.x
                     sim_second = sim_center.y
-                ax = place_label(
-                    ax,
-                    el.label,
-                    center_first,
-                    center_second,
-                    sim_first,
-                    sim_second,
-                    label_parameters=default_label_geometry_parameters,
-                )
+                if el.label is not None:
+                    ax = place_label(
+                        ax,
+                        el.label,
+                        center_first,
+                        center_second,
+                        sim_first,
+                        sim_second,
+                        label_parameters=default_label_geometry_parameters,
+                    )
 
         ax.set_xlabel(xlabel)
         ax.set_ylabel(ylabel)


### PR DESCRIPTION
Closes https://github.com/NanoComp/meep/issues/2614

PR adds labels for geometrical objects to show them on plots

Example 
```
import meep as mp
import argparse
import matplotlib.pyplot as plt

resolution = 50   # pixels/um
lk = mp.Block(size=mp.Vector3(mp.inf,5.0,mp.inf), material=mp.Medium(epsilon=3.0), label="main block")
geometry = [blk]

for i in range(1,2):
    geometry.append(mp.Cylinder(0.2, center=mp.Vector3(2 * i), label = "right hole"))
    geometry.append(mp.Cylinder(0.2, center=mp.Vector3(-2 * i), label = "left hole"))

src = [mp.Source(mp.GaussianSource(1.0, fwidth=0.5),
                     component=mp.Ex,
                     center=mp.Vector3(0.0, -3.0,0.0),
                     size=mp.Vector3(5,0))]


sim = mp.Simulation(cell_size=mp.Vector3(10,10,0),
                    geometry=geometry,
                    boundary_layers= [mp.PML(1.0)],
                    sources= src,
                    resolution=resolution)

sim.run(until=0)
sim.plot2D(label_geometry=True,labels=True)
plt.show()

```

![image](https://github.com/NanoComp/meep/assets/44506630/966c0c1e-506c-4678-9b67-80ae29822b57)
