### PR TITLE
Add support for `dft_force` with mirror symmetry

### DIFF
--- a/python/simulation.py
+++ b/python/simulation.py
@@ -3399,8 +3399,9 @@ class Simulation:
     def _add_force(self, freq, forces, decimation_factor):
         if self.fields is None:
             self.init_sim()
+        use_symmetry = not self.symmetries
         return self._add_fluxish_stuff(
-            self.fields.add_dft_force, freq, forces, decimation_factor
+            self.fields.add_dft_force, freq, forces, decimation_factor, use_symmetry
         )
 
     def display_forces(self, *forces):

--- a/python/tests/test_force.py
+++ b/python/tests/test_force.py
@@ -5,50 +5,93 @@ import meep as mp
 
 class TestForce(unittest.TestCase):
     def setUp(self):
+        self.resolution = 20
+        self.cell = mp.Vector3(10, 10)
+        self.pml_layers = mp.PML(1.0)
 
-        resolution = 20
-        cell = mp.Vector3(10, 10)
-        pml_layers = mp.PML(1.0)
-        fcen = 1.0
-        df = 1.0
-        sources = mp.Source(
-            src=mp.GaussianSource(fcen, fwidth=df), center=mp.Vector3(), component=mp.Ez
+        self.fcen = 1.0
+        self.df = 1.0
+        self.sources = mp.Source(
+            src=mp.GaussianSource(frequency=self.fcen, fwidth=self.df),
+            center=mp.Vector3(),
+            component=mp.Ez,
         )
 
-        self.sim = mp.Simulation(
-            resolution=resolution,
-            cell_size=cell,
-            boundary_layers=[pml_layers],
-            sources=[sources],
-        )
-
-        fr = mp.ForceRegion(mp.Vector3(y=1.27), direction=mp.Y, size=mp.Vector3(4.38))
-        self.myforce = self.sim.add_force(fcen, 0, 1, fr, decimation_factor=1)
-        self.myforce_decimated = self.sim.add_force(
-            fcen, 0, 1, fr, decimation_factor=10
+        self.fr = mp.ForceRegion(
+            center=mp.Vector3(0, 1.27), direction=mp.Y, size=mp.Vector3(4.38, 0)
         )
 
     def test_force(self):
+        """Test force calculations using a golden master."""
 
-        self.sim.run(
+        sim = mp.Simulation(
+            resolution=self.resolution,
+            cell_size=self.cell,
+            boundary_layers=[self.pml_layers],
+            sources=[self.sources],
+        )
+
+        force = sim.add_force(self.fcen, 0, 1, self.fr, decimation_factor=1)
+        force_decimated = sim.add_force(self.fcen, 0, 1, self.fr, decimation_factor=10)
+
+        sim.run(
             until_after_sources=mp.stop_when_fields_decayed(
                 50, mp.Ez, mp.Vector3(), 1e-6
             )
         )
 
-        # Test store and load of force as numpy array
-        fdata = self.sim.get_force_data(self.myforce)
-        self.sim.load_force_data(self.myforce, fdata)
-
-        self.sim.display_forces(self.myforce)
-        f = mp.get_forces(self.myforce)
+        sim.display_forces(force)
+        f = mp.get_forces(force)
+        f_decimated = mp.get_forces(force_decimated)
 
         self.assertAlmostEqual(f[0], -0.11039089113393187)
 
         places = 6 if mp.is_single_precision() else 7
-        self.assertAlmostEqual(
-            f[0], mp.get_forces(self.myforce_decimated)[0], places=places
+        self.assertAlmostEqual(f[0], f_decimated[0], places=places)
+
+        # Test store and load of force as numpy array
+        fdata = sim.get_force_data(force)
+        sim.load_force_data(force, fdata)
+        f_fdata = mp.get_forces(force)
+        self.assertAlmostEqual(f_fdata[0], f[0], places=7)
+
+    def test_force_with_symmetry(self):
+        """Test that force calculations produce correct results with mirror symmetry."""
+
+        # Run without mirror symmetry.
+        sim_nosym = mp.Simulation(
+            resolution=self.resolution,
+            cell_size=self.cell,
+            boundary_layers=[self.pml_layers],
+            sources=[self.sources],
         )
+
+        force_nosym = sim_nosym.add_force(self.fcen, 0, 1, self.fr)
+        sim_nosym.run(
+            until_after_sources=mp.stop_when_fields_decayed(
+                50, mp.Ez, mp.Vector3(), 1e-6
+            )
+        )
+        f_nosym = mp.get_forces(force_nosym)
+
+        # Run with mirror symmetry.
+        sim_sym = mp.Simulation(
+            resolution=self.resolution,
+            cell_size=self.cell,
+            boundary_layers=[self.pml_layers],
+            sources=[self.sources],
+            symmetries=[mp.Mirror(mp.Y)],
+        )
+
+        force_sym = sim_sym.add_force(self.fcen, 0, 1, self.fr)
+        sim_sym.run(
+            until_after_sources=mp.stop_when_fields_decayed(
+                50, mp.Ez, mp.Vector3(), 1e-6
+            )
+        )
+        f_sym = mp.get_forces(force_sym)
+
+        self.assertAlmostEqual(f_nosym[0], f_sym[0], places=7)
 
 
 if __name__ == "__main__":

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -2163,15 +2163,16 @@ public:
 
   // stress.cpp
   dft_force add_dft_force(const volume_list *where, double freq_min, double freq_max, int Nfreq,
-                          int decimation_factor = 0) {
-    return add_dft_force(where, linspace(freq_min, freq_max, Nfreq), decimation_factor);
+                          int decimation_factor = 0, bool use_symmetry = true) {
+    return add_dft_force(where, linspace(freq_min, freq_max, Nfreq), decimation_factor,
+                         use_symmetry);
   }
   dft_force add_dft_force(const volume_list *where, const std::vector<double> &freq,
-                          int decimation_factor = 0) {
-    return add_dft_force(where, freq.data(), freq.size(), decimation_factor);
+                          int decimation_factor = 0, bool use_symmetry = true) {
+    return add_dft_force(where, freq.data(), freq.size(), decimation_factor, use_symmetry);
   }
   dft_force add_dft_force(const volume_list *where, const double *freq, size_t Nfreq,
-                          int decimation_factor = 0);
+                          int decimation_factor = 0, bool use_symmetry = true);
 
   // near2far.cpp
   dft_near2far add_dft_near2far(const volume_list *where, double freq_min, double freq_max,

--- a/src/stress.cpp
+++ b/src/stress.cpp
@@ -151,10 +151,10 @@ void dft_force::scale_dfts(complex<double> scale) {
    force to be computed, so they should be vector components (such as
    Ex, Ey, ... or Sx, ...)  rather than pseudovectors (like Hx, ...). */
 dft_force fields::add_dft_force(const volume_list *where_, const double *freq, size_t Nfreq,
-                                int decimation_factor) {
+                                int decimation_factor, bool use_symmetry) {
   dft_chunk *offdiag1 = 0, *offdiag2 = 0, *diag = 0;
 
-  volume_list *where = S.reduce(where_);
+  volume_list *where = use_symmetry ? S.reduce(where_) : new volume_list(where_);
   volume_list *where_save = where;
   volume everywhere = where->v;
 


### PR DESCRIPTION
Fixes #129.

**Context**

#129 reports field instability when combining DFT force monitors with symmetry objects. The root cause is that `fields::add_dft_force()` in `src/stress.cpp` unconditionally calls `S.reduce(where_)` to apply symmetry reduction to the force region volumes. In contrast, `fields::add_dft_flux()` in `src/dft.cpp` has a `use_symmetry` parameter (defaulting to `true`) that allows bypassing `S.reduce()`.

The `S.reduce()` operation is problematic for force calculations because the stress tensor involves pairing different field components (E in force direction vs. E in normal direction) as off-diagonal terms. When symmetry transforms the volume and modifies the component weights, the paired DFT chunk lists (`offdiag1`, `offdiag2`) can end up with mismatched structures, producing incorrect/unstable force values.

**Fix**

**Step 1: Add `use_symmetry` parameter to `add_dft_force` in C++ (3 files)**

`src/meep.hpp` (lines 2165-2174): Add `bool use_symmetry = true` parameter to all three `add_dft_force` overloads, matching the pattern of `add_dft_flux` (lines 2045-2057).

`src/stress.cpp` (lines 153-157): Accept the new `use_symmetry` parameter and conditionally apply `S.reduce()`: `volume_list *where = use_symmetry ? S.reduce(where_): new volume_list(where_)`; This mirrors dft.cpp line 607.

**Step 2: Pass `use_symmetry=False` from Python when symmetries are present (1 file)**

`python/simulation.py` (lines 3399-3404): Modify `_add_force` to pass `use_symmetry=False` to `add_dft_force` when the simulation has symmetry objects. This is done by passing an extra argument through `_add_fluxish_stuff`, which already supports `*args` forwarding (line 3818: `add_dft_stuff(vol_list, freq, decimation_factor, *args)`).

**Step 3: Add unit test (1 file)**

1. Runs a force calculation on a geometry with mirror symmetry using `symmetries=[mp.Mirror(mp.Y)]`.
2. Runs the same geometry without symmetry.
3. Asserts both produce the same force values (within tolerance).