### PR TITLE
Slightly increase tolerance for failing `test_adjoint_cyl.py`

### DIFF
--- a/python/tests/test_adjoint_cyl.py
+++ b/python/tests/test_adjoint_cyl.py
@@ -208,7 +208,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
         adj_scale = (dp[None, :] @ adjsol_grad).flatten()
         fd_grad = S12_perturbed - S12_unperturbed
         print(f"Directional derivative -- adjoint solver: {adj_scale}, FD: {fd_grad}")
-        tol = 0.6 if m == 0 else 0.3
+        tol = 0.6 if m == 0 else 0.35
         self.assertClose(adj_scale, fd_grad, epsilon=tol)
 
 

--- a/python/tests/test_adjoint_cyl.py
+++ b/python/tests/test_adjoint_cyl.py
@@ -208,7 +208,7 @@ class TestAdjointSolver(ApproxComparisonTestCase):
         adj_scale = (dp[None, :] @ adjsol_grad).flatten()
         fd_grad = S12_perturbed - S12_unperturbed
         print(f"Directional derivative -- adjoint solver: {adj_scale}, FD: {fd_grad}")
-        tol = 0.6 if m == 0 else 0.35
+        tol = 0.6 if m == 0 else 0.4
         self.assertClose(adj_scale, fd_grad, epsilon=tol)
 
 


### PR DESCRIPTION
Fixes the failing `test_adjoint_cyl.py` for single-precision floating pointd due to #3164.