### PR TITLE
Modify skip condition for tests not involving MPI to include compile-time and runtime check

### DIFF
--- a/python/tests/test_dump_load.py
+++ b/python/tests/test_dump_load.py
@@ -120,7 +120,7 @@ class TestLoadDump(ApproxComparisonTestCase):
         self._load_dump_structure_2d()
 
     @unittest.skipIf(
-        not mp.with_mpi() or mp.count_processors < 2,
+        not mp.with_mpi() or mp.count_processors() < 2,
         "MPI specific test (requires mpirun with more than 1 process)",
     )
     def test_load_dump_structure_sharded_2d(self):
@@ -230,7 +230,7 @@ class TestLoadDump(ApproxComparisonTestCase):
         self._load_dump_structure_3d()
 
     @unittest.skipIf(
-        not mp.with_mpi() or mp.count_processors < 2,
+        not mp.with_mpi() or mp.count_processors() < 2,
         "MPI specific test (requires mpirun with more than 1 process)",
     )
     def test_load_dump_structure_sharded_3d(self):
@@ -355,7 +355,7 @@ class TestLoadDump(ApproxComparisonTestCase):
         self._load_dump_fields_2d()
 
     @unittest.skipIf(
-        not mp.with_mpi() or mp.count_processors < 2,
+        not mp.with_mpi() or mp.count_processors() < 2,
         "MPI specific test (requires mpirun with more than 1 process)",
     )
     def test_load_dump_fields_sharded_2d(self):
@@ -478,7 +478,7 @@ class TestLoadDump(ApproxComparisonTestCase):
         self._load_dump_fields_3d()
 
     @unittest.skipIf(
-        not mp.with_mpi() or mp.count_processors < 2,
+        not mp.with_mpi() or mp.count_processors() < 2,
         "MPI specific test (requires mpirun with more than 1 process)",
     )
     def test_load_dump_fields_sharded_3d(self):

--- a/python/tests/test_dump_load.py
+++ b/python/tests/test_dump_load.py
@@ -119,7 +119,10 @@ class TestLoadDump(ApproxComparisonTestCase):
     def test_load_dump_structure_2d(self):
         self._load_dump_structure_2d()
 
-    @unittest.skipIf(not mp.with_mpi(), "MPI specific test")
+    @unittest.skipIf(
+        not mp.with_mpi() or mp.count_processors < 2,
+        "MPI specific test (requires mpirun with more than 1 process)",
+    )
     def test_load_dump_structure_sharded_2d(self):
         self._load_dump_structure_2d(single_parallel_file=False)
 
@@ -226,7 +229,10 @@ class TestLoadDump(ApproxComparisonTestCase):
     def test_load_dump_structure_3d(self):
         self._load_dump_structure_3d()
 
-    @unittest.skipIf(not mp.with_mpi(), "MPI specific test")
+    @unittest.skipIf(
+        not mp.with_mpi() or mp.count_processors < 2,
+        "MPI specific test (requires mpirun with more than 1 process)",
+    )
     def test_load_dump_structure_sharded_3d(self):
         self._load_dump_structure_3d(single_parallel_file=False)
 
@@ -348,7 +354,10 @@ class TestLoadDump(ApproxComparisonTestCase):
     def test_load_dump_fields_2d(self):
         self._load_dump_fields_2d()
 
-    @unittest.skipIf(not mp.with_mpi(), "MPI specific test")
+    @unittest.skipIf(
+        not mp.with_mpi() or mp.count_processors < 2,
+        "MPI specific test (requires mpirun with more than 1 process)",
+    )
     def test_load_dump_fields_sharded_2d(self):
         self._load_dump_fields_2d(single_parallel_file=False)
 
@@ -468,7 +477,10 @@ class TestLoadDump(ApproxComparisonTestCase):
     def test_load_dump_fields_3d(self):
         self._load_dump_fields_3d()
 
-    @unittest.skipIf(not mp.with_mpi(), "MPI specific test")
+    @unittest.skipIf(
+        not mp.with_mpi() or mp.count_processors < 2,
+        "MPI specific test (requires mpirun with more than 1 process)",
+    )
     def test_load_dump_fields_sharded_3d(self):
         self._load_dump_fields_3d(single_parallel_file=False)
 

--- a/python/tests/test_simulation.py
+++ b/python/tests/test_simulation.py
@@ -220,7 +220,7 @@ class TestSimulation(unittest.TestCase):
         )
 
     @unittest.skipIf(
-        not mp.with_mpi() or mp.count_processors < 2,
+        not mp.with_mpi() or mp.count_processors() < 2,
         "MPI specific test (requires mpirun with more than 1 process)",
     )
     def test_mpi(self):

--- a/python/tests/test_simulation.py
+++ b/python/tests/test_simulation.py
@@ -219,9 +219,12 @@ class TestSimulation(unittest.TestCase):
             **kwargs,
         )
 
-    @unittest.skipIf(not mp.with_mpi(), "MPI specific test")
+    @unittest.skipIf(
+        not mp.with_mpi() or mp.count_processors < 2,
+        "MPI specific test (requires mpirun with more than 1 process)",
+    )
     def test_mpi(self):
-        self.assertGreater(mp.comm.Get_size(), 1)
+        self.assertGreater(mp.count_processors(), 1)
 
     def test_use_output_directory_default(self):
         sim = self.init_simple_simulation()


### PR DESCRIPTION
**Root cause:** The `test_mpi` skip condition used in `test_simulation.py` (as well as `test_dump_load.py`) only checks the compile-time flag `mp.with_mpi()` (was Meep built with MPI?), but contains an assertion which requires a runtime condition (multiple MPI processes via `mpirun`). When compiled with `--with-mpi --with-openmp` and run *directly* (e.g., `OMP_NUM_THREADS=2 python -m unittest`, i.e., not as part of `make check` which uses `mpirun -np 2 python ...`), the test is not skipped but the assertion fails because `Get_size()` returns 1 (no `mpirun`).

**Fix:** Add `mp.count_processors() < 2` to the skip condition, so the test is skipped (not failed) when not running `mpirun` with multiple processes. Also switch from `mp.comm.Get_size()` to `mp.count_processors()` for consistency with the C++ API.