### PR TITLE
Prepare for 1.30 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # Meep Release Notes
 
+## Meep 1.30.0
+
+3/27/2025
+
+* Improvements to smoothed projection function of adjoint solver ([#2970]).
+
+* Bug fix in Harminv wrapper ([#2959]).
+
+* Bug fix in vec initialization of C++ unit test ([#2955]).
+
+* Improvements to step function of Python interface ([#2895]).
+
+* Rename flags in plot2D ([#2885]).
+
+* Various improvements and additional documentation ([#2792], [#2862], [#2874], [#2878], [#2883], [#2894], [#2949], [#2950], [#2951], [#2965], [#2978]).
+
 ## Meep 1.29.0
 
 5/30/2024

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([meep],[m4_esyscmd(./version.sh 1.30.0-beta)])
+AC_INIT([meep],[m4_esyscmd(./version.sh 1.30.0)])
 AC_CONFIG_SRCDIR(src/step.cpp)
 
 # Shared-library version number; indicates api compatibility, and is
 # not the same as the "public" version number.  (Don't worry about this
 # except for public releases.) Note that any change to a C++ class
 # definition (in the .hpp file) generally breaks binary compatibility.
-SHARED_VERSION_INFO="33:0:0" # CURRENT:REVISION:AGE
+SHARED_VERSION_INFO="34:0:0" # CURRENT:REVISION:AGE
 
 AM_INIT_AUTOMAKE([foreign color-tests parallel-tests silent-rules 1.11])
 AM_SILENT_RULES(yes)


### PR DESCRIPTION
The next tarball release is tentatively scheduled for Thursday March 27, 2025.