### PR TITLE
Modify dependency strategy for sanitizer workflows in GitHub CI Actions

### DIFF
--- a/.github/workflows/build-san.yml
+++ b/.github/workflows/build-san.yml
@@ -31,12 +31,11 @@ jobs:
         path: ~/apt-cache
         key: apt-san-${{ runner.os }}-${{ hashFiles('.github/workflows/build-san.yml') }}
 
-    - name: Restore cached apt sources
+    - name: Restore cached apt packages
       if: steps.apt-cache.outputs.cache-hit == 'true'
-      run: sudo dpkg -i ~/apt-cache/*.deb 2>/dev/null || true
+      run: sudo cp ~/apt-cache/*.deb /var/cache/apt/archives/ 2>/dev/null || true
 
     - name: Install Dependencies
-      if: steps.apt-cache.outputs.cache-hit != 'true'
       run: |
         sudo apt-get update -y
         sudo apt-get install -y autoconf automake clang libaec-dev libctl-dev \


### PR DESCRIPTION
The sanitizer workflows (UBSAN and ASAN) for the GitHub CI Actions are currently [failing](https://github.com/NanoComp/meep/actions/runs/25988813659) with the error: `checking for hdf5... Package hdf5 was not found in the pkg-config search path.`

The root cause of this error is the [`dpkg -i` restore strategy](https://github.com/NanoComp/meep/blob/ac1c67543ffbc599ea41792da8c73e29aee020c0/.github/workflows/build-san.yml#L36) on cache hit. Here's the problem:
1. **On cache miss** (first run): `apt-get install` properly installs `libhdf5-dev` and all its dependencies. Only the `.deb` files present in `/var/cache/apt/archives/` are copied to `~/apt-cache/` — but packages already installed on the runner image aren't re-downloaded, so their `.deb` files are **never cached**.
2. **On cache hit** (subsequent runs): The runner image may have changed (Ubuntu updates the image periodically), but the cache key only hashes the workflow file, not the runner image. `dpkg -i ~/apt-cache/*.deb` tries to install the cached subset of packages, and `2>/dev/null || true` **silently suppresses** dependency errors. The "Install Dependencies" step is skipped entirely, so any missing packages — like HDF5 dependencies that were pre-installed on the original image but removed in a newer image — are never installed.
3. The result: `libhdf5-dev` (or a dependency it needs to register its `.pc` file) is missing, so `pkg-config --cflags hdf5` fails during `./configure`.

**The fix:** Always run `apt-get install` for proper dependency resolution, but pre-populate apt's local archive from cache so it doesn't re-download packages that are already cached.