### PR TITLE
Add CI check for `mkdocs build`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+---
+name: docs
+
+on:
+  pull_request:
+    paths:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  push:
+    paths:
+      - 'doc/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.11
+      - name: Install documentation dependencies
+        run: pip install -r doc/requirements.txt
+      # Build the HTML docs from the committed Markdown tree (which includes the
+      # generated Python_User_Interface.md) to catch broken doc builds. The
+      # --strict flag turns warnings (broken links, missing nav entries, etc.)
+      # into errors. This does not rebuild meep, so it does not regenerate the
+      # Python API doc from docstrings; run `make docs` locally after changing
+      # docstrings.
+      - name: Build documentation
+        run: python -m mkdocs build --strict -f mkdocs.yml

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,11 +4,15 @@ markdown (.md) files are in the `doc/docs` folder.
 
 To build and visualize the HTML documentation locally using the mkdocs package
 (useful for verifying changes on your local machine before committing), first
-install `mkdocs` as well as two auxiliary packages via e.g.:
+install the pinned documentation dependencies via e.g.:
 
 ```
-% pip3 install --user mkdocs python-markdown-math mkdocs-material
+% pip3 install --user -r doc/requirements.txt
 ```
+
+This installs `mkdocs` and `pymdown-extensions` (the latter provides the
+`pymdownx.arithmatex` extension used to render LaTex math). Use Python 3.11, the
+same version used to build and test the rest of the project.
 
 The main Python API document (`Python_User_Interface.md`) is generated from a
 template file (named the same, with a `.in` extension), and the docstrings
@@ -21,11 +25,11 @@ formatting. To control where the docstrings are inserted into the documentation
 a simple tagging system is used. See the documentation in the
 `doc/generate_py_api.py` file for details.
 
-If a docstring contains an "alternate function signature", usually to make
+A docstring may contain an "alternate function signature", usually to make
 functions that accept a variety of positional or keyword arguments more clear to
 the reader. Functions that fall into this category typically use Python's `*` or
 `**` syntax. These lines can be tagged to indicate to the tool that they should
-be moved or copied to the code block in the documentation where they function
+be moved or copied to the code block in the documentation where the function
 signature is declared.  For example:
 
 ```python
@@ -54,7 +58,11 @@ Note that this command should be rerun after making any changes to main template
 file or the docstrings in the source, and rebuilding the project, in order to
 update the documentation.
 
-The view an auto-updating version of the documentation, run the following
+Unlike the Python API document, the Scheme API document
+(`doc/docs/Scheme_User_Interface.md`) has no `.md.in` template or generator; it
+is maintained by hand, so edits should be made directly to that file.
+
+To view an auto-updating version of the documentation, run the following
 command from the top-level MEEP repository tree:
 
 ```

--- a/doc/README.md
+++ b/doc/README.md
@@ -86,6 +86,18 @@ To build the static HTML version of the documentation, run:
 
 The results will be put into the `./doc/site` folder.
 
+To verify that the documentation builds without any warnings (broken links,
+missing navigation entries, etc.) before committing, pass the
+[`--strict`](https://www.mkdocs.org/user-guide/cli/#mkdocs-build) flag, which
+turns warnings into errors:
+
+```
+% mkdocs build --strict
+```
+
+This is the same check that runs in continuous integration (see
+`.github/workflows/docs.yml`).
+
 Alternatively, the project `Makefile` can also be used to build the
 documentation and to build a distribution archive containing the
 documentation. To do so, run one of the following commands from the


### PR DESCRIPTION
Added `.github/workflows/docs.yml`:
- Triggers only on changes to `doc/**`, `mkdocs.yml`, or the workflow itself (keeps it off unrelated pushes).
- Checks out, sets up Python 3.11, installs `doc/requirements.txt`, and runs `mkdocs build`
- This catches broken doc builds on every PR **without** having to compile Meep (it builds from the committed Markdown tree, which already includes the generated `Python_User_Interface.md`).
- A comment documents the one thing it can't do — regenerate the API doc from docstrings (that needs a Meep build; `make docs` locally covers it).

**Not implemented** (possible feature to add separately)
Catching a *stale committed* `Python_User_Interface.md` (docstrings changed but the generated file wasn't regenerated). This would require running `make docs` inside `build-ci.yml` (where Meep is already compiled) and failing on a non-empty `git diff`.