### PR TITLE
Fix no-MPB stub for `get_eigenmode` to match updated declaration

### DIFF
--- a/src/mpb.cpp
+++ b/src/mpb.cpp
@@ -1075,7 +1075,8 @@ void fields::get_eigenmode_coefficients(dft_flux flux, const volume &eig_vol, in
 void *fields::get_eigenmode(double frequency, direction d, const volume where, const volume eig_vol,
                             int band_num, const vec &kpoint, bool match_frequency, int parity,
                             double resolution, double eigensolver_tol, double *kdom,
-                            void **user_mdata, diffractedplanewave *dp) {
+                            void **user_mdata, diffractedplanewave *dp, bool *cache_dispersive,
+                            double *cache_frequency) {
 
   (void)frequency;
   (void)d;
@@ -1090,6 +1091,8 @@ void *fields::get_eigenmode(double frequency, direction d, const volume where, c
   (void)kdom;
   (void)user_mdata;
   (void)dp;
+  (void)cache_dispersive;
+  (void)cache_frequency;
   meep::abort("Meep must be configured/compiled with MPB for get_eigenmode");
 }
 


### PR DESCRIPTION
PR #3167 added `cache_dispersive` and `cache_frequency` parameters to `fields::get_eigenmode` in `meep.hpp`, but only updated the no-MPB stub for `get_eigenmode_coefficients`. The get_eigenmode stub was missed. This causes a compile error when building without MPB (e.g., the ASAN and UBSAN CI jobs):                      
```                                                                                           
mpb.cpp:1075:15: error: out-of-line definition of 'get_eigenmode' does not match any declaration in 'meep::fields'
 1075 | void *fields::get_eigenmode(double frequency, direction d, const volume where, const volume eig_vol,
      |               ^~~~~~~~~~~~~
```
This PR adds the two missing parameters to the no-MPB stub signature.
This PR was tested against the sanitizers CI [here](https://github.com/Luochenghuang/meep/actions/runs/24584241142/job/71889652000).