### PR TITLE
Prepare for 1.33 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,27 @@
 # Meep Release Notes
 
+## Meep 1.33.0
+
+4/16/2026
+
+* Performance optimization for time stepping in cylindrical coordinates ([#3158]).
+
+* Multithreading support for epsilon initialization ([#3166], [#3171]).
+
+* Bug fix when combining mirror symmetries and Bloch-periodic boundaries ([#3155]).
+
+* Bug fix when combining Bloch-periodic boundaries and single-precision floating point ([#3157]).
+
+* Bug fix in interpolation of epsilon grid from Meep to MPB ([#3163]).
+
+* Bug fix when combining dft_force and mirror symmetry ([#3161]).
+
+* Bug fix in grid_volume::init_subvolume in cylindrical coordinates ([#3174]).
+
+* Bug fix in Simulation.load_chunk_layout ([#3189]).
+
+* Various improvements and additional documentation ([#3159], [#3169], [#3179], [#3185], [#3187], [#3190], [#3195], [#3193], [#3199]).
+
 ## Meep 1.32.0
 
 2/20/2026

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * Multithreading support for epsilon initialization ([#3166], [#3171]).
 
-* Bug fix when combining mirror symmetries and Bloch-periodic boundaries ([#3155]).
+* Bug fix when combining Bloch-periodic boundaries and mirror symmetries ([#3155]).
 
 * Bug fix when combining Bloch-periodic boundaries and single-precision floating point ([#3157]).
 
@@ -20,7 +20,7 @@
 
 * Bug fix in Simulation.load_chunk_layout ([#3189]).
 
-* Various improvements and additional documentation ([#3159], [#3169], [#3179], [#3185], [#3187], [#3190], [#3195], [#3193], [#3199]).
+* Various improvements and additional documentation ([#3159], [#3169], [#3179], [#3185], [#3187], [#3190], [#3193], [#3195], [#3199]).
 
 ## Meep 1.32.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Performance optimization for time stepping in cylindrical coordinates ([#3158]).
 
+* Performance optimization for repeated eigenmode solves ([#3167]).
+
 * Multithreading support for epsilon initialization ([#3166], [#3171]).
 
 * Bug fix when combining Bloch-periodic boundaries and mirror symmetries ([#3155]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,7 +22,7 @@
 
 * Bug fix in Simulation.load_chunk_layout ([#3189]).
 
-* Various improvements and additional documentation ([#3159], [#3169], [#3179], [#3185], [#3187], [#3190], [#3193], [#3195], [#3199]).
+* Various improvements and additional documentation ([#3159], [#3169], [#3179], [#3185], [#3187], [#3188], [#3190], [#3193], [#3195], [#3199]).
 
 ## Meep 1.32.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Meep 1.33.0
 
-4/16/2026
+4/24/2026
 
 * Performance optimization for time stepping in cylindrical coordinates ([#3158]).
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([meep],[m4_esyscmd(./version.sh 1.33.0-beta)])
+AC_INIT([meep],[m4_esyscmd(./version.sh 1.33.0)])
 AC_CONFIG_SRCDIR(src/step.cpp)
 AC_CONFIG_AUX_DIR([build-aux])
 
@@ -8,7 +8,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 # not the same as the "public" version number.  (Don't worry about this
 # except for public releases.) Note that any change to a C++ class
 # definition (in the .hpp file) generally breaks binary compatibility.
-SHARED_VERSION_INFO="36:0:1" # CURRENT:REVISION:AGE
+SHARED_VERSION_INFO="36:0:2" # CURRENT:REVISION:AGE
 
 AM_INIT_AUTOMAKE([foreign color-tests parallel-tests silent-rules 1.11])
 AM_SILENT_RULES(yes)

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 # not the same as the "public" version number.  (Don't worry about this
 # except for public releases.) Note that any change to a C++ class
 # definition (in the .hpp file) generally breaks binary compatibility.
-SHARED_VERSION_INFO="36:0:2" # CURRENT:REVISION:AGE
+SHARED_VERSION_INFO="37:0:0" # CURRENT:REVISION:AGE
 
 AM_INIT_AUTOMAKE([foreign color-tests parallel-tests silent-rules 1.11])
 AM_SILENT_RULES(yes)


### PR DESCRIPTION
The next tarball release is tentatively scheduled for Thursday April 16, 2026.