### PR TITLE
Extract single element of array before declaring amplitude of adjoint source

### DIFF
--- a/python/source.py
+++ b/python/source.py
@@ -124,7 +124,10 @@ class Source:
 
         self.src = src
         self.component = component
-        self.amplitude = complex(amplitude)
+        if isinstance(amplitude, np.ndarray) and amplitude.ndim == 1:
+            self.amplitude = complex(amplitude.item())
+        else:
+            self.amplitude = complex(amplitude)
         self.amp_func = amp_func
         self.amp_func_file = amp_func_file
         self.amp_data = amp_data


### PR DESCRIPTION
A unit test for the adjoint solver (`test_two_objfunc` of `test_adjoint_solver.py`) recently started failing during CI for Python 3.11 due to the following line:

https://github.com/NanoComp/meep/blob/e407a5a2f1c7db897b2e8835b9d080f4775bbcfa/python/source.py#L127

The error is triggered when `amplitude` is passed to the `Source` constructor as a Numpy array with a *single* element. Python's [`complex`](https://docs.python.org/3/library/functions.html#complex) function supports 0-dimensional Numpy arrays. The fix simply involves extracting the element of the array before applying the `complex` function.

(It is not clear why this error was triggered recently and only for Python 3.11.)