### PR TITLE
Add check for cylindrical coordinates to `get_array_metadata`

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4053,7 +4053,7 @@ class Simulation:
         or `center`/`size`. In both cases, the return value is a tuple `(x,y,z,w)`, where:
 
         + `x,y,z` are 1d NumPy arrays storing the $x,y,z$ coordinates of the points in the
-          grid slice
+          grid slice. Cylindrical coordinates is not supported.
         + `w` is a NumPy array of the same dimensions as the array returned by
           `get_array`/`get_dft_array`, whose entries are the weights in a cubature rule
           for integrating over the spatial region (with the points in the cubature rule

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -786,6 +786,8 @@ complex<realnum> *fields::get_source_slice(const volume &where, component source
 /***************************************************************/
 /***************************************************************/
 std::vector<double> fields::get_array_metadata(const volume &where) {
+  if (where.dim == Dcyl)
+    meep::abort("get_array_metadata does not support cylindrical coordinates.");
 
   /* get extremal corners of subgrid and array of weights, collapsed if necessary */
   size_t dims[3];


### PR DESCRIPTION
Adds a check for cylindrical coordinates to `fields::get_array_metadata` and updates its docstrings.