### PR TITLE
Markdown formatting fix in extraction-efficiency tutorial

### DIFF
--- a/doc/docs/Python_Tutorials/Local_Density_of_States.md
+++ b/doc/docs/Python_Tutorials/Local_Density_of_States.md
@@ -335,7 +335,7 @@ Note: because of a [bug](https://github.com/NanoComp/meep/issues/2704) for an $E
 
 ![](../images/dipole_extraction_eff_cyl.png#center)
 
-The total emitted power obtained from the LDOS terms of the formula above must be multiplied by $\Delta V$, the volume of the voxel. In cylindrical coordinates, $\Delta V = \Delta r \times \Delta z \times 2 \pi r$. Meep implements an $r = 0$ source at $r = 0.5 \Delta r$, corresponding to the smallest-$r$ $E_r$ Yee grid point. This means that for a source at $r = 0$, $\Delta V = \pi / resolution^3$ since $\Delta r = \Delta z = 1 / resolution$. In 3D, $\Delta V = \Delta x \times \Delta y \times \Delta z = 1 / resolution^3$ for every voxel in the cell.
+The total emitted power obtained from the LDOS terms of the formula above must be multiplied by $\Delta V$, the volume of the voxel. In cylindrical coordinates, $\Delta V = \Delta r \times \Delta z \times 2 \pi r$. Meep implements an $r = 0$ source at $r = 0.5 \Delta r$, corresponding to the smallest-$r$ $E_r$ Yee grid point. This means that for a source at $r = 0$, $\Delta V = \pi /$`resolution`$^3$ since $\Delta r = \Delta z = 1 /$`resolution`. In 3D, $\Delta V = \Delta x \times \Delta y \times \Delta z = 1 /$`resolution`$^3$ for every voxel in the cell.
 
 As shown in the figure below, the results from the two coordinate systems have good agreement.
 


### PR DESCRIPTION
Slight improvement to [Extraction Efficiency of a Collection of Dipoles in a Disc](https://meep.readthedocs.io/en/latest/Python_Tutorials/Near_to_Far_Field_Spectra/#extraction-efficiency-of-a-collection-of-dipoles-in-a-disc).