### PR TITLE
Various fixes and tweaks for the tutorial on computing the radiation pattern from a disc in cylindrical coordinates

### DIFF
--- a/doc/docs/Python_Tutorials/Near_to_Far_Field_Spectra.md
+++ b/doc/docs/Python_Tutorials/Near_to_Far_Field_Spectra.md
@@ -383,7 +383,7 @@ Radiation Pattern of a Disc in Cylindrical Coordinates
 
 The near-to-far field transformation feature can also be used in [cylindrical coordinates](Cylindrical_Coordinates.md). As a demonstration, we compute the radiation pattern of a dielectric disc and verify Poynting's theorem: the total radiated flux computed from the far fields is equivalent to using the near fields via `add_flux`. This example involves a ring-current source generating a circularly polarized field. (The radiation pattern of an off-axis *point* dipole with *linear* polarization is demonstrated in [Tutorial/Radiation Pattern of an Antenna in Cylindrical Coordinates](#radiation-pattern-of-an-antenna-in-cylindrical-coordinates).)
 
-The simulation consists of an $E_r$ "ring"-current source with $\lambda$ = 1.0 μm and radius of 0.6 μm embedded within a disc of radius 1.2 μm, refractive index $n$ = 2.4, and thickness $0.7 \lambda / n$. The disc is positioned above a perfect-metallic ground plane. The source has azimuthal dependence $e^{im\phi}$ with $m = -1$, which leads to circularly polarized fields (unlike $|m| \ne 1$). Unlike the [infinitely extended slab of the LED](Local_Density_of_States.md#extraction-efficiency-of-a-light-emitting-diode-led), a *finite* structure such as the disc ensures that all the power from the source is radiated away. The LED contains waveguide modes which are more challenging to disentagle from the radiated power.
+The simulation consists of an $E_r$ ring-current source with $\lambda$ = 1.0 μm and radius of 0.6 μm embedded within a disc of radius 1.2 μm, refractive index $n$ = 2.4, and thickness $0.7 \lambda / n$. The disc is positioned above a perfect-metallic ground plane. The source has azimuthal dependence $e^{im\phi}$ with $m = -1$, which leads to circularly polarized fields (unlike $|m| \ne 1$). Unlike the [infinitely extended slab of the LED](Local_Density_of_States.md#extraction-efficiency-of-a-light-emitting-diode-led), a *finite* structure such as the disc ensures that all the power from the source is radiated away. The LED contains waveguide modes which are more challenging to disentagle from the radiated power.
 
 A schematic of the simulation layout is shown below. The flux and near-field monitors (shown in blue) are overlapping.
 
@@ -402,12 +402,12 @@ A plot of the radiation pattern in polar coordinates and 3D is shown below. Note
 The total flux computed using the near and far fields is shown to be in close agreement with a relative error of ~7%.
 
 ```
-total_flux:, 643.65058 (near), 597.72713 (far), 0.07135 (error)
+total_flux:, 643.65058 (near), 597.77009 (far), 7.13% (error)
 ```
 
 The error decreases with increasing (1) grid resolution, (2) runtime, and (3) number of angular grid points. However, this only applies to a *closed* near-field surface which is not the case in this example. This is because the ground plane, which extends to infinity, contains $H_r$ and $H_\phi$ fields on its surface which are not zero (unlike the $E_r$ and $E_\phi$ fields). These magnetic fields produce equivalent currents which radiate into the far field. The PML in the $r$ direction does not mitigate this effect.
 
-Because the near-field surface actually extends to infinity in the $r$ direction, one approach to reducing the error introduced by its finite truncation would be to simply make the cell size in the $r$ direction larger (the parameter `L` in the script below). Another option which would remove this error entirely would be to simulate the same structure using a closed surface by removing the ground plane and duplicating the structure and source below the $z = 0$ plane. This is known as the method of images. See [Tutorial/Antenna above a Perfect Electric Conductor Ground Plane ](#antenna-above-a-perfect-electric-conductor-ground-plane) for a demonstration of this approach.
+Because the near-field surface actually extends to infinity in the $r$ direction, one approach to reducing the error introduced by its finite truncation would be to simply make the cell size in the $r$ direction larger (the parameter `cell_r_um` in the script below). Another option which would remove this error entirely would be to simulate the same structure using a closed surface by removing the ground plane and duplicating the structure and source below the $z = 0$ plane. This is known as the method of images. See [Tutorial/Antenna above a Perfect Electric Conductor Ground Plane ](#antenna-above-a-perfect-electric-conductor-ground-plane) for a demonstration of this approach.
 
 The simulation script is in [examples/disc_radiation_pattern.py](https://github.com/NanoComp/meep/blob/master/python/examples/disc_radiation_pattern.py).
 
@@ -415,48 +415,41 @@ The simulation script is in [examples/disc_radiation_pattern.py](https://github.
 import math
 from typing import Tuple
 
-import matplotlib
+import matplotlib.pyplot as plt
 import meep as mp
 import numpy as np
 
-matplotlib.use("agg")
-import matplotlib.pyplot as plt
+
+RESOLUTION_UM = 100
+PML_UM = 0.5
+AIR_UM = 1.0
+DISC_RADIUS_UM = 1.2
+N_DISC = 2.4
+WAVELENGTH_UM = 1.0
+NUM_AZIMUTH = 50
+NUM_POLAR = 100
+FARFIELD_RADIUS_UM = 1e6 * WAVELENGTH_UM
+FIELD_DECAY_TOL = 1e-8
+FIELD_DECAY_PERIOD = 50
+GREENCYL_TOL = 1e-8
+
+frequency = 1 / WAVELENGTH_UM
+polar_rad = np.linspace(0, 0.5 * math.pi, NUM_POLAR)
+azimuth_rad = np.linspace(0, 2 * math.pi, NUM_AZIMUTH)
 
 
-resolution = 100  # pixels/μm
-dpml = 0.5  # thickness of PML
-dair = 1.0  # thickness of air padding
-L = 6.0  # length of non-PML region
-n = 2.4  # refractive index of surrounding medium
-wvl = 1.0  # wavelength (in vacuum)
-
-fcen = 1 / wvl  # center frequency of source/monitor
-
-# field decay threshold for runtime termination criteria
-tol = 1e-8
-
-# number of angular grid points in [0, π/2]
-npts = 100
-
-# grid of polar angles for computing radiated flux in far field
-thetas = np.linspace(0, 0.5 * math.pi, npts)
-
-# radius of quarter circle for computing flux in far field
-r = 1000 * wvl
-
-
-def plot_radiation_pattern_polar(Ptheta: np.ndarray):
+def plot_radiation_pattern_polar(radial_flux: np.ndarray):
     """Plots the radiation pattern in polar coordinates.
 
     The angles increase clockwise with zero at the top (+z direction).
 
     Args:
-        Ptheta: radial flux of the far fields in polar coordinates.
+        radial_flux: radial flux of the far fields in polar coordinates.
     """
-    fig, ax = plt.subplots(subplot_kw={"projection": "polar"}, figsize=(6,6))
+    fig, ax = plt.subplots(subplot_kw={"projection": "polar"}, figsize=(6, 6))
     ax.plot(
-        thetas,
-        Ptheta,
+        polar_rad,
+        radial_flux,
         "b-",
     )
     ax.set_theta_direction(-1)
@@ -469,40 +462,38 @@ def plot_radiation_pattern_polar(Ptheta: np.ndarray):
 
     if mp.am_master():
         fig.savefig(
-            "led_radpattern_polar.png",
+            "disc_radiation_pattern_polar.png",
             dpi=150,
             bbox_inches="tight",
         )
 
 
-def plot_radiation_pattern_3d(Ptheta: np.ndarray):
+def plot_radiation_pattern_3d(radial_flux: np.ndarray):
     """Plots the radiation pattern in 3d Cartesian coordinates.
 
     Args:
-        Ptheta: radial flux of the far fields in polar coordinates.
+        radial_flux: radial flux of the far fields in polar coordinates.
     """
-    phis = np.linspace(0, 2 * np.pi, npts)
+    x_coord = np.zeros((NUM_POLAR, NUM_AZIMUTH))
+    y_coord = np.zeros((NUM_POLAR, NUM_AZIMUTH))
+    z_coord = np.zeros((NUM_POLAR, NUM_AZIMUTH))
 
-    xs = np.zeros((len(thetas), len(phis)))
-    ys = np.zeros((len(thetas), len(phis)))
-    zs = np.zeros((len(thetas), len(phis)))
+    for i in range(NUM_POLAR):
+        for j in range(NUM_AZIMUTH):
+            x_coord[i, j] = radial_flux[i] * np.sin(polar_rad[i]) * np.cos(azimuth_rad[j])
+            y_coord[i, j] = radial_flux[i] * np.sin(polar_rad[i]) * np.sin(azimuth_rad[j])
+            z_coord[i, j] = radial_flux[i] * np.cos(polar_rad[i])
 
-    for i, theta in enumerate(thetas):
-        for j, phi in enumerate(phis):
-            xs[i, j] = Ptheta[i] * np.sin(theta) * np.cos(phi)
-            ys[i, j] = Ptheta[i] * np.sin(theta) * np.sin(phi)
-            zs[i, j] = Ptheta[i] * np.cos(theta)
-
-    fig, ax = plt.subplots(subplot_kw={"projection": "3d"}, figsize=(6,6))
-    ax.plot_surface(xs, ys, zs, cmap="inferno")
+    fig, ax = plt.subplots(subplot_kw={"projection": "3d"}, figsize=(6, 6))
+    ax.plot_surface(x_coord, y_coord, z_coord, cmap="inferno")
     ax.set_title("radiation pattern in 3d")
-    ax.set_box_aspect((np.amax(xs), np.amax(ys), np.amax(zs)))
+    ax.set_box_aspect((np.amax(x_coord), np.amax(y_coord), np.amax(z_coord)))
     ax.set_zlabel("radial flux (a.u.)")
     ax.set(xticklabels=[], yticklabels=[])
 
     if mp.am_master():
         fig.savefig(
-            "led_radpattern_3d.png",
+            "disc_radiation_pattern_3d.png",
             dpi=150,
             bbox_inches="tight",
         )
@@ -520,49 +511,63 @@ def radiation_pattern(sim: mp.Simulation, n2f_mon: mp.DftNear2Far) -> np.ndarray
         a quarter circle with angular range of [0, π/2] rad. 0 rad is the +z
         direction and π/2 is +r.
     """
-    E = np.zeros((npts, 3), dtype=np.complex128)
-    H = np.zeros((npts, 3), dtype=np.complex128)
-    for n in range(npts):
-        ff = sim.get_farfield(
-            n2f_mon, mp.Vector3(r * math.sin(thetas[n]), 0, r * math.cos(thetas[n]))
+    e_field = np.zeros((NUM_POLAR, 3), dtype=np.complex128)
+    h_field = np.zeros((NUM_POLAR, 3), dtype=np.complex128)
+    for i in range(NUM_POLAR):
+        far_field = sim.get_farfield(
+            n2f_mon,
+            mp.Vector3(
+                FARFIELD_RADIUS_UM * math.sin(polar_rad[i]),
+                0,
+                FARFIELD_RADIUS_UM * math.cos(polar_rad[i])
+            ),
+            GREENCYL_TOL
         )
-        E[n, :] = [np.conj(ff[j]) for j in range(3)]
-        H[n, :] = [ff[j + 3] for j in range(3)]
+        e_field[i, :] = [far_field[j] for j in range(3)]
+        h_field[i, :] = [far_field[j + 3] for j in range(3)]
 
-    Pr = np.real(E[:, 1] * H[:, 2] - E[:, 2] * H[:, 1])
-    Pz = np.real(E[:, 0] * H[:, 1] - E[:, 1] * H[:, 0])
-    Prz = np.sqrt(np.square(Pr) + np.square(Pz))
+    flux_x = np.real(
+        np.conj(e_field[:, 1]) * h_field[:, 2] -
+        np.conj(e_field[:, 2]) * h_field[:, 1]
+    )
+    flux_z = np.real(
+        np.conj(e_field[:, 0]) * h_field[:, 1] -
+        np.conj(e_field[:, 1]) * h_field[:, 0]
+    )
+    flux_r = np.sqrt(np.square(flux_x) + np.square(flux_z))
 
-    return Prz
+    return flux_r
 
 
-def disc_total_flux(dmat: float, h: float) -> Tuple[float, float]:
-    """Computes the total radiated flux from a point dipole embedded
-    within a dielectric disc above a lossless ground plane using
-    its near and far fields as separate calculations.
+def disc_radiated_flux(
+        disc_um: float, source_zpos: float
+) -> Tuple[float, float]:
+    """Computes the  radiated flux from a "ring" current source within a disc.
 
     Args:
-        dmat: thickness of dielectric disc.
-        h: height of dipole above ground plane as fraction of dmat.
+        disc_um: thickness of dielectric disc.
+        source_zpos: height of the dipole source above the ground plane as
+            a fraction of disc_um.
 
     Returns:
         A 2-tuple of the total flux computed using the near and far fields,
         respectively.
     """
-    sr = L + dpml
-    sz = dmat + dair + dpml
+    cell_r_um = 6.0
+    sr = cell_r_um + PML_UM
+    sz = disc_um + AIR_UM + PML_UM
     cell_size = mp.Vector3(sr, 0, sz)
 
     boundary_layers = [
-        mp.PML(dpml, direction=mp.R),
-        mp.PML(dpml, direction=mp.Z, side=mp.High),
+        mp.PML(PML_UM, direction=mp.R),
+        mp.PML(PML_UM, direction=mp.Z, side=mp.High),
     ]
 
     src_cmpt = mp.Er
-    src_pt = mp.Vector3(0.1 * L, 0, -0.5 * sz + h * dmat)
+    src_pt = mp.Vector3(0.5 * DISC_RADIUS_UM, 0, -0.5 * sz + source_zpos * disc_um)
     sources = [
         mp.Source(
-            src=mp.GaussianSource(fcen, fwidth=0.1 * fcen),
+            src=mp.GaussianSource(frequency, fwidth=0.1 * frequency),
             component=src_cmpt,
             center=src_pt,
         )
@@ -570,14 +575,16 @@ def disc_total_flux(dmat: float, h: float) -> Tuple[float, float]:
 
     geometry = [
         mp.Block(
-            material=mp.Medium(index=n),
-            center=mp.Vector3(0.1 * L, 0, -0.5 * sz + 0.5 * dmat),
-            size=mp.Vector3(0.2 * L, mp.inf, dmat),
+            material=mp.Medium(index=N_DISC),
+            center=mp.Vector3(
+                0.5 * DISC_RADIUS_UM, 0, -0.5 * sz + 0.5 * disc_um
+            ),
+            size=mp.Vector3(DISC_RADIUS_UM, mp.inf, disc_um),
         )
     ]
 
     sim = mp.Simulation(
-        resolution=resolution,
+        resolution=RESOLUTION_UM,
         cell_size=cell_size,
         dimensions=mp.CYLINDRICAL,
         m=-1,
@@ -588,31 +595,31 @@ def disc_total_flux(dmat: float, h: float) -> Tuple[float, float]:
 
     # flux monitor
     flux_mon = sim.add_flux(
-        fcen,
+        frequency,
         0,
         1,
         mp.FluxRegion(
-            center=mp.Vector3(0.5 * L, 0, 0.5 * sz - dpml),
-            size=mp.Vector3(L, 0, 0),
+            center=mp.Vector3(0.5 * cell_r_um, 0, 0.5 * sz - PML_UM),
+            size=mp.Vector3(cell_r_um, 0, 0),
         ),
         mp.FluxRegion(
-            center=mp.Vector3(L, 0, 0.5 * sz - dpml - 0.5 * (dair + dmat)),
-            size=mp.Vector3(0, 0, dair + dmat),
+            center=mp.Vector3(cell_r_um, 0, 0.5 * sz - PML_UM - 0.5 * (AIR_UM + disc_um)),
+            size=mp.Vector3(0, 0, AIR_UM + disc_um),
         ),
     )
 
     # near-field monitor
     n2f_mon = sim.add_near2far(
-        fcen,
+        frequency,
         0,
         1,
         mp.FluxRegion(
-            center=mp.Vector3(0.5 * L, 0, 0.5 * sz - dpml),
-            size=mp.Vector3(L, 0, 0),
+            center=mp.Vector3(0.5 * cell_r_um, 0, 0.5 * sz - PML_UM),
+            size=mp.Vector3(cell_r_um, 0, 0),
         ),
         mp.FluxRegion(
-            center=mp.Vector3(L, 0, 0.5 * sz - dpml - 0.5 * (dair + dmat)),
-            size=mp.Vector3(0, 0, dair + dmat),
+            center=mp.Vector3(cell_r_um, 0, 0.5 * sz - PML_UM - 0.5 * (AIR_UM + disc_um)),
+            size=mp.Vector3(0, 0, AIR_UM + disc_um),
         ),
     )
 
@@ -623,36 +630,43 @@ def disc_total_flux(dmat: float, h: float) -> Tuple[float, float]:
 
     sim.run(
         until_after_sources=mp.stop_when_fields_decayed(
-            50,
+            FIELD_DECAY_PERIOD,
             src_cmpt,
             src_pt,
-            tol,
+            FIELD_DECAY_TOL,
         ),
     )
 
     flux_near = mp.get_fluxes(flux_mon)[0]
 
-    Ptheta = radiation_pattern(sim, n2f_mon)
-    plot_radiation_pattern_polar(r * r * Ptheta)
-    plot_radiation_pattern_3d(r * r * Ptheta)
+    radial_flux = radiation_pattern(sim, n2f_mon)
+    radial_flux_scaled = FARFIELD_RADIUS_UM * FARFIELD_RADIUS_UM * radial_flux
+    plot_radiation_pattern_polar(radial_flux_scaled)
+    plot_radiation_pattern_3d(radial_flux_scaled)
 
-    dtheta = 0.5 * math.pi / (npts - 1)
-    dphi = 2 * math.pi
-    flux_far = np.sum(Ptheta * np.sin(thetas)) * r * r * dtheta * dphi
+    delta_polar = 0.5 * math.pi / (NUM_POLAR - 1)
+    delta_azimuth = 2 * math.pi
+    flux_far = (
+        np.sum(radial_flux * np.sin(polar_rad)) *
+        FARFIELD_RADIUS_UM *
+        FARFIELD_RADIUS_UM *
+        delta_polar *
+        delta_azimuth
+    )
 
     return flux_near, flux_far
 
 
 if __name__ == "__main__":
-    disc_thickness = 0.7 * wvl / n
+    disc_thickness_um = 0.7 * WAVELENGTH_UM / N_DISC
     dipole_height = 0.5
 
-    near_flux, far_flux = disc_total_flux(disc_thickness, dipole_height)
+    flux_near, flux_far = disc_radiated_flux(disc_thickness_um, dipole_height)
 
-    err = abs(near_flux - far_flux) / near_flux
+    err = abs(flux_near - flux_far) / flux_near
     print(
-        f"total_flux:, {near_flux:.5f} (near), {far_flux:.5f} (far), "
-        f"{err:.5f} (error)"
+        f"total_flux:, {flux_near:.5f} (near), {flux_far:.5f} (far), "
+        f"{100 * err:.2f}% (error)"
     )
 ```
 

--- a/python/examples/disc_radiation_pattern.py
+++ b/python/examples/disc_radiation_pattern.py
@@ -1,55 +1,48 @@
-# Verifies that the total flux from a lossless dielectric disc computed in
-# cylindrical coordinates using its near fields is equivalent to using
-# its far fields via the radiation pattern obtained using a near-to-far field
-# transformation.
+"""Radiated flux of a lossless dielectric disc in cylindrical coordinates.
 
-# tutorial reference: https://meep.readthedocs.io/en/latest/Python_Tutorials/Near_to_Far_Field_Spectra/#radiation-pattern-of-a-disc-in-cylindrical-coordinates
+Tutorial Reference:
+
+https://meep.readthedocs.io/en/latest/Python_Tutorials/Near_to_Far_Field_Spectra/#radiation-pattern-of-a-disc-in-cylindrical-coordinates
+"""
 
 import math
 from typing import Tuple
 
-import matplotlib
+import matplotlib.pyplot as plt
 import meep as mp
 import numpy as np
 
-matplotlib.use("agg")
-import matplotlib.pyplot as plt
+
+RESOLUTION_UM = 100
+PML_UM = 0.5
+AIR_UM = 1.0
+DISC_RADIUS_UM = 1.2
+N_DISC = 2.4
+WAVELENGTH_UM = 1.0
+NUM_AZIMUTH = 50
+NUM_POLAR = 100
+FARFIELD_RADIUS_UM = 1e6 * WAVELENGTH_UM
+FIELD_DECAY_TOL = 1e-8
+FIELD_DECAY_PERIOD = 50
+GREENCYL_TOL = 1e-8
+
+frequency = 1 / WAVELENGTH_UM
+polar_rad = np.linspace(0, 0.5 * math.pi, NUM_POLAR)
+azimuth_rad = np.linspace(0, 2 * math.pi, NUM_AZIMUTH)
 
 
-resolution = 100  # pixels/μm
-dpml = 0.5  # thickness of PML
-dair = 1.0  # thickness of air padding
-L = 6.0  # length of non-PML region
-n = 2.4  # refractive index of surrounding medium
-wvl = 1.0  # wavelength (in vacuum)
-
-fcen = 1 / wvl  # center frequency of source/monitor
-
-# field decay threshold for runtime termination criteria
-tol = 1e-8
-
-# number of angular grid points in [0, π/2]
-npts = 100
-
-# grid of polar angles for computing radiated flux in far field
-thetas = np.linspace(0, 0.5 * math.pi, npts)
-
-# radius of quarter circle for computing flux in far field
-r = 1000 * wvl
-
-
-def plot_radiation_pattern_polar(Ptheta: np.ndarray):
+def plot_radiation_pattern_polar(radial_flux: np.ndarray):
     """Plots the radiation pattern in polar coordinates.
 
     The angles increase clockwise with zero at the top (+z direction).
 
     Args:
-        Ptheta: radial flux of the far fields in polar coordinates.
+        radial_flux: radial flux of the far fields in polar coordinates.
     """
     fig, ax = plt.subplots(subplot_kw={"projection": "polar"}, figsize=(6, 6))
     ax.plot(
-        thetas,
-        Ptheta,
+        polar_rad,
+        radial_flux,
         "b-",
     )
     ax.set_theta_direction(-1)
@@ -62,40 +55,42 @@ def plot_radiation_pattern_polar(Ptheta: np.ndarray):
 
     if mp.am_master():
         fig.savefig(
-            "led_radpattern_polar.png",
+            "disc_radiation_pattern_polar.png",
             dpi=150,
             bbox_inches="tight",
         )
 
 
-def plot_radiation_pattern_3d(Ptheta: np.ndarray):
+def plot_radiation_pattern_3d(radial_flux: np.ndarray):
     """Plots the radiation pattern in 3d Cartesian coordinates.
 
     Args:
-        Ptheta: radial flux of the far fields in polar coordinates.
+        radial_flux: radial flux of the far fields in polar coordinates.
     """
-    phis = np.linspace(0, 2 * np.pi, npts)
+    x_coord = np.zeros((NUM_POLAR, NUM_AZIMUTH))
+    y_coord = np.zeros((NUM_POLAR, NUM_AZIMUTH))
+    z_coord = np.zeros((NUM_POLAR, NUM_AZIMUTH))
 
-    xs = np.zeros((len(thetas), len(phis)))
-    ys = np.zeros((len(thetas), len(phis)))
-    zs = np.zeros((len(thetas), len(phis)))
-
-    for i, theta in enumerate(thetas):
-        for j, phi in enumerate(phis):
-            xs[i, j] = Ptheta[i] * np.sin(theta) * np.cos(phi)
-            ys[i, j] = Ptheta[i] * np.sin(theta) * np.sin(phi)
-            zs[i, j] = Ptheta[i] * np.cos(theta)
+    for i in range(NUM_POLAR):
+        for j in range(NUM_AZIMUTH):
+            x_coord[i, j] = (
+                radial_flux[i] * np.sin(polar_rad[i]) * np.cos(azimuth_rad[j])
+            )
+            y_coord[i, j] = (
+                radial_flux[i] * np.sin(polar_rad[i]) * np.sin(azimuth_rad[j])
+            )
+            z_coord[i, j] = radial_flux[i] * np.cos(polar_rad[i])
 
     fig, ax = plt.subplots(subplot_kw={"projection": "3d"}, figsize=(6, 6))
-    ax.plot_surface(xs, ys, zs, cmap="inferno")
+    ax.plot_surface(x_coord, y_coord, z_coord, cmap="inferno")
     ax.set_title("radiation pattern in 3d")
-    ax.set_box_aspect((np.amax(xs), np.amax(ys), np.amax(zs)))
+    ax.set_box_aspect((np.amax(x_coord), np.amax(y_coord), np.amax(z_coord)))
     ax.set_zlabel("radial flux (a.u.)")
     ax.set(xticklabels=[], yticklabels=[])
 
     if mp.am_master():
         fig.savefig(
-            "led_radpattern_3d.png",
+            "disc_radiation_pattern_3d.png",
             dpi=150,
             bbox_inches="tight",
         )
@@ -113,49 +108,59 @@ def radiation_pattern(sim: mp.Simulation, n2f_mon: mp.DftNear2Far) -> np.ndarray
         a quarter circle with angular range of [0, π/2] rad. 0 rad is the +z
         direction and π/2 is +r.
     """
-    E = np.zeros((npts, 3), dtype=np.complex128)
-    H = np.zeros((npts, 3), dtype=np.complex128)
-    for n in range(npts):
-        ff = sim.get_farfield(
-            n2f_mon, mp.Vector3(r * math.sin(thetas[n]), 0, r * math.cos(thetas[n]))
+    e_field = np.zeros((NUM_POLAR, 3), dtype=np.complex128)
+    h_field = np.zeros((NUM_POLAR, 3), dtype=np.complex128)
+    for i in range(NUM_POLAR):
+        far_field = sim.get_farfield(
+            n2f_mon,
+            mp.Vector3(
+                FARFIELD_RADIUS_UM * math.sin(polar_rad[i]),
+                0,
+                FARFIELD_RADIUS_UM * math.cos(polar_rad[i]),
+            ),
+            GREENCYL_TOL,
         )
-        E[n, :] = [np.conj(ff[j]) for j in range(3)]
-        H[n, :] = [ff[j + 3] for j in range(3)]
+        e_field[i, :] = [far_field[j] for j in range(3)]
+        h_field[i, :] = [far_field[j + 3] for j in range(3)]
 
-    Pr = np.real(E[:, 1] * H[:, 2] - E[:, 2] * H[:, 1])
-    Pz = np.real(E[:, 0] * H[:, 1] - E[:, 1] * H[:, 0])
-    Prz = np.sqrt(np.square(Pr) + np.square(Pz))
+    flux_x = np.real(
+        np.conj(e_field[:, 1]) * h_field[:, 2] - np.conj(e_field[:, 2]) * h_field[:, 1]
+    )
+    flux_z = np.real(
+        np.conj(e_field[:, 0]) * h_field[:, 1] - np.conj(e_field[:, 1]) * h_field[:, 0]
+    )
+    flux_r = np.sqrt(np.square(flux_x) + np.square(flux_z))
 
-    return Prz
+    return flux_r
 
 
-def disc_total_flux(dmat: float, h: float) -> Tuple[float, float]:
-    """Computes the total radiated flux from a point dipole embedded
-    within a dielectric disc above a lossless ground plane using
-    its near and far fields as separate calculations.
+def disc_radiated_flux(disc_um: float, source_zpos: float) -> Tuple[float, float]:
+    """Computes the  radiated flux from a "ring" current source within a disc.
 
     Args:
-        dmat: thickness of dielectric disc.
-        h: height of dipole above ground plane as fraction of dmat.
+        disc_um: thickness of dielectric disc.
+        source_zpos: height of the dipole source above the ground plane as
+            a fraction of disc_um.
 
     Returns:
         A 2-tuple of the total flux computed using the near and far fields,
         respectively.
     """
-    sr = L + dpml
-    sz = dmat + dair + dpml
+    cell_r_um = 6.0
+    sr = cell_r_um + PML_UM
+    sz = disc_um + AIR_UM + PML_UM
     cell_size = mp.Vector3(sr, 0, sz)
 
     boundary_layers = [
-        mp.PML(dpml, direction=mp.R),
-        mp.PML(dpml, direction=mp.Z, side=mp.High),
+        mp.PML(PML_UM, direction=mp.R),
+        mp.PML(PML_UM, direction=mp.Z, side=mp.High),
     ]
 
     src_cmpt = mp.Er
-    src_pt = mp.Vector3(0.1 * L, 0, -0.5 * sz + h * dmat)
+    src_pt = mp.Vector3(0.5 * DISC_RADIUS_UM, 0, -0.5 * sz + source_zpos * disc_um)
     sources = [
         mp.Source(
-            src=mp.GaussianSource(fcen, fwidth=0.1 * fcen),
+            src=mp.GaussianSource(frequency, fwidth=0.1 * frequency),
             component=src_cmpt,
             center=src_pt,
         )
@@ -163,14 +168,14 @@ def disc_total_flux(dmat: float, h: float) -> Tuple[float, float]:
 
     geometry = [
         mp.Block(
-            material=mp.Medium(index=n),
-            center=mp.Vector3(0.1 * L, 0, -0.5 * sz + 0.5 * dmat),
-            size=mp.Vector3(0.2 * L, mp.inf, dmat),
+            material=mp.Medium(index=N_DISC),
+            center=mp.Vector3(0.5 * DISC_RADIUS_UM, 0, -0.5 * sz + 0.5 * disc_um),
+            size=mp.Vector3(DISC_RADIUS_UM, mp.inf, disc_um),
         )
     ]
 
     sim = mp.Simulation(
-        resolution=resolution,
+        resolution=RESOLUTION_UM,
         cell_size=cell_size,
         dimensions=mp.CYLINDRICAL,
         m=-1,
@@ -181,31 +186,35 @@ def disc_total_flux(dmat: float, h: float) -> Tuple[float, float]:
 
     # flux monitor
     flux_mon = sim.add_flux(
-        fcen,
+        frequency,
         0,
         1,
         mp.FluxRegion(
-            center=mp.Vector3(0.5 * L, 0, 0.5 * sz - dpml),
-            size=mp.Vector3(L, 0, 0),
+            center=mp.Vector3(0.5 * cell_r_um, 0, 0.5 * sz - PML_UM),
+            size=mp.Vector3(cell_r_um, 0, 0),
         ),
         mp.FluxRegion(
-            center=mp.Vector3(L, 0, 0.5 * sz - dpml - 0.5 * (dair + dmat)),
-            size=mp.Vector3(0, 0, dair + dmat),
+            center=mp.Vector3(
+                cell_r_um, 0, 0.5 * sz - PML_UM - 0.5 * (AIR_UM + disc_um)
+            ),
+            size=mp.Vector3(0, 0, AIR_UM + disc_um),
         ),
     )
 
     # near-field monitor
     n2f_mon = sim.add_near2far(
-        fcen,
+        frequency,
         0,
         1,
         mp.FluxRegion(
-            center=mp.Vector3(0.5 * L, 0, 0.5 * sz - dpml),
-            size=mp.Vector3(L, 0, 0),
+            center=mp.Vector3(0.5 * cell_r_um, 0, 0.5 * sz - PML_UM),
+            size=mp.Vector3(cell_r_um, 0, 0),
         ),
         mp.FluxRegion(
-            center=mp.Vector3(L, 0, 0.5 * sz - dpml - 0.5 * (dair + dmat)),
-            size=mp.Vector3(0, 0, dair + dmat),
+            center=mp.Vector3(
+                cell_r_um, 0, 0.5 * sz - PML_UM - 0.5 * (AIR_UM + disc_um)
+            ),
+            size=mp.Vector3(0, 0, AIR_UM + disc_um),
         ),
     )
 
@@ -216,34 +225,41 @@ def disc_total_flux(dmat: float, h: float) -> Tuple[float, float]:
 
     sim.run(
         until_after_sources=mp.stop_when_fields_decayed(
-            50,
+            FIELD_DECAY_PERIOD,
             src_cmpt,
             src_pt,
-            tol,
+            FIELD_DECAY_TOL,
         ),
     )
 
     flux_near = mp.get_fluxes(flux_mon)[0]
 
-    Ptheta = radiation_pattern(sim, n2f_mon)
-    plot_radiation_pattern_polar(r * r * Ptheta)
-    plot_radiation_pattern_3d(r * r * Ptheta)
+    radial_flux = radiation_pattern(sim, n2f_mon)
+    radial_flux_scaled = FARFIELD_RADIUS_UM * FARFIELD_RADIUS_UM * radial_flux
+    plot_radiation_pattern_polar(radial_flux_scaled)
+    plot_radiation_pattern_3d(radial_flux_scaled)
 
-    dtheta = 0.5 * math.pi / (npts - 1)
-    dphi = 2 * math.pi
-    flux_far = np.sum(Ptheta * np.sin(thetas)) * r * r * dtheta * dphi
+    delta_polar = 0.5 * math.pi / (NUM_POLAR - 1)
+    delta_azimuth = 2 * math.pi
+    flux_far = (
+        np.sum(radial_flux * np.sin(polar_rad))
+        * FARFIELD_RADIUS_UM
+        * FARFIELD_RADIUS_UM
+        * delta_polar
+        * delta_azimuth
+    )
 
     return flux_near, flux_far
 
 
 if __name__ == "__main__":
-    disc_thickness = 0.7 * wvl / n
+    disc_thickness_um = 0.7 * WAVELENGTH_UM / N_DISC
     dipole_height = 0.5
 
-    near_flux, far_flux = disc_total_flux(disc_thickness, dipole_height)
+    flux_near, flux_far = disc_radiated_flux(disc_thickness_um, dipole_height)
 
-    err = abs(near_flux - far_flux) / near_flux
+    err = abs(flux_near - flux_far) / flux_near
     print(
-        f"total_flux:, {near_flux:.5f} (near), {far_flux:.5f} (far), "
-        f"{err:.5f} (error)"
+        f"total_flux:, {flux_near:.5f} (near), {flux_far:.5f} (far), "
+        f"{100 * err:.2f}% (error)"
     )


### PR DESCRIPTION
Fixes and tweaks including improvements to Python readability for [Tutorial/Validating the LDOS of a dipole using a 1D simulation](https://meep.readthedocs.io/en/latest/Python_Tutorials/Near_to_Far_Field_Spectra/#radiation-pattern-of-a-disc-in-cylindrical-coordinates). Also adds the `greencyl_tol` argument to the function `Simulation.get_farfield` (from #3064).