### PR TITLE
Swap gamma for Drude and Lorentzian terms in epsilon fitting parameters for Au from Johnson and Christy and update Titanium

### DIFF
--- a/python/materials.py
+++ b/python/materials.py
@@ -729,11 +729,11 @@ Au_JC_visible = mp.Medium(
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
 Au_visible_frq0 = 1 / (0.0473629248511456 * um_scale)
-Au_visible_gam0 = 1 / (0.381870287531951 * um_scale)
+Au_visible_gam0 = 1 / (0.255476199605166 * um_scale)
 Au_visible_sig0 = 1
 
 Au_visible_frq1 = 1 / (0.800619321082804 * um_scale)
-Au_visible_gam1 = 1 / (0.255476199605166 * um_scale)
+Au_visible_gam1 = 1 / (0.381870287531951 * um_scale)
 Au_visible_sig1 = -169.060953137985
 
 Au_visible_susc = [
@@ -756,11 +756,11 @@ Au_visible = mp.Medium(
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
 Ag_visible_frq0 = 1 / (0.142050162130618 * um_scale)
-Ag_visible_gam0 = 1 / (0.257794324096575 * um_scale)
+Ag_visible_gam0 = 1 / (18.0357292925015 * um_scale)
 Ag_visible_sig0 = 1
 
 Ag_visible_frq1 = 1 / (0.115692151792108 * um_scale)
-Ag_visible_gam1 = 1 / (18.0357292925015 * um_scale)
+Ag_visible_gam1 = 1 / (0.257794324096575 * um_scale)
 Ag_visible_sig1 = 3.74465275944019
 
 Ag_visible_susc = [
@@ -783,11 +783,11 @@ Ag_visible = mp.Medium(
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
 Al_visible_frq0 = 1 / (0.0625841659042985 * um_scale)
-Al_visible_gam0 = 1 / (0.291862527666814 * um_scale)
+Al_visible_gam0 = 1 / (0.606007002962666 * um_scale)
 Al_visible_sig0 = 1
 
 Al_visible_frq1 = 1 / (0.528191199577075 * um_scale)
-Al_visible_gam1 = 1 / (0.606007002962666 * um_scale)
+Al_visible_gam1 = 1 / (0.291862527666814 * um_scale)
 Al_visible_sig1 = -44.4456675577921
 
 Al_visible_susc = [
@@ -810,12 +810,12 @@ Al_visible = mp.Medium(
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
 Cr_visible_frq0 = 1 / (0.118410119507342 * um_scale)
-Cr_visible_gam0 = 1 / (0.731117670900812 * um_scale)
+Cr_visible_gam0 = 1 / (0.628596264869804 * um_scale)
 Cr_visible_sig0 = 1
 
 Cr_visible_frq1 = 1 / (0.565709598452496 * um_scale)
-Cr_visible_gam1 = 1 / (0.628596264869804 * um_scale)
-Cr_visible_sig1 = 13.2912419951294
+Cr_visible_gam1 = 1 / (0.731117670900812 * um_scale)
+Cr_visible_sig1 = 13.2908
 
 Cr_visible_susc = [
     mp.DrudeSusceptibility(
@@ -836,13 +836,13 @@ Cr_visible = mp.Medium(
 # titanium (Ti)
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
-Ti_visible_frq0 = 1 / (0.101331651921602 * um_scale)
-Ti_visible_gam0 = 1 / (5.86441957443603e-10 * um_scale)
+Ti_visible_frq0 = 1 / (0.2213799986964903 * um_scale)
+Ti_visible_gam0 = 1 / (12.815176733218491 * um_scale)
 Ti_visible_sig0 = 1
 
-Ti_visible_frq1 = 1 / (4.56839173979216e-09 * um_scale)
-Ti_visible_gam1 = 1 / (0.365743382258719 * um_scale)
-Ti_visible_sig1 = 54742662.1963414
+Ti_visible_frq1 = 1 / (0.6425774603632576 * um_scale)
+Ti_visible_gam1 = 1 / (0.1738808794709548 * um_scale)
+Ti_visible_sig1 = 74.4496
 
 Ti_visible_susc = [
     mp.DrudeSusceptibility(
@@ -854,7 +854,7 @@ Ti_visible_susc = [
 ]
 
 Ti_visible = mp.Medium(
-    epsilon=-5.4742e7,
+    epsilon=2.17069,
     E_susceptibilities=Ti_visible_susc,
     valid_freq_range=metal_visible_range,
 )

--- a/python/materials.py
+++ b/python/materials.py
@@ -752,6 +752,8 @@ Au_visible = mp.Medium(
 )
 
 # ------------------------------------------------------------------
+## WARNING: unstable; field divergence may occur
+
 # silver (Au)
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
@@ -779,6 +781,8 @@ Ag_visible = mp.Medium(
 )
 
 # ------------------------------------------------------------------
+## WARNING: unstable; field divergence may occur
+
 # aluminum (Al)
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
@@ -815,7 +819,7 @@ Cr_visible_sig0 = 1
 
 Cr_visible_frq1 = 1 / (0.565709598452496 * um_scale)
 Cr_visible_gam1 = 1 / (0.731117670900812 * um_scale)
-Cr_visible_sig1 = 13.2908
+Cr_visible_sig1 = 13.2912419951294
 
 Cr_visible_susc = [
     mp.DrudeSusceptibility(

--- a/python/materials.py
+++ b/python/materials.py
@@ -692,7 +692,8 @@ W_susc = [
 W = mp.Medium(epsilon=1.0, E_susceptibilities=W_susc, valid_freq_range=metal_range)
 
 # ------------------------------------------------------------------
-# metals from D. Barchiesi and T. Grosges, J. Nanophotonics, Vol. 8, 08996 (2015)
+# metals from D. Barchiesi and T. Grosges, J. Nanophotonics, Vol. 8, 083097 (2014)
+# including Errata from J. Nanophotonics, Vol. 8, 089996 (2014)
 # wavelength range: 0.4 - 0.8 μm
 
 metal_visible_range = mp.FreqRange(min=um_scale / 0.8, max=um_scale / 0.4)
@@ -701,11 +702,11 @@ metal_visible_range = mp.FreqRange(min=um_scale / 0.8, max=um_scale / 0.4)
 # fit to P.B. Johnson and R.W. Christy, Physical Review B, Vol. 6, pp. 4370-9 (1972)
 
 Au_JC_visible_frq0 = 1 / (0.139779231751333 * um_scale)
-Au_JC_visible_gam0 = 1 / (1.12834046202759 * um_scale)
+Au_JC_visible_gam0 = 1 / (26.1269913352870 * um_scale)
 Au_JC_visible_sig0 = 1
 
 Au_JC_visible_frq1 = 1 / (0.404064525036786 * um_scale)
-Au_JC_visible_gam1 = 1 / (26.1269913352870 * um_scale)
+Au_JC_visible_gam1 = 1 / (1.12834046202759 * um_scale)
 Au_JC_visible_sig1 = 2.07118534879440
 
 Au_JC_visible_susc = [
@@ -728,11 +729,11 @@ Au_JC_visible = mp.Medium(
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
 Au_visible_frq0 = 1 / (0.0473629248511456 * um_scale)
-Au_visible_gam0 = 1 / (0.255476199605166 * um_scale)
+Au_visible_gam0 = 1 / (0.381870287531951 * um_scale)
 Au_visible_sig0 = 1
 
 Au_visible_frq1 = 1 / (0.800619321082804 * um_scale)
-Au_visible_gam1 = 1 / (0.381870287531951 * um_scale)
+Au_visible_gam1 = 1 / (0.255476199605166 * um_scale)
 Au_visible_sig1 = -169.060953137985
 
 Au_visible_susc = [
@@ -751,17 +752,15 @@ Au_visible = mp.Medium(
 )
 
 # ------------------------------------------------------------------
-## WARNING: unstable; field divergence may occur
-
 # silver (Au)
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
 Ag_visible_frq0 = 1 / (0.142050162130618 * um_scale)
-Ag_visible_gam0 = 1 / (18.0357292925015 * um_scale)
+Ag_visible_gam0 = 1 / (0.257794324096575 * um_scale)
 Ag_visible_sig0 = 1
 
 Ag_visible_frq1 = 1 / (0.115692151792108 * um_scale)
-Ag_visible_gam1 = 1 / (0.257794324096575 * um_scale)
+Ag_visible_gam1 = 1 / (18.0357292925015 * um_scale)
 Ag_visible_sig1 = 3.74465275944019
 
 Ag_visible_susc = [
@@ -780,17 +779,15 @@ Ag_visible = mp.Medium(
 )
 
 # ------------------------------------------------------------------
-## WARNING: unstable; field divergence may occur
-
 # aluminum (Al)
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
 Al_visible_frq0 = 1 / (0.0625841659042985 * um_scale)
-Al_visible_gam0 = 1 / (0.606007002962666 * um_scale)
+Al_visible_gam0 = 1 / (0.291862527666814 * um_scale)
 Al_visible_sig0 = 1
 
 Al_visible_frq1 = 1 / (0.528191199577075 * um_scale)
-Al_visible_gam1 = 1 / (0.291862527666814 * um_scale)
+Al_visible_gam1 = 1 / (0.606007002962666 * um_scale)
 Al_visible_sig1 = -44.4456675577921
 
 Al_visible_susc = [
@@ -813,11 +810,11 @@ Al_visible = mp.Medium(
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
 Cr_visible_frq0 = 1 / (0.118410119507342 * um_scale)
-Cr_visible_gam0 = 1 / (0.628596264869804 * um_scale)
+Cr_visible_gam0 = 1 / (0.731117670900812 * um_scale)
 Cr_visible_sig0 = 1
 
 Cr_visible_frq1 = 1 / (0.565709598452496 * um_scale)
-Cr_visible_gam1 = 1 / (0.731117670900812 * um_scale)
+Cr_visible_gam1 = 1 / (0.628596264869804 * um_scale)
 Cr_visible_sig1 = 13.2912419951294
 
 Cr_visible_susc = [
@@ -836,17 +833,15 @@ Cr_visible = mp.Medium(
 )
 
 # ------------------------------------------------------------------
-## WARNING: unstable; field divergence may occur
-
 # titanium (Ti)
 # fit to E.D. Palik, Handbook of Optical Constants, Academic Press (1985)
 
 Ti_visible_frq0 = 1 / (0.101331651921602 * um_scale)
-Ti_visible_gam0 = 1 / (0.365743382258719 * um_scale)
+Ti_visible_gam0 = 1 / (5.86441957443603e-10 * um_scale)
 Ti_visible_sig0 = 1
 
 Ti_visible_frq1 = 1 / (4.56839173979216e-09 * um_scale)
-Ti_visible_gam1 = 1 / (5.86441957443603e-10 * um_scale)
+Ti_visible_gam1 = 1 / (0.365743382258719 * um_scale)
 Ti_visible_sig1 = 54742662.1963414
 
 Ti_visible_susc = [


### PR DESCRIPTION
The material fitting parameters for Au at visible wavelengths from Johnson and Christy provided in [D. Barciesi and T. Grosges, J. Nanophotonics, Vol. 8, 083097 (2014)](https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=e93db899c22bbb6e7495435d88b2955cdfdf065c) contain an error described in the [errata](https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=dcca866b075aa385caf72cf63c6f713045647bd3) in which $\gamma_D$ and  $\gamma_L$ (the loss rate for the Drude and Lorentzian terms, respectively) are swapped. Unfortunately, the current values for these fitting parameters in the materials library  do *not* contain the correction described in the errata. This PR updates these fitting parameters with the correct values. 

As validation, a plot of the real and imaginary parts of $\epsilon$ using the updated parameters matches the plot in Figure 1(a) of the original paper. (The abstract in the errata states "Fortunately the curves in Ref. 1 [original paper] are correct.") The script used to generate this plot is provided below as a reference. 

Also, because of a likely error for the fitting parameters of Ti in the errata, this PR uses the fitting parameters from the *original* paper with the corrected $\gamma$ terms.

cc @kombatEldridge 

![epsilon_Au_JC_visible](https://github.com/NanoComp/meep/assets/7152530/fa0b8d2a-9438-49f1-bb71-7d89f925f36a)

![Screenshot from 2023-12-28 21-32-23](https://github.com/NanoComp/meep/assets/7152530/4f99ee30-64ab-4b9f-8913-ae39d7ab63e5)

```py
"""Plot the complex epsilon for Au in the materials library."""

import matplotlib
matplotlib.use('agg')
import matplotlib.pyplot as plt
from meep.materials import Au_JC_visible
import numpy as np


wavelength_um = np.linspace(0.4, 0.8, 50)
frequency = 1 / wavelength_um

epsilon_r = [Au_JC_visible.epsilon(f)[0][0].real for f in frequency]
epsilon_i = [Au_JC_visible.epsilon(f)[0][0].imag for f in frequency]

um_to_nm_scale = 1000

fig, ax = plt.subplots()
ax.plot(
    wavelength_um * um_to_nm_scale, epsilon_r, 'bo-', label='$\Re{(\epsilon)}$'
)
ax.plot(
    wavelength_um * um_to_nm_scale, epsilon_i, 'ro-', label='$\Im{(\epsilon)}$'
)
ax.set_xlabel('wavelength (nm)')
ax.set_ylabel('$\epsilon$')
ax.set_title('Au_JC_visible from materials.py')
ax.legend()
fig.savefig('epsilon_Au_JC_visible.png', dpi=150, bbox_inches='tight')
```

![epsilon_Ti_visible](https://github.com/NanoComp/meep/assets/7152530/ffe68e3a-c8e9-4c56-9828-75551bd03a3a)
