### PR TITLE
Fix bug when combining 2+ mirror symmetries and Bloch-periodic boundary conditions

### DIFF
--- a/src/boundaries.cpp
+++ b/src/boundaries.cpp
@@ -91,11 +91,15 @@ void fields::use_bloch(direction d, complex<double> kk) {
   k[d] = kk;
   for (int b = 0; b < 2; b++)
     set_boundary(boundary_side(b), d, Periodic);
-  if (real(kk) * gv.num_direction(d) == 0.5 * a) // check b.z. edge exactly
-    eikna[d] = -exp(-imag(kk) * ((2 * pi / a) * gv.num_direction(d)));
+  // Use user_volume (full cell) size, not gv (symmetry-reduced cell) size,
+  // because ilattice_vector and locate_point_in_user_volume translate by
+  // the full cell period. Using gv here would give the wrong Bloch phase
+  // when the cell is halved by mirror symmetries. (See issue #132.)
+  if (real(kk) * user_volume.num_direction(d) == 0.5 * a) // check b.z. edge exactly
+    eikna[d] = -exp(-imag(kk) * ((2 * pi / a) * user_volume.num_direction(d)));
   else {
     const complex<double> I = complex<double>(0.0, 1.0);
-    eikna[d] = exp(I * kk * ((2 * pi / a) * gv.num_direction(d)));
+    eikna[d] = exp(I * kk * ((2 * pi / a) * user_volume.num_direction(d)));
   }
   coskna[d] = real(eikna[d]);
   sinkna[d] = imag(eikna[d]);


### PR DESCRIPTION
Fixes #132.

**Root Cause**

The Bloch phase factor `eikna[d]` is computed using the **symmetry-reduced** grid volume (`gv`) size, while the periodic lattice translation vector (`ilattice_vector`) is computed using the **full** cell size (`user_volume`). This creates a mismatch between the phase applied per periodic translation and the actual translation distance.

**Why it only manifests with 2+ mirror symmetries + periodioc boundaries**

-  **single mirror** (e.g., `Mirror(Y)`) + **periodic in X**: only Y is halved, so `gv.num_direction(X)` equals the original full `user_volume.nx()`. The phase in X is correct. The Y direction typically has k_y = 0 with mirror symmetry, so `eikna[Y] = 1` regardless.
- **2+ mirrors** (e.g., `Mirror(X) + Mirror(Y)`) + **periodic**: Both X and Y are halved. If k_x ≠ 0, then `gv.num_direction(X)` ≈ `user_volume.nx() / 2` and `eikna[X]` is computed for the wrong period. The periodic translation moves by the full cell but applies the phase for half the cell. This produces incorrect field values at boundary conditions leading to expontentially growing errors (instability).
- **k = 0** (pure periodic, no Bloch phase): `eikna = exp(0) = 1` regardless of cell size, so the bug is latent and harmless.

Two new unit tests are added to compare the symmetry-exploiting simulation  against a reference simulation without symmetry, checking field values at multiple points and energies at regular intervals.