### PR TITLE
Temporary fix for two failing MPI tests related to chunk partition

### DIFF
--- a/python/tests/test_dump_load.py
+++ b/python/tests/test_dump_load.py
@@ -135,7 +135,7 @@ class TestLoadDump(ApproxComparisonTestCase):
     ):
         from meep.materials import aSi
 
-        resolution = 15
+        resolution = 20
         cell = mp.Vector3(2.3, 2.1, 2.7)
         sources = mp.Source(
             src=mp.GaussianSource(2.5, fwidth=0.1), center=mp.Vector3(), component=mp.Hy

--- a/python/tests/test_dump_load.py
+++ b/python/tests/test_dump_load.py
@@ -153,8 +153,8 @@ class TestLoadDump(ApproxComparisonTestCase):
         boundary_layers = [mp.Absorber(0.2)]
         k_point = mp.Vector3(0.4, -1.3, 0.7)
 
-        if mp.with_mpi():
-            chunk_layout = mp.BinaryPartition(data=[(mp.X, 0), 0, 1])
+        if mp.count_processors() == 2:
+            chunk_layout = mp.BinaryPartition(data=[(mp.Z, 0), 0, 1])
         else:
             chunk_layout = None
 

--- a/python/tests/test_dump_load.py
+++ b/python/tests/test_dump_load.py
@@ -153,6 +153,11 @@ class TestLoadDump(ApproxComparisonTestCase):
         boundary_layers = [mp.Absorber(0.2)]
         k_point = mp.Vector3(0.4, -1.3, 0.7)
 
+        if mp.with_mpi():
+            chunk_layout = mp.BinaryPartition(data=[(mp.Z, 0), 0, 1])
+        else:
+            chunk_layout = None
+
         sim1 = mp.Simulation(
             resolution=resolution,
             cell_size=cell,
@@ -161,6 +166,7 @@ class TestLoadDump(ApproxComparisonTestCase):
             boundary_layers=boundary_layers,
             default_material=default_material,
             sources=[sources],
+            chunk_layout=chunk_layout,
         )
 
         sample_point = mp.Vector3(0.73, -0.33, 0.61)

--- a/python/tests/test_dump_load.py
+++ b/python/tests/test_dump_load.py
@@ -135,7 +135,7 @@ class TestLoadDump(ApproxComparisonTestCase):
     ):
         from meep.materials import aSi
 
-        resolution = 20
+        resolution = 15
         cell = mp.Vector3(2.3, 2.1, 2.7)
         sources = mp.Source(
             src=mp.GaussianSource(2.5, fwidth=0.1), center=mp.Vector3(), component=mp.Hy
@@ -154,7 +154,7 @@ class TestLoadDump(ApproxComparisonTestCase):
         k_point = mp.Vector3(0.4, -1.3, 0.7)
 
         if mp.with_mpi():
-            chunk_layout = mp.BinaryPartition(data=[(mp.Z, 0), 0, 1])
+            chunk_layout = mp.BinaryPartition(data=[(mp.X, 0), 0, 1])
         else:
             chunk_layout = None
 

--- a/python/tests/test_dump_load.py
+++ b/python/tests/test_dump_load.py
@@ -195,6 +195,9 @@ class TestLoadDump(ApproxComparisonTestCase):
         if chunk_sim:
             chunk_layout = sim1
 
+        if chunk_layout is None and mp.count_processors() == 2:
+            chunk_layout = mp.BinaryPartition(data=[(mp.Z, 0), 0, 1])
+
         sim = mp.Simulation(
             resolution=resolution,
             cell_size=cell,

--- a/python/tests/test_fragment_stats.py
+++ b/python/tests/test_fragment_stats.py
@@ -680,34 +680,34 @@ class TestPMLToVolList(unittest.TestCase):
 @unittest.skipIf(mp.count_processors() != 2, "MPI specific test")
 class TestChunkCommunicationArea(unittest.TestCase):
     def test_2d_periodic(self):
-        sim = make_sim(mp.Vector3(10, 6), 10, [mp.PML(1)], 2, k_point=mp.Vector3(1, 1))
+        sim = make_sim(mp.Vector3(10, 6), 25, [mp.PML(1)], 2, k_point=mp.Vector3(1, 1))
         max_comm = sim.get_max_chunk_communication_area()
         avg_comm = sim.get_avg_chunk_communication_area()
-        self.assertEqual(max_comm, 220)
-        self.assertEqual(avg_comm, 220)
+        self.assertEqual(max_comm, 550)
+        self.assertEqual(avg_comm, 550)
 
     def test_3d_periodic(self):
         sim = make_sim(
-            mp.Vector3(10, 8, 6), 10, [mp.PML(1)], 3, k_point=mp.Vector3(1, 1, 1)
+            mp.Vector3(10, 8, 6), 25, [mp.PML(1)], 3, k_point=mp.Vector3(1, 1, 1)
         )
         max_comm = sim.get_max_chunk_communication_area()
         avg_comm = sim.get_avg_chunk_communication_area()
-        self.assertEqual(max_comm, 2360)
-        self.assertEqual(avg_comm, 2360)
+        self.assertEqual(max_comm, 5900)
+        self.assertEqual(avg_comm, 5900)
 
     def test_2d(self):
-        sim = make_sim(mp.Vector3(10, 6), 10, [mp.PML(1)], 2)
+        sim = make_sim(mp.Vector3(10, 6), 25, [mp.PML(1)], 2)
         max_comm = sim.get_max_chunk_communication_area()
         avg_comm = sim.get_avg_chunk_communication_area()
-        self.assertEqual(max_comm, 60)
-        self.assertEqual(avg_comm, 60)
+        self.assertEqual(max_comm, 150)
+        self.assertEqual(avg_comm, 150)
 
     def test_3d(self):
-        sim = make_sim(mp.Vector3(10, 8, 6), 10, [mp.PML(1)], 3)
+        sim = make_sim(mp.Vector3(10, 8, 6), 25, [mp.PML(1)], 3)
         max_comm = sim.get_max_chunk_communication_area()
         avg_comm = sim.get_avg_chunk_communication_area()
-        self.assertEqual(max_comm, 480)
-        self.assertEqual(avg_comm, 480)
+        self.assertEqual(max_comm, 1200)
+        self.assertEqual(avg_comm, 1200)
 
 
 if __name__ == "__main__":

--- a/python/tests/test_fragment_stats.py
+++ b/python/tests/test_fragment_stats.py
@@ -24,7 +24,7 @@ def make_dft_vecs(
 
 
 def make_sim(cell, res, pml, dims, create_gv=True, k_point=False):
-    if mp.with_mpi():
+    if mp.with_mpi() and dims == 3:
         chunk_layout = mp.BinaryPartition(data=[(mp.X, 0), 0, 1])
     else:
         chunk_layout = None

--- a/python/tests/test_fragment_stats.py
+++ b/python/tests/test_fragment_stats.py
@@ -24,7 +24,7 @@ def make_dft_vecs(
 
 
 def make_sim(cell, res, pml, dims, create_gv=True, k_point=False):
-    if mp.count_processors() == 2 and dims == 3:
+    if mp.count_processors() == 2:
         chunk_layout = mp.BinaryPartition(data=[(mp.X, 0), 0, 1])
     else:
         chunk_layout = None

--- a/python/tests/test_fragment_stats.py
+++ b/python/tests/test_fragment_stats.py
@@ -24,12 +24,18 @@ def make_dft_vecs(
 
 
 def make_sim(cell, res, pml, dims, create_gv=True, k_point=False):
+    if mp.with_mpi():
+        chunk_layout = mp.BinaryPartition(data=[(mp.X, 0), 0, 1])
+    else:
+        chunk_layout = None
+
     sim = mp.Simulation(
         cell_size=cell,
         resolution=res,
         boundary_layers=pml,
         dimensions=dims,
         k_point=k_point,
+        chunk_layout=chunk_layout,
     )
     if create_gv:
         sim._create_grid_volume(False)
@@ -680,34 +686,34 @@ class TestPMLToVolList(unittest.TestCase):
 @unittest.skipIf(mp.count_processors() != 2, "MPI specific test")
 class TestChunkCommunicationArea(unittest.TestCase):
     def test_2d_periodic(self):
-        sim = make_sim(mp.Vector3(10, 6), 25, [mp.PML(1)], 2, k_point=mp.Vector3(1, 1))
+        sim = make_sim(mp.Vector3(10, 6), 10, [mp.PML(1)], 2, k_point=mp.Vector3(1, 1))
         max_comm = sim.get_max_chunk_communication_area()
         avg_comm = sim.get_avg_chunk_communication_area()
-        self.assertEqual(max_comm, 550)
-        self.assertEqual(avg_comm, 550)
+        self.assertEqual(max_comm, 220)
+        self.assertEqual(avg_comm, 220)
 
     def test_3d_periodic(self):
         sim = make_sim(
-            mp.Vector3(10, 8, 6), 25, [mp.PML(1)], 3, k_point=mp.Vector3(1, 1, 1)
+            mp.Vector3(10, 8, 6), 10, [mp.PML(1)], 3, k_point=mp.Vector3(1, 1, 1)
         )
         max_comm = sim.get_max_chunk_communication_area()
         avg_comm = sim.get_avg_chunk_communication_area()
-        self.assertEqual(max_comm, 5900)
-        self.assertEqual(avg_comm, 5900)
+        self.assertEqual(max_comm, 2360)
+        self.assertEqual(avg_comm, 2360)
 
     def test_2d(self):
-        sim = make_sim(mp.Vector3(10, 6), 25, [mp.PML(1)], 2)
+        sim = make_sim(mp.Vector3(10, 6), 10, [mp.PML(1)], 2)
         max_comm = sim.get_max_chunk_communication_area()
         avg_comm = sim.get_avg_chunk_communication_area()
-        self.assertEqual(max_comm, 150)
-        self.assertEqual(avg_comm, 150)
+        self.assertEqual(max_comm, 60)
+        self.assertEqual(avg_comm, 60)
 
     def test_3d(self):
-        sim = make_sim(mp.Vector3(10, 8, 6), 25, [mp.PML(1)], 3)
+        sim = make_sim(mp.Vector3(10, 8, 6), 10, [mp.PML(1)], 3)
         max_comm = sim.get_max_chunk_communication_area()
         avg_comm = sim.get_avg_chunk_communication_area()
-        self.assertEqual(max_comm, 1200)
-        self.assertEqual(avg_comm, 1200)
+        self.assertEqual(max_comm, 480)
+        self.assertEqual(avg_comm, 480)
 
 
 if __name__ == "__main__":

--- a/python/tests/test_fragment_stats.py
+++ b/python/tests/test_fragment_stats.py
@@ -24,11 +24,8 @@ def make_dft_vecs(
 
 
 def make_sim(cell, res, pml, dims, create_gv=True, k_point=False):
-    if mp.with_mpi():
-        if dims == 3:
-            chunk_layout = mp.BinaryPartition(data=[(mp.X, 0), 0, 1])
-        else:
-            chunk_layout = mp.BinaryPartition(data=[(mp.Z, 0), 0, 1])
+    if mp.count_processors() == 2 and dims == 3:
+        chunk_layout = mp.BinaryPartition(data=[(mp.X, 0), 0, 1])
     else:
         chunk_layout = None
 

--- a/python/tests/test_fragment_stats.py
+++ b/python/tests/test_fragment_stats.py
@@ -24,8 +24,11 @@ def make_dft_vecs(
 
 
 def make_sim(cell, res, pml, dims, create_gv=True, k_point=False):
-    if mp.with_mpi() and dims == 3:
-        chunk_layout = mp.BinaryPartition(data=[(mp.X, 0), 0, 1])
+    if mp.with_mpi():
+        if dims == 3:
+            chunk_layout = mp.BinaryPartition(data=[(mp.X, 0), 0, 1])
+        else:
+            chunk_layout = mp.BinaryPartition(data=[(mp.Z, 0), 0, 1])
     else:
         chunk_layout = None
 


### PR DESCRIPTION
Starting with dc27a1e, two MPI tests starting failing during CI: `test_fragment_stats.py` and `test_dump_load.py`. I was not able to reproduce the test failures on my local machine. After some invesgitation, the cause of the failure seems to be related to the chunking algorithm ([`split_by_cost`](https://github.com/NanoComp/meep/blob/55634c2e6622609e4fabf536b6a695be3dbd538c/src/structure.cpp#L66-L94) in `src/structure.cpp`) based on splitting the chunks according to the number of pixels (i.e., the default option `split_chunks_evenly=True` passed to the `Simulation` constructor).

This PR provides a temporary fix by updating the two failing tests to explicitly specify the chunk partition rather than calling [`structure::choose_chunkdivision`](https://github.com/NanoComp/meep/blob/55634c2e6622609e4fabf536b6a695be3dbd538c/src/structure.cpp#L151-L198) during initialization.