### PR TITLE
Fix `Box`-related issues in `plot3D`

### DIFF
--- a/python/visualization.py
+++ b/python/visualization.py
@@ -1204,7 +1204,7 @@ def plot3D(sim, save_to_image: bool = False, image_name: str = "sim.png", **kwar
     import itertools
 
     for boundary in sim.boundary_layers:
-        if boundary.direction == mp.ALL and side == mp.ALL:  # same boundary everywhere
+        if boundary.direction == mp.ALL and boundary.side == mp.ALL:  # same boundary everywhere
             for permutation in itertools.product([mp.X, mp.Y, mp.Z], [mp.Low, mp.High]):
                 vol = get_boundary_volumes(sim, boundary.thickness, *permutation)
                 box = _build_3d_pml(vol.size, vol.center + sim.cell_size / 2)

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -719,6 +719,7 @@ def get_boundary_volumes(
     else:
         raise ValueError("Invalid boundary type")
 
+
 def plot_boundaries(
     sim: Simulation,
     ax: Axes,
@@ -762,7 +763,9 @@ def plot_boundaries(
                     sim.dimensions == mp.CYLINDRICAL or sim.is_cylindrical
                 ):
                     continue
-                vol = get_boundary_volumes(sim, boundary.thickness, boundary.direction, side)
+                vol = get_boundary_volumes(
+                    sim, boundary.thickness, boundary.direction, side
+                )
                 ax = plot_volume(
                     sim, ax, vol, output_plane, plotting_parameters=boundary_parameters
                 )
@@ -1062,12 +1065,29 @@ def plot2D(
         sleep(0.05)
     return ax
 
+
 # colors for styling appearance of boxes in `plot3D`
-SOURCE_COLOR_3D: tuple[float, float, float, float] = (234/255, 32/255, 39/255, 1.0) # red
-MONITOR_COLOR_3D: tuple[float, float, float, float] = (55/255, 66/255, 250/255, 1.0) # blue
-BOUNDARY_COLOR_3D: tuple[float, float, float, float] = (8/255, 203/255, 0/255, .2) # transparent green
-CELL_COLOR_3D: tuple[float, float, float, float] = (.75, .75, .75, .1) # gray
-CELL_EDGE_COLOR_3D: tuple[float, float, float, float] = (.75, .75, .75, 1) # transparent gray
+SOURCE_COLOR_3D: tuple[float, float, float, float] = (  # red
+    234 / 255,
+    32 / 255,
+    39 / 255,
+    1.0,
+)
+MONITOR_COLOR_3D: tuple[float, float, float, float] = (  # blue
+    55 / 255,
+    66 / 255,
+    250 / 255,
+    1.0,
+)
+BOUNDARY_COLOR_3D: tuple[float, float, float, float] = (  # transparent green
+    8 / 255,
+    203 / 255,
+    0 / 255,
+    0.1,
+)
+CELL_COLOR_3D = None
+CELL_EDGE_COLOR_3D: tuple[float, float, float, float] = (0.75, 0.75, 0.75, 1)  # gray
+
 
 def plot3D(sim, save_to_image: bool = False, image_name: str = "sim.png", **kwargs):
     from vispy.scene.visuals import Box, Mesh
@@ -1146,9 +1166,11 @@ def plot3D(sim, save_to_image: bool = False, image_name: str = "sim.png", **kwar
     for source in sim.sources:
         size = tuple(source.size)
         source_box = Box(
-            size[0], size[2], size[1], # vispy input is x-, z-, y-size
+            size[0],
+            size[2],
+            size[1],  # vispy input is x-, z-, y-size
             color=SOURCE_COLOR_3D,
-            edge_color = (0,0,0,1),
+            edge_color=(0, 0, 0, 1),
         )
         center = list(source.center)
         source_box.transform = transforms.MatrixTransform()
@@ -1162,9 +1184,11 @@ def plot3D(sim, save_to_image: bool = False, image_name: str = "sim.png", **kwar
         for reg in mon.regions:
             size = list(reg.size)
             monitor_box = Box(
-                size[0], size[2], size[1], # vispy input is x-, z-, y-size
+                size[0],
+                size[2],
+                size[1],  # vispy input is x-, z-, y-size
                 color=MONITOR_COLOR_3D,
-                edge_color = (0,0,0,1),
+                edge_color=(0, 0, 0, 1),
             )
             center = list(reg.center)
             monitor_box.transform = transforms.MatrixTransform()
@@ -1178,28 +1202,39 @@ def plot3D(sim, save_to_image: bool = False, image_name: str = "sim.png", **kwar
 
     # Build boundary regions
     import itertools
+
     for boundary in sim.boundary_layers:
-        if boundary.direction == mp.ALL and side == mp.ALL: # same boundary everywhere
+        if boundary.direction == mp.ALL and side == mp.ALL:  # same boundary everywhere
             for permutation in itertools.product([mp.X, mp.Y, mp.Z], [mp.Low, mp.High]):
                 vol = get_boundary_volumes(sim, boundary.thickness, *permutation)
-                box = _build_3d_pml(vol.size, vol.center + sim.cell_size/2)
+                box = _build_3d_pml(vol.size, vol.center + sim.cell_size / 2)
                 view.add(box)
-        elif boundary.side == mp.ALL: # same boundary on both sides
+        elif boundary.side == mp.ALL:  # same boundary on both sides
             for side in [mp.Low, mp.High]:
-                vol = get_boundary_volumes(sim, boundary.thickness, boundary.direction, side)
-                box = _build_3d_pml(vol.size, vol.center + sim.cell_size/2)
-                view.add(box)               
-        else: # boundary on just one side
-            vol = get_boundary_volumes(sim, boundary.thickness, boundary.direction, boundary.side)
-            box = _build_3d_pml(vol.size, vol.center + sim.cell_size/2)
+                vol = get_boundary_volumes(
+                    sim, boundary.thickness, boundary.direction, side
+                )
+                box = _build_3d_pml(vol.size, vol.center + sim.cell_size / 2)
+                view.add(box)
+        else:  # boundary on just one side
+            vol = get_boundary_volumes(
+                sim, boundary.thickness, boundary.direction, boundary.side
+            )
+            box = _build_3d_pml(vol.size, vol.center + sim.cell_size / 2)
             view.add(box)
-    
+
     # Add simulation cell volume
-    box = Box(sim.cell_size.x, sim.cell_size.z, sim.cell_size.y,
-        color=CELL_COLOR_3D, edge_color=CELL_EDGE_COLOR_3D,
+    box = Box(
+        sim.cell_size.x,
+        sim.cell_size.z,
+        sim.cell_size.y,
+        color=CELL_COLOR_3D,
+        edge_color=CELL_EDGE_COLOR_3D,
     )
     box.transform = transforms.MatrixTransform()
-    box.transform.translate((sim.cell_size.x/2, sim.cell_size.y/2, sim.cell_size.z/2))
+    box.transform.translate(
+        (sim.cell_size.x / 2, sim.cell_size.y / 2, sim.cell_size.z / 2)
+    )
     view.add(box)
 
     # Camera options
@@ -1222,12 +1257,17 @@ def plot3D(sim, save_to_image: bool = False, image_name: str = "sim.png", **kwar
 
     canvas.show(run=True)
 
+
 def _build_3d_pml(width: Vector3, translate: Vector3):
     from vispy.scene.visuals import Box
     from vispy.scene import transforms
 
-    box = Box(width.x, width.z, width.y, # vispy input is x-, z-, y-size
-        color = BOUNDARY_COLOR_3D, edge_color = (0,0,0,1),
+    box = Box(
+        width.x,
+        width.z,
+        width.y,  # vispy input is x-, z-, y-size
+        color=BOUNDARY_COLOR_3D,
+        edge_color=(0, 0, 0, 1),
     )
     box.transform = transforms.MatrixTransform()
     box.transform.translate(tuple(translate))


### PR DESCRIPTION
This fixes #3000 (and #2429) following the suggestion in https://github.com/NanoComp/meep/issues/3000#issuecomment-2803982467, i.e. wrong orientation of sources and monitors in 3D.

While fixing this, I also noticed that the boundary layer visualization was quite broken, so this fixes it also (by factoring out `get_boundary_volumes` and reusing that). Previously, the implementation assumed that all boundary layers were identical, and also had the orientation wrong on the x- and y-boundaries. This also fixes #2913.

I also took the opportunity to try to make the visualization a bit prettier by (1) using some nicer colors that weren't 100% R, G, or B values, (2) dropping the wireframe on the boundary regions, and (3) adding a faint outline for the simulation cell.

---

Example of change below (photonic crystal with weirdly arranged PMLs, boundary details in code below examples):

| Before | After |
|---|---|
| <img width="91" height="439" alt="image" src="https://github.com/user-attachments/assets/4bf51405-37e0-49d7-b720-590d6b63ca24" /> | <img width="102" height="439" alt="image" src="https://github.com/user-attachments/assets/600a24c4-3abd-4503-ab7a-a25f775678fe" /> |

```py
pml_layerZ1 = mp.PML(thickness = .5,   direction=mp.Z, side=mp.Low)
pml_layerZ2 = mp.PML(thickness = 5,    direction=mp.Z, side=mp.High)
pml_layerX  = mp.PML(thickness = .25,  direction=mp.X, side=mp.Low)
pml_layerY  = mp.PML(thickness = .5/3, direction=mp.Y, side=mp.High)
boundary_layers = [pml_layerZ1, pml_layerZ2, pml_layerX, pml_layerY]
```


Here's another before/after:
| Before | After |
|---|---|
| <img width="212" height="423" alt="image" src="https://github.com/user-attachments/assets/ffd630c7-f65c-453a-8ffc-74016f22c041" /> | <img width="79" height="393" alt="image" src="https://github.com/user-attachments/assets/bd7c55e4-c344-4633-b4cd-91857b7c9375" /> |

```py
pml_layerZ1 = mp.PML(thickness = 3,     direction=mp.Z, side=mp.Low)
pml_layerZ2 = mp.PML(thickness = 5,     direction=mp.Z, side=mp.High)
pml_layerX  = mp.PML(thickness = .125,  direction=mp.X, side=mp.Low)
pml_layerY  = mp.PML(thickness = .25/3, direction=mp.Y, side=mp.High)
boundary_layers = [pml_layerZ1, pml_layerZ2, pml_layerX, pml_layerY]
```