### PR TITLE
Add `stop_when_flux_decayed` termination criteria

### DIFF
--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -505,6 +505,7 @@ In particular, a useful value for `until_after_sources` or `until` is often `sto
 @@ stop_when_fields_decayed @@
 @@ stop_when_energy_decayed @@
 @@ stop_when_dft_decayed @@
+@@ stop_when_flux_decayed @@
 @@ stop_after_walltime @@
 @@ stop_on_interrupt @@
 
@@ -926,6 +927,7 @@ Miscellaneous Functions Reference
 - [`stop_when_fields_decayed`](#stop_when_fields_decayed)
 - [`stop_when_energy_decayed`](#stop_when_energy_decayed)
 - [`stop_when_dft_decayed`](#stop_when_dft_decayed)
+- [`stop_when_flux_decayed`](#stop_when_flux_decayed)
 - [`stop_after_walltime`](#stop_after_walltime)
 - [`stop_on_intercept`](#stop_on_intercept)
 

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -93,6 +93,7 @@ TESTS =                                        \
     $(TEST_DIR)/test_simulation.py             \
     $(TEST_DIR)/test_special_kz.py             \
     $(TEST_DIR)/test_source.py                 \
+    $(TEST_DIR)/test_stop_when_flux_decayed.py \
     $(TEST_DIR)/test_timing_measurements.py    \
     $(TEST_DIR)/test_user_defined_material.py  \
     $(TEST_DIR)/test_verbosity_mgr.py          \

--- a/python/meep.i
+++ b/python/meep.i
@@ -1766,6 +1766,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         stop_when_dft_decayed,
         stop_when_fields_decayed,
         stop_when_energy_decayed,
+        stop_when_flux_decayed,
         synchronized_magnetic,
         to_appended,
         vec,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -5452,6 +5452,81 @@ def stop_when_dft_decayed(tol=1e-11, minimum_run_time=0, maximum_run_time=None):
     return _stop
 
 
+def stop_when_flux_decayed(flux, tol=1e-11, minimum_run_time=0, maximum_run_time=None):
+    """
+    Return a `condition` function, suitable for passing to `Simulation.run` as the `until`
+    or `until_after_sources` parameter, that checks the DFT Poynting flux in the given
+    `flux` object (a `DftFlux` obtained from `Simulation.add_flux`) and stops the simulation
+    once the relative change in flux has decayed below `tol` for *all* frequencies in the
+    monitor.
+
+    The check interval is determined automatically from the frequency content of the flux
+    monitor. There are two optional parameters: a minimum run time `minimum_run_time`
+    (default: 0) or a maximum run time `maximum_run_time` (no default).
+
+    Args:
+        flux: a `DftFlux` object from `Simulation.add_flux(...)`.
+        tol: convergence tolerance (default: 1e-11).
+        minimum_run_time: minimum simulation time before stopping (default: 0).
+        maximum_run_time: maximum simulation time before stopping (default: None).
+    """
+    if flux is None:
+        raise ValueError("flux is required.")
+    if not isinstance(flux, DftFlux):
+        raise TypeError(
+            "flux must be a DftFlux object obtained from Simulation.add_flux(). "
+            f"Got {type(flux)}"
+        )
+
+    closure = {
+        "previous_fluxes": None,
+        "t0": 0,
+        "dt": 0,
+        "maxchange": None,
+    }
+
+    def _stop(sim):
+        if sim.fields.t == 0:
+            closure["dt"] = max(
+                1 / sim.fields.dft_maxfreq() / sim.fields.dt,
+                sim.fields.max_decimation(),
+            )
+
+        if maximum_run_time and sim.round_time() > maximum_run_time:
+            return True
+
+        if sim.fields.t <= closure["dt"] + closure["t0"]:
+            return False
+
+        current_fluxes = np.array(get_fluxes(flux))
+
+        if closure["previous_fluxes"] is None:
+            closure["previous_fluxes"] = current_fluxes
+            closure["maxchange"] = np.zeros_like(current_fluxes)
+            closure["t0"] = sim.fields.t
+            return False
+
+        change = np.abs(current_fluxes - closure["previous_fluxes"])
+        closure["maxchange"] = np.maximum(closure["maxchange"], change)
+        closure["previous_fluxes"] = current_fluxes
+        closure["t0"] = sim.fields.t
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            relative_change = np.where(
+                closure["maxchange"] > 0,
+                change / closure["maxchange"],
+                0.0,
+            )
+
+        if verbosity.meep > 1:
+            fmt = "flux decay(t = {0:0.2f}): {1:0.4e}"
+            print(fmt.format(sim.meep_time(), np.real(relative_change)))
+
+        return np.all(relative_change <= tol) and sim.round_time() >= minimum_run_time
+
+    return _stop
+
+
 def combine_step_funcs(*step_funcs):
     """
     Given zero or more step functions, return a new step function that on each step calls

--- a/python/tests/test_stop_when_flux_decayed.py
+++ b/python/tests/test_stop_when_flux_decayed.py
@@ -1,0 +1,162 @@
+import unittest
+
+import meep as mp
+import numpy as np
+
+
+class TestStopWhenFluxDecayed(unittest.TestCase):
+    def setUp(self):
+        self.resolution = 20
+        self.dpml = 1.0
+        self.sxy = 6.0
+        self.cell_size = mp.Vector3(self.sxy + 2 * self.dpml, self.sxy + 2 * self.dpml)
+        self.fcen = 1.0
+        self.df = 0.2
+        self.nfreq = 3
+        self.sources = [
+            mp.Source(
+                src=mp.GaussianSource(self.fcen, fwidth=self.df),
+                center=mp.Vector3(),
+                component=mp.Ez,
+            )
+        ]
+        self.pml_layers = [mp.PML(self.dpml)]
+
+    def _make_sim(self):
+        return mp.Simulation(
+            cell_size=self.cell_size,
+            resolution=self.resolution,
+            sources=self.sources,
+            boundary_layers=self.pml_layers,
+            symmetries=[
+                mp.Mirror(mp.X, phase=+1),
+                mp.Mirror(mp.Y, phase=+1),
+            ],
+        )
+
+    def test_single_frequency(self):
+        """Simulation terminates and produces non-zero flux with one frequency."""
+        sim = self._make_sim()
+        flux_mon = sim.add_flux(
+            self.fcen,
+            0,
+            1,
+            mp.FluxRegion(
+                center=mp.Vector3(0.5 * self.sxy, 0),
+                size=mp.Vector3(0, self.sxy),
+            ),
+        )
+
+        sim.run(until_after_sources=mp.stop_when_flux_decayed(flux_mon, tol=1e-3))
+
+        fluxes = mp.get_fluxes(flux_mon)
+        self.assertEqual(len(fluxes), 1)
+        self.assertGreater(abs(fluxes[0]), 0)
+
+    def test_multiple_frequencies(self):
+        """All frequencies must converge before termination."""
+        sim = self._make_sim()
+        flux_mon = sim.add_flux(
+            self.fcen,
+            self.df,
+            self.nfreq,
+            mp.FluxRegion(
+                center=mp.Vector3(0.5 * self.sxy, 0),
+                size=mp.Vector3(0, self.sxy),
+            ),
+        )
+
+        sim.run(until_after_sources=mp.stop_when_flux_decayed(flux_mon, tol=1e-3))
+
+        fluxes = mp.get_fluxes(flux_mon)
+        self.assertEqual(len(fluxes), self.nfreq)
+        for f in fluxes:
+            self.assertGreater(abs(f), 0)
+
+    def test_maximum_run_time(self):
+        """Simulation stops at maximum_run_time even if not converged."""
+        sim = self._make_sim()
+        flux_mon = sim.add_flux(
+            self.fcen,
+            0,
+            1,
+            mp.FluxRegion(
+                center=mp.Vector3(0.5 * self.sxy, 0),
+                size=mp.Vector3(0, self.sxy),
+            ),
+        )
+
+        max_time = 50
+        sim.run(
+            until_after_sources=mp.stop_when_flux_decayed(
+                flux_mon, tol=1e-30, maximum_run_time=max_time
+            )
+        )
+
+        self.assertLessEqual(sim.round_time(), max_time + 1)
+
+    def test_minimum_run_time(self):
+        """Simulation runs at least minimum_run_time."""
+        sim = self._make_sim()
+        flux_mon = sim.add_flux(
+            self.fcen,
+            0,
+            1,
+            mp.FluxRegion(
+                center=mp.Vector3(0.5 * self.sxy, 0),
+                size=mp.Vector3(0, self.sxy),
+            ),
+        )
+
+        min_time = 50
+        sim.run(
+            until_after_sources=mp.stop_when_flux_decayed(
+                flux_mon, tol=1e-3, minimum_run_time=min_time
+            )
+        )
+
+        self.assertGreaterEqual(sim.round_time(), min_time)
+
+    def test_agrees_with_long_run(self):
+        """Flux values from stop_when_flux_decayed match a long fixed-time run."""
+        sim1 = self._make_sim()
+        flux_mon1 = sim1.add_flux(
+            self.fcen,
+            self.df,
+            self.nfreq,
+            mp.FluxRegion(
+                center=mp.Vector3(0.5 * self.sxy, 0),
+                size=mp.Vector3(0, self.sxy),
+            ),
+        )
+        sim1.run(until_after_sources=mp.stop_when_flux_decayed(flux_mon1, tol=1e-5))
+        fluxes_decayed = np.array(mp.get_fluxes(flux_mon1))
+
+        sim2 = self._make_sim()
+        flux_mon2 = sim2.add_flux(
+            self.fcen,
+            self.df,
+            self.nfreq,
+            mp.FluxRegion(
+                center=mp.Vector3(0.5 * self.sxy, 0),
+                size=mp.Vector3(0, self.sxy),
+            ),
+        )
+        sim2.run(until_after_sources=500)
+        fluxes_long = np.array(mp.get_fluxes(flux_mon2))
+
+        np.testing.assert_allclose(fluxes_decayed, fluxes_long, rtol=1e-3)
+
+    def test_invalid_flux_argument(self):
+        """Raises TypeError for non-DftFlux arguments."""
+        with self.assertRaises(TypeError):
+            mp.stop_when_flux_decayed("not_a_flux_object")
+
+    def test_none_flux_argument(self):
+        """Raises ValueError for None flux argument."""
+        with self.assertRaises(ValueError):
+            mp.stop_when_flux_decayed(None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a new `stop_when_flux_decayed` termination criteria which is similar to the existing `stop_when_dft_decayed`. Also includes a unit test.

The new termination criteria is particularly useful in cases involving **glancing-angle waves** which are [poorly absorbed by PML](https://meep.readthedocs.io/en/latest/FAQ/#why-are-the-fields-not-being-absorbed-by-the-pml) (and for which the existing termination criteria `stop_when_fields_decayed` and `stop_when_dft_decayed` tend to require long run times which can cause field instabilities). 

As an example, a planewave incident at oblique angles on a [binary grating](https://meep.readthedocs.io/en/latest/Python_Tutorials/Mode_Decomposition/#diffraction-spectrum-of-a-binary-grating) produces  high-angle diffraction orders which tend to be slowly decaying within the periodic unit cell. Tracking the convergence of the Poynting flux in the direction of the PML absorption (i.e., $z$ direction for a 3D unit cell periodic in $x$ and $y$) enables terminating the simulation within a reasonable time (although choosing the `tol` parameter based on empirical testing requires some care).