### PR TITLE
Update Ubuntu version for GitHub Workflow runner

### DIFF
--- a/.github/workflows/build-san.yml
+++ b/.github/workflows/build-san.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: "Test C++ with ${{ matrix.name-suffix }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The version of Ubuntu (20.04) currently used for the runner for GitHub Workflow Actions was [deprecated on April 15, 2025](https://github.com/processone/ejabberd/issues/4281). This is causing the sanitizer workflow action to start failing on that date. This PR updates the Ubuntu version to 24.04.