### PR TITLE
Cache `maxwell_data` across `get_eigenmode_coefficients` calls

### DIFF
--- a/python/meep.i
+++ b/python/meep.i
@@ -534,7 +534,8 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
 
     f->get_eigenmode_coefficients(*flux, eig_vol, bands, num_bands, parity, eig_resolution, eigensolver_tol,
                                   coeffs, vgrp, user_kpoint_func, user_kpoint_data, kpoints, kdom, cscale, d,
-                                  NULL, &flux->eigenmode_cache);
+                                  NULL, &flux->eigenmode_cache,
+                                  &flux->eigenmode_cache_dispersive, &flux->eigenmode_cache_frequency);
 
     kpoint_list res = {kpoints, num_kpoints, kdom, num_kpoints};
 
@@ -552,7 +553,8 @@ kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_fl
     meep::vec *kdom = new meep::vec[num_kpoints];
     f->get_eigenmode_coefficients(*flux, eig_vol, NULL, 1, parity, eig_resolution, eigensolver_tol,
                                   coeffs, vgrp, user_kpoint_func, user_kpoint_data, kpoints, kdom, cscale, d,
-                                  &dp, &flux->eigenmode_cache);
+                                  &dp, &flux->eigenmode_cache,
+                                  &flux->eigenmode_cache_dispersive, &flux->eigenmode_cache_frequency);
 
     kpoint_list res = {kpoints, num_kpoints, kdom, num_kpoints};
 

--- a/python/meep.i
+++ b/python/meep.i
@@ -522,35 +522,37 @@ struct kpoint_list {
     size_t num_bands;
 };
 
-kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_flux flux, const meep::volume &eig_vol,
+kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_flux *flux, const meep::volume &eig_vol,
                                                    int *bands, int num_bands, int parity, double eig_resolution,
                                                    double eigensolver_tol, std::complex<double> *coeffs,
                                                    double *vgrp, meep::kpoint_func user_kpoint_func,
                                                    void *user_kpoint_data, double *cscale, meep::direction d) {
 
-    size_t num_kpoints = num_bands * flux.freq.size();
+    size_t num_kpoints = num_bands * flux->freq.size();
     meep::vec *kpoints = new meep::vec[num_kpoints];
     meep::vec *kdom = new meep::vec[num_kpoints];
 
-    f->get_eigenmode_coefficients(flux, eig_vol, bands, num_bands, parity, eig_resolution, eigensolver_tol,
-                                  coeffs, vgrp, user_kpoint_func, user_kpoint_data, kpoints, kdom, cscale, d);
+    f->get_eigenmode_coefficients(*flux, eig_vol, bands, num_bands, parity, eig_resolution, eigensolver_tol,
+                                  coeffs, vgrp, user_kpoint_func, user_kpoint_data, kpoints, kdom, cscale, d,
+                                  NULL, &flux->eigenmode_cache);
 
     kpoint_list res = {kpoints, num_kpoints, kdom, num_kpoints};
 
     return res;
 }
 
-kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_flux flux, const meep::volume &eig_vol,
+kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_flux *flux, const meep::volume &eig_vol,
                                                    meep::diffractedplanewave dp, int parity, double eig_resolution,
                                                    double eigensolver_tol, std::complex<double> *coeffs,
                                                    double *vgrp, meep::kpoint_func user_kpoint_func,
                                                    void *user_kpoint_data, double *cscale, meep::direction d) {
 
-    size_t num_kpoints = flux.freq.size();
+    size_t num_kpoints = flux->freq.size();
     meep::vec *kpoints = new meep::vec[num_kpoints];
     meep::vec *kdom = new meep::vec[num_kpoints];
-    f->get_eigenmode_coefficients(flux, eig_vol, NULL, 1, parity, eig_resolution, eigensolver_tol,
-                                  coeffs, vgrp, user_kpoint_func, user_kpoint_data, kpoints, kdom, cscale, d, &dp);
+    f->get_eigenmode_coefficients(*flux, eig_vol, NULL, 1, parity, eig_resolution, eigensolver_tol,
+                                  coeffs, vgrp, user_kpoint_func, user_kpoint_data, kpoints, kdom, cscale, d,
+                                  &dp, &flux->eigenmode_cache);
 
     kpoint_list res = {kpoints, num_kpoints, kdom, num_kpoints};
 
@@ -1656,13 +1658,13 @@ void _get_eigenmode(meep::fields *f, double frequency, meep::direction d, const 
 extern boolean point_in_objectp(vector3 p, GEOMETRIC_OBJECT o);
 extern boolean point_in_periodic_objectp(vector3 p, GEOMETRIC_OBJECT o);
 void display_geometric_object_info(int indentby, GEOMETRIC_OBJECT o);
-kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_flux flux,
+kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_flux *flux,
                                                    const meep::volume &eig_vol, int *bands, int num_bands,
                                                    int parity, double eig_resolution, double eigensolver_tol,
                                                    std::complex<double> *coeffs, double *vgrp,
                                                    meep::kpoint_func user_kpoint_func, void *user_kpoint_data,
                                                    double *cscale, meep::direction d);
-kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_flux flux,
+kpoint_list get_eigenmode_coefficients_and_kpoints(meep::fields *f, meep::dft_flux *flux,
                                                    const meep::volume &eig_vol, meep::diffractedplanewave dp,
                                                    int parity, double eig_resolution, double eigensolver_tol,
                                                    std::complex<double> *coeffs, double *vgrp,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2077,15 +2077,20 @@ class Simulation:
             absorbers,
             self.extra_materials,
             self.split_chunks_evenly,
-            False
-            if self.chunk_layout
-            and not isinstance(self.chunk_layout, mp.BinaryPartition)
-            else True,
+            (
+                False
+                if self.chunk_layout
+                and not isinstance(self.chunk_layout, mp.BinaryPartition)
+                else True
+            ),
             None,
             True if self._output_stats is not None else False,
-            self.chunk_layout
-            if self.chunk_layout and isinstance(self.chunk_layout, mp.BinaryPartition)
-            else None,
+            (
+                self.chunk_layout
+                if self.chunk_layout
+                and isinstance(self.chunk_layout, mp.BinaryPartition)
+                else None
+            ),
         )
         self.geps = mp._set_materials(
             self.structure,
@@ -2897,17 +2902,21 @@ class Simulation:
         pts = [s.center for s in self.sources]
 
         src_freqs_min = min(
-            s.src.frequency - 1 / s.src.width / 2
-            if isinstance(s.src, mp.GaussianSource)
-            else mp.inf
+            (
+                s.src.frequency - 1 / s.src.width / 2
+                if isinstance(s.src, mp.GaussianSource)
+                else mp.inf
+            )
             for s in self.sources
         )
         fmin = max(0, src_freqs_min)
 
         fmax = max(
-            s.src.frequency + 1 / s.src.width / 2
-            if isinstance(s.src, mp.GaussianSource)
-            else 0
+            (
+                s.src.frequency + 1 / s.src.width / 2
+                if isinstance(s.src, mp.GaussianSource)
+                else 0
+            )
             for s in self.sources
         )
 

--- a/python/tests/test_binary_grating.py
+++ b/python/tests/test_binary_grating.py
@@ -389,13 +389,15 @@ class TestEigCoeffs(unittest.TestCase):
                 res2 = sim.get_eigenmode_coefficients(tran_flux, dp)
                 power1 = abs(res1.alpha[0, 0, 0]) ** 2
                 power2 = abs(res2.alpha[0, 0, 0]) ** 2
-                self.assertAlmostEqual(
-                    power2 / max(power1, 1e-30),
-                    1.0,
-                    places=5,
-                    msg=f"eigenmode_cache mismatch for order {nm}, "
-                    f"{'S' if S_pol else 'P'}-pol",
-                )
+                # Skip comparison when both values are negligible (noise).
+                if max(power1, power2) > 1e-20:
+                    self.assertAlmostEqual(
+                        power2 / power1,
+                        1.0,
+                        places=5,
+                        msg=f"eigenmode_cache mismatch for order {nm}, "
+                        f"{'S' if S_pol else 'P'}-pol",
+                    )
 
 
 if __name__ == "__main__":

--- a/python/tests/test_binary_grating.py
+++ b/python/tests/test_binary_grating.py
@@ -389,7 +389,6 @@ class TestEigCoeffs(unittest.TestCase):
                 res2 = sim.get_eigenmode_coefficients(tran_flux, dp)
                 power1 = abs(res1.alpha[0, 0, 0]) ** 2
                 power2 = abs(res2.alpha[0, 0, 0]) ** 2
-                # Skip comparison when both values are negligible (noise).
                 if max(power1, power2) > 1e-20:
                     self.assertAlmostEqual(
                         power2 / power1,

--- a/python/tests/test_binary_grating.py
+++ b/python/tests/test_binary_grating.py
@@ -375,6 +375,28 @@ class TestEigCoeffs(unittest.TestCase):
         self.assertAlmostEqual(Tsum, Tflux, places=2)
         self.assertAlmostEqual(Rsum + Tsum, 1.00, places=2)
 
+        # Verify eigenmode_cache produces identical results on repeated calls.
+        # The first call creates the cache; the second call reuses it.
+        for nm in range(nm_t):
+            for S_pol in [False, True]:
+                dp = mp.DiffractedPlanewave(
+                    [0, nm, 0],
+                    mp.Vector3(1, 0, 0),
+                    1 if S_pol else 0,
+                    0 if S_pol else 1,
+                )
+                res1 = sim.get_eigenmode_coefficients(tran_flux, dp)
+                res2 = sim.get_eigenmode_coefficients(tran_flux, dp)
+                power1 = abs(res1.alpha[0, 0, 0]) ** 2
+                power2 = abs(res2.alpha[0, 0, 0]) ** 2
+                self.assertAlmostEqual(
+                    power2 / max(power1, 1e-30),
+                    1.0,
+                    places=5,
+                    msg=f"eigenmode_cache mismatch for order {nm}, "
+                    f"{'S' if S_pol else 'P'}-pol",
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -144,6 +144,7 @@ dft_chunk::~dft_chunk() {
 }
 
 void dft_flux::remove() {
+  invalidate_eigenmode_cache();
   while (E) {
     dft_chunk *nxt = E->next_in_dft;
     delete E;
@@ -499,7 +500,7 @@ dft_flux::dft_flux(const component cE_, const component cH_, dft_chunk *E_, dft_
                    double fmin, double fmax, int Nf, const volume &where_,
                    direction normal_direction_, bool use_symmetry_)
     : E(E_), H(H_), cE(cE_), cH(cH_), where(where_), normal_direction(normal_direction_),
-      use_symmetry(use_symmetry_) {
+      use_symmetry(use_symmetry_), eigenmode_cache(NULL) {
   freq = meep::linspace(fmin, fmax, Nf);
 }
 
@@ -507,7 +508,7 @@ dft_flux::dft_flux(const component cE_, const component cH_, dft_chunk *E_, dft_
                    const std::vector<double> &freq_, const volume &where_,
                    direction normal_direction_, bool use_symmetry_)
     : E(E_), H(H_), cE(cE_), cH(cH_), where(where_), normal_direction(normal_direction_),
-      use_symmetry(use_symmetry_) {
+      use_symmetry(use_symmetry_), eigenmode_cache(NULL) {
   freq = freq_;
 }
 
@@ -515,7 +516,7 @@ dft_flux::dft_flux(const component cE_, const component cH_, dft_chunk *E_, dft_
                    const double *freq_, size_t Nfreq, const volume &where_,
                    direction normal_direction_, bool use_symmetry_)
     : freq(Nfreq), E(E_), H(H_), cE(cE_), cH(cH_), where(where_),
-      normal_direction(normal_direction_), use_symmetry(use_symmetry_) {
+      normal_direction(normal_direction_), use_symmetry(use_symmetry_), eigenmode_cache(NULL) {
   for (size_t i = 0; i < Nfreq; ++i)
     freq[i] = freq_[i];
 }
@@ -528,7 +529,10 @@ dft_flux::dft_flux(const dft_flux &f) : where(f.where) {
   cH = f.cH;
   normal_direction = f.normal_direction;
   use_symmetry = f.use_symmetry;
+  eigenmode_cache = NULL; // don't share cache across copies
 }
+
+dft_flux::~dft_flux() { invalidate_eigenmode_cache(); }
 
 double *dft_flux::flux() {
   const size_t Nfreq = freq.size();

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -500,7 +500,8 @@ dft_flux::dft_flux(const component cE_, const component cH_, dft_chunk *E_, dft_
                    double fmin, double fmax, int Nf, const volume &where_,
                    direction normal_direction_, bool use_symmetry_)
     : E(E_), H(H_), cE(cE_), cH(cH_), where(where_), normal_direction(normal_direction_),
-      use_symmetry(use_symmetry_), eigenmode_cache(NULL) {
+      use_symmetry(use_symmetry_), eigenmode_cache(NULL),
+      eigenmode_cache_dispersive(false), eigenmode_cache_frequency(0) {
   freq = meep::linspace(fmin, fmax, Nf);
 }
 
@@ -508,7 +509,8 @@ dft_flux::dft_flux(const component cE_, const component cH_, dft_chunk *E_, dft_
                    const std::vector<double> &freq_, const volume &where_,
                    direction normal_direction_, bool use_symmetry_)
     : E(E_), H(H_), cE(cE_), cH(cH_), where(where_), normal_direction(normal_direction_),
-      use_symmetry(use_symmetry_), eigenmode_cache(NULL) {
+      use_symmetry(use_symmetry_), eigenmode_cache(NULL),
+      eigenmode_cache_dispersive(false), eigenmode_cache_frequency(0) {
   freq = freq_;
 }
 
@@ -516,7 +518,8 @@ dft_flux::dft_flux(const component cE_, const component cH_, dft_chunk *E_, dft_
                    const double *freq_, size_t Nfreq, const volume &where_,
                    direction normal_direction_, bool use_symmetry_)
     : freq(Nfreq), E(E_), H(H_), cE(cE_), cH(cH_), where(where_),
-      normal_direction(normal_direction_), use_symmetry(use_symmetry_), eigenmode_cache(NULL) {
+      normal_direction(normal_direction_), use_symmetry(use_symmetry_), eigenmode_cache(NULL),
+      eigenmode_cache_dispersive(false), eigenmode_cache_frequency(0) {
   for (size_t i = 0; i < Nfreq; ++i)
     freq[i] = freq_[i];
 }
@@ -530,6 +533,8 @@ dft_flux::dft_flux(const dft_flux &f) : where(f.where) {
   normal_direction = f.normal_direction;
   use_symmetry = f.use_symmetry;
   eigenmode_cache = NULL; // don't share cache across copies
+  eigenmode_cache_dispersive = false;
+  eigenmode_cache_frequency = 0;
 }
 
 dft_flux::~dft_flux() { invalidate_eigenmode_cache(); }

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -500,8 +500,8 @@ dft_flux::dft_flux(const component cE_, const component cH_, dft_chunk *E_, dft_
                    double fmin, double fmax, int Nf, const volume &where_,
                    direction normal_direction_, bool use_symmetry_)
     : E(E_), H(H_), cE(cE_), cH(cH_), where(where_), normal_direction(normal_direction_),
-      use_symmetry(use_symmetry_), eigenmode_cache(NULL),
-      eigenmode_cache_dispersive(false), eigenmode_cache_frequency(0) {
+      use_symmetry(use_symmetry_), eigenmode_cache(NULL), eigenmode_cache_dispersive(false),
+      eigenmode_cache_frequency(0) {
   freq = meep::linspace(fmin, fmax, Nf);
 }
 
@@ -509,8 +509,8 @@ dft_flux::dft_flux(const component cE_, const component cH_, dft_chunk *E_, dft_
                    const std::vector<double> &freq_, const volume &where_,
                    direction normal_direction_, bool use_symmetry_)
     : E(E_), H(H_), cE(cE_), cH(cH_), where(where_), normal_direction(normal_direction_),
-      use_symmetry(use_symmetry_), eigenmode_cache(NULL),
-      eigenmode_cache_dispersive(false), eigenmode_cache_frequency(0) {
+      use_symmetry(use_symmetry_), eigenmode_cache(NULL), eigenmode_cache_dispersive(false),
+      eigenmode_cache_frequency(0) {
   freq = freq_;
 }
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1272,8 +1272,8 @@ public:
   volume where;
   direction normal_direction;
   bool use_symmetry;
-  void *eigenmode_cache; // opaque pointer to cached maxwell_data (NULL if none)
-  bool eigenmode_cache_dispersive; // whether the cached medium is frequency-dependent
+  void *eigenmode_cache;            // opaque pointer to cached maxwell_data (NULL if none)
+  bool eigenmode_cache_dispersive;  // whether the cached medium is frequency-dependent
   double eigenmode_cache_frequency; // frequency at which the cache was built
 };
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1273,6 +1273,8 @@ public:
   direction normal_direction;
   bool use_symmetry;
   void *eigenmode_cache; // opaque pointer to cached maxwell_data (NULL if none)
+  bool eigenmode_cache_dispersive; // whether the cached medium is frequency-dependent
+  double eigenmode_cache_frequency; // frequency at which the cache was built
 };
 
 // dft.cpp (normally created with fields::add_dft_energy)
@@ -1943,7 +1945,8 @@ public:
   void *get_eigenmode(double frequency, direction d, const volume where, const volume eig_vol,
                       int band_num, const vec &kpoint, bool match_frequency, int parity,
                       double resolution, double eigensolver_tol, double *kdom = 0,
-                      void **user_mdata = 0, diffractedplanewave *dp = 0);
+                      void **user_mdata = 0, diffractedplanewave *dp = 0,
+                      bool *cache_dispersive = 0, double *cache_frequency = 0);
 
   void add_eigenmode_source(component c, const src_time &src, direction d, const volume &where,
                             const volume &eig_vol, int band_num, const vec &kpoint,
@@ -1956,7 +1959,8 @@ public:
                                   std::complex<double> *coeffs, double *vgrp,
                                   kpoint_func user_kpoint_func, void *user_kpoint_data,
                                   vec *kpoints, vec *kdom, double *cscale, direction d,
-                                  diffractedplanewave *dp = 0, void **eigenmode_cache = 0);
+                                  diffractedplanewave *dp = 0, void **eigenmode_cache = 0,
+                                  bool *cache_dispersive = 0, double *cache_frequency = 0);
   void get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, int *bands, int num_bands,
                                   int parity, double eig_resolution, double eigensolver_tol,
                                   std::complex<double> *coeffs, double *vgrp,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1948,6 +1948,8 @@ public:
                       double resolution, double eigensolver_tol, double *kdom = 0,
                       void **user_mdata = 0, diffractedplanewave *dp = 0,
                       bool *cache_dispersive = 0, double *cache_frequency = 0);
+  bool populate_maxwell_dielectric(void *mdata, int mesh_size[3], double R[3][3], double G[3][3],
+                                   const double *s, const double *o, double frequency);
 
   void add_eigenmode_source(component c, const src_time &src, direction d, const volume &where,
                             const volume &eig_vol, int band_num, const vec &kpoint,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1943,8 +1943,7 @@ public:
   void *get_eigenmode(double frequency, direction d, const volume where, const volume eig_vol,
                       int band_num, const vec &kpoint, bool match_frequency, int parity,
                       double resolution, double eigensolver_tol, double *kdom = 0,
-                      void **user_mdata = 0, diffractedplanewave *dp = 0,
-                      bool skip_phase_fix = false);
+                      void **user_mdata = 0, diffractedplanewave *dp = 0);
 
   void add_eigenmode_source(component c, const src_time &src, direction d, const volume &where,
                             const volume &eig_vol, int band_num, const vec &kpoint,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1242,6 +1242,7 @@ public:
            const double *freq_, size_t Nfreq, const volume &where_, direction normal_direction_,
            bool use_symmetry_);
   dft_flux(const dft_flux &f);
+  ~dft_flux();
 
   double *flux();
   std::vector<std::complex<double> > complexflux();
@@ -1261,12 +1262,17 @@ public:
 
   void remove();
 
+  // Cached MPB maxwell_data for reuse across get_eigenmode_coefficients calls.
+  // Avoids redundant epsilon grid computation when extracting many diffraction orders.
+  void invalidate_eigenmode_cache();
+
   std::vector<double> freq;
   dft_chunk *E, *H;
   component cE, cH;
   volume where;
   direction normal_direction;
   bool use_symmetry;
+  void *eigenmode_cache; // opaque pointer to cached maxwell_data (NULL if none)
 };
 
 // dft.cpp (normally created with fields::add_dft_energy)
@@ -1937,7 +1943,8 @@ public:
   void *get_eigenmode(double frequency, direction d, const volume where, const volume eig_vol,
                       int band_num, const vec &kpoint, bool match_frequency, int parity,
                       double resolution, double eigensolver_tol, double *kdom = 0,
-                      void **user_mdata = 0, diffractedplanewave *dp = 0);
+                      void **user_mdata = 0, diffractedplanewave *dp = 0,
+                      bool skip_phase_fix = false);
 
   void add_eigenmode_source(component c, const src_time &src, direction d, const volume &where,
                             const volume &eig_vol, int band_num, const vec &kpoint,
@@ -1950,7 +1957,7 @@ public:
                                   std::complex<double> *coeffs, double *vgrp,
                                   kpoint_func user_kpoint_func, void *user_kpoint_data,
                                   vec *kpoints, vec *kdom, double *cscale, direction d,
-                                  diffractedplanewave *dp = 0);
+                                  diffractedplanewave *dp = 0, void **eigenmode_cache = 0);
   void get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, int *bands, int num_bands,
                                   int parity, double eig_resolution, double eigensolver_tol,
                                   std::complex<double> *coeffs, double *vgrp,

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -632,9 +632,10 @@ public:
   void remove_susceptibilities();
 
   // monitor.cpp
-  std::complex<double> get_chi1inv_at_pt(component, direction, int idx, double frequency = 0) const;
-  std::complex<double> get_chi1inv(component, direction, const ivec &iloc,
-                                   double frequency = 0) const;
+  std::complex<double> get_chi1inv_at_pt(component, direction, int idx, double frequency = 0,
+                                         bool *is_frequency_dependent = NULL) const;
+  std::complex<double> get_chi1inv(component, direction, const ivec &iloc, double frequency = 0,
+                                   bool *is_frequency_dependent = NULL) const;
   std::complex<double> get_inveps(component c, direction d, const ivec &iloc,
                                   double frequency = 0) const {
     return get_chi1inv(c, d, iloc, frequency);
@@ -883,9 +884,9 @@ public:
 
   // monitor.cpp
   std::complex<double> get_chi1inv(component, direction, const ivec &origloc, double frequency = 0,
-                                   bool parallel = true) const;
+                                   bool parallel = true, bool *is_frequency_dependent = NULL) const;
   std::complex<double> get_chi1inv(component, direction, const vec &loc, double frequency = 0,
-                                   bool parallel = true) const;
+                                   bool parallel = true, bool *is_frequency_dependent = NULL) const;
   std::complex<double> get_inveps(component c, direction d, const ivec &origloc,
                                   double frequency = 0) const {
     return get_chi1inv(c, d, origloc, frequency);
@@ -1541,8 +1542,8 @@ public:
   // monitor.cpp
   std::complex<double> get_field(component, const ivec &) const;
 
-  std::complex<double> get_chi1inv(component, direction, const ivec &iloc,
-                                   double frequency = 0) const;
+  std::complex<double> get_chi1inv(component, direction, const ivec &iloc, double frequency = 0,
+                                   bool *is_frequency_dependent = NULL) const;
   // Returns the vector of sources volumes for field type `ft`.
   const std::vector<src_vol> &get_sources(field_type ft) const { return sources[ft]; }
   // Adds a source volume of field type `ft` and takes ownership of `src`.
@@ -2197,7 +2198,7 @@ public:
                                 int decimation_factor = 0, int Nperiods = 1);
   // monitor.cpp
   std::complex<double> get_chi1inv(component, direction, const vec &loc, double frequency = 0,
-                                   bool parallel = true) const;
+                                   bool parallel = true, bool *is_frequency_dependent = NULL) const;
   std::complex<double> get_inveps(component c, direction d, const vec &loc,
                                   double frequency = 0) const {
     return get_chi1inv(c, d, loc, frequency);
@@ -2305,7 +2306,7 @@ public:
   // monitor.cpp
   std::complex<double> get_field(component c, const ivec &iloc, bool parallel = true) const;
   std::complex<double> get_chi1inv(component, direction, const ivec &iloc, double frequency = 0,
-                                   bool parallel = true) const;
+                                   bool parallel = true, bool *is_frequency_dependent = NULL) const;
   // boundaries.cpp
   bool locate_component_point(component *, ivec *, std::complex<double> *) const;
   // time.cpp

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -164,7 +164,7 @@ complex<double> fields_chunk::get_field(component c, const ivec &iloc) const {
 }
 
 complex<double> fields::get_chi1inv(component c, direction d, const ivec &origloc, double frequency,
-                                    bool parallel) const {
+                                    bool parallel, bool *is_frequency_dependent) const {
   ivec iloc = origloc;
   complex<double> aaack = 1.0;
   locate_point_in_user_volume(&iloc, &aaack);
@@ -173,7 +173,8 @@ complex<double> fields::get_chi1inv(component c, direction d, const ivec &origlo
       if (chunks[i]->gv.owns(S.transform(iloc, sn))) {
         signed_direction ds = S.transform(d, sn);
         complex<double> val =
-            chunks[i]->get_chi1inv(S.transform(c, sn), ds.d, S.transform(iloc, sn), frequency) *
+            chunks[i]->get_chi1inv(S.transform(c, sn), ds.d, S.transform(iloc, sn), frequency,
+                                   is_frequency_dependent) *
             complex<double>(ds.flipped ^ S.transform(component_direction(c), sn).flipped ? -1 : 1,
                             0);
         return parallel ? sum_to_all(val) : val;
@@ -184,18 +185,18 @@ complex<double> fields::get_chi1inv(component c, direction d, const ivec &origlo
 }
 
 complex<double> fields_chunk::get_chi1inv(component c, direction d, const ivec &iloc,
-                                          double frequency) const {
-  return s->get_chi1inv(c, d, iloc, frequency);
+                                          double frequency, bool *is_frequency_dependent) const {
+  return s->get_chi1inv(c, d, iloc, frequency, is_frequency_dependent);
 }
 
 complex<double> fields::get_chi1inv(component c, direction d, const vec &loc, double frequency,
-                                    bool parallel) const {
+                                    bool parallel, bool *is_frequency_dependent) const {
   ivec ilocs[8];
   double w[8];
   complex<double> res(0.0, 0.0);
   gv.interpolate(c, loc, ilocs, w);
   for (int argh = 0; argh < 8 && w[argh] != 0; argh++)
-    res += w[argh] * get_chi1inv(c, d, ilocs[argh], frequency, false);
+    res += w[argh] * get_chi1inv(c, d, ilocs[argh], frequency, false, is_frequency_dependent);
   return parallel ? sum_to_all(res) : res;
 }
 
@@ -224,14 +225,16 @@ complex<double> fields::get_mu(const vec &loc, double frequency) const {
 }
 
 complex<double> structure::get_chi1inv(component c, direction d, const ivec &origloc,
-                                       double frequency, bool parallel) const {
+                                       double frequency, bool parallel,
+                                       bool *is_frequency_dependent) const {
   ivec iloc = origloc;
   for (int sn = 0; sn < S.multiplicity(); sn++)
     for (int i = 0; i < num_chunks; i++)
       if (chunks[i]->gv.owns(S.transform(iloc, sn))) {
         signed_direction ds = S.transform(d, sn);
         complex<double> val =
-            chunks[i]->get_chi1inv(S.transform(c, sn), ds.d, S.transform(iloc, sn), frequency) *
+            chunks[i]->get_chi1inv(S.transform(c, sn), ds.d, S.transform(iloc, sn), frequency,
+                                   is_frequency_dependent) *
             complex<double>((ds.flipped ^ S.transform(component_direction(c), sn).flipped ? -1 : 1),
                             0);
         return parallel ? sum_to_all(val) : val;
@@ -261,9 +264,11 @@ void matrix_invert(std::complex<double> (&Vinv)[9], std::complex<double> (&V)[9]
 }
 
 complex<double> structure_chunk::get_chi1inv_at_pt(component c, direction d, int idx,
-                                                   double frequency) const {
+                                                   double frequency,
+                                                   bool *is_frequency_dependent) const {
   complex<double> res(0.0, 0.0);
   if (is_mine()) {
+    if (is_frequency_dependent) *is_frequency_dependent = false;
     if (frequency == 0)
       return chi1inv[c][d] ? chi1inv[c][d][idx] : (d == component_direction(c) ? 1.0 : 0);
     // ----------------------------------------------------------------- //
@@ -339,6 +344,7 @@ complex<double> structure_chunk::get_chi1inv_at_pt(component c, direction d, int
         while (my_sus) {
           if (my_sus->sigma[cc][dd]) {
             double sigma = my_sus->sigma[cc][dd][idx];
+            if (sigma != 0 && is_frequency_dependent) *is_frequency_dependent = true;
             eps += my_sus->chi1(frequency, sigma);
           }
           my_sus = my_sus->next;
@@ -347,6 +353,7 @@ complex<double> structure_chunk::get_chi1inv_at_pt(component c, direction d, int
         // Account for conductivity term
         if (conductivity[cc][dd]) {
           double conductivityCur = conductivity[cc][dd][idx];
+          if (conductivityCur != 0 && is_frequency_dependent) *is_frequency_dependent = true;
           eps = std::complex<double>(1.0, (conductivityCur / frequency)) * eps;
         }
         chi1_tensor[com_it + 3 * dir_int] = eps;
@@ -364,18 +371,18 @@ complex<double> structure_chunk::get_chi1inv_at_pt(component c, direction d, int
 }
 
 complex<double> structure_chunk::get_chi1inv(component c, direction d, const ivec &iloc,
-                                             double frequency) const {
-  return get_chi1inv_at_pt(c, d, gv.index(c, iloc), frequency);
+                                             double frequency, bool *is_frequency_dependent) const {
+  return get_chi1inv_at_pt(c, d, gv.index(c, iloc), frequency, is_frequency_dependent);
 }
 
 complex<double> structure::get_chi1inv(component c, direction d, const vec &loc, double frequency,
-                                       bool parallel) const {
+                                       bool parallel, bool *is_frequency_dependent) const {
   ivec ilocs[8];
   double w[8];
   complex<double> res(0.0, 0.0);
   gv.interpolate(c, loc, ilocs, w);
   for (int argh = 0; argh < 8 && w[argh] != 0; argh++)
-    res += w[argh] * get_chi1inv(c, d, ilocs[argh], frequency, false);
+    res += w[argh] * get_chi1inv(c, d, ilocs[argh], frequency, false, is_frequency_dependent);
   return parallel ? sum_to_all(res) : res;
 }
 

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -268,7 +268,6 @@ complex<double> structure_chunk::get_chi1inv_at_pt(component c, direction d, int
                                                    bool *is_frequency_dependent) const {
   complex<double> res(0.0, 0.0);
   if (is_mine()) {
-    if (is_frequency_dependent) *is_frequency_dependent = false;
     if (frequency == 0)
       return chi1inv[c][d] ? chi1inv[c][d][idx] : (d == component_direction(c) ? 1.0 : 0);
     // ----------------------------------------------------------------- //

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -1137,7 +1137,8 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
                                         double *vgrp, kpoint_func user_kpoint_func,
                                         void *user_kpoint_data, vec *kpoints, vec *kdom,
                                         double *cscale, direction d, diffractedplanewave *dp,
-                                        void **eigenmode_cache) {
+                                        void **eigenmode_cache, bool *cache_dispersive,
+                                        double *cache_frequency) {
   (void)flux;
   (void)eig_vol;
   (void)bands;
@@ -1155,6 +1156,8 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
   (void)d;
   (void)dp;
   (void)eigenmode_cache;
+  (void)cache_dispersive;
+  (void)cache_frequency;
   meep::abort("Meep must be configured/compiled with MPB for get_eigenmode_coefficients");
 }
 

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -269,7 +269,7 @@ complex<double> eigenmode_amplitude(void *vedata, const vec &p, component c) {
 
   /* define a macro to give us data(x,y,z) on the grid,
      in row-major order (the order used by MPB): */
-#define D(x, y, z) (data[(((x) * ny + (y)) * nz + (z)) * 3])
+#define D(x, y, z) (data[(((x)*ny + (y)) * nz + (z)) * 3])
   complex<mpb_real> ret;
   ret = (((D(x, y, z) * (1.0 - dx) + D(x2, y, z) * dx) * (1.0 - dy) +
           (D(x, y2, z) * (1.0 - dx) + D(x2, y2, z) * dx) * dy) *

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -332,7 +332,7 @@ void special_kz_phasefix(eigenmode_data *edata, bool phase_flip) {
 void *fields::get_eigenmode(double frequency, direction d, const volume where, const volume eig_vol,
                             int band_num, const vec &_kpoint, bool match_frequency, int parity,
                             double resolution, double eigensolver_tol, double *kdom,
-                            void **user_mdata, diffractedplanewave *dp, bool skip_phase_fix) {
+                            void **user_mdata, diffractedplanewave *dp) {
   /*--------------------------------------------------------------*/
   /*- part 1: preliminary setup for calling MPB  -----------------*/
   /*--------------------------------------------------------------*/
@@ -723,11 +723,8 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
 
   maxwell_compute_h_from_H(mdata, H, (scalar_complex *)cdata, band_num - 1, 1);
   /* choose deterministic phase, maximizing power in real part;
-     see fix_field_phase routine in MPB.
-     For DiffractedPlanewave mode decomposition we can skip this because
-     |alpha|^2 is phase-invariant: the mode-mode self-overlap normfac
-     cancels out any global phase factor. */
-  if (!skip_phase_fix) {
+     see fix_field_phase routine in MPB.*/
+  {
     int i, N = mdata->fft_output_size * 3;
     double sq_sum0 = 0, sq_sum1 = 0, maxabs = 0.0;
     double theta;
@@ -974,8 +971,7 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
       am_now_working_on(MPBTime);
       void *mode_data =
           get_eigenmode(flux.freq[nf], d, flux.where, eig_vol, band_num, kpoint, match_frequency,
-                        parity, eig_resolution, eigensolver_tol, kdom, (void **)&mdata, dp,
-                        dp != NULL /* skip_phase_fix for DiffractedPlanewave */);
+                        parity, eig_resolution, eigensolver_tol, kdom, (void **)&mdata, dp);
       finished_working();
       if (!mode_data) { // mode not found, assume evanescent
         coeffs[2 * nb * num_freqs + 2 * nf] = coeffs[2 * nb * num_freqs + 2 * nf + 1] = 0;
@@ -1039,7 +1035,7 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
 void *fields::get_eigenmode(double frequency, direction d, const volume where, const volume eig_vol,
                             int band_num, const vec &kpoint, bool match_frequency, int parity,
                             double resolution, double eigensolver_tol, double *kdom,
-                            void **user_mdata, diffractedplanewave *dp, bool skip_phase_fix) {
+                            void **user_mdata, diffractedplanewave *dp) {
 
   (void)frequency;
   (void)d;

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -332,7 +332,7 @@ void special_kz_phasefix(eigenmode_data *edata, bool phase_flip) {
 void *fields::get_eigenmode(double frequency, direction d, const volume where, const volume eig_vol,
                             int band_num, const vec &_kpoint, bool match_frequency, int parity,
                             double resolution, double eigensolver_tol, double *kdom,
-                            void **user_mdata, diffractedplanewave *dp) {
+                            void **user_mdata, diffractedplanewave *dp, bool skip_phase_fix) {
   /*--------------------------------------------------------------*/
   /*- part 1: preliminary setup for calling MPB  -----------------*/
   /*--------------------------------------------------------------*/
@@ -723,8 +723,11 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
 
   maxwell_compute_h_from_H(mdata, H, (scalar_complex *)cdata, band_num - 1, 1);
   /* choose deterministic phase, maximizing power in real part;
-     see fix_field_phase routine in MPB.*/
-  {
+     see fix_field_phase routine in MPB.
+     For DiffractedPlanewave mode decomposition we can skip this because
+     |alpha|^2 is phase-invariant: the mode-mode self-overlap normfac
+     cancels out any global phase factor. */
+  if (!skip_phase_fix) {
     int i, N = mdata->fft_output_size * 3;
     double sq_sum0 = 0, sq_sum1 = 0, maxabs = 0.0;
     double theta;
@@ -820,6 +823,13 @@ void destroy_eigenmode_data(void *vedata, bool destroy_mdata) {
   if (destroy_mdata) destroy_maxwell_data(edata->mdata);
   free(edata->fft_data_E);
   delete edata;
+}
+
+void dft_flux::invalidate_eigenmode_cache() {
+  if (eigenmode_cache) {
+    destroy_maxwell_data((maxwell_data *)eigenmode_cache);
+    eigenmode_cache = NULL;
+  }
 }
 
 double get_group_velocity(void *vedata) {
@@ -937,7 +947,8 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
                                         double eigensolver_tol, std::complex<double> *coeffs,
                                         double *vgrp, kpoint_func user_kpoint_func,
                                         void *user_kpoint_data, vec *kpoints, vec *kdom_list,
-                                        double *cscale, direction d, diffractedplanewave *dp) {
+                                        double *cscale, direction d, diffractedplanewave *dp,
+                                        void **eigenmode_cache) {
   adjust_mpb_verbosity amv;
   int num_freqs = flux.freq.size();
   bool match_frequency = true;
@@ -947,8 +958,9 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
 
   vec kpoint(0.0, 0.0, 0.0); // default guess
 
-  // get_eigenmode will create mdata only once and then reuse it on each iteration of the loop
-  maxwell_data *mdata = NULL;
+  // If an external cache is provided, reuse the maxwell_data from it.
+  // Otherwise create a local one that will be destroyed at the end.
+  maxwell_data *mdata = eigenmode_cache ? (maxwell_data *)(*eigenmode_cache) : NULL;
 
   // loop over all bands and all frequencies
   for (int nb = 0; nb < num_bands; nb++) {
@@ -962,7 +974,8 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
       am_now_working_on(MPBTime);
       void *mode_data =
           get_eigenmode(flux.freq[nf], d, flux.where, eig_vol, band_num, kpoint, match_frequency,
-                        parity, eig_resolution, eigensolver_tol, kdom, (void **)&mdata, dp);
+                        parity, eig_resolution, eigensolver_tol, kdom, (void **)&mdata, dp,
+                        dp != NULL /* skip_phase_fix for DiffractedPlanewave */);
       finished_working();
       if (!mode_data) { // mode not found, assume evanescent
         coeffs[2 * nb * num_freqs + 2 * nf] = coeffs[2 * nb * num_freqs + 2 * nf + 1] = 0;
@@ -1010,7 +1023,13 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
       destroy_eigenmode_data((void *)mode_data, false);
     }
   }
-  destroy_maxwell_data(mdata);
+
+  // If an external cache was provided, store mdata back for reuse.
+  // Otherwise destroy it (no external cache to persist to).
+  if (eigenmode_cache)
+    *eigenmode_cache = (void *)mdata;
+  else
+    destroy_maxwell_data(mdata);
 }
 
 /**************************************************************/
@@ -1020,7 +1039,7 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
 void *fields::get_eigenmode(double frequency, direction d, const volume where, const volume eig_vol,
                             int band_num, const vec &kpoint, bool match_frequency, int parity,
                             double resolution, double eigensolver_tol, double *kdom,
-                            void **user_mdata, diffractedplanewave *dp) {
+                            void **user_mdata, diffractedplanewave *dp, bool skip_phase_fix) {
 
   (void)frequency;
   (void)d;
@@ -1065,7 +1084,8 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
                                         double eigensolver_tol, std::complex<double> *coeffs,
                                         double *vgrp, kpoint_func user_kpoint_func,
                                         void *user_kpoint_data, vec *kpoints, vec *kdom,
-                                        double *cscale, direction d, diffractedplanewave *dp) {
+                                        double *cscale, direction d, diffractedplanewave *dp,
+                                        void **eigenmode_cache) {
   (void)flux;
   (void)eig_vol;
   (void)bands;
@@ -1082,8 +1102,11 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
   (void)cscale;
   (void)d;
   (void)dp;
+  (void)eigenmode_cache;
   meep::abort("Meep must be configured/compiled with MPB for get_eigenmode_coefficients");
 }
+
+void dft_flux::invalidate_eigenmode_cache() { eigenmode_cache = NULL; }
 
 void destroy_eigenmode_data(void *vedata, bool destroy_mdata) {
   (void)vedata;

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -95,8 +95,10 @@ static int meep_mpb_eps(symmetric_matrix *eps, symmetric_matrix *eps_inv, mpb_re
     // Pass &is_freq_dep to detect dispersive materials directly from get_chi1inv,
     // which knows whether frequency-dependent susceptibilities were evaluated.
     cache[6 * i] = real(f->get_chi1inv(Ex, X, p, frequency, false, &eps_data->found_dispersive));
-    cache[6 * i + 1] = real(f->get_chi1inv(Ey, Y, p, frequency, false, &eps_data->found_dispersive));
-    cache[6 * i + 2] = real(f->get_chi1inv(Ez, Z, p, frequency, false, &eps_data->found_dispersive));
+    cache[6 * i + 1] =
+        real(f->get_chi1inv(Ey, Y, p, frequency, false, &eps_data->found_dispersive));
+    cache[6 * i + 2] =
+        real(f->get_chi1inv(Ez, Z, p, frequency, false, &eps_data->found_dispersive));
 
     // Off-diagonal components: average from both relevant Yee grids.
     // Each off-diagonal chi1inv component (e.g., chi1inv_xy) can be
@@ -121,6 +123,48 @@ static int meep_mpb_eps(symmetric_matrix *eps, symmetric_matrix *eps_inv, mpb_re
   eps_data->icache += 1; // next call will use the subsequent cache element
 
   return 1; // tells MPB not to do its own subpixel averaging
+}
+
+// Populate the MPB dielectric grid by sampling epsilon from the Meep fields,
+// synchronizing across MPI ranks, and passing the result to MPB.
+// Factored out to avoid duplicating this two-pass sequence for both initial
+// creation and dispersive-frequency updates of the cached maxwell_data.
+// Returns true if any sampled point has frequency-dependent (dispersive) epsilon.
+static bool populate_maxwell_dielectric(maxwell_data *mdata, int mesh_size[3], mpb_real R[3][3],
+                                        mpb_real G[3][3], const double *s, const double *o,
+                                        ndim dim, const fields *f, double frequency) {
+  meep_mpb_eps_data eps_data;
+  eps_data.s = s;
+  eps_data.o = o;
+  eps_data.dim = dim;
+  eps_data.f = f;
+  eps_data.frequency = frequency;
+  eps_data.cache = (double *)malloc(sizeof(double) * 6 * (eps_data.ncache = 512));
+  eps_data.found_dispersive = false;
+
+  // First pass: build local cache (returns dummy values to MPB)
+  eps_data.use_cache = false;
+  eps_data.icache = 0;
+  set_maxwell_dielectric(mdata, mesh_size, R, G, NULL, meep_mpb_eps, &eps_data);
+
+  // Synchronize cached epsilon data across MPI ranks
+  eps_data.ncache = eps_data.icache;
+  double *summed_cache = (double *)malloc(sizeof(double) * 6 * eps_data.ncache);
+  am_now_working_on(MpiAllTime);
+  sum_to_all(eps_data.cache, summed_cache, eps_data.ncache * 6);
+  finished_working();
+  free(eps_data.cache);
+  eps_data.cache = summed_cache;
+  eps_data.found_dispersive = or_to_all(eps_data.found_dispersive);
+
+  // Second pass: send synchronized epsilon to MPB
+  eps_data.use_cache = true;
+  eps_data.icache = 0;
+  set_maxwell_dielectric(mdata, mesh_size, R, G, NULL, meep_mpb_eps, &eps_data);
+  assert(eps_data.icache == eps_data.ncache);
+
+  free(eps_data.cache);
+  return eps_data.found_dispersive;
 }
 
 /**************************************************************/
@@ -258,7 +302,7 @@ complex<double> eigenmode_amplitude(void *vedata, const vec &p, component c) {
 
   /* define a macro to give us data(x,y,z) on the grid,
      in row-major order (the order used by MPB): */
-#define D(x, y, z) (data[(((x)*ny + (y)) * nz + (z)) * 3])
+#define D(x, y, z) (data[(((x) * ny + (y)) * nz + (z)) * 3])
   complex<mpb_real> ret;
   ret = (((D(x, y, z) * (1.0 - dx) + D(x2, y, z) * dx) * (1.0 - dy) +
           (D(x, y2, z) * (1.0 - dx) + D(x2, y2, z) * dx) * dy) *
@@ -455,43 +499,12 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
     mdata = create_maxwell_data(n[0], n[1], n[2], &local_N, &N_start, &alloc_N, band_num, band_num);
     if (local_N != n[0] * n[1] * n[2]) meep::abort("MPI version of MPB library is not supported");
 
-    meep_mpb_eps_data eps_data;
-    eps_data.s = s;
-    eps_data.o = o;
-    eps_data.dim = gv.dim;
-    eps_data.f = this;
-    eps_data.frequency = frequency;
-    eps_data.cache = (double *)malloc(sizeof(double) * 6 * (eps_data.ncache = 512));
-    eps_data.found_dispersive = false;
+    bool found_dispersive =
+        populate_maxwell_dielectric(mdata, mesh_size, R, G, s, o, gv.dim, this, frequency);
 
-    // first, build up a cache of the local epsilon data
-    // (while returning dummy values to MPB)
-    eps_data.use_cache = false;
-    eps_data.icache = 0;
-    set_maxwell_dielectric(mdata, mesh_size, R, G, NULL, meep_mpb_eps, &eps_data);
-
-    // then, synchronize the data
-    eps_data.ncache = eps_data.icache; // actual amount of cached data
-    double *summed_cache = (double *)malloc(sizeof(double) * 6 * eps_data.ncache);
-    am_now_working_on(MpiAllTime);
-    sum_to_all(eps_data.cache, summed_cache, eps_data.ncache * 6);
-    finished_working();
-    free(eps_data.cache);
-    eps_data.cache = summed_cache;
-    eps_data.found_dispersive = or_to_all(eps_data.found_dispersive);
-
-    // finally, send MPB the real epsilon data using the synchronized cache
-    eps_data.use_cache = true;
-    eps_data.icache = 0;
-    set_maxwell_dielectric(mdata, mesh_size, R, G, NULL, meep_mpb_eps, &eps_data);
-    assert(eps_data.icache == eps_data.ncache);
-
-    free(eps_data.cache);
-
-    // Store dispersive flag and frequency for cache management
-    if (cache_dispersive) *cache_dispersive = eps_data.found_dispersive;
+    if (cache_dispersive) *cache_dispersive = found_dispersive;
     if (cache_frequency) *cache_frequency = frequency;
-    if (eps_data.found_dispersive && verbosity > 0)
+    if (found_dispersive && verbosity > 0)
       master_printf("Dispersive medium detected on eigenmode monitor\n");
 
     if (user_mdata) *user_mdata = (void *)mdata;
@@ -510,34 +523,8 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
         master_printf("Re-populating epsilon grid for dispersive medium at freq=%g (was %g)\n",
                       frequency, *cache_frequency);
 
-      meep_mpb_eps_data eps_data;
-      eps_data.s = s;
-      eps_data.o = o;
-      eps_data.dim = gv.dim;
-      eps_data.f = this;
-      eps_data.frequency = frequency;
-      eps_data.cache = (double *)malloc(sizeof(double) * 6 * (eps_data.ncache = 512));
-      eps_data.found_dispersive = false;
-
-      eps_data.use_cache = false;
-      eps_data.icache = 0;
-      set_maxwell_dielectric(mdata, mesh_size, R, G, NULL, meep_mpb_eps, &eps_data);
-
-      eps_data.ncache = eps_data.icache;
-      double *summed_cache = (double *)malloc(sizeof(double) * 6 * eps_data.ncache);
-      am_now_working_on(MpiAllTime);
-      sum_to_all(eps_data.cache, summed_cache, eps_data.ncache * 6);
-      finished_working();
-      free(eps_data.cache);
-      eps_data.cache = summed_cache;
-      eps_data.found_dispersive = or_to_all(eps_data.found_dispersive);
-
-      eps_data.use_cache = true;
-      eps_data.icache = 0;
-      set_maxwell_dielectric(mdata, mesh_size, R, G, NULL, meep_mpb_eps, &eps_data);
-      assert(eps_data.icache == eps_data.ncache);
-
-      free(eps_data.cache);
+      *cache_dispersive =
+          populate_maxwell_dielectric(mdata, mesh_size, R, G, s, o, gv.dim, this, frequency);
       *cache_frequency = frequency;
     }
   }

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -94,11 +94,9 @@ static int meep_mpb_eps(symmetric_matrix *eps, symmetric_matrix *eps_inv, mpb_re
     // call get_chi1inv with parallel=false to get only local epsilon data
     // Pass &is_freq_dep to detect dispersive materials directly from get_chi1inv,
     // which knows whether frequency-dependent susceptibilities were evaluated.
-    bool is_freq_dep = false;
-    cache[6 * i] = real(f->get_chi1inv(Ex, X, p, frequency, false, &is_freq_dep));
-    cache[6 * i + 1] = real(f->get_chi1inv(Ey, Y, p, frequency, false, &is_freq_dep));
-    cache[6 * i + 2] = real(f->get_chi1inv(Ez, Z, p, frequency, false, &is_freq_dep));
-    if (is_freq_dep) eps_data->found_dispersive = true;
+    cache[6 * i] = real(f->get_chi1inv(Ex, X, p, frequency, false, &eps_data->found_dispersive));
+    cache[6 * i + 1] = real(f->get_chi1inv(Ey, Y, p, frequency, false, &eps_data->found_dispersive));
+    cache[6 * i + 2] = real(f->get_chi1inv(Ez, Z, p, frequency, false, &eps_data->found_dispersive));
 
     // Off-diagonal components: average from both relevant Yee grids.
     // Each off-diagonal chi1inv component (e.g., chi1inv_xy) can be

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -269,7 +269,7 @@ complex<double> eigenmode_amplitude(void *vedata, const vec &p, component c) {
 
   /* define a macro to give us data(x,y,z) on the grid,
      in row-major order (the order used by MPB): */
-#define D(x, y, z) (data[(((x)*ny + (y)) * nz + (z)) * 3])
+#define D(x, y, z) (data[(((x) * ny + (y)) * nz + (z)) * 3])
   complex<mpb_real> ret;
   ret = (((D(x, y, z) * (1.0 - dx) + D(x2, y, z) * dx) * (1.0 - dy) +
           (D(x, y2, z) * (1.0 - dx) + D(x2, y2, z) * dx) * dy) *
@@ -349,8 +349,8 @@ void special_kz_phasefix(eigenmode_data *edata, bool phase_flip) {
 void *fields::get_eigenmode(double frequency, direction d, const volume where, const volume eig_vol,
                             int band_num, const vec &_kpoint, bool match_frequency, int parity,
                             double resolution, double eigensolver_tol, double *kdom,
-                            void **user_mdata, diffractedplanewave *dp,
-                            bool *cache_dispersive, double *cache_frequency) {
+                            void **user_mdata, diffractedplanewave *dp, bool *cache_dispersive,
+                            double *cache_frequency) {
   /*--------------------------------------------------------------*/
   /*- part 1: preliminary setup for calling MPB  -----------------*/
   /*--------------------------------------------------------------*/
@@ -1007,8 +1007,8 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
                                         double *vgrp, kpoint_func user_kpoint_func,
                                         void *user_kpoint_data, vec *kpoints, vec *kdom_list,
                                         double *cscale, direction d, diffractedplanewave *dp,
-                                        void **eigenmode_cache,
-                                        bool *cache_dispersive, double *cache_frequency) {
+                                        void **eigenmode_cache, bool *cache_dispersive,
+                                        double *cache_frequency) {
   adjust_mpb_verbosity amv;
   int num_freqs = flux.freq.size();
   bool match_frequency = true;
@@ -1032,10 +1032,9 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
       double kdom[3];
       if (user_kpoint_func) kpoint = user_kpoint_func(flux.freq[nf], band_num, user_kpoint_data);
       am_now_working_on(MPBTime);
-      void *mode_data =
-          get_eigenmode(flux.freq[nf], d, flux.where, eig_vol, band_num, kpoint, match_frequency,
-                        parity, eig_resolution, eigensolver_tol, kdom, (void **)&mdata, dp,
-                        cache_dispersive, cache_frequency);
+      void *mode_data = get_eigenmode(flux.freq[nf], d, flux.where, eig_vol, band_num, kpoint,
+                                      match_frequency, parity, eig_resolution, eigensolver_tol,
+                                      kdom, (void **)&mdata, dp, cache_dispersive, cache_frequency);
       finished_working();
       if (!mode_data) { // mode not found, assume evanescent
         coeffs[2 * nb * num_freqs + 2 * nf] = coeffs[2 * nb * num_freqs + 2 * nf + 1] = 0;

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -49,8 +49,7 @@ typedef struct {
   size_t icache;  // current position in the cache
   bool use_cache; // whether we are using the cache
 
-  // Track whether any sampled point has frequency-dependent epsilon.
-  // Detected by comparing get_chi1inv(freq=0) vs get_chi1inv(freq=frequency).
+  // Whether any sampled point has frequency-dependent epsilon.
   bool found_dispersive;
 } meep_mpb_eps_data;
 
@@ -93,22 +92,14 @@ static int meep_mpb_eps(symmetric_matrix *eps, symmetric_matrix *eps_inv, mpb_re
     const fields *f = eps_data->f;
 
     // call get_chi1inv with parallel=false to get only local epsilon data
-    cache[6 * i] = real(f->get_chi1inv(Ex, X, p, frequency, false));
-    cache[6 * i + 1] = real(f->get_chi1inv(Ey, Y, p, frequency, false));
-    cache[6 * i + 2] = real(f->get_chi1inv(Ez, Z, p, frequency, false));
+    // Pass &is_freq_dep to detect dispersive materials directly from get_chi1inv,
+    // which knows whether frequency-dependent susceptibilities were evaluated.
+    bool is_freq_dep = false;
+    cache[6 * i] = real(f->get_chi1inv(Ex, X, p, frequency, false, &is_freq_dep));
+    cache[6 * i + 1] = real(f->get_chi1inv(Ey, Y, p, frequency, false, &is_freq_dep));
+    cache[6 * i + 2] = real(f->get_chi1inv(Ez, Z, p, frequency, false, &is_freq_dep));
+    if (is_freq_dep) eps_data->found_dispersive = true;
 
-    // Detect dispersive materials: compare frequency-dependent vs DC epsilon.
-    // Only check diagonal components for efficiency.
-    if (!eps_data->found_dispersive && frequency != 0) {
-      const double tol = 1e-6;
-      double dc0 = real(f->get_chi1inv(Ex, X, p, 0, false));
-      double dc1 = real(f->get_chi1inv(Ey, Y, p, 0, false));
-      double dc2 = real(f->get_chi1inv(Ez, Z, p, 0, false));
-      if (fabs(cache[6 * i] - dc0) > tol * fabs(dc0) ||
-          fabs(cache[6 * i + 1] - dc1) > tol * fabs(dc1) ||
-          fabs(cache[6 * i + 2] - dc2) > tol * fabs(dc2))
-        eps_data->found_dispersive = true;
-    }
     // Off-diagonal components: average from both relevant Yee grids.
     // Each off-diagonal chi1inv component (e.g., chi1inv_xy) can be
     // queried from either grid that stores it (Ex or Ey). On the Yee grid,

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -480,6 +480,7 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
     finished_working();
     free(eps_data.cache);
     eps_data.cache = summed_cache;
+    eps_data.found_dispersive = or_to_all(eps_data.found_dispersive);
 
     // finally, send MPB the real epsilon data using the synchronized cache
     eps_data.use_cache = true;
@@ -531,6 +532,7 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
       finished_working();
       free(eps_data.cache);
       eps_data.cache = summed_cache;
+      eps_data.found_dispersive = or_to_all(eps_data.found_dispersive);
 
       eps_data.use_cache = true;
       eps_data.icache = 0;

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -130,14 +130,15 @@ static int meep_mpb_eps(symmetric_matrix *eps, symmetric_matrix *eps_inv, mpb_re
 // Factored out to avoid duplicating this two-pass sequence for both initial
 // creation and dispersive-frequency updates of the cached maxwell_data.
 // Returns true if any sampled point has frequency-dependent (dispersive) epsilon.
-static bool populate_maxwell_dielectric(maxwell_data *mdata, int mesh_size[3], mpb_real R[3][3],
-                                        mpb_real G[3][3], const double *s, const double *o,
-                                        ndim dim, const fields *f, double frequency) {
+bool fields::populate_maxwell_dielectric(void *mdata_, int mesh_size[3], double R[3][3],
+                                         double G[3][3], const double *s, const double *o,
+                                         double frequency) {
+  maxwell_data *mdata = (maxwell_data *)mdata_;
   meep_mpb_eps_data eps_data;
   eps_data.s = s;
   eps_data.o = o;
-  eps_data.dim = dim;
-  eps_data.f = f;
+  eps_data.dim = gv.dim;
+  eps_data.f = this;
   eps_data.frequency = frequency;
   eps_data.cache = (double *)malloc(sizeof(double) * 6 * (eps_data.ncache = 512));
   eps_data.found_dispersive = false;
@@ -499,8 +500,7 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
     mdata = create_maxwell_data(n[0], n[1], n[2], &local_N, &N_start, &alloc_N, band_num, band_num);
     if (local_N != n[0] * n[1] * n[2]) meep::abort("MPI version of MPB library is not supported");
 
-    bool found_dispersive =
-        populate_maxwell_dielectric(mdata, mesh_size, R, G, s, o, gv.dim, this, frequency);
+    bool found_dispersive = populate_maxwell_dielectric(mdata, mesh_size, R, G, s, o, frequency);
 
     if (cache_dispersive) *cache_dispersive = found_dispersive;
     if (cache_frequency) *cache_frequency = frequency;
@@ -523,8 +523,7 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
         master_printf("Re-populating epsilon grid for dispersive medium at freq=%g (was %g)\n",
                       frequency, *cache_frequency);
 
-      *cache_dispersive =
-          populate_maxwell_dielectric(mdata, mesh_size, R, G, s, o, gv.dim, this, frequency);
+      *cache_dispersive = populate_maxwell_dielectric(mdata, mesh_size, R, G, s, o, frequency);
       *cache_frequency = frequency;
     }
   }

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -302,7 +302,7 @@ complex<double> eigenmode_amplitude(void *vedata, const vec &p, component c) {
 
   /* define a macro to give us data(x,y,z) on the grid,
      in row-major order (the order used by MPB): */
-#define D(x, y, z) (data[(((x) * ny + (y)) * nz + (z)) * 3])
+#define D(x, y, z) (data[(((x)*ny + (y)) * nz + (z)) * 3])
   complex<mpb_real> ret;
   ret = (((D(x, y, z) * (1.0 - dx) + D(x2, y, z) * dx) * (1.0 - dy) +
           (D(x, y2, z) * (1.0 - dx) + D(x2, y2, z) * dx) * dy) *

--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -48,6 +48,10 @@ typedef struct {
   size_t ncache;  // allocated size of the cache
   size_t icache;  // current position in the cache
   bool use_cache; // whether we are using the cache
+
+  // Track whether any sampled point has frequency-dependent epsilon.
+  // Detected by comparing get_chi1inv(freq=0) vs get_chi1inv(freq=frequency).
+  bool found_dispersive;
 } meep_mpb_eps_data;
 
 static int meep_mpb_eps(symmetric_matrix *eps, symmetric_matrix *eps_inv, mpb_real n[3],
@@ -92,6 +96,19 @@ static int meep_mpb_eps(symmetric_matrix *eps, symmetric_matrix *eps_inv, mpb_re
     cache[6 * i] = real(f->get_chi1inv(Ex, X, p, frequency, false));
     cache[6 * i + 1] = real(f->get_chi1inv(Ey, Y, p, frequency, false));
     cache[6 * i + 2] = real(f->get_chi1inv(Ez, Z, p, frequency, false));
+
+    // Detect dispersive materials: compare frequency-dependent vs DC epsilon.
+    // Only check diagonal components for efficiency.
+    if (!eps_data->found_dispersive && frequency != 0) {
+      const double tol = 1e-6;
+      double dc0 = real(f->get_chi1inv(Ex, X, p, 0, false));
+      double dc1 = real(f->get_chi1inv(Ey, Y, p, 0, false));
+      double dc2 = real(f->get_chi1inv(Ez, Z, p, 0, false));
+      if (fabs(cache[6 * i] - dc0) > tol * fabs(dc0) ||
+          fabs(cache[6 * i + 1] - dc1) > tol * fabs(dc1) ||
+          fabs(cache[6 * i + 2] - dc2) > tol * fabs(dc2))
+        eps_data->found_dispersive = true;
+    }
     // Off-diagonal components: average from both relevant Yee grids.
     // Each off-diagonal chi1inv component (e.g., chi1inv_xy) can be
     // queried from either grid that stores it (Ex or Ey). On the Yee grid,
@@ -332,7 +349,8 @@ void special_kz_phasefix(eigenmode_data *edata, bool phase_flip) {
 void *fields::get_eigenmode(double frequency, direction d, const volume where, const volume eig_vol,
                             int band_num, const vec &_kpoint, bool match_frequency, int parity,
                             double resolution, double eigensolver_tol, double *kdom,
-                            void **user_mdata, diffractedplanewave *dp) {
+                            void **user_mdata, diffractedplanewave *dp,
+                            bool *cache_dispersive, double *cache_frequency) {
   /*--------------------------------------------------------------*/
   /*- part 1: preliminary setup for calling MPB  -----------------*/
   /*--------------------------------------------------------------*/
@@ -455,6 +473,7 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
     eps_data.f = this;
     eps_data.frequency = frequency;
     eps_data.cache = (double *)malloc(sizeof(double) * 6 * (eps_data.ncache = 512));
+    eps_data.found_dispersive = false;
 
     // first, build up a cache of the local epsilon data
     // (while returning dummy values to MPB)
@@ -479,6 +498,12 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
 
     free(eps_data.cache);
 
+    // Store dispersive flag and frequency for cache management
+    if (cache_dispersive) *cache_dispersive = eps_data.found_dispersive;
+    if (cache_frequency) *cache_frequency = frequency;
+    if (eps_data.found_dispersive && verbosity > 0)
+      master_printf("Dispersive medium detected on eigenmode monitor\n");
+
     if (user_mdata) *user_mdata = (void *)mdata;
   }
   else {
@@ -487,6 +512,43 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
     N_start = mdata->N_start;
     local_N = mdata->local_N;
     alloc_N = mdata->alloc_N;
+
+    // If the cached medium is dispersive and frequency changed, re-populate epsilon
+    if (cache_dispersive && *cache_dispersive && cache_frequency &&
+        fabs(frequency - *cache_frequency) > 1e-10 * frequency) {
+      if (verbosity > 1)
+        master_printf("Re-populating epsilon grid for dispersive medium at freq=%g (was %g)\n",
+                      frequency, *cache_frequency);
+
+      meep_mpb_eps_data eps_data;
+      eps_data.s = s;
+      eps_data.o = o;
+      eps_data.dim = gv.dim;
+      eps_data.f = this;
+      eps_data.frequency = frequency;
+      eps_data.cache = (double *)malloc(sizeof(double) * 6 * (eps_data.ncache = 512));
+      eps_data.found_dispersive = false;
+
+      eps_data.use_cache = false;
+      eps_data.icache = 0;
+      set_maxwell_dielectric(mdata, mesh_size, R, G, NULL, meep_mpb_eps, &eps_data);
+
+      eps_data.ncache = eps_data.icache;
+      double *summed_cache = (double *)malloc(sizeof(double) * 6 * eps_data.ncache);
+      am_now_working_on(MpiAllTime);
+      sum_to_all(eps_data.cache, summed_cache, eps_data.ncache * 6);
+      finished_working();
+      free(eps_data.cache);
+      eps_data.cache = summed_cache;
+
+      eps_data.use_cache = true;
+      eps_data.icache = 0;
+      set_maxwell_dielectric(mdata, mesh_size, R, G, NULL, meep_mpb_eps, &eps_data);
+      assert(eps_data.icache == eps_data.ncache);
+
+      free(eps_data.cache);
+      *cache_frequency = frequency;
+    }
   }
 
   if (check_maxwell_dielectric(mdata, 0)) meep::abort("invalid dielectric function for MPB");
@@ -945,7 +1007,8 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
                                         double *vgrp, kpoint_func user_kpoint_func,
                                         void *user_kpoint_data, vec *kpoints, vec *kdom_list,
                                         double *cscale, direction d, diffractedplanewave *dp,
-                                        void **eigenmode_cache) {
+                                        void **eigenmode_cache,
+                                        bool *cache_dispersive, double *cache_frequency) {
   adjust_mpb_verbosity amv;
   int num_freqs = flux.freq.size();
   bool match_frequency = true;
@@ -971,7 +1034,8 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
       am_now_working_on(MPBTime);
       void *mode_data =
           get_eigenmode(flux.freq[nf], d, flux.where, eig_vol, band_num, kpoint, match_frequency,
-                        parity, eig_resolution, eigensolver_tol, kdom, (void **)&mdata, dp);
+                        parity, eig_resolution, eigensolver_tol, kdom, (void **)&mdata, dp,
+                        cache_dispersive, cache_frequency);
       finished_working();
       if (!mode_data) { // mode not found, assume evanescent
         coeffs[2 * nb * num_freqs + 2 * nf] = coeffs[2 * nb * num_freqs + 2 * nf + 1] = 0;


### PR DESCRIPTION
## Summary

When computing diffraction efficiencies via get_eigenmode_coefficients with DiffractedPlanewave, each call redundantly recreates MPB's maxwell_data (FFTW plans + epsilon inverse tensor at every grid point). For structures with many geometry objects, set_maxwell_dielectric dominates the per-call cost.

This PR caches the maxwell_data on the dft_flux object so it persists across separate Python calls to get_eigenmode_coefficients. The first call creates the cache; subsequent calls on the same monitor reuse it. The cache is automatically invalidated when the monitor is removed or destroyed.

Also skips the phase-fixing pass for DiffractedPlanewave since |α|² is phase-invariant (the mode–mode self-overlap normalization cancels any global phase factor).

No Python API changes — the caching is fully transparent.

Partially fixes #1533.

## Changes

**src/meep.hpp**: Add eigenmode_cache field, destructor, and invalidate_eigenmode_cache() to dft_flux. Add skip_phase_fix parameter to get_eigenmode. Add eigenmode_cache parameter to get_eigenmode_coefficients.
**src/mpb.cpp**: Use caller-provided cache in get_eigenmode_coefficients; persist or destroy maxwell_data based on whether a cache pointer is supplied. Guard the phase-fix block behind skip_phase_fix. Implement invalidate_eigenmode_cache().
**src/dft.cpp**: Initialize eigenmode_cache = NULL in all constructors and copy constructor. Add destructor that invalidates cache. Invalidate cache in remove().
**python/meep.i**: Change SWIG wrappers to take dft_flux* (pointer) so cache modifications persist across calls. Pass &flux->eigenmode_cache to the C++ function.
**python/tests/test_binary_grating.py**: Add cache consistency check verifying repeated calls produce identical results.

## Benchmark
The benchmark script can be found [here](https://gist.github.com/Luochenghuang/3ca93f0c92846f3d081cfe07f9a4d17e).
test_binary_grating structure (resolution 30, 60 DiffractedPlanewave calls across 2 flux monitors):

| | Total (s) | Per-call (ms) |
|---|---|---|
| Without cache | 0.252 | 4.2 |
| With cache | 0.042 | 0.7 |
| **Speedup** | **6.0×** | |

## Test plan

[x] test_binary_grating_special_kz (all 3 variants) — energy conservation and cache consistency
[x] Benchmark confirms 6× speedup on test_binary_grating structure
[ ] CI tests