### PR TITLE
Increase initial number of grid points used in phi quadrature for near-to-far field transformation in cylindrical coordinates

### DIFF
--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -288,7 +288,7 @@ void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, d
   /* Perform phi integral.  Since phi integrand is smooth, quadrature with equally spaced points
      should converge exponentially fast with the number N of quadrature points.  We
      repeatedly double N until convergence to tol is achieved, re-using previous points. */
-  const int N0 = 4;
+  const int N0 = 128;
   double dphi = 2.0 / N0; // factor of 2*pi*r is already included in add_dft weight
   for (int N = N0; N <= 65536; N *= 2) {
     std::complex<double> EH_sum[6];

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -288,7 +288,7 @@ void greencyl(std::complex<double> *EH, const vec &x, double freq, double eps, d
   /* Perform phi integral.  Since phi integrand is smooth, quadrature with equally spaced points
      should converge exponentially fast with the number N of quadrature points.  We
      repeatedly double N until convergence to tol is achieved, re-using previous points. */
-  const int N0 = 128;
+  const int N0 = 16 + int(4 * abs(m));
   double dphi = 2.0 / N0; // factor of 2*pi*r is already included in add_dft weight
   for (int N = N0; N <= 65536; N *= 2) {
     std::complex<double> EH_sum[6];


### PR DESCRIPTION
Closes #2764.

Rather than make the number of grid points in the $\phi$ quadrature a user parameter in `get_farfields`, it is simpler just to increase the hard-coded value for `N0` set internally in `greencyl`. The impact of integrating over a larger number of grid points should be insignificant when compared to the accuracy improvements enabled by this modification as this integral converges exponentially fast.