### PR TITLE
Changes to _eval_step_func

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -4996,14 +4996,13 @@ def _combine_step_funcs(*step_funcs):
 
 def _eval_step_func(sim, func, todo):
     num_args = get_num_args(func)
+    name_args = func.__code__.co_varnames
+    self_count = int("self" in name_args)
 
-    if num_args != 1 and num_args != 2:
-        raise ValueError(f"Step function '{func.__name__}'' requires 1 or 2 arguments")
-    elif num_args == 1:
-        if todo == "step":
-            func(sim)
-    elif num_args == 2:
-        func(sim, todo)
+    if num_args not in {1 + self_count, 2 + self_count}:
+        raise ValueError(f"Step function '{func.__name__}' requires 1 or 2 arguments")
+
+    func(sim, todo) if num_args == 2 + self_count else func(sim)
 
 
 def _when_true_funcs(cond, *step_funcs):

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -97,7 +97,7 @@ def get_num_args(func):
     if isinstance(func, Harminv) or isinstance(func, PadeDFT):
         return 2
     elif inspect.ismethod(func):
-        return func.__code__.co_argcount - 1 # remove 'self' from count
+        return func.__code__.co_argcount - 1  # remove 'self' from count
     else:
         return func.__code__.co_argcount
 

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -97,7 +97,7 @@ def get_num_args(func):
     return (
         2
         if isinstance(func, Harminv) or isinstance(func, PadeDFT)
-        else func.__code__.co_argcount - 1 # first argument is "self", passed implicitly for bound methods
+        else func.__code__.co_argcount - 1 # first argument is "self"
         if inspect.ismethod(func)
         else func.__code__.co_argcount
     )

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -97,7 +97,7 @@ def get_num_args(func):
     return (
         2
         if isinstance(func, Harminv) or isinstance(func, PadeDFT)
-        else func.__code__.co_argcount - 1
+        else func.__code__.co_argcount - 1 # first argument is "self", passed implicitly for bound methods
         if inspect.ismethod(func)
         else func.__code__.co_argcount
     )

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -94,13 +94,12 @@ def fix_dft_args(args, i):
 
 
 def get_num_args(func):
-    return (
-        2
-        if isinstance(func, Harminv) or isinstance(func, PadeDFT)
-        else func.__code__.co_argcount - 1  # first argument is "self"
-        if inspect.ismethod(func)
-        else func.__code__.co_argcount
-    )
+    if isinstance(func, Harminv) or isinstance(func, PadeDFT):
+        return 2
+    elif inspect.ismethod(func):
+        return func.__code__.co_argcount - 1 # remove 'self' from count
+    else:
+        return func.__code__.co_argcount
 
 
 def vec(*args):

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -99,6 +99,12 @@ def get_num_args(func):
         else func.__code__.co_argcount
     )
 
+def get_name_args(func):
+    return (
+        ("sim", "todo")
+        if isinstance(func, Harminv) or isinstance(func, PadeDFT)
+        else func.__code__.co_varnames[: func.__code__.co_argcount]
+    )
 
 def vec(*args):
     try:
@@ -4996,7 +5002,7 @@ def _combine_step_funcs(*step_funcs):
 
 def _eval_step_func(sim, func, todo):
     num_args = get_num_args(func)
-    name_args = func.__code__.co_varnames
+    name_args = get_name_args(func)
     self_count = int("self" in name_args)
 
     if num_args not in {1 + self_count, 2 + self_count}:

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -99,12 +99,14 @@ def get_num_args(func):
         else func.__code__.co_argcount
     )
 
+
 def get_name_args(func):
     return (
         ("sim", "todo")
         if isinstance(func, Harminv) or isinstance(func, PadeDFT)
         else func.__code__.co_varnames[: func.__code__.co_argcount]
     )
+
 
 def vec(*args):
     try:

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -5009,8 +5009,11 @@ def _eval_step_func(sim, func, todo):
 
     if num_args not in {1 + self_count, 2 + self_count}:
         raise ValueError(f"Step function '{func.__name__}' requires 1 or 2 arguments")
-
-    func(sim, todo) if num_args == 2 + self_count else func(sim)
+    elif num_args == 2 + self_count:
+        func(sim, todo)
+    elif num_args == 1 + self_count:
+        if todo == "step":
+            func(sim)
 
 
 def _when_true_funcs(cond, *step_funcs):

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -97,7 +97,7 @@ def get_num_args(func):
     return (
         2
         if isinstance(func, Harminv) or isinstance(func, PadeDFT)
-        else func.__code__.co_argcount - 1 # first argument is "self"
+        else func.__code__.co_argcount - 1  # first argument is "self"
         if inspect.ismethod(func)
         else func.__code__.co_argcount
     )


### PR DESCRIPTION
In my project, I am wanting to use some step functions while Meep runs. Currently, my entire simulation of Meep runs in a Simulation class and I would like to keep my step functions in this class as well. That being said, they must have `self` as an arg. With the current `_eval_step_func`, the arg handler is a bit too strict. There is probably a reason for this, and please disregard this PR if so.

The changes I am requesting would include the possibility that the step functions contain an arg named `self` but should still keep the intended limitations of the previous version.