### PR TITLE
Add warning for non-positive semidefinite `sigma` tensor for Lorentzian susceptibility

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -474,6 +474,30 @@ void structure::add_susceptibility(double sigma(const vec &), field_type ft,
   add_susceptibility(sig, ft, sus);
 }
 
+/* Heuristic check for a non-positive-semidefinite (non-passive) anisotropic
+   susceptibility tensor: an off-diagonal sigma_ab with sigma_ab^2 > sigma_aa *
+   sigma_bb makes the local 2x2 tensor have a negative eigenvalue, which is
+   non-physical and drives instabilities.  We only test pixels where both
+   diagonal entries are nonzero, so material-boundary pixels (where one diagonal
+   has tapered to zero — a discretization effect handled by the update_P guard)
+   are skipped to avoid false positives. */
+static bool sigma_not_psd(const susceptibility *sus, const grid_volume &gv, field_type ft) {
+  FOR_FT_COMPONENTS(ft, ca) {
+    const realnum *saa = sus->sigma[ca][component_direction(ca)];
+    if (!saa) continue;
+    FOR_FT_COMPONENTS(ft, cb) {
+      if (cb == ca) continue;
+      const realnum *sbb = sus->sigma[cb][component_direction(cb)];
+      const realnum *sab = sus->sigma[ca][component_direction(cb)];
+      if (!sbb || !sab) continue;
+      LOOP_OVER_VOL(gv, ca, idx) {
+        const realnum a = saa[idx], b = sbb[idx], o = sab[idx];
+        if (a > 0 && b > 0 && o * o > a * b * (1 + 1e-6)) return true;
+      }
+    }
+  }
+}
+
 void structure::add_susceptibility(material_function &sigma, field_type ft,
                                    const susceptibility &sus) {
   changing_chunks();
@@ -504,6 +528,20 @@ void structure::add_susceptibility(material_function &sigma, field_type ft,
       newsus->trivial_sigma[c][d] = trivial_sigma_sync[c][d];
     }
   }
+
+  /* Warn if the user supplied a non-positive-semidefinite (non-passive)
+     anisotropic sigma tensor, which is non-physical and can make the
+     simulation diverge.  (This is distinct from the boundary instability that
+     the update_P guard handles; here the bulk tensor itself is bad.) */
+  bool local_bad = false;
+  for (int i = 0; i < num_chunks; i++)
+    if (chunks[i]->is_mine() && chunks[i]->chiP[ft])
+      local_bad = local_bad || sigma_not_psd(chunks[i]->chiP[ft], chunks[i]->gv, ft);
+  if (or_to_all(local_bad))
+    master_printf("Warning: an anisotropic susceptibility sigma tensor is not "
+                  "positive-semidefinite (an off-diagonal sigma exceeds "
+                  "sqrt(diagonal product)); this medium is non-passive and may "
+                  "cause the simulation to diverge.\n");
 }
 
 void structure::use_pml(direction d, boundary_side b, double dx) {

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -496,6 +496,7 @@ static bool sigma_not_psd(const susceptibility *sus, const grid_volume &gv, fiel
       }
     }
   }
+  return false;
 }
 
 void structure::add_susceptibility(material_function &sigma, field_type ft,

--- a/src/susceptibility.cpp
+++ b/src/susceptibility.cpp
@@ -226,26 +226,30 @@ void lorentzian_susceptibility::update_P(realnum *W[NUM_FIELD_COMPONENTS][2],
         }
         if (s1 && s2) { // 3x3 anisotropic
           PLOOP_OVER_VOL_OWNED(gv, c, i) {
-            // s[i] != 0 check is a bit of a hack to work around
-            // some instabilities that occur near the boundaries
-            // of materials; see PR #666
-            if (s[i] != 0) {
-              realnum pcur = p[i];
-              p[i] = gamma1inv * (pcur * (2 - omega0dtsqr_denom) - gamma1 * pp[i] +
-                                  omega0dtsqr * (s[i] * w[i] + OFFDIAG(s1, w1, is1, is) +
-                                                 OFFDIAG(s2, w2, is2, is)));
-              pp[i] = pcur;
-            }
+            // The s[i] != 0 mask works around instabilities near material
+            // boundaries (see PR #666). sigma is static in time, so the
+            // predicate is the same every step; apply it branchlessly so the
+            // loop still vectorizes. Where s[i] == 0, p[i] and pp[i] are left
+            // unchanged, exactly as the original guarded update did.
+            const realnum mask = (s[i] != 0) ? 1 : 0;
+            const realnum pcur = p[i];
+            const realnum pnew =
+                gamma1inv *
+                (pcur * (2 - omega0dtsqr_denom) - gamma1 * pp[i] +
+                 omega0dtsqr * (s[i] * w[i] + OFFDIAG(s1, w1, is1, is) + OFFDIAG(s2, w2, is2, is)));
+            p[i] = mask * pnew + (1 - mask) * pcur;
+            pp[i] = mask * pcur + (1 - mask) * pp[i];
           }
         }
         else if (s1) { // 2x2 anisotropic
           PLOOP_OVER_VOL_OWNED(gv, c, i) {
-            if (s[i] != 0) { // see above
-              realnum pcur = p[i];
-              p[i] = gamma1inv * (pcur * (2 - omega0dtsqr_denom) - gamma1 * pp[i] +
-                                  omega0dtsqr * (s[i] * w[i] + OFFDIAG(s1, w1, is1, is)));
-              pp[i] = pcur;
-            }
+            const realnum mask = (s[i] != 0) ? 1 : 0; // see above
+            const realnum pcur = p[i];
+            const realnum pnew =
+                gamma1inv * (pcur * (2 - omega0dtsqr_denom) - gamma1 * pp[i] +
+                             omega0dtsqr * (s[i] * w[i] + OFFDIAG(s1, w1, is1, is)));
+            p[i] = mask * pnew + (1 - mask) * pcur;
+            pp[i] = mask * pcur + (1 - mask) * pp[i];
           }
         }
         else { // isotropic


### PR DESCRIPTION
Related to #3229.

This PR adds a warning if the user-supplied anisotropic Lorentzian susceptibility tensor (`sigma`) is non positive semidefinite. Additionally, the guard introduced in #666 to skip update of the polarization fields at material interfaces (to ensure stability) is reorganized to enable loop vectorization.