### PR TITLE
Add note on Purcell enhancement factor for QW emission to tutorial on extraction efficiency

### DIFF
--- a/doc/docs/Python_Tutorials/Near_to_Far_Field_Spectra.md
+++ b/doc/docs/Python_Tutorials/Near_to_Far_Field_Spectra.md
@@ -674,6 +674,8 @@ This figure shows the radiation pattern from $N=11$ dipoles with $\lambda$ of 1.
 
 ![](../images/disc_dipoles_radiation_pattern.png#center)
 
+Note: in addition to calculating the extraction efficiency, it may also be useful to compute the "enhancement factor" for the QW emission. The "enhancement factor" is the ratio of the total power from the QW in a given structure to a reference structure for which the internal quantum efficiency may be known. The "enhancement factor" is a generalization of the Purcell enhancement factor which applies only to a *single* dipole emitter via the local density of states as described in Section 4.4.6 of the [book chapter](https://arxiv.org/pdf/1301.5366).
+
 The simulation script is in [examples/disc_extraction_efficiency.py](https://github.com/NanoComp/meep/blob/master/python/examples/disc_extraction_efficiency.py).
 
 


### PR DESCRIPTION
Adds a note regarding an additional metric to [Tutorial/Extraction Efficiency of a Collection of Dipoles in a Disc](https://meep.readthedocs.io/en/latest/Python_Tutorials/Near_to_Far_Field_Spectra/#extraction-efficiency-of-a-collection-of-dipoles-in-a-disc).