### PR TITLE
Cleanup `python/Makefile.am`

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -12,11 +12,6 @@ endif # WITH_MPI
 
 if WITH_MPB
   MPBPYTEST=$(TEST_DIR)/test_mpb.py
-else
-  MPBPYTEST=
-endif # WITH_MPB
-
-if WITH_MPB
   BINARY_GRATING_TEST = $(TEST_DIR)/test_binary_grating.py
   DIFFRACTED_PLANEWAVE_TEST = $(TEST_DIR)/test_diffracted_planewave.py
   DISPERSIVE_EIGENMODE_TEST = $(TEST_DIR)/test_dispersive_eigenmode.py
@@ -25,6 +20,7 @@ if WITH_MPB
   MODE_DECOMPOSITION_TEST = $(TEST_DIR)/test_mode_decomposition.py
   WVG_SRC_TEST = $(TEST_DIR)/test_wvg_src.py
 else
+  MPBPYTEST =
   BINARY_GRATING_TEST =
   DIFFRACTED_PLANEWAVE_TEST =
   DISPERSIVE_EIGENMODE_TEST =
@@ -56,8 +52,8 @@ TESTS =                                        \
     $(TEST_DIR)/test_cyl_ellipsoid.py          \
     $(TEST_DIR)/test_dft_energy.py             \
     $(TEST_DIR)/test_dft_fields.py             \
-    ${DIFFRACTED_PLANEWAVE_TEST}               \
-    ${DISPERSIVE_EIGENMODE_TEST}               \
+    $(DIFFRACTED_PLANEWAVE_TEST)               \
+    $(DISPERSIVE_EIGENMODE_TEST)               \
     $(TEST_DIR)/test_divide_mpi_processes.py   \
     $(TEST_DIR)/test_dump_load.py              \
     $(TEST_DIR)/test_eigfreq.py                \
@@ -231,7 +227,6 @@ HL_IFACE =                  \
     $(srcdir)/materials.py  \
     $(srcdir)/verbosity_mgr.py
 
-
 pkgpython_PYTHON = __init__.py $(HL_IFACE)
 
 adjointdir = $(pkgpythondir)/adjoint
@@ -246,12 +241,6 @@ adjoint_PYTHON  = $(srcdir)/adjoint/__init__.py              \
                   $(srcdir)/adjoint/wrapper.py               \
                   $(srcdir)/adjoint/utils.py
 
-######################################################################
-# finally, specification of what gets installed in the meep python
-# module directory of the python site-packages installation
-# Q: Why is this not redundant since e.g. the HL_IFACE files should
-#    already be installed by virtue of being in pkgpython_PYTHON
-######################################################################
 PY_PKG_FILES = $(INIT_PY) $(HL_IFACE) .libs/_meep.so
 
 meep: _meep.la $(MPB_LA) __init__.py $(HL_IFACE)


### PR DESCRIPTION
Four cleanups for `python/Makefile.am`:
1. Consolidate the two `WITH_MPB` conditional blocks (lines 13-17 and 19-35). `MPBPYTEST` is defined in its own block for no reason - it can be merged into the second block, reducing 23 lines to ~15.
2. Inconsistent `$()` vs. `${}` syntax - lines 61-62 use `${DIFFRACTED_PLANEWAVE_TEST}` and `${DISPERSIVE_EIGENMODE_TEST}` while every other variable reference uses `$()`. Both work in GNU Make, but mixing them is needless inconsistency.
3. Remove the stale comment on lines 251-256 - the `Q: Why is this not redundant...` comment describes a confusion, not a constraint. The `meep:` target on line 259 builds a local `meep/` package tree for in-tree testing (so `import meep` works before `make install`), which is distinct from what `pkgpython_PYTHON` does at install time. The comment is removed.
4. Extra blank line at line 234. Minor formatting.