### PR TITLE
make greencyl_tol a parameter

### DIFF
--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -443,6 +443,7 @@ class Near2FarFields(ObjectiveQuantity):
         nperiods: Optional[int] = 1,
         decimation_factor: Optional[int] = 0,
         norm_near_fields: Optional[NearToFarData] = None,
+        greencyl_tol: float = 1e-3,
     ):
         """Initialize an instance of differentiable Fourier fields instance.
 
@@ -470,6 +471,7 @@ class Near2FarFields(ObjectiveQuantity):
         self.decimation_factor = decimation_factor
         self.norm_near_fields = norm_near_fields
         self.nperiods = nperiods
+        self.greencyl_tol = greencyl_tol
 
     def register_monitors(self, frequencies):
         self._frequencies = np.asarray(frequencies)
@@ -501,7 +503,7 @@ class Near2FarFields(ObjectiveQuantity):
         )
 
         all_nearsrcdata = self._monitor.swigobj.near_sourcedata(
-            far_pt_vec, farpt_list, self._nfar_pts, dJ
+            far_pt_vec, farpt_list, self._nfar_pts, dJ, self.greencyl_tol
         )
         for near_data in all_nearsrcdata:
             cur_comp = near_data.near_fd_comp

--- a/python/meep.i
+++ b/python/meep.i
@@ -329,12 +329,12 @@ PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, i
 }
 
 // Wrapper around meep::dft_near2far::farfield
-PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v) {
+PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v, double greencyl_tol) {
     // Return value: New reference
     Py_ssize_t len = f->freq.size() * 6;
     PyObject *res = PyList_New(len);
 
-    std::complex<double> *ff_arr = f->farfield(v);
+    std::complex<double> *ff_arr = f->farfield(v, greencyl_tol);
 
     for (Py_ssize_t i = 0; i < len; i++) {
         PyList_SetItem(res, i, PyComplex_FromDoubles(ff_arr[i].real(), ff_arr[i].imag()));
@@ -347,13 +347,13 @@ PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v) {
 
 // Wrapper around meep::dft_near2far::get_farfields_array
 PyObject *_get_farfields_array(meep::dft_near2far *n2f, const meep::volume &where,
-                               double resolution) {
+                               double resolution, double greencyl_tol) {
     // Return value: New reference
     size_t dims[4] = {1, 1, 1, 1};
     int rank = 0;
     size_t N = 1;
 
-    double *EH = n2f->get_farfields_array(where, rank, dims, N, resolution);
+    double *EH = n2f->get_farfields_array(where, rank, dims, N, resolution, greencyl_tol);
 
     if (!EH) return PyArray_SimpleNew(0, 0, NPY_CDOUBLE);
 
@@ -662,8 +662,8 @@ PyObject *py_do_harminv(PyObject *vals, double dt, double f_min, double f_max, i
                      double spectral_density, double Q_thresh, double rel_err_thresh,
                      double err_thresh, double rel_amp_thresh, double amp_thresh);
 
-PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v);
-PyObject *_get_farfields_array(meep::dft_near2far *n2f, const meep::volume &where, double resolution);
+PyObject *_get_farfield(meep::dft_near2far *f, const meep::vec & v, double greencyl_tol);
+PyObject *_get_farfields_array(meep::dft_near2far *n2f, const meep::volume &where, double resolution, double greencyl_tol);
 PyObject *_dft_ldos_ldos(meep::dft_ldos *f);
 PyObject *_dft_ldos_F(meep::dft_ldos *f);
 PyObject *_dft_ldos_J(meep::dft_ldos *f);

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3211,7 +3211,7 @@ class Simulation:
         self.load_energy(fname, energy)
         energy.scale_dfts(-1.0)
 
-    def get_farfield(self, near2far, x):
+    def get_farfield(self, near2far, x, greencyl_tol: float = 1e-3):
         """
         Given a `Vector3` point `x` which can lie anywhere outside the near-field surface,
         including outside the cell and a `near2far` object, returns the computed
@@ -3224,6 +3224,7 @@ class Simulation:
         return mp._get_farfield(
             near2far.swigobj,
             py_v3_to_vec(self.dimensions, x, is_cylindrical=self.is_cylindrical),
+            greencyl_tol,
         )
 
     def get_farfields(
@@ -3233,6 +3234,7 @@ class Simulation:
         where: Volume = None,
         center: Vector3Type = None,
         size: Vector3Type = None,
+        greencyl_tol: float = 1e-3,
     ):
         """
         Like `output_farfields` but returns a dictionary of NumPy arrays instead of
@@ -3249,7 +3251,9 @@ class Simulation:
             self.init_sim()
         vol = self._volume_from_kwargs(where, center, size)
         self.fields.am_now_working_on(mp.GetFarfieldsTime)
-        result = mp._get_farfields_array(near2far.swigobj, vol, resolution)
+        result = mp._get_farfields_array(
+            near2far.swigobj, vol, resolution, greencyl_tol
+        )
         self.fields.finished_working()
         res_ex = complexarray(result[0], result[1])
         res_ey = complexarray(result[2], result[3])

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1359,17 +1359,17 @@ public:
   dft_near2far(const dft_near2far &f);
 
   /* return an array (Ex,Ey,Ez,Hx,Hy,Hz) x Nfreq of the far fields at x */
-  std::complex<double> *farfield(const vec &x);
+  std::complex<double> *farfield(const vec &x, double greencyl_tol = 1e-3);
 
   /* like farfield, but requires F to be Nfreq*6 preallocated array, and
      does *not* perform the reduction over processes...an MPI allreduce
      summation by the caller is required to get the final result ... used
      by other output routine to efficiently get far field on a grid of pts */
-  void farfield_lowlevel(std::complex<double> *F, const vec &x);
+  void farfield_lowlevel(std::complex<double> *F, const vec &x, double greencyl_tol = 1e-3);
 
   /* Return a newly allocated array with all far fields */
   double *get_farfields_array(const volume &where, int &rank, size_t *dims, size_t &N,
-                              double resolution);
+                              double resolution, double greencyl_tol = 1e-3);
 
   /* output far fields on a grid to an HDF5 file */
   void save_farfields(const char *fname, const char *prefix, const volume &where,
@@ -1399,7 +1399,8 @@ public:
   double periodic_k[2], period[2];
 
   std::vector<sourcedata> near_sourcedata(const vec &x_0, double *farpt_list, size_t nfar_pts,
-                                          const std::complex<double> *dJ);
+                                          const std::complex<double> *dJ,
+                                          double greencyl_tol = 1e-3);
 };
 
 /* Class to compute local-density-of-states spectra: the power spectrum

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1399,8 +1399,7 @@ public:
   double periodic_k[2], period[2];
 
   std::vector<sourcedata> near_sourcedata(const vec &x_0, double *farpt_list, size_t nfar_pts,
-                                          const std::complex<double> *dJ,
-                                          double greencyl_tol = 1e-3);
+                                          const std::complex<double> *dJ, double greencyl_tol);
 };
 
 /* Class to compute local-density-of-states spectra: the power spectrum


### PR DESCRIPTION
The tolerance for computing the cylindrical Green's function (`greencyl`) is now a parameter `greencyl_tol` (currently undocumented), rather than being fixed at `1e-3`.   This is especially important with #3047, in case you want to calculate the (small) high-$`m`$ contributions with greater relative accuracy.