### PR TITLE
Add the equation relating the pulse width and FWHM to the docs for `GaussianSource`

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -6954,8 +6954,9 @@ Construct a `GaussianSource`.
 + **`width` [`number`]** — The width $w$ used in the Gaussian. No default value.
   You can instead specify `fwidth=x`, which is a synonym for `width=1/x` (i.e. the
   frequency width is proportional to the inverse of the temporal width). Note: the
-  relationship between the full width at half maximum $FWHM_f$ (for the spectral
-  power density) and $w$ is given by: $FWHM_f = \frac{\sqrt{\ln 2}}{\pi w} \approx \frac{0.265}{w}$.
+  relationship between $w$ and the full width at half maximum $\Delta\lambda$ (for the spectral
+  power density) is given by $w = \frac{\lambda_0^2\sqrt{\ln 2}}{\pi \Delta\lambda}$
+  where $\lambda_0$ is the center wavelength.
 
 + **`start_time` [`number`]** — The starting time for the source; default is 0
   (turn on at $t=0$). This is not the time of the peak. See below.

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -6956,8 +6956,7 @@ Construct a `GaussianSource`.
   frequency width is proportional to the inverse of the temporal width). Note: the
   relationship between $w$ and the full width at half maximum $\Delta\lambda$ (for the spectral
   power density) is given by $w \approx \frac{\lambda_0^2\sqrt{\ln 2}}{\pi \Delta\lambda}$
-  where $\lambda_0$ is the center wavelength (for narrowband pulses, where the difference
-  between a Gaussian pulse and the derivative of a Gaussian is negligible).
+  where $\lambda_0$ is the center wavelength (for narrowband pulses).
 
 + **`start_time` [`number`]** — The starting time for the source; default is 0
   (turn on at $t=0$). This is not the time of the peak. See below.

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -6953,7 +6953,9 @@ Construct a `GaussianSource`.
 
 + **`width` [`number`]** — The width $w$ used in the Gaussian. No default value.
   You can instead specify `fwidth=x`, which is a synonym for `width=1/x` (i.e. the
-  frequency width is proportional to the inverse of the temporal width).
+  frequency width is proportional to the inverse of the temporal width). Note: the
+  relationship between the full width at half maximum $FWHM_f$ (for the spectral
+  power density) and $w$ is given by: $FWHM_f = \frac{\sqrt{\ln 2}}{\pi w} \approx \frac{0.265}{w}$.
 
 + **`start_time` [`number`]** — The starting time for the source; default is 0
   (turn on at $t=0$). This is not the time of the peak. See below.

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -6955,8 +6955,9 @@ Construct a `GaussianSource`.
   You can instead specify `fwidth=x`, which is a synonym for `width=1/x` (i.e. the
   frequency width is proportional to the inverse of the temporal width). Note: the
   relationship between $w$ and the full width at half maximum $\Delta\lambda$ (for the spectral
-  power density) is given by $w = \frac{\lambda_0^2\sqrt{\ln 2}}{\pi \Delta\lambda}$
-  where $\lambda_0$ is the center wavelength.
+  power density) is given by $w \approx \frac{\lambda_0^2\sqrt{\ln 2}}{\pi \Delta\lambda}$
+  where $\lambda_0$ is the center wavelength (for narrowband pulses, where the difference
+  between a Gaussian pulse and the derivative of a Gaussian is negligible).
 
 + **`start_time` [`number`]** — The starting time for the source; default is 0
   (turn on at $t=0$). This is not the time of the peak. See below.

--- a/python/source.py
+++ b/python/source.py
@@ -284,7 +284,9 @@ class GaussianSource(SourceTime):
 
         + **`width` [`number`]** — The width $w$ used in the Gaussian. No default value.
           You can instead specify `fwidth=x`, which is a synonym for `width=1/x` (i.e. the
-          frequency width is proportional to the inverse of the temporal width).
+          frequency width is proportional to the inverse of the temporal width). Note: the
+          relationship between the full width at half maximum $FWHM_f$ (for the spectral
+          power density) and $w$ is given by $FWHM_f = \\frac{\\sqrt{\\ln 2}}{\\pi w} \\approx \\frac{0.265}{w}$.
 
         + **`start_time` [`number`]** — The starting time for the source; default is 0
           (turn on at $t=0$). This is not the time of the peak. See below.

--- a/python/source.py
+++ b/python/source.py
@@ -285,9 +285,9 @@ class GaussianSource(SourceTime):
         + **`width` [`number`]** — The width $w$ used in the Gaussian. No default value.
           You can instead specify `fwidth=x`, which is a synonym for `width=1/x` (i.e. the
           frequency width is proportional to the inverse of the temporal width). Note: the
-          relationship between $w$ and the full width at half maximum $\Delta\lambda$ (for the spectral
-          power density) is given by $w \approx \frac{\lambda_0^2\sqrt{\ln 2}}{\pi \Delta\lambda}$
-          where $\lambda_0$ is the center wavelength (for narrowband pulses).
+          relationship between $w$ and the full width at half maximum $\\Delta\\lambda$ (for the spectral
+          power density) is given by $w \\approx \\frac{\\lambda_0^2\\sqrt{\\ln 2}}{\\pi \\Delta\\lambda}$
+          where $\\lambda_0$ is the center wavelength (for narrowband pulses).
 
         + **`start_time` [`number`]** — The starting time for the source; default is 0
           (turn on at $t=0$). This is not the time of the peak. See below.

--- a/python/source.py
+++ b/python/source.py
@@ -285,9 +285,10 @@ class GaussianSource(SourceTime):
         + **`width` [`number`]** — The width $w$ used in the Gaussian. No default value.
           You can instead specify `fwidth=x`, which is a synonym for `width=1/x` (i.e. the
           frequency width is proportional to the inverse of the temporal width). Note: the
-          relationship between $w$ and the full width at half maximum $\\Delta\\lambda$ (for the spectral
-          power density) is given by $w = \\frac{\\lambda_0^2\\sqrt{\\ln 2}}{\\pi \\Delta\\lambda}$
-          where $\\lambda_0$ is the center wavelength.
+          relationship between $w$ and the full width at half maximum $\Delta\lambda$ (for the spectral
+          power density) is given by $w \approx \frac{\lambda_0^2\sqrt{\ln 2}}{\pi \Delta\lambda}$
+          where $\lambda_0$ is the center wavelength (for narrowband pulses, where the difference
+          between a Gaussian pulse and the derivative of a Gaussian is negligible).
 
         + **`start_time` [`number`]** — The starting time for the source; default is 0
           (turn on at $t=0$). This is not the time of the peak. See below.

--- a/python/source.py
+++ b/python/source.py
@@ -287,8 +287,7 @@ class GaussianSource(SourceTime):
           frequency width is proportional to the inverse of the temporal width). Note: the
           relationship between $w$ and the full width at half maximum $\Delta\lambda$ (for the spectral
           power density) is given by $w \approx \frac{\lambda_0^2\sqrt{\ln 2}}{\pi \Delta\lambda}$
-          where $\lambda_0$ is the center wavelength (for narrowband pulses, where the difference
-          between a Gaussian pulse and the derivative of a Gaussian is negligible).
+          where $\lambda_0$ is the center wavelength (for narrowband pulses).
 
         + **`start_time` [`number`]** — The starting time for the source; default is 0
           (turn on at $t=0$). This is not the time of the peak. See below.

--- a/python/source.py
+++ b/python/source.py
@@ -285,8 +285,9 @@ class GaussianSource(SourceTime):
         + **`width` [`number`]** — The width $w$ used in the Gaussian. No default value.
           You can instead specify `fwidth=x`, which is a synonym for `width=1/x` (i.e. the
           frequency width is proportional to the inverse of the temporal width). Note: the
-          relationship between the full width at half maximum $FWHM_f$ (for the spectral
-          power density) and $w$ is given by $FWHM_f = \\frac{\\sqrt{\\ln 2}}{\\pi w} \\approx \\frac{0.265}{w}$.
+          relationship between $w$ and the full width at half maximum $\\Delta\\lambda$ (for the spectral
+          power density) is given by $w = \\frac{\\lambda_0^2\\sqrt{\\ln 2}}{\\pi \\Delta\\lambda}$
+          where $\\lambda_0$ is the center wavelength.
 
         + **`start_time` [`number`]** — The starting time for the source; default is 0
           (turn on at $t=0$). This is not the time of the peak. See below.


### PR DESCRIPTION
Adds the equation relating the full width at half maximum $\Delta \lambda$ (for the spectral power density) and the pulse width $w$ to the docs for the `width` parameter of [`GaussianSource`](https://meep.readthedocs.io/en/latest/Python_User_Interface/#gaussiansource). This is especially useful for setting up sources based on experimental parameters (i.e., emission spectra obtained from photo- or electro-luminescence).

<img width="672" height="233" alt="image" src="https://github.com/user-attachments/assets/f18e8386-157d-4f03-8b7d-8c17ecae0a33" />

The derivation of this formula is provided by Gemini:

```
What is the relationship between the pulse width w and the FWHM in the wavelength λ of a
Gaussian pulse described by the equation exp(-iωt - (t - t0)² / (2w²))?
```

<img width="664" height="873" alt="image" src="https://github.com/user-attachments/assets/4887ec8f-8f4f-4ab0-800c-e58e60b97e51" />
<img width="643" height="647" alt="image" src="https://github.com/user-attachments/assets/729d895c-bdfb-4799-83e5-54785389f25e" />
