### PR TITLE
Performance optimization for time stepping in cylindrical coordinates for m ≠ 0

### DIFF
--- a/src/step_db.cpp
+++ b/src/step_db.cpp
@@ -199,13 +199,6 @@ bool fields_chunk::step_db(field_type ft) {
         const realnum the_m =
             2 * m * (1 - 2 * cmp) * (1 - 2 * (ft == B_stuff)) * (1 - 2 * (d_c == R)) * Courant;
 
-        // Precompute reciprocal-r table (rinv only varies with R loop dimension)
-        const int is_r = is.in_direction(R);
-        const int nr_loop = (gv.big_corner().in_direction(R) - is_r) / 2 + 1;
-        realnum *rinv_arr = new realnum[nr_loop];
-        for (int ir = 0; ir < nr_loop; ++ir)
-          rinv_arr[ir] = the_m / (is_r + 2 * ir);
-
         // 8 special cases of the same loop (sigh):
         if (siginv) { // PML in f update
           KSTRIDE_DEF(dsig, k, is, gv);
@@ -214,7 +207,7 @@ bool fields_chunk::step_db(field_type ft) {
             if (cndinv) // PML + fu + conductivity
               //////////////////// MOST GENERAL CASE //////////////////////
               PLOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                realnum rinv = rinv_arr[loop_i2];
+                realnum rinv = the_m / (loop_is2 + 2 * loop_i2);
                 DEF_k;
                 DEF_ku;
                 realnum df, dfcnd = rinv * g[i] * cndinv[i];
@@ -225,7 +218,7 @@ bool fields_chunk::step_db(field_type ft) {
             /////////////////////////////////////////////////////////////
             else // PML + fu - conductivity
               PLOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                realnum rinv = rinv_arr[loop_i2];
+                realnum rinv = the_m / (loop_is2 + 2 * loop_i2);
                 DEF_k;
                 DEF_ku;
                 realnum df, dfcnd = rinv * g[i];
@@ -236,7 +229,7 @@ bool fields_chunk::step_db(field_type ft) {
           else {        // PML - fu
             if (cndinv) // PML - fu + conductivity
               PLOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                realnum rinv = rinv_arr[loop_i2];
+                realnum rinv = the_m / (loop_is2 + 2 * loop_i2);
                 DEF_k;
                 realnum dfcnd = rinv * g[i] * cndinv[i];
                 fcnd[i] += dfcnd;
@@ -244,7 +237,7 @@ bool fields_chunk::step_db(field_type ft) {
               }
             else // PML - fu - conductivity
               PLOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                realnum rinv = rinv_arr[loop_i2];
+                realnum rinv = the_m / (loop_is2 + 2 * loop_i2);
                 DEF_k;
                 realnum dfcnd = rinv * g[i];
                 the_f[i] += dfcnd * siginv[k];
@@ -256,7 +249,7 @@ bool fields_chunk::step_db(field_type ft) {
             KSTRIDE_DEF(dsigu, ku, is, gv);
             if (cndinv) // no PML + fu + conductivity
               PLOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                realnum rinv = rinv_arr[loop_i2];
+                realnum rinv = the_m / (loop_is2 + 2 * loop_i2);
                 DEF_ku;
                 realnum df = rinv * g[i] * cndinv[i];
                 fu[i] += df;
@@ -264,7 +257,7 @@ bool fields_chunk::step_db(field_type ft) {
               }
             else // no PML + fu - conductivity
               PLOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                realnum rinv = rinv_arr[loop_i2];
+                realnum rinv = the_m / (loop_is2 + 2 * loop_i2);
                 DEF_ku;
                 realnum df = rinv * g[i];
                 fu[i] += df;
@@ -274,17 +267,16 @@ bool fields_chunk::step_db(field_type ft) {
           else {        // no PML - fu
             if (cndinv) // no PML - fu + conductivity
               PLOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                realnum rinv = rinv_arr[loop_i2];
+                realnum rinv = the_m / (loop_is2 + 2 * loop_i2);
                 the_f[i] += rinv * g[i] * cndinv[i];
               }
             else // no PML - fu - conductivity
               PLOOP_OVER_VOL_OWNED0(gv, cc, i) {
-                realnum rinv = rinv_arr[loop_i2];
+                realnum rinv = the_m / (loop_is2 + 2 * loop_i2);
                 the_f[i] += rinv * g[i];
               }
           }
         }
-        delete[] rinv_arr;
       }
     }
 


### PR DESCRIPTION
**Context**

The FDTD time-stepping hot path calls `step_db()` and `update_eh()` twice per timestep each (once for B/H, once for D/E). The inner loop kernels in `step_generic.cpp` / `step_generic_stride1.cpp` are already well-optimized with OpenMP (`PLOOP_OVER_IVECS`), SIMD vectorization (`PS1LOOP`), `restrict` pointers, and specialized code paths for each PML/conductivity combination.

However, the cylindrical-coordinate (`Dcyl`) m≠0  code in `step_db.cpp` (lines 178-293) is a major performance bottleneck:
1. It uses **serial** `LOOP_OVER_VOL_OWNED0` instead of parallel `PLOOP` variants.
2. Every grid point constructs an `ivec` object via `IVEC_LOOP_ILOC`, calls `.r()`, and performs a floating-point division – yet the r-coordinate only changes with the outer (R) loop.
3. The `KSTRIDE_DEF` PML-index setup is redundantly placed inside the loop body instead of outside.

These issues make cylindrical simulations with m≠0 significantly slower than they need to be.

**Optimizations**

**1. Precompute reciprocal-r table for cylindrical m≠0 loops (HIGH IMPACT)**

File: `src/step_db.cpp`, lines 178-293

Before the 8 special-case loops, precompute a 1D array of `the_m / r_int` values indexed by the R loop dimension. Inside the loop, replace:
```
IVEC_LOOP_ILOC(gv, here);
realnum rinv = the_m / here.r();
```
with a direct lookup using the R loop index. This eliminates per-point ivec construction, `.r()` method dispatch, and floating-point division. The R loop index maps to `loop_i1` for Dcyl (R is outermost, Z is innermost/stride-1).

Implementation: after computing `the_m` (line 200) and `is` (line 193), determine the R dimension's loop parameters from `gv.yucky_direction()` and precompute `rinv_arr[ir] = the_m / (is.in_direction(R) + 2 * ir)` for `ir = 0..nr-1`.

**2. Parallelize cylindrical m≠0 loops (HIGH IMPACT)**

File: `src/step_db.cpp`, lines 203-291

Replace all 8 instances of serial `LOOP_OVER_VOL_OWNED0(gv, cc, i)` with `PLOOP_OVER_VOL_OWNED(gv, cc, i)` (or `PS1LOOP_OVER_VOL_OWNED0` when stride-1). This enables OpenMP multi-threading for the cylindrical m≠0 field updates, which are currently the only serial loops on the hot path.

With the precomputed rinv table (optimization 1), the loop body becomes pure array arithmetic, ideal for parallization and SIMD.

**3. Host `KSTRIDE_DEF` outside loops (MEDIUM IMPACT)**

File: `src/step_db.cpp`, lines 203-291

Move `KSTRIDE_DEF(dsig, k, is, gv)` and `KSTRIDE_DEF(dsigu, ku, is, gv)` from inside the loop body to before the loop, matching the pattern used in `step_generic.cpp`. Currently these define `const` variables every iteration; hoisting them:
- Reduces redundant computation (even if compiler may hoist them for serial loops)
- Is required for correct OpenMP parallel behavior (avoids per-thread redundant setup)
- Matches the established pattern from the well-optimized `step_generic.cpp`

**4. Add SIMD hint to f_rderiv_int inner loop (MEDIUM IMPACT)**

File: `src/step_db.cpp`, lines 109-117

The Z inner loop in the `f_rderiv_int` computation has no cross-iteration dependencies within a given R row. Add `IVDEP` pragma before the inner loop to enable auto-vectorization.

**5. Use memset for f_rderiv_int initialization (LOW IMPACT)**

Replace explicit zero-initialization loop with `memset`.