### PR TITLE
add dft_flux::complexflux

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -943,6 +943,14 @@ void _get_gradient(PyObject *grad, double scalegrad,
     delete[] $1;
 }
 
+%typemap(out) std::vector<std::complex<double>> complexflux {
+    size_t size = $1.size();
+    $result = PyList_New(size);
+    for(size_t i = 0; i < size; i++) {
+        PyList_SetItem($result, i, PyComplex_FromDoubles(real($1[i]), imag($1[i])));
+    }
+}
+
 // Typemap suite for dft_force
 
 %typemap(out) double* force {

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -699,6 +699,10 @@ class DftFlux(DftObj):
         return self.swigobj_attr("flux")
 
     @property
+    def complexflux(self):
+        return self.swigobj_attr("complexflux")
+
+    @property
     def E(self):
         return self.swigobj_attr("E")
 

--- a/python/tests/test_bend_flux.py
+++ b/python/tests/test_bend_flux.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 import numpy as np
+from numpy.testing import assert_array_equal
 from utils import ApproxComparisonTestCase
 
 import meep as mp
@@ -209,6 +210,10 @@ class TestBendFlux(ApproxComparisonTestCase):
         tol = 1e-3
         self.assertClose(np.array(expected), np.array(res[:20]), epsilon=tol)
         self.assertClose(np.array(expected), np.array(res_decimated[:20]), epsilon=tol)
+
+        trans_flux_real = np.array(self.trans.flux())
+        trans_flux_complex = np.array(self.trans.complexflux())
+        assert_array_equal(trans_flux_real, np.real(trans_flux_complex))
 
     def test_bend_flux(self):
         self.run_bend_flux(False)

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -546,6 +546,21 @@ double *dft_flux::flux() {
   return Fsum;
 }
 
+std::vector<std::complex<double> > dft_flux::complexflux() {
+  const size_t Nfreq = freq.size();
+  std::vector<std::complex<double> > F(Nfreq);
+  for (size_t i = 0; i < Nfreq; ++i)
+    F[i] = 0.0;
+  for (dft_chunk *curE = E, *curH = H; curE && curH;
+       curE = curE->next_in_dft, curH = curH->next_in_dft)
+    for (size_t k = 0; k < curE->N; ++k)
+      for (size_t i = 0; i < Nfreq; ++i)
+        F[i] += curE->dft[k * Nfreq + i] * conj(curH->dft[k * Nfreq + i]);
+  std::vector<std::complex<double> > Fsum(Nfreq);
+  sum_to_all(&F[0], &Fsum[0], int(Nfreq));
+  return Fsum;
+}
+
 void dft_flux::save_hdf5(h5file *file, const char *dprefix) {
   save_dft_hdf5(E, cE, file, dprefix);
   file->prevent_deadlock(); // hackery

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1244,6 +1244,7 @@ public:
   dft_flux(const dft_flux &f);
 
   double *flux();
+  std::vector<std::complex<double> > complexflux();
 
   void save_hdf5(h5file *file, const char *dprefix = 0);
   void load_hdf5(h5file *file, const char *dprefix = 0);


### PR DESCRIPTION
Adds a new `::complexflux()` method, analogous to flux, for `dft_flux` objects that returns the *complex* Poynting flux (not taking the real part).  The imaginary part can be interpreted as the "reactive" flux and some people find it useful.

It may also be useful for #3063.