### PR TITLE
Add `plot1D` function for visualizing layout of 1D simulation

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -653,6 +653,32 @@ section for valid `side`, `direction`, and `boundary_condition` values.
 
 ---
 
+<a id="Simulation.get_boundary"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def get_boundary(side, direction):
+```
+
+<div class="method_docstring" markdown="1">
+
+Returns the condition of the boundary on the specified side in the specified
+direction. This is the counterpart of `set_boundary`. See the [Constants
+(Enumerated Types)](#constants-enumerated-types) section for valid `side`,
+`direction`, and `boundary_condition` values.
+
+The default boundary condition is `mp.Metallic` (i.e., a perfect electric
+conductor), unless a `k_point` has been specified in which case it is
+`mp.Periodic` (i.e., Bloch-periodic).
+
+</div>
+
+</div>
+
+
+---
+
 <a id="Simulation.phase_in_material"></a>
 
 <div class="class_members" markdown="1">
@@ -2883,8 +2909,8 @@ the master process.
 
 **Parameters:**
 
-* `ax`: a `matplotlib` axis object. `plot1D()` will add plot objects, like lines,
-  and patches to this object. If no `ax` is supplied, then the routine will
+* `ax`: a `matplotlib` axis object. `plot1D()` will add plot objects, like lines
+  and patches, to this object. If no `ax` is supplied, then the routine will
   create a new figure and grab its axis.
 * `frequency`: for materials with a [frequency-dependent
   permittivity](Materials.md#material-dispersion) $\varepsilon(f)$, specifies the

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -2828,6 +2828,120 @@ This module provides basic visualization functionality for the simulation domain
 
 ---
 
+<a id="Simulation.plot1D"></a>
+
+<div class="class_members" markdown="1">
+
+```python
+def plot1D(ax=None,
+           frequency=None,
+           index_parameters=None,
+           pml_parameters=None,
+           pec_parameters=None,
+           source_parameters=None,
+           monitor_parameters=None,
+           legend_parameters=None,
+           show_index=True,
+           show_boundary_layers=True,
+           show_pec=True,
+           show_sources=True,
+           show_monitors=True,
+           show_legend=True,
+           nb=False):
+```
+
+<div class="method_docstring" markdown="1">
+
+Plots an annotated view of the cell of a 1D simulation using `matplotlib`. The
+single axis of a 1D cell in Meep is always $z$ and thus the cell must have been
+specified as `cell_size=mp.Vector3(0, 0, size_z)`. The plot shows the refractive
+index profile $n(z)$ as well as the PML regions (shaded grey), the PEC walls
+(solid black lines), the sources (dashed red lines), and the DFT monitors (dotted
+green lines). A legend of these elements is added to the plot. Requires
+[matplotlib](https://matplotlib.org). Calling this function would look something
+like:
+
+```py
+sim = mp.Simulation(...)
+import matplotlib.pyplot as plt
+sim.plot1D()
+plt.savefig('sim_domain_1D.png')
+```
+
+There is no need to invoke the `run` function prior to calling `plot1D`. Just
+define the `Simulation` object followed by any DFT monitors and then invoke
+`plot1D`.
+
+A boundary of the cell is drawn as a PEC wall whenever no `k_point` has been
+specified (the default boundary condition of Meep is a metallic wall) or
+whenever `set_boundary` has been used to set the boundary condition of that
+side of the cell to `mp.Metallic`.
+
+Note: When running a [parallel simulation](Parallel_Meep.md), the `plot1D`
+function expects to be called on all processes, but only generates a plot on
+the master process.
+
+**Parameters:**
+
+* `ax`: a `matplotlib` axis object. `plot1D()` will add plot objects, like lines,
+  and patches to this object. If no `ax` is supplied, then the routine will
+  create a new figure and grab its axis.
+* `frequency`: for materials with a [frequency-dependent
+  permittivity](Materials.md#material-dispersion) $\varepsilon(f)$, specifies the
+  frequency $f$ (in Meep units) of the real part of the permittivity used to
+  compute the refractive index. Defaults to the `frequency` parameter of the
+  [Source](#source) object.
+* `index_parameters`: a `dict` of optional plotting parameters that override the
+  default parameters for the refractive-index profile.
+    - `color='b'`: color of the index profile
+    - `linestyle='-'`: line style of the index profile
+    - `linewidth=1.5`: line width of the index profile
+    - `alpha=1.0`: transparency of the index profile
+    - `label='refractive index'`: legend label of the index profile
+    - `frequency=None`: same as the `frequency` parameter above
+    - `resolution=None`: the resolution at which $\varepsilon$ is sampled.
+      Defaults to the `resolution` of the `Simulation` object.
+* `pml_parameters`: a `dict` of optional plotting parameters that override the
+  default parameters for the PML (and `Absorber`) regions.
+    - `color='0.7'`: color of the shaded region
+    - `alpha=1.0`: transparency of the shaded region
+    - `label='PML'`: legend label of the shaded region
+* `pec_parameters`: a `dict` of optional plotting parameters that override the
+  default parameters for the PEC walls.
+    - `color='k'`: color of the walls
+    - `linestyle='-'`: line style of the walls
+    - `linewidth=3.0`: line width of the walls
+    - `alpha=1.0`: transparency of the walls
+    - `label='PEC'`: legend label of the walls
+* `source_parameters`: a `dict` of optional plotting parameters that override the
+  default parameters for the sources.
+    - `color='r'`: color of the sources
+    - `linestyle='--'`: line style of the sources
+    - `linewidth=1.5`: line width of the sources
+    - `alpha=1.0`: transparency of the sources
+    - `label='source'`: legend label of the sources
+* `monitor_parameters`: a `dict` of optional plotting parameters that override the
+  default parameters for the monitors.
+    - `color='g'`: color of the monitors
+    - `linestyle=':'`: line style of the monitors
+    - `linewidth=1.5`: line width of the monitors
+    - `alpha=1.0`: transparency of the monitors
+    - `label='monitor'`: legend label of the monitors
+* `legend_parameters`: a `dict` of optional parameters passed to
+  `matplotlib.axes.Axes.legend`. Defaults to
+  `{'loc': 'best', 'fontsize': 'small', 'framealpha': 0.8}`.
+* `show_index`, `show_boundary_layers`, `show_pec`, `show_sources`,
+  elements of the plot is drawn. All default to `True`.
+* `nb`: set this to True if plotting in a Jupyter ntoebook to use ipympl for
+  plotting. Note: this requires ipympl to be installed.
+
+</div>
+
+</div>
+
+
+---
+
 <a id="Simulation.plot2D"></a>
 
 <div class="class_members" markdown="1">

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -473,6 +473,7 @@ As for `solve_cw` above, you are required to set `force_complex_fields=True` to 
 
 This module provides basic visualization functionality for the simulation domain. The intent of the module is to provide functions that can be called with *no customization options whatsoever* and will do useful relevant things by default, but which can also be customized in cases where you *do* want to take the time to spruce up the output. The `Simulation` class provides the following methods:
 
+@@ Simulation.plot1D @@
 @@ Simulation.plot2D @@
 @@ Simulation.plot3D @@
 @@ Simulation.visualize_chunks @@

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -96,6 +96,7 @@ The `Simulation` class provides the following time-related methods:
 Meep supports a large number of functions to perform computations on the fields. Most of them are accessed via the lower-level C++/SWIG interface. Some of them are based on the following simpler, higher-level versions. They are accessible as methods of a `Simulation` instance.
 
 @@ Simulation.set_boundary @@
+@@ Simulation.get_boundary @@
 @@ Simulation.phase_in_material @@
 @@ Simulation.get_field_point @@
 @@ Simulation.get_epsilon_point @@

--- a/python/meep.i
+++ b/python/meep.i
@@ -1790,6 +1790,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         get_equiv_sources,
     )
     from .visualization import (
+        plot1D,
         plot2D,
         plot3D,
         plot_fields,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1540,7 +1540,6 @@ class Simulation:
         self.epsilon_func = epsilon_func
         self.dft_objects = []
         self._is_initialized = False
-        self._boundary_conditions = {}
         self.force_all_components = force_all_components
         self.split_chunks_evenly = split_chunks_evenly
         self.chunk_layout = chunk_layout
@@ -2678,10 +2677,21 @@ class Simulation:
 
         self.fields.set_boundary(side, direction, condition)
 
-        # Keep track of the boundary conditions which have been explicitly
-        # set because they cannot be queried from the `fields` object. This
-        # is used by e.g. `plot1D` to annotate the boundaries of the cell.
-        self._boundary_conditions[(side, direction)] = condition
+    def get_boundary(self, side, direction):
+        """
+        Returns the condition of the boundary on the specified side in the specified
+        direction. This is the counterpart of `set_boundary`. See the [Constants
+        (Enumerated Types)](#constants-enumerated-types) section for valid `side`,
+        `direction`, and `boundary_condition` values.
+
+        The default boundary condition is `mp.Metallic` (i.e., a perfect electric
+        conductor), unless a `k_point` has been specified in which case it is
+        `mp.Periodic` (i.e., Bloch-periodic).
+        """
+        if self.fields is None:
+            self.init_sim()
+
+        return self.fields.get_boundary(side, direction)
 
     def get_field_point(self, c: int = None, pt: Vector3Type = None):
         """
@@ -4507,7 +4517,6 @@ class Simulation:
         self.num_chunks = self._num_chunks_original
         self.chunk_layout = self._chunk_layout_original
         self._is_initialized = False
-        self._boundary_conditions = {}
 
     def restart_fields(self):
         """
@@ -4852,8 +4861,8 @@ class Simulation:
 
         **Parameters:**
 
-        * `ax`: a `matplotlib` axis object. `plot1D()` will add plot objects, like lines,
-          and patches to this object. If no `ax` is supplied, then the routine will
+        * `ax`: a `matplotlib` axis object. `plot1D()` will add plot objects, like lines
+          and patches, to this object. If no `ax` is supplied, then the routine will
           create a new figure and grab its axis.
         * `frequency`: for materials with a [frequency-dependent
           permittivity](Materials.md#material-dispersion) $\\varepsilon(f)$, specifies the

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -1540,6 +1540,7 @@ class Simulation:
         self.epsilon_func = epsilon_func
         self.dft_objects = []
         self._is_initialized = False
+        self._boundary_conditions = {}
         self.force_all_components = force_all_components
         self.split_chunks_evenly = split_chunks_evenly
         self.chunk_layout = chunk_layout
@@ -2676,6 +2677,11 @@ class Simulation:
             self.init_sim()
 
         self.fields.set_boundary(side, direction, condition)
+
+        # Keep track of the boundary conditions which have been explicitly
+        # set because they cannot be queried from the `fields` object. This
+        # is used by e.g. `plot1D` to annotate the boundaries of the cell.
+        self._boundary_conditions[(side, direction)] = condition
 
     def get_field_point(self, c: int = None, pt: Vector3Type = None):
         """
@@ -4501,6 +4507,7 @@ class Simulation:
         self.num_chunks = self._num_chunks_original
         self.chunk_layout = self._chunk_layout_original
         self._is_initialized = False
+        self._boundary_conditions = {}
 
     def restart_fields(self):
         """
@@ -4794,6 +4801,129 @@ class Simulation:
 
     def get_sfield_p(self, snap=False):
         return self.get_array(mp.Sp, cmplx=not self.fields.is_real, snap=snap)
+
+    def plot1D(
+        self,
+        ax: Optional[Axes] = None,
+        frequency: Optional[float] = None,
+        index_parameters: Optional[dict] = None,
+        pml_parameters: Optional[dict] = None,
+        pec_parameters: Optional[dict] = None,
+        source_parameters: Optional[dict] = None,
+        monitor_parameters: Optional[dict] = None,
+        legend_parameters: Optional[dict] = None,
+        show_index: bool = True,
+        show_boundary_layers: bool = True,
+        show_pec: bool = True,
+        show_sources: bool = True,
+        show_monitors: bool = True,
+        show_legend: bool = True,
+        nb: bool = False,
+    ) -> None:
+        """
+        Plots an annotated view of the cell of a 1D simulation using `matplotlib`. The
+        single axis of a 1D cell in Meep is always $z$ and thus the cell must have been
+        specified as `cell_size=mp.Vector3(0, 0, size_z)`. The plot shows the refractive
+        index profile $n(z)$ as well as the PML regions (shaded grey), the PEC walls
+        (solid black lines), the sources (dashed red lines), and the DFT monitors (dotted
+        green lines). A legend of these elements is added to the plot. Requires
+        [matplotlib](https://matplotlib.org). Calling this function would look something
+        like:
+
+        ```py
+        sim = mp.Simulation(...)
+        import matplotlib.pyplot as plt
+        sim.plot1D()
+        plt.savefig('sim_domain_1D.png')
+        ```
+
+        There is no need to invoke the `run` function prior to calling `plot1D`. Just
+        define the `Simulation` object followed by any DFT monitors and then invoke
+        `plot1D`.
+
+        A boundary of the cell is drawn as a PEC wall whenever no `k_point` has been
+        specified (the default boundary condition of Meep is a metallic wall) or
+        whenever `set_boundary` has been used to set the boundary condition of that
+        side of the cell to `mp.Metallic`.
+
+        Note: When running a [parallel simulation](Parallel_Meep.md), the `plot1D`
+        function expects to be called on all processes, but only generates a plot on
+        the master process.
+
+        **Parameters:**
+
+        * `ax`: a `matplotlib` axis object. `plot1D()` will add plot objects, like lines,
+          and patches to this object. If no `ax` is supplied, then the routine will
+          create a new figure and grab its axis.
+        * `frequency`: for materials with a [frequency-dependent
+          permittivity](Materials.md#material-dispersion) $\\varepsilon(f)$, specifies the
+          frequency $f$ (in Meep units) of the real part of the permittivity used to
+          compute the refractive index. Defaults to the `frequency` parameter of the
+          [Source](#source) object.
+        * `index_parameters`: a `dict` of optional plotting parameters that override the
+          default parameters for the refractive-index profile.
+            - `color='b'`: color of the index profile
+            - `linestyle='-'`: line style of the index profile
+            - `linewidth=1.5`: line width of the index profile
+            - `alpha=1.0`: transparency of the index profile
+            - `label='refractive index'`: legend label of the index profile
+            - `frequency=None`: same as the `frequency` parameter above
+            - `resolution=None`: the resolution at which $\\varepsilon$ is sampled.
+              Defaults to the `resolution` of the `Simulation` object.
+        * `pml_parameters`: a `dict` of optional plotting parameters that override the
+          default parameters for the PML (and `Absorber`) regions.
+            - `color='0.7'`: color of the shaded region
+            - `alpha=1.0`: transparency of the shaded region
+            - `label='PML'`: legend label of the shaded region
+        * `pec_parameters`: a `dict` of optional plotting parameters that override the
+          default parameters for the PEC walls.
+            - `color='k'`: color of the walls
+            - `linestyle='-'`: line style of the walls
+            - `linewidth=3.0`: line width of the walls
+            - `alpha=1.0`: transparency of the walls
+            - `label='PEC'`: legend label of the walls
+        * `source_parameters`: a `dict` of optional plotting parameters that override the
+          default parameters for the sources.
+            - `color='r'`: color of the sources
+            - `linestyle='--'`: line style of the sources
+            - `linewidth=1.5`: line width of the sources
+            - `alpha=1.0`: transparency of the sources
+            - `label='source'`: legend label of the sources
+        * `monitor_parameters`: a `dict` of optional plotting parameters that override the
+          default parameters for the monitors.
+            - `color='g'`: color of the monitors
+            - `linestyle=':'`: line style of the monitors
+            - `linewidth=1.5`: line width of the monitors
+            - `alpha=1.0`: transparency of the monitors
+            - `label='monitor'`: legend label of the monitors
+        * `legend_parameters`: a `dict` of optional parameters passed to
+          `matplotlib.axes.Axes.legend`. Defaults to
+          `{'loc': 'best', 'fontsize': 'small', 'framealpha': 0.8}`.
+        * `show_index`, `show_boundary_layers`, `show_pec`, `show_sources`,
+          elements of the plot is drawn. All default to `True`.
+        * `nb`: set this to True if plotting in a Jupyter ntoebook to use ipympl for
+          plotting. Note: this requires ipympl to be installed.
+        """
+        import meep.visualization as vis
+
+        return vis.plot1D(
+            self,
+            ax=ax,
+            frequency=frequency,
+            index_parameters=index_parameters,
+            pml_parameters=pml_parameters,
+            pec_parameters=pec_parameters,
+            source_parameters=source_parameters,
+            monitor_parameters=monitor_parameters,
+            legend_parameters=legend_parameters,
+            show_index=show_index,
+            show_boundary_layers=show_boundary_layers,
+            show_pec=show_pec,
+            show_sources=show_sources,
+            show_monitors=show_monitors,
+            show_legend=show_legend,
+            nb=nb,
+        )
 
     def plot2D(
         self,

--- a/python/tests/test_visualization.py
+++ b/python/tests/test_visualization.py
@@ -141,6 +141,57 @@ def setup_sim(zDim=0):
     return sim
 
 
+def setup_sim_1d(k_point=None, absorber=False):
+    """Sets up a 1D simulation of a slab surrounded by PML (or an `Absorber`)."""
+    size_z = 12.0
+    thickness_pml = 1.0
+    frequency = 1.0
+
+    boundary_layers = [
+        mp.Absorber(thickness_pml) if absorber else mp.PML(thickness_pml)
+    ]
+
+    geometry = [
+        mp.Block(
+            size=mp.Vector3(mp.inf, mp.inf, 3.0),
+            center=mp.Vector3(0, 0, 1.0),
+            material=mp.Medium(index=3.5),
+        )
+    ]
+
+    sources = [
+        mp.Source(
+            mp.GaussianSource(frequency, fwidth=0.2 * frequency),
+            component=mp.Ex,
+            center=mp.Vector3(0, 0, -0.5 * size_z + thickness_pml + 0.5),
+        ),
+        # An extended source is drawn using one line per edge.
+        mp.Source(
+            mp.ContinuousSource(frequency),
+            component=mp.Ex,
+            center=mp.Vector3(0, 0, -2.0),
+            size=mp.Vector3(0, 0, 1.0),
+        ),
+    ]
+
+    sim = mp.Simulation(
+        cell_size=mp.Vector3(0, 0, size_z),
+        dimensions=1,
+        resolution=20,
+        boundary_layers=boundary_layers,
+        default_material=mp.Medium(index=1.2),
+        geometry=geometry,
+        k_point=k_point,
+        sources=sources,
+    )
+
+    sim.add_flux(
+        frequency, 0, 1, mp.FluxRegion(center=mp.Vector3(0, 0, 0.5 * size_z - 2.0))
+    )
+
+    return sim
+
+
 def view_sim():
     sim = setup_sim(8)
     xy0 = mp.Volume(
@@ -183,6 +234,70 @@ class TestVisualization(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         mp.delete_directory(cls.temp_dir)
+
+    def test_plot1D(self):
+        # Check plotting of the index profile, PML, PEC walls, sources,
+        # and monitors of a 1D simulation.
+        f = plt.figure()
+        ax = sim1d = None
+        if mp.am_master():
+            ax = f.gca()
+        sim1d = setup_sim_1d()
+        ax = sim1d.plot1D(ax=ax)
+
+        if mp.am_master():
+            labels = ax.get_legend_handles_labels()[1]
+            self.assertEqual(
+                set(labels), {"refractive index", "PML", "PEC", "source", "monitor"}
+            )
+            # The PEC walls are at the two edges of the cell, the two
+            # sources are drawn using three lines, and the monitor using one.
+            self.assertEqual(len(ax.lines), 1 + 2 + 3 + 1)
+            self.assertEqual(ax.get_xlim(), (-6.0, 6.0))
+            hash_figure(f)
+
+        # Check that the boundaries of a Bloch-periodic cell are not
+        # labeled as PEC and that an `Absorber` is labeled as such.
+        f = plt.figure()
+        ax = f.gca() if mp.am_master() else None
+        sim1d = setup_sim_1d(k_point=mp.Vector3(0.2, 0, 0.3), absorber=True)
+        ax = sim1d.plot1D(ax=ax)
+
+        if mp.am_master():
+            labels = ax.get_legend_handles_labels()[1]
+            self.assertEqual(
+                set(labels), {"refractive index", "absorber", "source", "monitor"}
+            )
+
+        # Check that a boundary condition which was set explicitly
+        # overrides the default.
+        sim1d.set_boundary(mp.Low, mp.Z, mp.Metallic)
+        f = plt.figure()
+        ax = f.gca() if mp.am_master() else None
+        ax = sim1d.plot1D(ax=ax)
+
+        if mp.am_master():
+            self.assertIn("PEC", ax.get_legend_handles_labels()[1])
+
+        # Check the customization options.
+        f = plt.figure()
+        ax = f.gca() if mp.am_master() else None
+        ax = setup_sim_1d().plot1D(
+            ax=ax,
+            index_parameters={"color": "k", "label": "n(z)"},
+            show_monitors=False,
+            show_legend=False,
+        )
+
+        if mp.am_master():
+            self.assertIsNone(ax.get_legend())
+            self.assertEqual(ax.lines[0].get_color(), "k")
+            # The monitor is not drawn.
+            self.assertEqual(len(ax.lines), 1 + 2 + 3)
+
+        # A simulation which is not 1D is an error.
+        with self.assertRaises(ValueError):
+            setup_sim().plot1D()
 
     def test_plot2D(self):
         # Check plotting of geometry with several sources, monitors, and PMLs

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -99,6 +99,65 @@ default_label_geometry_parameters = {
     "label_alpha": 0.8,
 }
 
+# Default plotting parameters used by `plot1D`. Each element of a 1D
+# simulation is drawn as a line (or a shaded region) along the single
+# (z) axis of the cell rather than as a 2D patch.
+
+default_1d_index_parameters = {
+    "color": "b",
+    "linestyle": "-",
+    "linewidth": 1.5,
+    "alpha": 1.0,
+    "label": "refractive index",
+    "frequency": None,
+    "resolution": None,
+    "zorder": 3,
+}
+
+default_1d_pml_parameters = {
+    "color": "0.7",
+    "alpha": 1.0,
+    "label": "PML",
+    "zorder": 0,
+}
+
+default_1d_pec_parameters = {
+    "color": "k",
+    "linestyle": "-",
+    "linewidth": 3.0,
+    "alpha": 1.0,
+    "label": "PEC",
+    "zorder": 5,
+    # The PEC walls lie exactly on the edges of the cell and would
+    # therefore be half hidden by the border of the plot.
+    "clip_on": False,
+}
+
+default_1d_source_parameters = {
+    "color": "r",
+    "linestyle": "--",
+    "linewidth": 1.5,
+    "alpha": 1.0,
+    "label": "source",
+    "zorder": 4,
+}
+
+default_1d_monitor_parameters = {
+    "color": "g",
+    "linestyle": ":",
+    "linewidth": 1.5,
+    "alpha": 1.0,
+    "label": "monitor",
+    "zorder": 4,
+}
+
+default_1d_legend_parameters = {
+    "loc": "best",
+    "fontsize": "small",
+    "framealpha": 0.8,
+}
+
+
 # Used to remove the elements of a dictionary (dict_to_filter) that
 # don't correspond to the keyword arguments of a particular
 # function (func_with_kwargs.)
@@ -175,7 +234,31 @@ def place_label(
 
 
 # ------------------------------------------------------- #
+# Helper function used to determine the frequency at which
+# the permittivity of a dispersive material is evaluated
+
+
+def get_default_frequency(sim: Simulation) -> float:
+    """Returns the frequency of the first source of `sim` (0 if there are none)."""
+    try:
+        # Continuous sources
+        return sim.sources[0].frequency
+    except:
+        try:
+            # Gaussian sources
+            return sim.sources[0].src.frequency
+        except:
+            try:
+                # Custom sources
+                return sim.sources[0].src.center_frequency
+            except:
+                # No sources
+                return 0
+
+
+# ------------------------------------------------------- #
 # Helper functions used to plot volumes on a 2D plane
+
 
 # Returns the intersection points of two Volumes.
 # Volumes must be a line, plane, or rectangular prism
@@ -536,20 +619,7 @@ def plot_eps(
         )
         eps_parameters["frequency"] = frequency
     if eps_parameters["frequency"] is None:
-        try:
-            # Continuous sources
-            eps_parameters["frequency"] = sim.sources[0].frequency
-        except:
-            try:
-                # Gaussian sources
-                eps_parameters["frequency"] = sim.sources[0].src.frequency
-            except:
-                try:
-                    # Custom sources
-                    eps_parameters["frequency"] = sim.sources[0].src.center_frequency
-                except:
-                    # No sources
-                    eps_parameters["frequency"] = 0
+        eps_parameters["frequency"] = get_default_frequency(sim)
 
     # Get domain measurements
     sim_center, sim_size = get_2D_dimensions(sim, output_plane)
@@ -945,6 +1015,346 @@ def plot_fields(
     return ax
 
 
+# ------------------------------------------------------- #
+# Plotting routines for a 1D simulation. In Meep, the single
+# axis of a 1D cell is always Z.
+
+# Keys of the 1D plotting-parameter dictionaries which are not
+# `matplotlib` keyword arguments and are thus handled separately.
+_1d_non_artist_keys = ("label", "frequency", "resolution")
+
+
+def artist_kwargs(plotting_parameters: dict, label: Optional[str] = None) -> dict:
+    """Returns the `matplotlib` keyword arguments of a 1D plotting-parameter dict.
+
+    A `label` is only attached to the first artist of a given type so that
+    each element of the plot appears exactly once in the legend.
+    """
+    kwargs = {
+        key: value
+        for key, value in plotting_parameters.items()
+        if key not in _1d_non_artist_keys
+    }
+    if label is not None:
+        kwargs["label"] = label
+
+    return kwargs
+
+
+def _label_once(labels_used: set, label: str) -> Optional[str]:
+    """Returns `label` the first time it is requested and `None` thereafter."""
+    if label in labels_used:
+        return None
+    labels_used.add(label)
+
+    return label
+
+
+def get_1D_dimensions(sim: Simulation) -> Tuple[float, float]:
+    """Returns the endpoints (zmin, zmax) of the cell of a 1D simulation."""
+    if sim.is_cylindrical or (sim.cell_size.x != 0) or (sim.cell_size.y != 0):
+        raise ValueError(
+            "plot1D can only be used with a 1D simulation for which the cell "
+            "extends along Z (i.e., cell_size = mp.Vector3(0, 0, size_z))."
+        )
+
+    zmin = sim.geometry_center.z - 0.5 * sim.cell_size.z
+    zmax = sim.geometry_center.z + 0.5 * sim.cell_size.z
+
+    return zmin, zmax
+
+
+def get_1D_boundary_condition(sim: Simulation, side: int) -> int:
+    """Returns the boundary condition on `side` (`mp.Low` or `mp.High`) of a 1D cell.
+
+    The return value is one of the `boundary_condition` constants
+    (e.g., `mp.Metallic` or `mp.Periodic`).
+    """
+    # A boundary condition which was specified explicitly using
+    # `Simulation.set_boundary` takes precedence over the default.
+    conditions = getattr(sim, "_boundary_conditions", {})
+    if (side, mp.Z) in conditions:
+        return conditions[(side, mp.Z)]
+
+    # Otherwise, the boundaries are Bloch periodic whenever a `k_point` has
+    # been specified and PEC (metallic) walls otherwise.
+    return mp.Periodic if sim.k_point else mp.Metallic
+
+
+def plot_1d_index(
+    sim: Simulation,
+    ax: Axes,
+    index_parameters: Optional[dict] = None,
+    frequency: Optional[float] = None,
+) -> Union[Axes, Any]:
+    """Plots the refractive-index profile n(z) of a 1D simulation."""
+    if index_parameters is None:
+        index_parameters = default_1d_index_parameters
+    else:
+        index_parameters = dict(default_1d_index_parameters, **index_parameters)
+
+    if frequency is not None:
+        index_parameters["frequency"] = frequency
+    if index_parameters["frequency"] is None:
+        index_parameters["frequency"] = get_default_frequency(sim)
+
+    zmin, zmax = get_1D_dimensions(sim)
+
+    grid_resolution = index_parameters["resolution"] or sim.resolution
+    num_z = int((zmax - zmin) * grid_resolution) + 1
+    ztics = np.linspace(zmin, zmax, num_z)
+
+    eps_data = np.atleast_1d(
+        np.squeeze(
+            sim.get_epsilon_grid(
+                np.array([sim.geometry_center.x]),
+                np.array([sim.geometry_center.y]),
+                ztics,
+                index_parameters["frequency"],
+            )
+        )
+    )
+
+    # The real part of sqrt(ε) is the refractive index. Note that ε is
+    # complex whenever the material is lossy and that the real part of
+    # the index vanishes for a lossless material with ε < 0.
+    index_data = np.real(np.sqrt(eps_data.astype(np.complex128)))
+
+    # If an Axes was not provided, just return the index profile.
+    if not ax:
+        return ztics, index_data
+
+    if mp.am_master():
+        ax.plot(
+            ztics,
+            index_data,
+            **artist_kwargs(index_parameters, index_parameters["label"]),
+        )
+
+    return ax
+
+
+def plot_1d_boundaries(
+    sim: Simulation,
+    ax: Axes,
+    pml_parameters: Optional[dict] = None,
+) -> Axes:
+    """Shades the PML (and `Absorber`) regions of a 1D simulation."""
+    if pml_parameters is None:
+        pml_parameters = default_1d_pml_parameters
+    else:
+        pml_parameters = dict(default_1d_pml_parameters, **pml_parameters)
+
+    zmin, zmax = get_1D_dimensions(sim)
+
+    if not mp.am_master():
+        return ax
+
+    # `Absorber` is a drop-in replacement for `PML` and is therefore drawn
+    # in the same way but labeled differently in the legend.
+    labels_used = set()
+
+    for boundary in sim.boundary_layers:
+        # The only direction of a 1D cell is Z. (For a simulation with
+        # `dimensions=1`, the direction of a boundary layer is ignored by
+        # Meep and thus also ignored here.)
+        if boundary.direction not in (mp.ALL, mp.Z) and sim.dimensions != 1:
+            warnings.warn(
+                "plot1D: ignoring the boundary layer in direction "
+                f"{boundary.direction} of a 1D simulation."
+            )
+            continue
+
+        spans = []
+        if boundary.side in (mp.ALL, mp.Low):
+            spans.append((zmin, zmin + boundary.thickness))
+        if boundary.side in (mp.ALL, mp.High):
+            spans.append((zmax - boundary.thickness, zmax))
+
+        if isinstance(boundary, mp.Absorber):
+            label = "absorber"
+        else:
+            label = pml_parameters["label"]
+
+        for span in spans:
+            ax.axvspan(
+                *span, **artist_kwargs(pml_parameters, _label_once(labels_used, label))
+            )
+
+    return ax
+
+
+def plot_1d_pec(
+    sim: Simulation,
+    ax: Axes,
+    pec_parameters: Optional[dict] = None,
+) -> Axes:
+    """Draws the PEC (metallic) walls, if any, of a 1D simulation."""
+    if pec_parameters is None:
+        pec_parameters = default_1d_pec_parameters
+    else:
+        pec_parameters = dict(default_1d_pec_parameters, **pec_parameters)
+
+    zmin, zmax = get_1D_dimensions(sim)
+
+    if not mp.am_master():
+        return ax
+
+    labels_used = set()
+
+    for side, z in zip([mp.Low, mp.High], [zmin, zmax]):
+        if get_1D_boundary_condition(sim, side) == mp.Metallic:
+            ax.axvline(
+                z,
+                **artist_kwargs(
+                    pec_parameters, _label_once(labels_used, pec_parameters["label"])
+                ),
+            )
+
+    return ax
+
+
+def plot_1d_sources(
+    sim: Simulation,
+    ax: Axes,
+    source_parameters: Optional[dict] = None,
+) -> Axes:
+    """Draws the sources of a 1D simulation."""
+    if source_parameters is None:
+        source_parameters = default_1d_source_parameters
+    else:
+        source_parameters = dict(default_1d_source_parameters, **source_parameters)
+
+    if mp.am_master():
+        labels_used = set()
+        for src in sim.sources:
+            _plot_1d_object(
+                ax, src.center.z, src.size.z, source_parameters, labels_used
+            )
+
+    return ax
+
+
+def plot_1d_monitors(
+    sim: Simulation,
+    ax: Axes,
+    monitor_parameters: Optional[dict] = None,
+) -> Axes:
+    """Draws the DFT monitors of a 1D simulation."""
+    if monitor_parameters is None:
+        monitor_parameters = default_1d_monitor_parameters
+    else:
+        monitor_parameters = dict(default_1d_monitor_parameters, **monitor_parameters)
+
+    if mp.am_master():
+        labels_used = set()
+        for mon in sim.dft_objects:
+            for reg in getattr(mon, "regions", []):
+                _plot_1d_object(
+                    ax, reg.center.z, reg.size.z, monitor_parameters, labels_used
+                )
+
+    return ax
+
+
+def _plot_1d_object(
+    ax: Axes,
+    center_z: float,
+    size_z: float,
+    plotting_parameters: dict,
+    labels_used: set,
+) -> None:
+    """Draws a point (line) or extended (pair of lines) object of a 1D simulation."""
+    if size_z == 0:
+        positions = [center_z]
+    else:
+        positions = [center_z - 0.5 * size_z, center_z + 0.5 * size_z]
+
+    for z in positions:
+        ax.axvline(
+            z,
+            **artist_kwargs(
+                plotting_parameters,
+                _label_once(labels_used, plotting_parameters["label"]),
+            ),
+        )
+
+
+def plot1D(
+    sim: Simulation,
+    ax: Optional[Axes] = None,
+    frequency: Optional[float] = None,
+    index_parameters: Optional[dict] = None,
+    pml_parameters: Optional[dict] = None,
+    pec_parameters: Optional[dict] = None,
+    source_parameters: Optional[dict] = None,
+    monitor_parameters: Optional[dict] = None,
+    legend_parameters: Optional[dict] = None,
+    show_index: bool = True,
+    show_boundary_layers: bool = True,
+    show_pec: bool = True,
+    show_sources: bool = True,
+    show_monitors: bool = True,
+    show_legend: bool = True,
+    nb: bool = False,
+) -> Axes:
+    # Ensure that the simulation is 1D before doing anything else.
+    zmin, zmax = get_1D_dimensions(sim)
+
+    # Ensure a figure axis exists.
+    if ax is None and mp.am_master():
+        from matplotlib import pyplot as plt
+
+        ax = plt.gca()
+
+    # Shade the PML regions. These are plotting first so that everything
+    # else is drawn on top of them.
+    if show_boundary_layers:
+        ax = plot_1d_boundaries(sim, ax, pml_parameters=pml_parameters)
+
+    # Plot the refractive-index profile. (The return value is not the Axes
+    # object whenever one was not provided, which is the case for all of the
+    # non-master processes of a parallel simulation.)
+    if show_index:
+        plot_1d_index(
+            sim,
+            ax,
+            index_parameters=index_parameters,
+            frequency=frequency,
+        )
+
+    # Draw the PEC walls.
+    if show_pec:
+        ax = plot_1d_pec(sim, ax, pec_parameters=pec_parameters)
+
+    # Draw the sources.
+    if show_sources:
+        ax = plot_1d_sources(sim, ax, source_parameters=source_parameters)
+
+    # Draw the monitors.
+    if show_monitors:
+        ax = plot_1d_monitors(sim, ax, monitor_parameters=monitor_parameters)
+
+    if mp.am_master():
+        ax.set_xlim(zmin, zmax)
+        ax.set_xlabel("Z")
+        ax.set_ylabel("refractive index")
+
+        if show_legend and ax.get_legend_handles_labels()[0]:
+            legend_parameters = dict(
+                default_1d_legend_parameters, **(legend_parameters or {})
+            )
+            ax.legend(**legend_parameters)
+
+        # If using the %matplotlib ipympl magic, we need to force the figure
+        # to be displayed immediately.
+        if nb:
+            display_figure_immediately(ax.figure)
+            sleep(0.05)
+
+    return ax
+
+
 def plot2D(
     sim: Simulation,
     ax: Optional[Axes] = None,
@@ -964,7 +1374,7 @@ def plot2D(
     show_monitors: bool = True,
     show_boundary_layers: bool = True,
     nb: bool = False,
-    **kwargs
+    **kwargs,
 ) -> Axes:
 
     plot_eps_flag = kwargs.get("plot_eps_flag")
@@ -1470,7 +1880,7 @@ class Animate2D:
         plot_modifiers: Optional[list] = None,
         update_epsilon: bool = False,
         nb: bool = False,
-        **customization_args
+        **customization_args,
     ):
         """
         Construct an `Animate2D` object.

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -1064,23 +1064,6 @@ def get_1D_dimensions(sim: Simulation) -> Tuple[float, float]:
     return zmin, zmax
 
 
-def get_1D_boundary_condition(sim: Simulation, side: int) -> int:
-    """Returns the boundary condition on `side` (`mp.Low` or `mp.High`) of a 1D cell.
-
-    The return value is one of the `boundary_condition` constants
-    (e.g., `mp.Metallic` or `mp.Periodic`).
-    """
-    # A boundary condition which was specified explicitly using
-    # `Simulation.set_boundary` takes precedence over the default.
-    conditions = getattr(sim, "_boundary_conditions", {})
-    if (side, mp.Z) in conditions:
-        return conditions[(side, mp.Z)]
-
-    # Otherwise, the boundaries are Bloch periodic whenever a `k_point` has
-    # been specified and PEC (metallic) walls otherwise.
-    return mp.Periodic if sim.k_point else mp.Metallic
-
-
 def plot_1d_index(
     sim: Simulation,
     ax: Axes,
@@ -1197,19 +1180,26 @@ def plot_1d_pec(
 
     zmin, zmax = get_1D_dimensions(sim)
 
+    # Note that the boundary conditions must be queried on every process
+    # because doing so initializes the simulation if necessary.
+    pec_walls = [
+        z
+        for side, z in zip([mp.Low, mp.High], [zmin, zmax])
+        if sim.get_boundary(side, mp.Z) == mp.Metallic
+    ]
+
     if not mp.am_master():
         return ax
 
     labels_used = set()
 
-    for side, z in zip([mp.Low, mp.High], [zmin, zmax]):
-        if get_1D_boundary_condition(sim, side) == mp.Metallic:
-            ax.axvline(
-                z,
-                **artist_kwargs(
-                    pec_parameters, _label_once(labels_used, pec_parameters["label"])
-                ),
-            )
+    for z in pec_walls:
+        ax.axvline(
+            z,
+            **artist_kwargs(
+                pec_parameters, _label_once(labels_used, pec_parameters["label"])
+            ),
+        )
 
     return ax
 

--- a/src/boundaries.cpp
+++ b/src/boundaries.cpp
@@ -87,6 +87,10 @@ void fields::set_boundary(boundary_side b, direction d, boundary_condition cond)
   }
 }
 
+boundary_condition fields::get_boundary(boundary_side b, direction d) const {
+  return boundaries[b][d];
+}
+
 void fields::use_bloch(direction d, complex<double> kk) {
   k[d] = kk;
   for (int b = 0; b < 2; b++)

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1759,6 +1759,7 @@ public:
   void print_times();
   // boundaries.cpp
   void set_boundary(boundary_side, direction, boundary_condition);
+  boundary_condition get_boundary(boundary_side, direction) const;
   void use_bloch(direction d, double k) { use_bloch(d, (std::complex<double>)k); }
   void use_bloch(direction, std::complex<double> kz);
   void use_bloch(const vec &k);


### PR DESCRIPTION
Adds a `plot1D` function for visualizing the layout of 1D simulation. This mirrors the existing [`plot2D`](https://meep.readthedocs.io/en/latest/Python_User_Interface/#data-visualization).

**PEC detection.** A wall is PEC when the cell boundary is metallic — i.e. no `k_point` was given (Meep's default) or `set_boundary(..., mp.Metallic)` was called. Since `fields.boundaries` is only exposed to Python as an opaque SWIG pointer, `Simulation.set_boundary` now records what it set in `self._boundary_conditions` (cleared by `reset_meep`), which `plot1D` consults. This makes the tutorial setup in `antenna_pec_ground_plane_1D.py` (Bloch `k_point` + explicit metallic walls) plot correctly.

Everything is customizable through the same `*_parameters` dict / `show_*` flag convention as `plot2D` (`index_parameters`, `pml_parameters`, `pec_parameters`, `source_parameters`, `monitor_parameters`, `legend_parameters`), and the dispersive-permittivity frequency defaults to the first source's frequency (that lookup is now the shared `get_default_frequency` helper, also used by `plot_eps`).

An example of the output (involving a dielectric slab above a PEC ground plane) produced by `plot1D` is shown below.

<img width="803" height="554" alt="layout_1D_plot1D" src="https://github.com/user-attachments/assets/68bc5340-f9cd-4181-8b36-8ef9d9d5d369" />


**Files changed**
- `python/visualization.py` — `plot1D` and its `plot_1d_*` helpers, 1D default-parameter dicts
- `python/simulation.py` — `Simulation.plot1D` with full docstring; boundary-condition tracking
- `python/meep.i` — export `plot1D` from the package
- `python/tests/test_visualization.py` — `test_plot1D` covering legend contents, artist counts, PEC vs. Bloch-periodic, `Absorber`, `set_boundary` override, customization, and the non-1D `ValueError`
- `doc/docs/Python_User_Interface.md{, .in}` — API docs (inserted exactly the block `generate_py_api.py` emits)


**Verification**
- `python/tests/test_visualization.py`: 3 tests pass, serially and under `mpirun -np 2`
- Checked against variants: PML both/one side, `Absorber`, Bloch-periodic, explicit metallic wall, extended sources, dispersive material (Si reads 3.478 at 1.55 μm), nonzero `geometry_center`, `dimensions=1` and unset-`dimensions` 1D cells