### PR TITLE
fix swig conflict with READONLY #define

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -40,6 +40,9 @@
  */
 #define SWIG_PYTHON_THREAD_SCOPED_BLOCK   SWIG_PYTHON_THREAD_BEGIN_BLOCK
 
+/* this #define from Python's structmember.h, used by swig, conflicts with meep.hpp */
+#undef READONLY
+
 #include <complex>
 #include <string>
 

--- a/python/mpb.i
+++ b/python/mpb.i
@@ -20,6 +20,9 @@
 %{
 #define SWIG_FILE_WITH_INIT
 
+/* this #define from Python's structmember.h, used by swig, conflicts with meep.hpp */
+#undef READONLY
+
 #include "pympb.hpp"
 #include "meepgeom.hpp"
 


### PR DESCRIPTION
This works around a conflict between Meep's `READONLY` `enum` and a `#define READONLY` in Python's `structmember.h`, which is apparently included by SWIG, maybe only recently (https://github.com/swig/swig/commit/e6283e7552a54825a5f134f444f9fc6796596365?). 