### PR TITLE
Remove deprecated `monitor_point` C++ class

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,7 +143,7 @@ LT_INIT
 AC_CHECK_LIB(m, sin)
 
 # FFTW3 is preferred; FFTW2 (dfftw/fftw) is also supported by Meep
-# (see src/monitor.cpp and src/casimir.cpp for FFTW2 code paths).
+# (see src/casimir.cpp for FFTW2 code paths).
 AC_CHECK_LIB(fftw3, fftw_plan_dft_1d, [],
   [AC_CHECK_LIB(dfftw, fftw_create_plan, [],
     [AC_CHECK_LIB(fftw, fftw_create_plan, [],

--- a/doc/docs/C++_Developer_Information.md
+++ b/doc/docs/C++_Developer_Information.md
@@ -80,7 +80,6 @@ Beware that some of the interfaces in the source code and in the old manual are 
 
 In particular, you should probably avoid:
 
--   The `monitor_point` class. Just declare an array to store the fields you want, get them with `fields::get_field`, and analyze them with `do_harminv`. Or, to accumulate the DFT as you run, use the `dft_chunk` class via `fields::add_dft`.
 -   Slice and EPS output. This has been superseded by HDF5 output, which is much more flexible and efficient.
 
 ---

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1097,36 +1097,6 @@ private:
   double start_time, end_time, fwidth;
 };
 
-class monitor_point {
-public:
-  monitor_point();
-  ~monitor_point();
-  vec loc;
-  double t;
-  std::complex<double> f[NUM_FIELD_COMPONENTS];
-  monitor_point *next;
-
-  std::complex<double> get_component(component);
-  double poynting_in_direction(direction d);
-  double poynting_in_direction(vec direction_v);
-
-  // When called with only its first four arguments, fourier_transform
-  // performs an FFT on its monitor points, putting the frequencies in f
-  // and the amplitudes in a.  Yes, the frequencies are trivial and
-  // redundant, but this saves you the risk of making a mistake in
-  // converting your units.  Note also, that in this case f is always a
-  // real number, although it's stored in a complex.
-  //
-  // Note that in either case, fourier_transform assumes that the monitor
-  // points are all equally spaced in time.
-  void fourier_transform(component w, std::complex<double> **a, std::complex<double> **f,
-                         int *numout, double fmin = 0.0, double fmax = 0.0, int maxbands = 100);
-  // harminv works much like fourier_transform, except that it is not yet
-  // implemented.
-  void harminv(component w, std::complex<double> **a, std::complex<double> **f, int *numout,
-               double fmin, double fmax, int maxbands);
-};
-
 // dft.cpp
 // this should normally only be created with fields::add_dft
 class dft_chunk {
@@ -2209,8 +2179,6 @@ public:
   }
   std::complex<double> get_eps(const vec &loc, double frequency = 0) const;
   std::complex<double> get_mu(const vec &loc, double frequency = 0) const;
-  void get_point(monitor_point *p, const vec &) const;
-  monitor_point *get_new_point(const vec &, monitor_point *p = NULL) const;
 
   std::complex<double> get_field(int c, const vec &loc, bool parallel = true) const;
   std::complex<double> get_field(component c, const vec &loc, bool parallel = true) const;

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -22,45 +22,14 @@
 #include "meep.hpp"
 #include "meep_internals.hpp"
 
-#include "config.h"
-#if defined(HAVE_LIBFFTW3)
-#include <fftw3.h>
-#elif defined(HAVE_LIBDFFTW)
-#include <dfftw.h>
-#elif defined(HAVE_LIBFFTW)
-#include <fftw.h>
-#endif
-#if defined(HAVE_LIBFFTW3) || defined(HAVE_LIBFFTW) || defined(HAVE_LIBDFFTW)
-#define HAVE_SOME_FFTW 1
-#else
-#define HAVE_SOME_FFTW 0
-#endif
-
-/* Below are the monitor point routines. */
+/* Below are the field point routines. */
 
 using namespace std;
 
 namespace meep {
 
-monitor_point::monitor_point() { next = NULL; }
-
-monitor_point::~monitor_point() {
-  if (next) delete next;
-}
-
 inline complex<double> getcm(const realnum *const f[2], size_t i) {
   return complex<double>(f[0][i], f[1][i]);
-}
-
-void fields::get_point(monitor_point *pt, const vec &loc) const {
-  if (pt == NULL) meep::abort("Error:  get_point passed a null pointer!\n");
-  for (int i = 0; i < 10; i++)
-    pt->f[i] = 0.0;
-  pt->loc = loc;
-  pt->t = time();
-  FOR_COMPONENTS(c) {
-    if (gv.has_field(c)) pt->f[c] = get_field(c, loc);
-  }
 }
 
 complex<double> fields::get_field(int c, const vec &loc, bool parallel) const {
@@ -407,139 +376,6 @@ complex<double> structure::get_mu(const vec &loc, double frequency) const {
     }
   }
   return complex<double>(nc, 0) / sum_to_all(tr);
-}
-
-monitor_point *fields::get_new_point(const vec &loc, monitor_point *the_list) const {
-  monitor_point *p = new monitor_point();
-  get_point(p, loc);
-  p->next = the_list;
-  return p;
-}
-
-complex<double> monitor_point::get_component(component w) { return f[w]; }
-
-double monitor_point::poynting_in_direction(direction d) {
-  direction d1 = cycle_direction(loc.dim, d, 1);
-  direction d2 = cycle_direction(loc.dim, d, 2);
-
-  // below Ex and Hx are used just to say that we want electric or magnetic component
-  complex<double> E1 = get_component(direction_component(Ex, d1));
-  complex<double> E2 = get_component(direction_component(Ex, d2));
-  complex<double> H1 = get_component(direction_component(Hx, d1));
-  complex<double> H2 = get_component(direction_component(Hx, d2));
-
-  return (real(E1) * real(H2) - real(E2) * real(H1)) + (imag(E1) * imag(H2) - imag(E2) * imag(H1));
-}
-
-double monitor_point::poynting_in_direction(vec dir) {
-  if (dir.dim != loc.dim) meep::abort("poynting_in_direction: dir.dim != loc.dim\n");
-  dir = dir / abs(dir);
-  double result = 0.0;
-  LOOP_OVER_DIRECTIONS(dir.dim, d) { result += dir.in_direction(d) * poynting_in_direction(d); }
-  return result;
-}
-
-void monitor_point::fourier_transform(component w, complex<double> **a, complex<double> **f,
-                                      int *numout, double fmin, double fmax, int maxbands) {
-  int n = 1;
-  monitor_point *p = next;
-  double tmax = t, tmin = t;
-  while (p) {
-    n++;
-    if (p->t > tmax) tmax = p->t;
-    if (p->t < tmin) tmin = p->t;
-    p = p->next;
-  }
-  p = this;
-  complex<double> *d = new complex<double>[n];
-  for (int i = 0; i < n; i++, p = p->next) {
-    d[i] = p->get_component(w);
-  }
-  if (fmin > 0.0) { // Get rid of any static fields_chunk!
-    complex<double> mean = 0.0;
-    for (int i = 0; i < n; i++)
-      mean += d[i];
-    mean /= n;
-    for (int i = 0; i < n; i++)
-      d[i] -= mean;
-  }
-#if HAVE_SOME_FFTW
-  if ((fmin > 0.0 || fmax > 0.0) && maxbands > 0) {
-#else
-  if ((fmin <= 0.0 && fmax <= 0.0) || maxbands <= 0) {
-    maxbands = n;
-    fmin = 0;
-    fmax = (n - 1) * (1.0 / (tmax - tmin));
-  }
-#endif
-    *a = new complex<double>[maxbands];
-    *f = new complex<double>[maxbands];
-    *numout = maxbands;
-    delete[] d;
-    for (int i = 0; i < maxbands; i++) {
-      double df = (maxbands == 1) ? 0.0 : (fmax - fmin) / (maxbands - 1);
-      (*f)[i] = fmin + i * df;
-      (*a)[i] = 0.0;
-      p = this;
-      while (p) {
-        double inside = 2 * pi * real((*f)[i]) * p->t;
-        (*a)[i] += p->get_component(w) * complex<double>(cos(inside), sin(inside));
-        p = p->next;
-      }
-      (*a)[i] /= (tmax - tmin);
-    }
-#if HAVE_SOME_FFTW
-  }
-  else {
-    *numout = n;
-    *a = new complex<double>[n];
-    *f = d;
-    fftw_complex *in = (fftw_complex *)d, *out = (fftw_complex *)*a;
-    fftw_plan p;
-#ifdef HAVE_LIBFFTW3
-    p = fftw_plan_dft_1d(n, in, out, FFTW_FORWARD, FFTW_ESTIMATE);
-    fftw_execute(p);
-    fftw_destroy_plan(p);
-#else
-    p = fftw_create_plan(n, FFTW_FORWARD, FFTW_ESTIMATE);
-    fftw_one(p, in, out);
-    fftw_destroy_plan(p);
-#endif
-    for (int i = 0; i < n; i++) {
-      (*f)[i] = i * (1.0 / (tmax - tmin));
-      if (real((*f)[i]) > 0.5 * n / (tmax - tmin)) (*f)[i] -= n / (tmax - tmin);
-      (*a)[i] *= (tmax - tmin) / n;
-    }
-  }
-#endif
-}
-
-void monitor_point::harminv(component w, complex<double> **a, complex<double> **f, int *numout,
-                            double fmin, double fmax, int maxbands) {
-  int n = 1;
-  monitor_point *p = next;
-  double tmax = t, tmin = t;
-  while (p) {
-    n++;
-    if (p->t > tmax) tmax = p->t;
-    if (p->t < tmin) tmin = p->t;
-    p = p->next;
-  }
-  p = this;
-  complex<double> *d = new complex<double>[n];
-  for (int i = 0; i < n; i++, p = p->next) {
-    d[i] = p->get_component(w);
-  }
-  *a = new complex<double>[n];
-  double *f_re = new double[n];
-  double *f_im = new double[n];
-  *numout = do_harminv(d, n, (tmax - tmin) / (n - 1), fmin, fmax, maxbands, *a, f_re, f_im, NULL);
-  *f = new complex<double>[*numout];
-  for (int i = 0; i < *numout; i++)
-    (*f)[i] = complex<double>(f_re[i], f_im[i]);
-  delete[] f_re;
-  delete[] f_im;
-  delete[] d;
 }
 
 } // namespace meep

--- a/tests/2D_convergence.cpp
+++ b/tests/2D_convergence.cpp
@@ -23,19 +23,19 @@ double holey_2d(const vec &xx) {
 
 double holey_shifted_2d(const vec &xx) { return holey_2d(xx + vec(pi * 0.01, 3 - pi) * 0.5); }
 
-double get_the_freq(monitor_point *p, component c) {
-  complex<double> *amp, *freqs;
-  int num;
-  p->harminv(c, &amp, &freqs, &num, 0.15, 0.20, 8);
+double get_the_freq(std::vector<complex<double> > &mon_data, double dt) {
+  const int maxbands = 8;
+  std::vector<complex<double> > amps(maxbands);
+  std::vector<double> freq_re(maxbands), freq_im(maxbands);
+  int num = do_harminv(mon_data.data(), int(mon_data.size()), dt, 0.15, 0.20, maxbands, amps.data(),
+                       freq_re.data(), freq_im.data(), NULL);
   if (!num) return 0.0;
-  double best_amp = abs(amp[0]), best_freq = fabs(real(freqs[0]));
+  double best_amp = abs(amps[0]), best_freq = fabs(freq_re[0]);
   for (int i = 1; i < num; i++)
-    if (abs(amp[i]) > best_amp && fabs(imag(freqs[i]) / real(freqs[i])) < 0.002) {
-      best_amp = abs(amp[i]);
-      best_freq = fabs(real(freqs[i]));
+    if (abs(amps[i]) > best_amp && fabs(freq_im[i] / freq_re[i]) < 0.002) {
+      best_amp = abs(amps[i]);
+      best_freq = fabs(freq_re[i]);
     }
-  delete[] freqs;
-  delete[] amp;
   return best_freq;
 }
 
@@ -54,13 +54,12 @@ double freq_at_resolution(double e(const vec &), double a, component c, double b
     f.step();
   const double fourier_timesteps = 3000.0;
   const double ttot = fourier_timesteps / a + f.time();
-  monitor_point *p = NULL;
+  std::vector<complex<double> > mon_data;
   while (f.time() <= ttot) {
     f.step();
-    p = f.get_new_point(vec(0.52, 0.97), p);
+    mon_data.push_back(f.get_field(c, vec(0.52, 0.97)));
   }
-  const double freq = get_the_freq(p, c);
-  delete p;
+  const double freq = get_the_freq(mon_data, f.dt);
   return freq;
 }
 

--- a/tests/convergence_cyl_waveguide.cpp
+++ b/tests/convergence_cyl_waveguide.cpp
@@ -50,11 +50,9 @@ void test_convergence_without_averaging() {
     int t_harminv_max = 2500; // try increasing this in case of failure
     std::vector<complex<double> > mon_data(t_harminv_max);
     int t = 0;
-    monitor_point mp;
     while (t < t_harminv_max) {
       f.step();
-      f.get_point(&mp, veccyl(0.2, 0.0));
-      mon_data[t] = mp.get_component(Er);
+      mon_data[t] = f.get_field(Er, veccyl(0.2, 0.0));
       t++;
     }
     const int maxbands = 10;
@@ -119,11 +117,9 @@ void test_convergence_with_averaging() {
     int t_harminv_max = 2500; // try increasing this in case of failure
     std::vector<complex<double> > mon_data(t_harminv_max);
     int t = 0;
-    monitor_point mp;
     while (t < t_harminv_max) {
       f.step();
-      f.get_point(&mp, veccyl(0.2, 0.0));
-      mon_data[t] = mp.get_component(Er);
+      mon_data[t] = f.get_field(Er, veccyl(0.2, 0.0));
       t++;
     }
     const int maxbands = 10;

--- a/tests/cylindrical.cpp
+++ b/tests/cylindrical.cpp
@@ -37,13 +37,10 @@ int compare(double a, double b, const char *n, double eps = 4e-15) {
 
 int compare_point(fields &f1, fields &f2, const vec &p, double eps = 4e-8) {
   if (sizeof(realnum) == sizeof(float)) eps = sqrt(eps);
-  monitor_point m1, m_test;
-  f1.get_point(&m_test, p);
-  f2.get_point(&m1, p);
   for (int i = 0; i < 10; i++) {
     component c = (component)i;
     if (f1.gv.has_field(c)) {
-      complex<double> v1 = m_test.get_component(c), v2 = m1.get_component(c);
+      complex<double> v1 = f1.get_field(c, p), v2 = f2.get_field(c, p);
       if (abs(v1 - v2) > eps * abs(v2) && abs(v2) > eps * 100) {
         master_printf("%s differs:  %g %g out of %g %g\n", component_name(c), real(v2 - v1),
                       imag(v2 - v1), real(v2), imag(v2));
@@ -165,31 +162,30 @@ int test_r_equals_zero(double eps(const vec &)) {
     f.add_point_source(Ez, 0.8, 0.6, 0.0, 4.0, veccyl(0.401, 0.301), 1.0);
     while (f.time() < ttot)
       f.step();
-    monitor_point p;
-    f.get_point(&p, veccyl(0.0, 0.5));
-    if (!issmall(p.get_component(Ez)) && (m & 1)) {
+    const vec p = veccyl(0.0, 0.5);
+    if (!issmall(f.get_field(Ez, p)) && (m & 1)) {
       master_printf("Got non-zero Ez with m == %d\n", m);
       return 0;
     }
-    if (!issmall(p.get_component(Hz)) && (m & 1)) {
+    if (!issmall(f.get_field(Hz, p)) && (m & 1)) {
       master_printf("Got non-zero Hz with m == %d\n", m);
       return 0;
     }
-    if (!issmall(p.get_component(Er)) && !(m & 1)) {
+    if (!issmall(f.get_field(Er, p)) && !(m & 1)) {
       master_printf("Got non-zero Er with m == %d\n", m);
       return 0;
     }
-    if (!issmall(p.get_component(Ep)) && !(m & 1)) {
+    if (!issmall(f.get_field(Ep, p)) && !(m & 1)) {
       master_printf("Got non-zero Ep with m == %d\n", m);
       return 0;
     }
-    if (!issmall(p.get_component(Hr)) && !(m & 1)) {
+    if (!issmall(f.get_field(Hr, p)) && !(m & 1)) {
       master_printf("Got non-zero Hr with m == %d\n", m);
       return 0;
     }
-    if (!issmall(p.get_component(Hp)) && !(m & 1)) {
-      master_printf("Got non-zero Hp of %g %g with m == %d\n", real(p.get_component(Hp)),
-                    imag(p.get_component(Hp)), m);
+    if (!issmall(f.get_field(Hp, p)) && !(m & 1)) {
+      master_printf("Got non-zero Hp of %g %g with m == %d\n", real(f.get_field(Hp, p)),
+                    imag(f.get_field(Hp, p)), m);
       return 0;
     }
   }

--- a/tests/dump_load.cpp
+++ b/tests/dump_load.cpp
@@ -49,13 +49,10 @@ int compare(double a, double b, const char *n) {
 }
 
 int compare_point(fields &f1, fields &f2, const vec &p) {
-  monitor_point m1, m_test;
-  f1.get_point(&m_test, p);
-  f2.get_point(&m1, p);
   for (int i = 0; i < 10; i++) {
     component c = (component)i;
     if (f1.gv.has_field(c)) {
-      complex<double> v1 = m_test.get_component(c), v2 = m1.get_component(c);
+      complex<double> v1 = f1.get_field(c, p), v2 = f2.get_field(c, p);
       if (abs(v1 - v2) > tol * abs(v2) && abs(v2) > thresh) {
         master_printf("%s differs:  %g %g out of %g %g\n", component_name(c), real(v2 - v1),
                       imag(v2 - v1), real(v2), imag(v2));
@@ -70,13 +67,10 @@ int compare_point(fields &f1, fields &f2, const vec &p) {
 }
 
 int approx_point(fields &f1, fields &f2, const vec &p) {
-  monitor_point m1, m_test;
-  f1.get_point(&m_test, p);
-  f2.get_point(&m1, p);
   for (int i = 0; i < 10; i++) {
     component c = (component)i;
     if (f1.gv.has_field(c)) {
-      complex<double> v1 = m_test.get_component(c), v2 = m1.get_component(c);
+      complex<double> v1 = f1.get_field(c, p), v2 = f2.get_field(c, p);
       if (abs(v1 - v2) > tol * abs(v2) && abs(v2) > thresh) {
         master_printf("%s differs:  %g %g out of %g %g\n", component_name(c), real(v2 - v1),
                       imag(v2 - v1), real(v2), imag(v2));

--- a/tests/known_results.cpp
+++ b/tests/known_results.cpp
@@ -57,9 +57,7 @@ double using_pml_ez(const grid_volume &gv, double eps(const vec &)) {
   f.add_point_source(Ez, 0.2, 3.0, 0.0, 2.0, gv.center(), complex<double>(0, -2 * pi * 0.2));
   while (f.round_time() < ttot)
     f.step();
-  monitor_point p;
-  f.get_point(&p, gv.center());
-  return real(p.get_component(Ez));
+  return real(f.get_field(Ez, gv.center()));
 }
 
 double x_periodic_y_pml(const grid_volume &gv, double eps(const vec &)) {
@@ -70,9 +68,7 @@ double x_periodic_y_pml(const grid_volume &gv, double eps(const vec &)) {
   f.use_bloch(X, 0.1);
   while (f.round_time() < ttot)
     f.step();
-  monitor_point p;
-  f.get_point(&p, gv.center());
-  return real(p.get_component(Ez));
+  return real(f.get_field(Ez, gv.center()));
 }
 
 double x_periodic(const grid_volume &gv, double eps(const vec &)) {
@@ -83,9 +79,7 @@ double x_periodic(const grid_volume &gv, double eps(const vec &)) {
   f.use_bloch(X, 0.1);
   while (f.round_time() < ttot)
     f.step();
-  monitor_point p;
-  f.get_point(&p, gv.center());
-  return real(p.get_component(Ez));
+  return real(f.get_field(Ez, gv.center()));
 }
 
 double periodic_ez(const grid_volume &gv, double eps(const vec &)) {
@@ -103,9 +97,7 @@ double periodic_ez(const grid_volume &gv, double eps(const vec &)) {
   f.use_bloch(k);
   while (f.round_time() < ttot)
     f.step();
-  monitor_point p;
-  f.get_point(&p, gv.center());
-  return real(p.get_component(Ez));
+  return real(f.get_field(Ez, gv.center()));
 }
 
 double metallic_ez(const grid_volume &gv, double eps(const vec &)) {
@@ -115,9 +107,7 @@ double metallic_ez(const grid_volume &gv, double eps(const vec &)) {
   f.add_point_source(Ez, 0.2, 3.0, 0.0, 2.0, gv.center(), complex<double>(0, -2 * pi * 0.2));
   while (f.round_time() < ttot)
     f.step();
-  monitor_point p;
-  f.get_point(&p, gv.center());
-  return real(p.get_component(Ez));
+  return real(f.get_field(Ez, gv.center()));
 }
 
 double sigma(const vec &) { return 7.63; }
@@ -130,9 +120,7 @@ double polariton_ex(const grid_volume &gv, double eps(const vec &)) {
   f.add_point_source(Ex, 0.2, 3.0, 0.0, 2.0, gv.center(), complex<double>(0, -2 * pi * 0.2));
   while (f.round_time() < ttot)
     f.step();
-  monitor_point p;
-  f.get_point(&p, gv.center());
-  return real(p.get_component(Ex));
+  return real(f.get_field(Ex, gv.center()));
 }
 
 double polariton_energy(const grid_volume &gv, double eps(const vec &)) {

--- a/tests/one_dimensional.cpp
+++ b/tests/one_dimensional.cpp
@@ -41,13 +41,10 @@ int compare(double a, double b, const char *n) {
 }
 
 int compare_point(fields &f1, fields &f2, const vec &p) {
-  monitor_point m1, m_test;
-  f1.get_point(&m_test, p);
-  f2.get_point(&m1, p);
   for (int i = 0; i < 10; i++) {
     component c = (component)i;
     if (f1.gv.has_field(c)) {
-      complex<double> v1 = m_test.get_component(c), v2 = m1.get_component(c);
+      complex<double> v1 = f1.get_field(c, p), v2 = f2.get_field(c, p);
       if (abs(v1 - v2) > tol * abs(v2) && abs(v2) > thresh) {
         master_printf("%s differs:  %g %g out of %g %g\n", component_name(c), real(v2 - v1),
                       imag(v2 - v1), real(v2), imag(v2));

--- a/tests/symmetry.cpp
+++ b/tests/symmetry.cpp
@@ -60,13 +60,10 @@ int compare(double a, double b, const char *n) {
 }
 
 int compare_point(fields &f1, fields &f2, const vec &p) {
-  monitor_point m1, m_test;
-  f1.get_point(&m_test, p);
-  f2.get_point(&m1, p);
   for (int i = 0; i < 10; i++) {
     component c = (component)i;
     if (f1.gv.has_field(c)) {
-      complex<double> v1 = m_test.get_component(c), v2 = m1.get_component(c);
+      complex<double> v1 = f1.get_field(c, p), v2 = f2.get_field(c, p);
       if (!compare(real(v1), real(v2), "real part") ||
           !compare(imag(v1), imag(v2), "imaginary part")) {
         master_printf("%s differs by %g%+gi from %g%+gi\n", component_name(c), real(v2 - v1),

--- a/tests/three_d.cpp
+++ b/tests/three_d.cpp
@@ -49,13 +49,10 @@ int compare(double a, double b, const char *n) {
 }
 
 int compare_point(fields &f1, fields &f2, const vec &p) {
-  monitor_point m1, m_test;
-  f1.get_point(&m_test, p);
-  f2.get_point(&m1, p);
   for (int i = 0; i < 10; i++) {
     component c = (component)i;
     if (f1.gv.has_field(c)) {
-      complex<double> v1 = m_test.get_component(c), v2 = m1.get_component(c);
+      complex<double> v1 = f1.get_field(c, p), v2 = f2.get_field(c, p);
       if (abs(v1 - v2) > tol * abs(v2) && abs(v2) > thresh) {
         master_printf("%s differs:  %g %g out of %g %g\n", component_name(c), real(v2 - v1),
                       imag(v2 - v1), real(v2), imag(v2));
@@ -70,13 +67,10 @@ int compare_point(fields &f1, fields &f2, const vec &p) {
 }
 
 int approx_point(fields &f1, fields &f2, const vec &p) {
-  monitor_point m1, m_test;
-  f1.get_point(&m_test, p);
-  f2.get_point(&m1, p);
   for (int i = 0; i < 10; i++) {
     component c = (component)i;
     if (f1.gv.has_field(c)) {
-      complex<double> v1 = m_test.get_component(c), v2 = m1.get_component(c);
+      complex<double> v1 = f1.get_field(c, p), v2 = f2.get_field(c, p);
       if (abs(v1 - v2) > tol * abs(v2) && abs(v2) > thresh) {
         master_printf("%s differs:  %g %g out of %g %g\n", component_name(c), real(v2 - v1),
                       imag(v2 - v1), real(v2), imag(v2));

--- a/tests/two_dimensional.cpp
+++ b/tests/two_dimensional.cpp
@@ -49,13 +49,10 @@ int compare(double a, double b, const char *n) {
 }
 
 int compare_point(fields &f1, fields &f2, const vec &p) {
-  monitor_point m1, m_test;
-  f1.get_point(&m_test, p);
-  f2.get_point(&m1, p);
   for (int i = 0; i < 10; i++) {
     component c = (component)i;
     if (f1.gv.has_field(c)) {
-      complex<double> v1 = m_test.get_component(c), v2 = m1.get_component(c);
+      complex<double> v1 = f1.get_field(c, p), v2 = f2.get_field(c, p);
       if (abs(v1 - v2) > tol * abs(v2) && abs(v2) > thresh) {
         master_printf("%s differs:  %g %g out of %g %g\n", component_name(c), real(v2 - v1),
                       imag(v2 - v1), real(v2), imag(v2));


### PR DESCRIPTION
Closes #3237.

The C++ class `monitor_point` (`src/meep.hpp:1100-1128`) is a legacy field-sampling helper that has long been documented as deprecated in `doc/docs/C++_Developer_Information.md:83`. It is a thin caching/bookkeeping wrapper: `fields::get_point()` already populates it by calling `fields::get_field()` internally (`src/monitor.cpp:62`). The documented replacement is to call `fields::get_field()` directly and, where spectral analysis is needed, feed a collected array into `do_harminv()`.

`monitor_point` is C++-only — the Python and Scheme front-ends never use it (Python field sampling already goes through `fields::get_field` via `fields::get_field_point`, and Python harminv uses the standalone `do_harminv` wrapper). It is exposed to SWIG only incidentally via `%include "meep.hpp"`, with no explicit typemaps, so removing it does not affect the bindings.

This PR deletes the class and its supporting `fields` methods, migrates the C++ unit tests that use it to `fields::get_field` (+ `do_harminv` where needed), and updates the docs.