### PR TITLE
Fix Python bindings build with SWIG >= 4.1 (Python 2 C-API removal)

### DIFF
--- a/python/numpy.i
+++ b/python/numpy.i
@@ -105,6 +105,16 @@
 %fragment("NumPy_Utilities",
           "header")
 {
+%#if PY_VERSION_HEX >= 0x03000000
+  /* Python 3 removed the PyInt/PyString C APIs; map the uses in this file
+     onto their Python 3 equivalents (SWIG >= 4.1 no longer provides these
+     backward-compatibility defines itself). */
+%#ifndef PyInt_Check
+%#define PyInt_Check(x) PyLong_Check(x)
+%#define PyInt_AsLong(x) PyLong_AsLong(x)
+%#endif
+%#endif
+
   /* Given a PyObject, return a string describing its type.
    */
   const char* pytype_string(PyObject* py_obj)
@@ -112,7 +122,12 @@
     if (py_obj == NULL          ) return "C NULL value";
     if (py_obj == Py_None       ) return "Python None" ;
     if (PyCallable_Check(py_obj)) return "callable"    ;
+%#if PY_VERSION_HEX >= 0x03000000
+    if (PyUnicode_Check( py_obj)) return "string"      ;
+    if (PyBytes_Check(   py_obj)) return "bytes"       ;
+%#else
     if (PyString_Check(  py_obj)) return "string"      ;
+%#endif
     if (PyInt_Check(     py_obj)) return "int"         ;
     if (PyFloat_Check(   py_obj)) return "float"       ;
     if (PyDict_Check(    py_obj)) return "dict"        ;

--- a/python/typemap_utils.cpp
+++ b/python/typemap_utils.cpp
@@ -504,7 +504,7 @@ static int pymaterial_grid_to_material_grid(PyObject *po, material_data *md) {
 
   // specify the type of material grid
   PyObject *type = PyObject_GetAttrString(po, "grid_type");
-  long gt_enum = PyInt_AsLong(type);
+  long gt_enum = PyInteger_AsLong(type);
   Py_DECREF(type);
 
   switch (gt_enum) {


### PR DESCRIPTION
SWIG 4.1 removed the `PyInt_*`/`PyString_*` backward-compatibility defines from
its generated Python runtime, so regenerating the wrappers with any recent SWIG
fails to compile under Python 3:

```
typemap_utils.cpp:507:18: error: 'PyInt_AsLong' was not declared in this scope
numpy.i (pytype_string): error: 'PyString_Check' was not declared in this scope
```

Two small fixes:

- `python/numpy.i`: guard the `pytype_string()` helper for Python 3 and define
  `PyInt_Check`/`PyInt_AsLong` in terms of `PyLong` (this file predates the
  numpy upstream Python-3 rework; this is the minimal change rather than a
  wholesale refresh of `numpy.i`).
- `python/typemap_utils.cpp`: one stray direct `PyInt_AsLong()` call; use the
  existing `PyInteger_AsLong` compatibility macro defined at the top of the
  file.

No functional change to the generated bindings. Verified by regenerating and
compiling the wrappers with SWIG 4.1.1 and 4.5.0 under Python 3.12 (both
previously failed; both now build and pass the Python test suite subset we ran).
CI with SWIG 4.0 is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
