### PR TITLE
Make `libGDSII` an optional dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -481,6 +481,7 @@ if test "x$have_gdsii" = xmaybe; then
     AC_MSG_RESULT($have_gdsii_getlayers)
   fi
 fi
+AM_CONDITIONAL(WITH_LIBGDSII, test "x$ac_cv_lib_GDSII_libGDSIIExists" = "xyes")
 
 ##############################################################################
 # The following function is used only for debugging.  Note that

--- a/python/tests/test_prism.py
+++ b/python/tests/test_prism.py
@@ -238,10 +238,11 @@ class TestPrism(unittest.TestCase):
         self.assertAlmostEqual(d_nosym[1], d_sym[1], places=3)
         self.assertAlmostEqual(d_nosym[2], d_sym[2], places=3)
 
-        print("Testing Non-Convex Prism from GDSII file...")
-        d = self.spiral_gds()
-        d_ref = 455.01744881372224
-        self.assertAlmostEqual(d, d_ref, places=5)
+        if mp.with_libGDSII():
+            print("Testing Non-Convex Prism from GDSII file...")
+            d = self.spiral_gds()
+            d_ref = 455.01744881372224
+            self.assertAlmostEqual(d, d_ref, places=5)
 
     def test_prism(self):
         print("Testing Non-Convex Prism #3 using marching squares algorithm...")

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,7 +16,11 @@ AM_CPPFLAGS = -I$(top_srcdir)/src -DDATADIR=\"$(srcdir)/\"
 
 .SUFFIXES = .dac .done
 
-check_PROGRAMS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical dump_load flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml pw-source-ll ring-ll cyl-ellipsoid-ll absorber-1d-ll array-slice-ll user-defined-material dft-fields gdsII-3d bend-flux-ll array-metadata
+check_PROGRAMS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical dump_load flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml pw-source-ll ring-ll cyl-ellipsoid-ll absorber-1d-ll array-slice-ll user-defined-material dft-fields bend-flux-ll array-metadata
+
+if WITH_LIBGDSII
+  check_PROGRAMS += gdsII-3d
+endif
 
 array_metadata_SOURCES = array-metadata.cpp
 array_metadata_LDADD   = $(MEEPLIBS)


### PR DESCRIPTION
Modifies the C++ and Python test suite to include the tests involving the GDSII-related functions only if `libGDSII` is included as part of the build.