### PR TITLE
Fix thread-safety bug for user-defined epsilon in `meepgeom.cpp`

### DIFF
--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -658,7 +658,8 @@ geom_epsilon::geom_epsilon(geometric_object_list g, material_type_list mlist,
   int length = g.num_items;
   geometry.num_items = length;
   geometry.items = new geometric_object[length];
-  has_user_materials = false;
+  has_user_materials = default_material && ((material_type)default_material)->which_subclass ==
+                                               material_data::MATERIAL_USER;
   for (int i = 0; i < length; i++) {
     geometric_object_copy(&g.items[i], &geometry.items[i]);
     geometry.items[i].material = new material_data();


### PR DESCRIPTION
**Root cause:** The `has_user_materials` flag in the `geom_epsilon` constructor (`src/meepgeom.cpp:661`) is initialized to `false` and only checks geometry objects' materials. It does not check the global `default_material`, which is where `material_function=my_material_func` (a Python callback passed at the `Simulation` level) ends up.

This causes `is_thread_safe()` to return `true`, so `set_chi1inv` takes the OMP parallel path (`PLOOP_OVER_IVECS_C` with `collapse(3)`). Multiple OMP threads then concurrently call `get_material_pt`, which invokes the Python callback (`md->user_func(...)`) from non-main threads. Python's interpreter is not safe to call from arbitrary native threads, which causes the segfault in `test_user_defined_material.py`.

**Fix:** Initialize `has_user_materials` by also checking whether `default_material` is a `MATERIAL_USER`. This ensures the serial code path is used when the default material is a Python callback.

**Validation:** `test_user_defined_material.py` now passes with `OMP_NUM_THREADS=1`, `2`, and `4`.