### PR TITLE
Update docstrings to state usage of border padding

### DIFF
--- a/python/adjoint/filters.py
+++ b/python/adjoint/filters.py
@@ -166,7 +166,7 @@ def convolve_design_weights_and_kernel(
 
         npadx = 0 if 0 in periodic_axes else sx
         npady = 0 if 1 in periodic_axes else sy
-        x = (
+        x = _edge_pad(
             x, ((npadx, npadx), (npady, npady))
         )  # pad only in nonperiodic directions
         h = _quarter_to_full_kernel(


### PR DESCRIPTION
The filter routines stated that they used zero padding of the design variables in convolution filters where they actually used border padding. I updated docstrings to reflect this.