### PR TITLE
tutorial for oblique planewave in cylindrical coordinate 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,13 +24,13 @@ repos:
 
 # Black, the code formatter, natively supports pre-commit
 - repo: https://github.com/psf/black
-  rev: "23.9.1"
+  rev: "4f1772e2aed8356e57b923eacf45f813ec3324a0"
   hooks:
     - id: black
 
 # Automatically upgrade syntax for newer versions of the language
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.13.0
+  rev: v3.9.0
   hooks:
     - id: pyupgrade
       args: [--py37-plus, --keep-runtime-typing]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,13 +24,13 @@ repos:
 
 # Black, the code formatter, natively supports pre-commit
 - repo: https://github.com/psf/black
-  rev: "4f1772e2aed8356e57b923eacf45f813ec3324a0"
+  rev: "23.9.1"
   hooks:
     - id: black
 
 # Automatically upgrade syntax for newer versions of the language
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.9.0
+  rev: v3.13.0
   hooks:
     - id: pyupgrade
       args: [--py37-plus, --keep-runtime-typing]

--- a/doc/docs/Python_Tutorials/Cylindrical_Coordinates.md
+++ b/doc/docs/Python_Tutorials/Cylindrical_Coordinates.md
@@ -455,10 +455,10 @@ As shown below, the results for the scattering cross section computed using cyli
 ![](../images/cylinder_cross_section.png#center)
 
 
-Scattering of Sphere with Oblique Planewave 
+Scattering of Sphere with Oblique Planewave
 -------------------------------------------
 
-It is also possible to launch an oblique incident planewave in cylindrical coordinate by decomposing the planewave $A_xe^{ik_xx+ik_yy}\hat{x} + A_ye^{ik_xx+ik_yy}\hat{y}$ into $\sum_m (J_r(r, m)\hat{r} + J_\phi(r, m)\hat{\phi})e^{im\phi}$. The exact expressions of $J_r(r,m)$ and $J_\phi(r,m)$ are given [here](http://github.com/zlin-opt/axisym_meta3d_inverse_design/blob/master/Implementation_of_FDFD_with_Cylindrical_Coordinates.pdf) by Zin Lin. In the simplest case of normal incidence, $J_r(r,m)$ and $J_\phi(r,m)$ are nonzero only when $m = \pm 1$, as shown in the [previous tutorial](https://meep.readthedocs.io/en/latest/Python_Tutorials/Cylindrical_Coordinates/#scattering-cross-section-of-a-finite-dielectric-cylinder). 
+It is also possible to launch an oblique incident planewave in cylindrical coordinate by decomposing the planewave $A_xe^{ik_xx+ik_yy}\hat{x} + A_ye^{ik_xx+ik_yy}\hat{y}$ into $\sum_m (J_r(r, m)\hat{r} + J_\phi(r, m)\hat{\phi})e^{im\phi}$. The exact expressions of $J_r(r,m)$ and $J_\phi(r,m)$ are given [here](http://github.com/zlin-opt/axisym_meta3d_inverse_design/blob/master/Implementation_of_FDFD_with_Cylindrical_Coordinates.pdf) by Zin Lin. In the simplest case of normal incidence, $J_r(r,m)$ and $J_\phi(r,m)$ are nonzero only when $m = \pm 1$, as shown in the [previous tutorial](https://meep.readthedocs.io/en/latest/Python_Tutorials/Cylindrical_Coordinates/#scattering-cross-section-of-a-finite-dielectric-cylinder).
 
 Given the decomposition of planewave into the sum of different current sources at each $m$, we can run individual simulations at each $m$ with their corresponding source amplitudes and record the relevant physical quantities. For quantities such fields, linearity implies that we can simply sum the results from each simulations; for quantities such as flux, orthogonality implies cross terms will be zero, and we can again simply sum the results. Moreover, simulations
 at each $m$ values are embarrassingly parallel so they can be run simultaneously.
@@ -480,7 +480,7 @@ frq_cen = 1 / wvl
 dfrq = 0.2
 nfrq = 1
 resolution, dair_fac, mrange = 50, 10, 5
-src_offset = 3/resolution # a small offset in source size 
+src_offset = 3/resolution # a small offset in source size
 dpml = 0.5 * wvl
 dair = 1.0 * wvl
 pml_layers = [mp.PML(thickness=dpml)]
@@ -506,7 +506,7 @@ for alpha_i in range(alpha_range):
     if abs(cur_m) > 1:
         src_cen = 0.5 * (r + dair_fac*dair) + 0.5*src_offset
     else:
-        src_cen = 0.5 * (r + dair_fac*dair) #+ 0.5*src_offset
+        src_cen = 0.5 * (r + dair_fac*dair)
     Jpm = lambda v3: coeff_p1 * special.jv(cur_m+1, kxy * (v3.x+src_cen)) + coeff_m1 * special.jv(cur_m-1, kxy * (v3.x+src_cen))
     Jrm = lambda v3: 1j * coeff_p1 * special.jv(cur_m+1, kxy * (v3.x+src_cen)) - 1j * coeff_m1 * special.jv(cur_m-1, kxy * (v3.x+src_cen))
 
@@ -538,7 +538,7 @@ for alpha_i in range(alpha_range):
                   center=mp.Vector3(src_cen, 0, -0.5 * sz + dpml),
                   size=mp.Vector3(r + dair_fac*dair),
                   amp_func = Jpm),]
-    
+
     sim = mp.Simulation(
         cell_size=cell_size,
         boundary_layers=pml_layers,


### PR DESCRIPTION
Documentation and tutorial for how to have oblique incident planewave in cylindrical coordinate. Compared the scattering flux of a sphere under different angles of incidence. Closes #2630. 

The setup of the tutorial looks like
![oblique_cyl](https://github.com/NanoComp/meep/assets/25192039/a948a005-a9e8-4656-8b02-c58715d533d3)

Part of the source around $r=0$ is currently excluded for $|m|>1$ due to #2644. In addition, as noted in https://github.com/NanoComp/meep/pull/2538#issuecomment-1686430983, source at $r=0$ for $|m|=1$ may also not be accurate. On the other hand, both issues should only introduce 1st order errors, which should go away with resolution. 

Here is a table of the results at various incidence angles at various cutoff of ``|m|`` at ``resolution=100``. 

|  Angle of incidence |  $$\|m\|=0$$ | $$\|m\| \le 1$$ |  $$\|m\| \le 2$$ |  $$\|m\| \le 3$$ |  $$\|m\| \le 4$$ | 
| --- | --- | --- | --- | --- | --- |
|  $$0^\circ$$ |  0.      |   17.83312867  | 17.83312867  | 17.83312867  | 17.83312867 | 
|  $$5^\circ$$ | 0.26219472  | 16.28351528  | 16.8657832   | 16.99266891 |  17.02334217 | 
|  $$7.5^\circ$$ | 0.32401024 | 15.14771059  | 16.08409591  | 16.12975925  | 16.17413882 | 
|  $$15^\circ$$ | 1.16801433 | 12.15571072  | 14.8310367   | 15.03711602  | 15.13986574 | 

A higher cutoff should have better convergence, but as mentioned in https://github.com/NanoComp/meep/issues/2644#issuecomment-1743208682,  a higher cutoff currently required excluding more pixels around $r=0$.