### PR TITLE
Prepare for 1.30.1 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Meep 1.30.1
 
-5/8/2025
+5/15/2025
 
 * Bug fix in DFT fields at a single point (zero-dimensional volume), where they were only first-order accurate and had the wrong weight ([#3010]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Meep Release Notes
 
+## Meep 1.30.1
+
+5/8/2025
+
+* Bug fix in DFT fields of a single point ([#3010]).
+
 ## Meep 1.30.0
 
 3/27/2025

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 5/8/2025
 
-* Bug fix in DFT fields of a single point ([#3010]).
+* Bug fix in DFT fields at a single point (zero-dimensional volume), where they were only first-order accurate and had the wrong weight ([#3010]).
 
 ## Meep 1.30.0
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,13 @@
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([meep],[m4_esyscmd(./version.sh 1.31.0-beta)])
+AC_INIT([meep],[m4_esyscmd(./version.sh 1.30.1)])
 AC_CONFIG_SRCDIR(src/step.cpp)
 
 # Shared-library version number; indicates api compatibility, and is
 # not the same as the "public" version number.  (Don't worry about this
 # except for public releases.) Note that any change to a C++ class
 # definition (in the .hpp file) generally breaks binary compatibility.
-SHARED_VERSION_INFO="34:0:0" # CURRENT:REVISION:AGE
+SHARED_VERSION_INFO="34:1:0" # CURRENT:REVISION:AGE
 
 AM_INIT_AUTOMAKE([foreign color-tests parallel-tests silent-rules 1.11])
 AM_SILENT_RULES(yes)


### PR DESCRIPTION
The next tarball release (a minor version update mainly because of an important bug fix) is tentatively scheduled for Thursday May 8, 2025.