### PR TITLE
Pythonic replacement for the mutable default for `vertices` argument of `Volume` class constructor

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -417,12 +417,12 @@ class Volume:
         size: Vector3Type = Vector3(),
         dims: int = 2,
         is_cylindrical: bool = False,
-        vertices: List[Vector3Type] = [],
+        vertices: Optional[List[Vector3Type]] = None,
     ):
         """
         Construct a Volume.
         """
-        if len(vertices) == 0:
+        if not vertices:
             self.center = Vector3(*center)
             self.size = Vector3(*size)
         else:


### PR DESCRIPTION
The `vertices` argument of the `Volume` class constructor uses a mutable default (a list). While this is not a functional bug since the list object is never mutated as `vertices` is a throwaway parameter used only to compute `center` and `size`, it is a **code smell** as it would fail a linter like `pylint` or `ruff` with `B006`/`W0102`. This PR replaces the mutable default with an idiomatic Python convention – `None` as a sentinel for "no value provided" is universally understood.