### PR TITLE
Speed up connect_the_chunks for large numbers of chunks

### DIFF
--- a/src/boundaries.cpp
+++ b/src/boundaries.cpp
@@ -19,6 +19,7 @@
 #include <map>
 #include <stdlib.h>
 #include <complex>
+#include <vector>
 
 #include "meep.hpp"
 #include "meep/mympi.hpp"
@@ -403,9 +404,30 @@ void fields::connect_the_chunks() {
   FOR_E_AND_H(c) { needs_W_notowned[c] = or_to_all(needs_W_notowned[c]); }
   finished_working();
 
+  /* In the common case with no periodic boundaries or symmetry transforms,
+     only chunks intersecting i's one-pixel halo can own one of its not-owned
+     boundary points.  Keep the original all-pairs scan for the more subtle
+     periodic and symmetry-reduced cases. */
+  bool prune_chunk_pairs = S.multiplicity() == 1;
+  LOOP_OVER_DIRECTIONS(gv.dim, d) {
+    if (boundaries[High][d] == Periodic) prune_chunk_pairs = false;
+  }
+  std::vector<std::vector<int> > chunk_candidates(num_chunks);
+  std::vector<bool> chunk_needed(num_chunks, false);
+  for (int i = 0; i < num_chunks; ++i) {
+    const grid_volume padded_i = chunks[i]->gv.pad();
+    for (int j = 0; j < num_chunks; ++j) {
+      if (!prune_chunk_pairs || padded_i.intersect_with(chunks[j]->gv)) {
+        chunk_candidates[i].push_back(j);
+        if (chunks[i]->is_mine() || chunks[j]->is_mine()) chunk_needed[i] = true;
+      }
+    }
+  }
+
   comm_sizes.clear();
   const size_t num_reals_per_voxel = is_real ? 1 : 2;
   for (int i = 0; i < num_chunks; i++) {
+    if (!chunk_needed[i]) continue;
     // First count the border elements...
     const grid_volume vi = chunks[i]->gv;
     FOR_COMPONENTS(corig) {
@@ -415,7 +437,7 @@ void fields::connect_the_chunks() {
           // We're looking at a border element...
           complex<double> thephase;
           if (locate_component_point(&c, &here, &thephase) && !on_metal_boundary(here))
-            for (int j = 0; j < num_chunks; j++) {
+            for (const int j : chunk_candidates[i]) {
               const std::pair<int, int> pair_j_to_i{j, i};
               if ((chunks[i]->is_mine() || chunks[j]->is_mine()) && chunks[j]->gv.owns(here) &&
                   !(is_B(corig) && is_B(c) && B_redundant[5 * i + corig - Bx] &&
@@ -474,6 +496,7 @@ void fields::connect_the_chunks() {
 
   // Next start setting up the connections...
   for (int i = 0; i < num_chunks; i++) {
+    if (!chunk_needed[i]) continue;
     const grid_volume &vi = chunks[i]->gv;
 
     FOR_COMPONENTS(corig) {
@@ -483,7 +506,7 @@ void fields::connect_the_chunks() {
           // We're looking at a border element...
           std::complex<double> thephase;
           if (locate_component_point(&c, &here, &thephase) && !on_metal_boundary(here)) {
-            for (int j = 0; j < num_chunks; j++) {
+            for (const int j : chunk_candidates[i]) {
               const std::pair<int, int> pair_j_to_i{j, i};
               const bool i_is_mine = chunks[i]->is_mine();
               const bool j_is_mine = chunks[j]->is_mine();


### PR DESCRIPTION
`fields::connect_the_chunks()` tests every not-owned boundary point of every
chunk against every other chunk, on every process. The expensive point scan
therefore grows as O(num_chunks² × boundary points), and workflows that rebuild
`fields` repeatedly pay this cost once per iteration.

This PR conservatively prunes candidate chunk pairs before the point scan.
The connection tables and per-point `owns()` checks are unchanged.

## What changed

For the common case with no periodic boundaries or symmetry transforms,
`chunk_candidates[i]` is precomputed by intersecting chunk `i`'s existing
one-grid-point-padded `grid_volume` with the other chunk volumes. Both point
scans then iterate only over those candidates.

Periodic or symmetry-reduced simulations use the original all-pairs scan.
This avoids adding new periodic-shift or symmetry-transform logic to the
already complicated boundary-connection code.

`chunk_needed[i]` also skips source chunks whose candidate pairs are all
remote-to-remote on the current process. The loop body previously rejected all
of those pairs individually with the same process-locality condition.

Communication-buffer allocation and lifetime are unchanged from `master`.

## Why the pruning is conservative

Without periodic wrapping or symmetry transforms,
`locate_component_point()` either leaves a boundary point at the same location
or rejects it. `grid_volume::pad()` contains the one-cell not-owned halo, so if
that padded volume does not intersect chunk `j`, chunk `j` cannot own any point
from the scan. The existing per-point `owns()` test remains the final check, so
false candidates only cost extra comparisons.

For periodic or symmetry-reduced cases no pair is pruned, so their behavior is
the original behavior.

## Measurements

Measured on a dual EPYC 9554 node using the 8×5×4 µm, resolution-24 3D PML
workload (approximately 2.2M voxels). Values are medians of three interleaved
runs with `OMP_NUM_THREADS=1` and one MPI rank bound per physical core. The
metric is the maximum-rank wall time for the first `fields::step()` after
`init_sim()`.

| MPI ranks | actual chunks | master | patched | speedup |
|---:|---:|---:|---:|---:|
| 64 | 240 | 12.136 s | 0.632 s | 19.2× |
| 128 | 360 | 21.506 s | 0.786 s | 27.4× |

Serial forced-chunk measurements at resolution 16:

| requested chunks | actual chunks | master | patched | speedup |
|---:|---:|---:|---:|---:|
| 16 | 96 | 4.524 s | 1.939 s | 2.33× |
| 48 | 208 | 11.581 s | 2.754 s | 4.21× |
| 96 | 312 | 19.734 s | 3.420 s | 5.77× |
| 192 | 480 | 35.921 s | 4.722 s | 7.61× |

The numerical Ez probe was exactly identical across all variants and repeats.
The pair enumeration remains O(num_chunks²), but the surviving box tests are
much cheaper than repeating the boundary-point scan for every chunk pair.

These measurements are from a separate, explicitly core-bound campaign and
should not be compared directly with absolute timings from the earlier
unbound campaign.
