### PR TITLE
Add documentation for `greencyl_tol` argument of `get_farfield` and `get_farfields`

### DIFF
--- a/doc/docs/Python_Tutorials/Near_to_Far_Field_Spectra.md
+++ b/doc/docs/Python_Tutorials/Near_to_Far_Field_Spectra.md
@@ -710,6 +710,7 @@ DISC_THICKNESS_UM = 0.7 * WAVELENGTH_UM / N_DISC
 NUM_FARFIELD_PTS = 200
 FARFIELD_RADIUS_UM = 1e6 * WAVELENGTH_UM
 NUM_DIPOLES = 11
+GREENCYL_TOL = 1e-6
 
 farfield_angles = np.linspace(0, 0.5 * math.pi, NUM_FARFIELD_PTS)
 
@@ -795,6 +796,7 @@ def radiation_pattern(sim: mp.Simulation, n2f_mon: mp.DftNear2Far) -> np.ndarray
                 0,
                 FARFIELD_RADIUS_UM * math.cos(farfield_angles[n]),
             ),
+            GREENCYL_TOL,
         )
         e_field[n, :] = [far_field[j] for j in range(3)]
         h_field[n, :] = [far_field[j + 3] for j in range(3)]

--- a/python/examples/dipole_in_vacuum_cyl_off_axis.py
+++ b/python/examples/dipole_in_vacuum_cyl_off_axis.py
@@ -22,6 +22,7 @@ FARFIELD_RADIUS_UM = 1e6 * WAVELENGTH_UM
 NUM_FARFIELD_PTS = 50
 AZIMUTHAL_RAD = 0
 POWER_DECAY_THRESHOLD = 1e-4
+GREENCYL_TOL = 1e-6
 
 frequency = 1 / WAVELENGTH_UM
 polar_rad = np.linspace(0, 0.5 * math.pi, NUM_FARFIELD_PTS)
@@ -124,6 +125,7 @@ def get_farfields(
                 0,
                 FARFIELD_RADIUS_UM * math.cos(polar_rad[n]),
             ),
+            GREENCYL_TOL,
         )
         e_field[n, :] = [far_field[j] for j in range(3)]
         h_field[n, :] = [far_field[j + 3] for j in range(3)]

--- a/python/examples/dipole_in_vacuum_cyl_on_axis.py
+++ b/python/examples/dipole_in_vacuum_cyl_on_axis.py
@@ -22,6 +22,7 @@ FARFIELD_RADIUS_UM = 1e6 * WAVELENGTH_UM
 NUM_FARFIELD_PTS = 50
 AZIMUTHAL_RAD = 0
 POWER_DECAY_THRESHOLD = 1e-4
+GREENCYL_TOL = 1e-6
 
 frequency = 1 / WAVELENGTH_UM
 polar_rad = np.linspace(0, 0.5 * math.pi, NUM_FARFIELD_PTS)
@@ -125,6 +126,7 @@ def get_farfields(
                 0,
                 FARFIELD_RADIUS_UM * math.cos(polar_rad[n]),
             ),
+            GREENCYL_TOL,
         )
         e_field[n, :] = [far_field[j] for j in range(3)]
         h_field[n, :] = [far_field[j + 3] for j in range(3)]

--- a/python/examples/disc_extraction_efficiency.py
+++ b/python/examples/disc_extraction_efficiency.py
@@ -20,6 +20,7 @@ DISC_THICKNESS_UM = 0.7 * WAVELENGTH_UM / N_DISC
 NUM_FARFIELD_PTS = 200
 FARFIELD_RADIUS_UM = 1e6 * WAVELENGTH_UM
 NUM_DIPOLES = 11
+GREENCYL_TOL = 1e-6
 
 farfield_angles = np.linspace(0, 0.5 * math.pi, NUM_FARFIELD_PTS)
 
@@ -105,6 +106,7 @@ def radiation_pattern(sim: mp.Simulation, n2f_mon: mp.DftNear2Far) -> np.ndarray
                 0,
                 FARFIELD_RADIUS_UM * math.cos(farfield_angles[n]),
             ),
+            GREENCYL_TOL,
         )
         e_field[n, :] = [far_field[j] for j in range(3)]
         h_field[n, :] = [far_field[j + 3] for j in range(3)]

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3223,7 +3223,8 @@ class Simulation:
         of fields $(E_x^1,E_y^1,E_z^1,H_x^1,H_y^1,H_z^1,E_x^2,E_y^2,E_z^2,H_x^2,H_y^2,H_z^2,...)$
         in Cartesian coordinates and
         $(E_r^1,E_\\phi^1,E_z^1,H_r^1,H_\\phi^1,H_z^1,E_r^2,E_\\phi^2,E_z^2,H_r^2,H_\\phi^2,H_z^2,...)$
-        in cylindrical coordinates for the frequencies 1,2,...,`nfreq`.
+        in cylindrical coordinates for the frequencies 1,2,...,`nfreq`. `greencyl_tol` specifies the
+        convergence tolerance of the azimuthal ($\\phi$) integral in the calculation of the far field.
         """
         return mp._get_farfield(
             near2far.swigobj,
@@ -3240,7 +3241,7 @@ class Simulation:
         size: Vector3Type = None,
         greencyl_tol: float = 1e-3,
     ):
-        """
+        r"""
         Like `output_farfields` but returns a dictionary of NumPy arrays instead of
         writing to a file. The dictionary keys are `Ex`, `Ey`, `Ez`, `Hx`, `Hy`, `Hz`.
         Each array has the same shape as described in `output_farfields`.
@@ -3249,7 +3250,9 @@ class Simulation:
         of the fields, and hence cannot be directly compared to time-domain fields. In
         practice, it is easiest to use the far fields in computations where overall
         scaling (units) cancel out or are irrelevant, e.g. to compute the fraction of the
-        far fields in one region vs. another region.
+        far fields in one region vs. another region. `greencyl_tol` specifies the
+        convergence tolerance of the azimuthal ($\phi$) integral in the calculation
+        of the far field.
         """
         if self.fields is None:
             self.init_sim()


### PR DESCRIPTION
Adds (missing) documentation for the `greencyl_tol` argument (recently added in #3064) to the functions `Simulation.get_farfield` and `Simulation.get_farfields`. 

Also adds the `greencyl_tol` argument to the scripts for [Tutorial/Extraction Efficiency of a Collection of Dipoles in a Disc](https://meep.readthedocs.io/en/latest/Python_Tutorials/Near_to_Far_Field_Spectra/#extraction-efficiency-of-a-collection-of-dipoles-in-a-disc) and [Tutorial/Radiation Pattern of an Antenna in Cylindrical Coordinates](https://meep.readthedocs.io/en/latest/Python_Tutorials/Near_to_Far_Field_Spectra/#radiation-pattern-of-an-antenna-in-cylindrical-coordinates).