### PR TITLE
Update copyright year from 2024 to 2025

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libpympb/pympb.cpp
+++ b/libpympb/pympb.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/libpympb/pympb.hpp
+++ b/libpympb/pympb.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/python/meep.i
+++ b/python/meep.i
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/python/mpb.i
+++ b/python/mpb.i
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/python/vec.i
+++ b/python/vec.i
@@ -1,6 +1,6 @@
 
 
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/scheme/meep.scm.in
+++ b/scheme/meep.scm.in
@@ -1,4 +1,4 @@
-; Copyright (C) 2005-2024 Massachusetts Institute of Technology
+; Copyright (C) 2005-2025 Massachusetts Institute of Technology
 ;
 ; This program is free software; you can redistribute it and/or modify
 ; it under the terms of the GNU General Public License as published by

--- a/src/GDSIIgeom.cpp
+++ b/src/GDSIIgeom.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/adjust_verbosity.hpp
+++ b/src/adjust_verbosity.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/anisotropic_averaging.cpp
+++ b/src/anisotropic_averaging.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/array_slice.cpp
+++ b/src/array_slice.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/bands.cpp
+++ b/src/bands.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/bicgstab.cpp
+++ b/src/bicgstab.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/bicgstab.hpp
+++ b/src/bicgstab.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/boundaries.cpp
+++ b/src/boundaries.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/casimir.cpp
+++ b/src/casimir.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/cw_fields.cpp
+++ b/src/cw_fields.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/dft_ldos.cpp
+++ b/src/dft_ldos.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/energy_and_flux.cpp
+++ b/src/energy_and_flux.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/fields.cpp
+++ b/src/fields.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/fields_dump.cpp
+++ b/src/fields_dump.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/fix_boundary_sources.cpp
+++ b/src/fix_boundary_sources.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/h5fields.cpp
+++ b/src/h5fields.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/h5file.cpp
+++ b/src/h5file.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/initialize.cpp
+++ b/src/initialize.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/integrate.cpp
+++ b/src/integrate.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/integrate2.cpp
+++ b/src/integrate2.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/loop_in_chunks.cpp
+++ b/src/loop_in_chunks.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/material_data.cpp
+++ b/src/material_data.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/material_data.hpp
+++ b/src/material_data.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/meep/mympi.hpp
+++ b/src/meep/mympi.hpp
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/meep/vec.hpp
+++ b/src/meep/vec.hpp
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/meep_internals.hpp
+++ b/src/meep_internals.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/multilevel-atom.cpp
+++ b/src/multilevel-atom.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/mympi.cpp
+++ b/src/mympi.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/output_directory.cpp
+++ b/src/output_directory.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/sphere-quad.cpp
+++ b/src/sphere-quad.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/step.cpp
+++ b/src/step.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/step_generic.cpp
+++ b/src/step_generic.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/stress.cpp
+++ b/src/stress.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/update_eh.cpp
+++ b/src/update_eh.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/update_pols.cpp
+++ b/src/update_pols.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/tests/aniso_disp.cpp
+++ b/tests/aniso_disp.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/bench.cpp
+++ b/tests/bench.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/tests/bragg_transmission.cpp
+++ b/tests/bragg_transmission.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/cylindrical.cpp
+++ b/tests/cylindrical.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/tests/dump_load.cpp
+++ b/tests/dump_load.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/tests/flux.cpp
+++ b/tests/flux.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/tests/harmonics.cpp
+++ b/tests/harmonics.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/integrate.cpp
+++ b/tests/integrate.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tests/known_results.cpp
+++ b/tests/known_results.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/tests/near2far.cpp
+++ b/tests/near2far.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/tests/one_dimensional.cpp
+++ b/tests/one_dimensional.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/tests/physical.cpp
+++ b/tests/physical.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/tests/symmetry.cpp
+++ b/tests/symmetry.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/tests/three_d.cpp
+++ b/tests/three_d.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by

--- a/tests/two_dimensional.cpp
+++ b/tests/two_dimensional.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2005-2024 Massachusetts Institute of Technology
+/* Copyright (C) 2005-2025 Massachusetts Institute of Technology
 %
 %  This program is free software; you can redistribute it and/or modify
 %  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
These changes were generated automatically using this Bash script executed from the Meep root directory:

```sh
sed -i 's/2005-2024/2005-2025/' COPYRIGHT

sed -i 's/2005-2024/2005-2025/' src/*.hpp
sed -i 's/2005-2024/2005-2025/' src/*.cpp

sed -i 's/2005-2024/2005-2025/' src/meep/*.hpp

sed -i 's/2005-2024/2005-2025/' tests/*.cpp

sed -i 's/2005-2024/2005-2025/' scheme/*.in

sed -i 's/2005-2024/2005-2025/' python/*.cpp
sed -i 's/2005-2024/2005-2025/' python/*.in
sed -i 's/2005-2024/2005-2025/' python/*.i

sed -i 's/2005-2024/2005-2025/' libpympb/pympb.*

sed -i 's/2005-2024/2005-2025/' doc/docs/License_and_Copyright.md
```