### PR TITLE
First-order subpixel smoothing for density-based TO

### DIFF
--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -1100,6 +1100,7 @@ def gray_indicator(x):
     """
     return npa.mean(4 * x.flatten() * (1 - x.flatten())) * 100
 
+
 def hybrid_levelset(
     x: ArrayLikeType,
     beta: float,
@@ -1147,7 +1148,7 @@ def hybrid_levelset(
             periodic. Default is None (all axes are non-periodic).
     Returns:
         The projected and smoothed output.
-    
+
     Example:
         >>> Lx = 2
         >>> Ly = 2
@@ -1196,7 +1197,8 @@ def hybrid_levelset(
     # with array-based AD tracers, apparently. See here:
     # https://github.com/google/jax/issues/1052#issuecomment-5140833520
     fill_factor = npa.where(
-        (d <= pixel_radius) & (npa.abs(d / pixel_radius) <= 1), # domain of arccos() and sqrt()
+        (d <= pixel_radius)
+        & (npa.abs(d / pixel_radius) <= 1),  # domain of arccos() and sqrt()
         (1 / (npa.pi * pixel_radius**2))
         * (
             pixel_radius**2


### PR DESCRIPTION
Here we implement first-order subpixel smoothing for density-based TO. This approach allows us to treat the density formulation as a level set, such that the user can now continuously increase β→∞.

This approach is 100% in python and leverages `autograd` to do all of the backpropagation. It's very straightforward, but currently only works for 2D degrees of freedom. Adding capability for 1D and 3D is trivial -- we just need to ensure the filters work in those dimension, and we need to add in the right fill factor kernel (analytically derived by assuming the smoothing kernel is a sphere). This is a "simple version" of what's implemented in #1951

Here's an example:

<img width="1684" alt="image" src="https://github.com/NanoComp/meep/assets/24902086/3bce3d88-bfde-4a72-be3c-c1601314da5a">

While the approach works well, it is still sensitive to numerical roundoff errors. Autograd doesn't really have any tooling in place to track where things are breaking down (particularly in the backward pass). So we'll have to get creative. Here's a plot that shows the norm of the gradient which breaks down due to numerical error with increasing β:

<img width="1653" alt="image" src="https://github.com/NanoComp/meep/assets/24902086/2784d67c-25d9-459a-9b7c-6c7e9b4615f1">

Also, still needs a test.
