### PR TITLE
Fixed use_output_directory clearing filename_prefix in all instances

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2768,6 +2768,7 @@ class Simulation:
         """
         if not dname:
             dname = self.get_filename_prefix() + "-out"
+            self.filename_prefix = None
 
         closure = {"trashed": False}
 
@@ -2783,7 +2784,6 @@ class Simulation:
 
         if self.fields is not None:
             hook()
-        self.filename_prefix = None
 
         return dname
 


### PR DESCRIPTION
The `simulation.use_output_directory()` function currently clears the `filename_prefix` variable whenever executed. The documentation says this should only happen when `dname` is not specified. I moved the clearing step into the if condition, so the `filename_prefix` is only cleared when `dname` is not specified. 