### PR TITLE
OpenMP parallelize susceptibility grid initialization

### DIFF
--- a/src/anisotropic_averaging.cpp
+++ b/src/anisotropic_averaging.cpp
@@ -367,9 +367,9 @@ void structure_chunk::add_susceptibility(material_function &sigma, field_type ft
       // need a reduction since each thread computes its local subset.
       if (sigma.is_thread_safe()) {
         bool trivial0 = true, trivial1 = true, trivial2 = true;
-        PLOOP_OVER_IVECS_C(
-            gv, gv.little_corner() + gv.iyee_shift(c), gv.big_corner() + gv.iyee_shift(c), i,
-            "omp parallel for collapse(3) reduction(&:trivial0,trivial1,trivial2)") {
+        PLOOP_OVER_IVECS_C(gv, gv.little_corner() + gv.iyee_shift(c),
+                           gv.big_corner() + gv.iyee_shift(c), i,
+                           "omp parallel for collapse(3) reduction(&:trivial0,trivial1,trivial2)") {
           double sigrow[3], sigrow_offdiag[3];
           IVEC_LOOP_LOC(gv, here);
           sigma.sigma_row(c, sigrow, here);


### PR DESCRIPTION
Parallelize the grid loop in `structure_chunk::add_susceptibility` using OpenMP, following the same pattern as `set_chi1inv` (#3166).
- When `sigma.is_thread_safe()` (C++ geometry, no Python callbacks), use `PLOOP_OVER_IVECS_C` with `collapse(3)` and a reduction on the `trivial_sigma` flags.
- Fall back to the serial `LOOP_OVER_VOL` path for non-thread-safe material functions.

Here's the [benchmark script](https://gist.github.com/Luochenghuang/23c3c09a9f6cdc5c9fa1cc22fb215151) and results on an AMD EPYC-Milan processor with 83 cores:

<img width="1500" height="600" alt="benchmark_susceptibility_loglog" src="https://github.com/user-attachments/assets/e31b2107-2c0b-41ff-ad0d-82f1c734aba6" />

```
------------------------------
Threads    Time (s)   Speedup
------------------------------
       1    134.5301     1.00x
       2     74.2737     1.81x
       4     42.7071     3.15x
       8     23.4926     5.73x
      16     13.8043     9.75x
      32     10.0469    13.39x
      64      7.1682    18.77x
     166      3.8825    34.65x
```