### PR TITLE
Pin to older Numpy version to prevent Autograd breakage during CI

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,7 +3,7 @@ h5py
 jax
 jaxlib
 matplotlib
-numpy
+numpy<2
 parameterized
 pytest
 scipy


### PR DESCRIPTION
Closes #2855.

Autograd is currently failing during CI because of an incompatibility with the recently released version 2.0.0 for Numpy (HIPS/autograd#618). As a workaround until a patch is merged, the Numpy version is pinned to an older version.