### PR TITLE
Disable subpixel smoothing by default in `MaterialGrid` class objects

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -4691,7 +4691,7 @@ def __init__(self,
              medium2: meep.geom.Medium,
              weights: numpy.ndarray = None,
              grid_type: str = 'U_DEFAULT',
-             do_averaging: bool = True,
+             do_averaging: bool = False,
              beta: float = 0,
              eta: float = 0.5,
              damping: float = 0):

--- a/python/geom.py
+++ b/python/geom.py
@@ -597,7 +597,7 @@ class MaterialGrid:
         medium2: Medium,
         weights: np.ndarray = None,
         grid_type: str = "U_DEFAULT",
-        do_averaging: bool = True,
+        do_averaging: bool = False,
         beta: float = 0,
         eta: float = 0.5,
         damping: float = 0,

--- a/python/tests/test_adjoint_cyl.py
+++ b/python/tests/test_adjoint_cyl.py
@@ -72,7 +72,11 @@ def get_source(m):
 
 def forward_simulation(design_params, m, far_x):
     matgrid = mp.MaterialGrid(
-        mp.Vector3(Nr, 0, Nz), SiO2, Si, weights=design_params.reshape(Nr, 1, Nz)
+        mp.Vector3(Nr, 0, Nz),
+        SiO2,
+        Si,
+        weights=design_params.reshape(Nr, 1, Nz),
+        do_averaging=True,
     )
 
     geometry = [
@@ -113,7 +117,9 @@ def forward_simulation(design_params, m, far_x):
 
 def adjoint_solver(design_params, m, far_x):
 
-    design_variables = mp.MaterialGrid(mp.Vector3(Nr, 0, Nz), SiO2, Si)
+    design_variables = mp.MaterialGrid(
+        mp.Vector3(Nr, 0, Nz), SiO2, Si, do_averaging=True
+    )
     design_region = mpa.DesignRegion(
         design_variables,
         volume=mp.Volume(


### PR DESCRIPTION
As described in #2757, there seems to be a bug in the subpixel smoothing feature for the `MaterialGrid` for 3D structures. Until this is resolved, it is better to disable subpixel smoothing by default. 