### PR TITLE
fix visualization.py for python 3.12

### DIFF
--- a/python/visualization.py
+++ b/python/visualization.py
@@ -1676,17 +1676,9 @@ class Animate2D:
         # ready for jupyter notebook embedding.
         # modified from matplotlib/animation.py code.
 
-        # Only works with Python3 and matplotlib > 3.1.0
-        from distutils.version import LooseVersion
         import matplotlib
 
-        if LooseVersion(matplotlib.__version__) < LooseVersion("3.1.0"):
-            print("-------------------------------")
-            print(
-                "Warning: JSHTML output is not supported with your current matplotlib build. Consider upgrading to 3.1.0+"
-            )
-            print("-------------------------------")
-            return
+        # Only works with Python3 and matplotlib > 3.1.0:
         if mp.am_master():
             from uuid import uuid4
             from matplotlib._animation_data import (


### PR DESCRIPTION
For #2819 — `distutils.version.LooseVersion` no longer exists, but I think we can delete this check (it's only used to issue a warning for people using versions of matplotlib prior to 2019).