### PR TITLE
Add `flux` member function for class `dft_near2far` in C++ and `DftNear2Far` in Python

### DIFF
--- a/python/examples/disc_radiation_pattern.py
+++ b/python/examples/disc_radiation_pattern.py
@@ -220,6 +220,9 @@ def disc_total_flux(dmat: float, h: float) -> Tuple[float, float]:
     )
 
     flux_near = mp.get_fluxes(flux_mon)[0]
+    flux_near_n2f = mp.get_fluxes(n2f_mon)[0]
+
+    print(f"flux:, {flux_near}, {flux_near_n2f}")
 
     Ptheta = radiation_pattern(sim, n2f_mon)
     plot_radiation_pattern_polar(r * r * Ptheta)

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -783,6 +783,10 @@ class DftNear2Far(DftObj):
     def mu(self):
         return self.swigobj_attr("mu")
 
+    @property
+    def flux(self):
+        return self.swigobj_attr("flux")
+
     def flux(
         self, direction: int = None, where: Volume = None, resolution: float = None
     ):

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1378,6 +1378,9 @@ public:
   /* output Poynting flux of far fields */
   double *flux(direction df, const volume &where, double resolution);
 
+  /* output Poynting flux of near/monitor fields */
+  double *flux();
+
   void save_hdf5(h5file *file, const char *dprefix = 0);
   void load_hdf5(h5file *file, const char *dprefix = 0);
 


### PR DESCRIPTION
Fixes #2665.

Requires a (working) SWIG wrapper and a unit test.