### PR TITLE
Provide `dt` option for `fourier_transform` member function of `GaussianSource`

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -7123,20 +7123,19 @@ Construct a `GaussianSource`.
 + **`fourier_transform(f, dt=None)`** — Returns the Fourier transform of the
   current evaluated at frequency $f$ ($\omega=2\pi f$). If `dt` is not specified,
   the transform of the idealized *continuous-time* current is returned:
-  $\widetilde G(\omega) \equiv \frac{1}{\sqrt{2\pi}} \int e^{i\omega t}G(t)\,dt \equiv \frac{1}{\Delta f} e^{i\omega t_0 -\frac{(\omega-\omega_0)^2}{2\Delta f^2}}$
-  where $G(t)$ is the current (not the dipole moment). In this formula, $\Delta f$
-  is the `fwidth` of the source, $\omega_0$ is $2\pi$ times its `frequency`, and
-  $t_0$ is the peak time discussed above.
+  $\widetilde G(\omega) \equiv \frac{1}{\sqrt{2\pi}} \int e^{i\omega t}G(t)\,dt \equiv \frac{\omega}{\omega_0} \frac{1}{\Delta f} e^{i\omega t_0 -\frac{(\omega-\omega_0)^2}{2\Delta f^2}}$
+  where $G(t) = p'(t)$ is the current (the time derivative of a Gaussian dipole moment $p(t)$).
+  In this formula, $\Delta f$ is the `fwidth` of the source, $\omega_0$ is $2\pi$ times
+  its `frequency`, and $t_0$ is the peak time discussed above. The $\omega/\omega_0$
+  factor is the exact time derivative of the Gaussian dipole moment.
 
       The current actually injected by the simulation is not $G(t)$ but rather its
       *discrete-time* counterpart: a finite difference of the Gaussian dipole moment
       $p(t)$ over one timestep $\Delta t$ (`sim.fields.dt`, which equals
       `Courant/resolution`). Passing `dt` returns the Fourier transform of that
-      discrete current, referenced to the field times at which the DFT field monitors
-      accumulate their sums: $\widetilde G_{\Delta t}(\omega) = \frac{\omega}{\omega_0}\mathrm{sinc}\left(\frac{\omega \Delta t}{2}\right)\widetilde G(\omega)$
-      with $\mathrm{sinc}(x) = \sin(x)/x$. The $\omega/\omega_0$ factor is the exact
-      time derivative of the Gaussian dipole moment in place of the $-i\omega_0$
-      approximation made by $\widetilde G(\omega)$, and the sinc factor is the error
+      finite-difference current, referenced to the field times at which the DFT field monitors
+      accumulate their sums: $\widetilde G_{\Delta t}(\omega) = \mathrm{sinc}\left(\frac{\omega \Delta t}{2}\right)\widetilde G(\omega)$
+      with $\mathrm{sinc}(x) = \sin(x)/x$. The sinc factor is the error
       of the discrete-time derivative. For an `is_integrated=True` source, $p(t)$ is
       added to the fields directly rather than differenced, and the sinc factor is
       therefore omitted.

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -6887,10 +6887,9 @@ def eig_power(freq, dt=None):
 
 Returns the total power of the fields from the eigenmode source at frequency `freq`.
 If the timestep `dt` (= `sim.fields.dt` = `Courant/resolution`) is specified, the
-discrete-time Fourier transform of the source is used, which is the power actually
-delivered at a finite resolution; see
-[`GaussianSource`](#gaussiansource). Otherwise, the continuous-time transform is
-used.
+Fourier transform of the discrete-time current is used, which is the power actually
+delivered at a finite resolution; see [`GaussianSource`](#gaussiansource). Otherwise,
+the continuous-time current is used.
 
 </div>
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -6880,12 +6880,17 @@ Construct an `EigenModeSource`.
 <div class="class_members" markdown="1">
 
 ```python
-def eig_power(freq):
+def eig_power(freq, dt=None):
 ```
 
 <div class="method_docstring" markdown="1">
 
 Returns the total power of the fields from the eigenmode source at frequency `freq`.
+If the timestep `dt` (= `sim.fields.dt` = `Courant/resolution`) is specified, the
+discrete-time Fourier transform of the source is used, which is the power actually
+delivered at a finite resolution; see
+[`GaussianSource`](#gaussiansource). Otherwise, the continuous-time transform is
+used.
 
 </div>
 
@@ -7115,18 +7120,29 @@ Construct a `GaussianSource`.
   [planewaves extending into PML](Perfectly_Matched_Layer.md#planewave-sources-extending-into-pml).
   Default is `False`.
 
-+ **`fourier_transform(f)`** — Returns the Fourier transform of the current
-  evaluated at frequency $f$ ($\omega=2\pi f$) given by:
-  $$
-  \widetilde G(\omega) \equiv \frac{1}{\sqrt{2\pi}}
-  \int e^{i\omega t}G(t)\,dt \equiv
-  \frac{1}{\Delta f}
-  e^{i\omega t_0 -\frac{(\omega-\omega_0)^2}{2\Delta f^2}}
-  $$
++ **`fourier_transform(f, dt=None)`** — Returns the Fourier transform of the
+  current evaluated at frequency $f$ ($\omega=2\pi f$). If `dt` is not specified,
+  the transform of the idealized *continuous-time* current is returned:
+  $\widetilde G(\omega) \equiv \frac{1}{\sqrt{2\pi}} \int e^{i\omega t}G(t)\,dt \equiv \frac{1}{\Delta f} e^{i\omega t_0 -\frac{(\omega-\omega_0)^2}{2\Delta f^2}}$
   where $G(t)$ is the current (not the dipole moment). In this formula, $\Delta f$
   is the `fwidth` of the source, $\omega_0$ is $2\pi$ times its `frequency,` and
-  $t_0$ is the peak time discussed above. Note that this does not include any
-  `amplitude` or `amp_func` factor that you specified for the source.
+  $t_0$ is the peak time discussed above.
+
+      The current actually injected by the simulation is not $G(t)$ but rather its
+      *discrete-time* counterpart: a finite difference of the Gaussian dipole moment
+      $p(t)$ over one timestep $\Delta t$ (`sim.fields.dt`, which equals
+      `Courant/resolution`). Passing `dt` returns the Fourier transform of that
+      discrete current, referenced to the field times at which the DFT field monitors
+      accumulate their sums: $\widetilde G_{\Delta t}(\omega) = \frac{\omega}{\omega_0}\mathrm{sinc}\left(\frac{\omega \Delta t}{2}\right)\widetilde G(\omega)$
+      with $\mathrm{sinc}(x) = \sin(x)/x$. The $\omega/\omega_0$ factor is the exact
+      time derivative of the Gaussian dipole moment in place of the $-i\omega_0$
+      approximation made by $\widetilde G(\omega)$, and the sinc factor is the error
+      of the discrete-time derivative. For an `is_integrated=True` source, $p(t)$ is
+      added to the fields directly rather than differenced, and the sinc factor is
+      therefore omitted.
+
+      Note that this does not include any `amplitude` or `amp_func` factor that you
+      specified for the source.
 
 </div>
 

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -7125,7 +7125,7 @@ Construct a `GaussianSource`.
   the transform of the idealized *continuous-time* current is returned:
   $\widetilde G(\omega) \equiv \frac{1}{\sqrt{2\pi}} \int e^{i\omega t}G(t)\,dt \equiv \frac{1}{\Delta f} e^{i\omega t_0 -\frac{(\omega-\omega_0)^2}{2\Delta f^2}}$
   where $G(t)$ is the current (not the dipole moment). In this formula, $\Delta f$
-  is the `fwidth` of the source, $\omega_0$ is $2\pi$ times its `frequency,` and
+  is the `fwidth` of the source, $\omega_0$ is $2\pi$ times its `frequency`, and
   $t_0$ is the peak time discussed above.
 
       The current actually injected by the simulation is not $G(t)$ but rather its

--- a/python/source.py
+++ b/python/source.py
@@ -308,9 +308,10 @@ class GaussianSource(SourceTime):
 
         + **`fourier_transform(f)`** — Returns the Fourier transform of the
           current evaluated at frequency $f$ ($\\omega=2\\pi f$). If `dt` is not specified,
-          the transform of the idealized *continuous-time* current is returned: $\\widetilde G(\\omega) \\equiv \\frac{1}{\\sqrt{2\\pi}}\\int e^{i\\omega t}G(t)\\,dt \\equiv\\frac{1}{\\Delta f}e^{i\\omega t_0 -\\frac{(\\omega-\\omega_0)^2}{2\\Delta f^2}}$
+          the transform of the idealized *continuous-time* current is returned:
+          $\\widetilde G(\\omega) \\equiv \\frac{1}{\\sqrt{2\\pi}} \\int e^{i\\omega t}G(t)\\,dt \\equiv \\frac{1}{\\Delta f} e^{i\\omega t_0 -\\frac{(\\omega-\\omega_0)^2}{2\\Delta f^2}}$
           where $G(t)$ is the current (not the dipole moment). In this formula, $\\Delta f$
-          is the `fwidth` of the source, $\\omega_0$ is $2\\pi$ times its `frequency,` and
+          is the `fwidth` of the source, $\\omega_0$ is $2\\pi$ times its `frequency`, and
           $t_0$ is the peak time discussed above.
 
               The current actually injected by the simulation is not $G(t)$ but rather its
@@ -318,8 +319,7 @@ class GaussianSource(SourceTime):
               $p(t)$ over one timestep $\\Delta t$ (`sim.fields.dt`, which equals
               `Courant/resolution`). Passing `dt` returns the Fourier transform of that
               discrete current, referenced to the field times at which the DFT field monitors
-              accumulate their sums: $\\widetilde G_{\\Delta t}(\\omega) = \\frac{\\omega}{\\omega_0}
-              \\mathrm{sinc}\\left(\\frac{\\omega \\Delta t}{2}\\right)\\widetilde G(\\omega)$
+              accumulate their sums: $\\widetilde G_{\\Delta t}(\\omega) = \\frac{\\omega}{\\omega_0}\\mathrm{sinc}\\left(\\frac{\\omega \\Delta t}{2}\\right)\\widetilde G(\\omega)$
               with $\\mathrm{sinc}(x) = \\sin(x)/x$. The $\\omega/\\omega_0$ factor is the exact
               time derivative of the Gaussian dipole moment in place of the $-i\\omega_0$
               approximation made by $\\widetilde G(\\omega)$, and the sinc factor is the error

--- a/python/source.py
+++ b/python/source.py
@@ -309,20 +309,19 @@ class GaussianSource(SourceTime):
         + **`fourier_transform(f)`** — Returns the Fourier transform of the
           current evaluated at frequency $f$ ($\\omega=2\\pi f$). If `dt` is not specified,
           the transform of the idealized *continuous-time* current is returned:
-          $\\widetilde G(\\omega) \\equiv \\frac{1}{\\sqrt{2\\pi}} \\int e^{i\\omega t}G(t)\\,dt \\equiv \\frac{1}{\\Delta f} e^{i\\omega t_0 -\\frac{(\\omega-\\omega_0)^2}{2\\Delta f^2}}$
-          where $G(t)$ is the current (not the dipole moment). In this formula, $\\Delta f$
+          $\\widetilde G(\\omega) \\equiv \\frac{1}{\\sqrt{2\\pi}} \\int e^{i\\omega t}G(t)\\,dt \\equiv \\frac{\\omega}{\\omega_0} \\frac{1}{\\Delta f} e^{i\\omega t_0 -\\frac{(\\omega-\\omega_0)^2}{2\\Delta f^2}}$
+         where $G(t) = p'(t)$ is the current (the time derivative of a Gaussian dipole moment $p(t)$). In this formula, $\\Delta f$
           is the `fwidth` of the source, $\\omega_0$ is $2\\pi$ times its `frequency`, and
-          $t_0$ is the peak time discussed above.
+          $t_0$ is the peak time discussed above.  The $\\omega/\\omega_0$ factor is the exact
+              time derivative of the Gaussian dipole moment
 
               The current actually injected by the simulation is not $G(t)$ but rather its
               *discrete-time* counterpart: a finite difference of the Gaussian dipole moment
               $p(t)$ over one timestep $\\Delta t$ (`sim.fields.dt`, which equals
               `Courant/resolution`). Passing `dt` returns the Fourier transform of that
-              discrete current, referenced to the field times at which the DFT field monitors
-              accumulate their sums: $\\widetilde G_{\\Delta t}(\\omega) = \\frac{\\omega}{\\omega_0}\\mathrm{sinc}\\left(\\frac{\\omega \\Delta t}{2}\\right)\\widetilde G(\\omega)$
-              with $\\mathrm{sinc}(x) = \\sin(x)/x$. The $\\omega/\\omega_0$ factor is the exact
-              time derivative of the Gaussian dipole moment in place of the $-i\\omega_0$
-              approximation made by $\\widetilde G(\\omega)$, and the sinc factor is the error
+              finite-difference current, referenced to the field times at which the DFT field monitors
+              accumulate their sums: $\\widetilde G_{\\Delta t}(\\omega) = \\mathrm{sinc}\\left(\\frac{\\omega \\Delta t}{2}\\right)\\widetilde G(\\omega)$
+              with $\\mathrm{sinc}(x) = \\sin(x)/x$. The sinc factor is the error
               of the discrete-time derivative. For an `is_integrated=True` source, $p(t)$ is
               added to the fields directly rather than differenced, and the sinc factor is
               therefore omitted.

--- a/python/source.py
+++ b/python/source.py
@@ -306,18 +306,29 @@ class GaussianSource(SourceTime):
           [planewaves extending into PML](Perfectly_Matched_Layer.md#planewave-sources-extending-into-pml).
           Default is `False`.
 
-        + **`fourier_transform(f)`** — Returns the Fourier transform of the current
-          evaluated at frequency $f$ ($\\omega=2\\pi f$) given by:
-          $$
-          \\widetilde G(\\omega) \\equiv \\frac{1}{\\sqrt{2\\pi}}
-          \\int e^{i\\omega t}G(t)\\,dt \\equiv
-          \\frac{1}{\\Delta f}
-          e^{i\\omega t_0 -\\frac{(\\omega-\\omega_0)^2}{2\\Delta f^2}}
-          $$
+        + **`fourier_transform(f)`** — Returns the Fourier transform of the
+          current evaluated at frequency $f$ ($\\omega=2\\pi f$). If `dt` is not specified,
+          the transform of the idealized *continuous-time* current is returned: $\\widetilde G(\\omega) \\equiv \\frac{1}{\\sqrt{2\\pi}}\\int e^{i\\omega t}G(t)\\,dt \\equiv\\frac{1}{\\Delta f}e^{i\\omega t_0 -\\frac{(\\omega-\\omega_0)^2}{2\\Delta f^2}}$
           where $G(t)$ is the current (not the dipole moment). In this formula, $\\Delta f$
           is the `fwidth` of the source, $\\omega_0$ is $2\\pi$ times its `frequency,` and
-          $t_0$ is the peak time discussed above. Note that this does not include any
-          `amplitude` or `amp_func` factor that you specified for the source.
+          $t_0$ is the peak time discussed above.
+
+              The current actually injected by the simulation is not $G(t)$ but rather its
+              *discrete-time* counterpart: a finite difference of the Gaussian dipole moment
+              $p(t)$ over one timestep $\\Delta t$ (`sim.fields.dt`, which equals
+              `Courant/resolution`). Passing `dt` returns the Fourier transform of that
+              discrete current, referenced to the field times at which the DFT field monitors
+              accumulate their sums: $\\widetilde G_{\\Delta t}(\\omega) = \\frac{\\omega}{\\omega_0}
+              \\mathrm{sinc}\\left(\\frac{\\omega \\Delta t}{2}\\right)\\widetilde G(\\omega)$
+              with $\\mathrm{sinc}(x) = \\sin(x)/x$. The $\\omega/\\omega_0$ factor is the exact
+              time derivative of the Gaussian dipole moment in place of the $-i\\omega_0$
+              approximation made by $\\widetilde G(\\omega)$, and the sinc factor is the error
+              of the discrete-time derivative. For an `is_integrated=True` source, $p(t)$ is
+              added to the fields directly rather than differenced, and the sinc factor is
+              therefore omitted.
+
+              Note that this does not include any `amplitude` or `amp_func` factor that you
+              specified for the source.
         """
         if frequency is None and wavelength is None:
             raise ValueError(
@@ -338,8 +349,8 @@ class GaussianSource(SourceTime):
         )
         self.swigobj.is_integrated = self.is_integrated
 
-    def fourier_transform(self, freq):
-        return self.swigobj.fourier_transform(freq)
+    def fourier_transform(self, freq, dt=None):
+        return self.swigobj.fourier_transform(freq, 0 if dt is None else dt)
 
 
 class CustomSource(SourceTime):
@@ -630,13 +641,18 @@ class EigenModeSource(Source):
     def eig_tolerance(self, val):
         self._eig_tolerance = check_positive("EigenModeSource.eig_tolerance", val)
 
-    def eig_power(self, freq):
+    def eig_power(self, freq, dt=None):
         """
         Returns the total power of the fields from the eigenmode source at frequency `freq`.
+        If the timestep `dt` (= `sim.fields.dt` = `Courant/resolution`) is specified, the
+        discrete-time Fourier transform of the source is used, which is the power actually
+        delivered at a finite resolution; see
+        [`GaussianSource`](#gaussiansource). Otherwise, the continuous-time transform is
+        used.
         """
         amp = self.amplitude
         if callable(getattr(self.src, "fourier_transform", None)):
-            amp *= self.src.fourier_transform(freq)
+            amp *= self.src.fourier_transform(freq, dt)
         return abs(amp) ** 2
 
     def add_source(self, sim):

--- a/python/source.py
+++ b/python/source.py
@@ -306,7 +306,7 @@ class GaussianSource(SourceTime):
           [planewaves extending into PML](Perfectly_Matched_Layer.md#planewave-sources-extending-into-pml).
           Default is `False`.
 
-        + **`fourier_transform(f)`** — Returns the Fourier transform of the
+        + **`fourier_transform(f, dt=None)`** — Returns the Fourier transform of the
           current evaluated at frequency $f$ ($\\omega=2\\pi f$). If `dt` is not specified,
           the transform of the idealized *continuous-time* current is returned:
           $\\widetilde G(\\omega) \\equiv \\frac{1}{\\sqrt{2\\pi}} \\int e^{i\\omega t}G(t)\\,dt \\equiv \\frac{\\omega}{\\omega_0} \\frac{1}{\\Delta f} e^{i\\omega t_0 -\\frac{(\\omega-\\omega_0)^2}{2\\Delta f^2}}$
@@ -644,10 +644,9 @@ class EigenModeSource(Source):
         """
         Returns the total power of the fields from the eigenmode source at frequency `freq`.
         If the timestep `dt` (= `sim.fields.dt` = `Courant/resolution`) is specified, the
-        discrete-time Fourier transform of the source is used, which is the power actually
-        delivered at a finite resolution; see
-        [`GaussianSource`](#gaussiansource). Otherwise, the continuous-time transform is
-        used.
+        Fourier transform of the discrete-time current is used, which is the power actually
+        delivered at a finite resolution; see [`GaussianSource`](#gaussiansource). Otherwise,
+        the continuous-time current is used.
         """
         amp = self.amplitude
         if callable(getattr(self.src, "fourier_transform", None)):

--- a/python/source.py
+++ b/python/source.py
@@ -310,10 +310,10 @@ class GaussianSource(SourceTime):
           current evaluated at frequency $f$ ($\\omega=2\\pi f$). If `dt` is not specified,
           the transform of the idealized *continuous-time* current is returned:
           $\\widetilde G(\\omega) \\equiv \\frac{1}{\\sqrt{2\\pi}} \\int e^{i\\omega t}G(t)\\,dt \\equiv \\frac{\\omega}{\\omega_0} \\frac{1}{\\Delta f} e^{i\\omega t_0 -\\frac{(\\omega-\\omega_0)^2}{2\\Delta f^2}}$
-         where $G(t) = p'(t)$ is the current (the time derivative of a Gaussian dipole moment $p(t)$). In this formula, $\\Delta f$
-          is the `fwidth` of the source, $\\omega_0$ is $2\\pi$ times its `frequency`, and
-          $t_0$ is the peak time discussed above.  The $\\omega/\\omega_0$ factor is the exact
-              time derivative of the Gaussian dipole moment
+          where $G(t) = p'(t)$ is the current (the time derivative of a Gaussian dipole moment $p(t)$).
+          In this formula, $\\Delta f$ is the `fwidth` of the source, $\\omega_0$ is $2\\pi$ times
+          its `frequency`, and $t_0$ is the peak time discussed above. The $\\omega/\\omega_0$
+          factor is the exact time derivative of the Gaussian dipole moment.
 
               The current actually injected by the simulation is not $G(t)$ but rather its
               *discrete-time* counterpart: a finite difference of the Gaussian dipole moment

--- a/python/tests/test_source.py
+++ b/python/tests/test_source.py
@@ -82,9 +82,10 @@ class TestSourceTime(unittest.TestCase):
 
     def test_gaussian_fourier_transform(self):
         # The discrete-time Fourier transform of the current injected by the
-        # time stepping should agree with the closed form returned by
+        # time stepping should very nearly match the closed-form continuous
+        # Fourier transform (differing only by exponentially small alias tails) returned by
         # GaussianSource.fourier_transform(f, dt). A large cutoff is used so
-        # that the truncation of the Gaussian is negligible.
+        # that the truncation in time of the Gaussian is negligible.
         fcen, fwidth, cutoff = 1.0, 0.2, 10.0
         freqs = np.linspace(fcen - 0.75 * fwidth, fcen + 0.75 * fwidth, 7)
 
@@ -117,8 +118,9 @@ class TestSourceTime(unittest.TestCase):
                     )
 
     def test_gaussian_fourier_transform_continuous(self):
-        # omitting dt gives the continuous-time transform
+        # omitting dt gives the continuous-time transform without the finite difference
         src = GaussianSource(1.0, fwidth=0.2)
+        # to do: implement a more nontrivial test
         for f in (0.9, 1.0, 1.1):
             self.assertEqual(src.fourier_transform(f), src.swigobj.fourier_transform(f))
 

--- a/python/tests/test_source.py
+++ b/python/tests/test_source.py
@@ -80,6 +80,48 @@ class TestSourceTime(unittest.TestCase):
         with self.assertRaises(ValueError):
             ContinuousSource()
 
+    def test_gaussian_fourier_transform(self):
+        # The discrete-time Fourier transform of the current injected by the
+        # time stepping should agree with the closed form returned by
+        # GaussianSource.fourier_transform(f, dt). A large cutoff is used so
+        # that the truncation of the Gaussian is negligible.
+        fcen, fwidth, cutoff = 1.0, 0.2, 10.0
+        freqs = np.linspace(fcen - 0.75 * fwidth, fcen + 0.75 * fwidth, 7)
+
+        for is_integrated in (False, True):
+            src = GaussianSource(
+                fcen, fwidth=fwidth, cutoff=cutoff, is_integrated=is_integrated
+            )
+            for resolution in (10, 40):
+                dt = 0.5 / resolution
+                # field times spanning the support of the source
+                t = np.arange(0, 2 * cutoff / fwidth + 2 * dt, dt)
+                if is_integrated:
+                    # the dipole moment is added directly at the field times
+                    signal = np.array([src.swigobj.dipole(tt) for tt in t])
+                else:
+                    # centered difference of the dipole moment about the field times
+                    signal = np.array(
+                        [src.swigobj.current(tt - 0.5 * dt, dt) for tt in t]
+                    )
+                for f in freqs:
+                    dtft = (
+                        np.sum(np.exp(1j * 2 * np.pi * f * t) * signal)
+                        * dt
+                        / np.sqrt(2 * np.pi)
+                    )
+                    if is_integrated:
+                        dtft *= -1j * 2 * np.pi * f
+                    self.assertAlmostEqual(
+                        dtft / src.fourier_transform(f, dt), 1.0, places=8
+                    )
+
+    def test_gaussian_fourier_transform_continuous(self):
+        # omitting dt gives the continuous-time transform
+        src = GaussianSource(1.0, fwidth=0.2)
+        for f in (0.9, 1.0, 1.1):
+            self.assertEqual(src.fourier_transform(f), src.swigobj.fourier_transform(f))
+
 
 class TestSourceTypemaps(unittest.TestCase):
     def setUp(self):

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1034,7 +1034,7 @@ public:
   virtual double get_fwidth() const { return fwidth; };
   virtual void set_fwidth(double fw) { fwidth = fw; };
   virtual void set_frequency(std::complex<double> f) { freq = real(f); }
-  std::complex<double> fourier_transform(const double f);
+  std::complex<double> fourier_transform(const double f, const double dt = 0);
 
 private:
   double freq, fwidth, width, peak_time, cutoff;

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -126,11 +126,8 @@ std::complex<double> gaussian_src_time::fourier_transform(const double f, const 
   double omega0 = 2.0 * pi * freq;
   double delta = (omega - omega0) * width;
   complex<double> ft = width * polar(1.0, omega * peak_time) * exp(-0.5 * delta * delta);
-  if (dt == 0) return ft;
-
-  // -i\omega instead of the -i\omega_0 assumed by the analytic formula above
-  ft *= f / freq;
-  if (!is_integrated) { // discrete-time (centered-difference) derivative
+  ft *= f / freq; // exact time derivative and i/omega_0 normalization
+  if (dt != 0 && !is_integrated) { // discrete-time (centered-difference) derivative
     double x = 0.5 * omega * dt;
     ft *= (x == 0) ? 1.0 : sin(x) / x;
   }

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -126,7 +126,7 @@ std::complex<double> gaussian_src_time::fourier_transform(const double f, const 
   double omega0 = 2.0 * pi * freq;
   double delta = (omega - omega0) * width;
   complex<double> ft = width * polar(1.0, omega * peak_time) * exp(-0.5 * delta * delta);
-  ft *= f / freq; // exact time derivative and i/omega_0 normalization
+  ft *= f / freq;                  // exact time derivative and i/omega_0 normalization
   if (dt != 0 && !is_integrated) { // discrete-time (centered-difference) derivative
     double x = 0.5 * omega * dt;
     ft *= (x == 0) ? 1.0 : sin(x) / x;

--- a/src/sources.cpp
+++ b/src/sources.cpp
@@ -108,12 +108,33 @@ complex<double> gaussian_src_time::dipole(double time) const {
 
 // (1/\sqrt{2*pi}) \int e^{i\omega t} G(t) dt
 // where G(t) is the *current* envelope, i.e. the time derivative
-// of the dipole envelope
-std::complex<double> gaussian_src_time::fourier_transform(const double f) {
+// of the dipole envelope.
+//
+// For dt == 0 (the default) this is the continuous-time transform of the
+// idealized envelope e^{-(t-t_0)^2/2w^2} e^{-i\omega_0 (t-t_0)}, which is only
+// an approximation to the current that is actually injected by the simulation.
+// For dt != 0 (the timestep, = Courant/resolution) the transform of the
+// *discrete* current is returned instead, referenced to the field times at
+// which the DFT is accumulated.  For a non-integrated source the injected
+// current is the centered difference [p(t+dt/2) - p(t-dt/2)]/dt of the dipole
+// envelope p(t) (src_time::curent evaluated a half timestep before the field
+// time; see fields::step), whose transform is -i\omega sinc(\omega dt/2) times
+// that of p(t).  An integrated source instead adds p(t) directly at the field
+// time, so it only picks up the exact -i\omega derivative factor.
+std::complex<double> gaussian_src_time::fourier_transform(const double f, const double dt) {
   double omega = 2.0 * pi * f;
   double omega0 = 2.0 * pi * freq;
   double delta = (omega - omega0) * width;
-  return width * polar(1.0, omega * peak_time) * exp(-0.5 * delta * delta);
+  complex<double> ft = width * polar(1.0, omega * peak_time) * exp(-0.5 * delta * delta);
+  if (dt == 0) return ft;
+
+  // -i\omega instead of the -i\omega_0 assumed by the analytic formula above
+  ft *= f / freq;
+  if (!is_integrated) { // discrete-time (centered-difference) derivative
+    double x = 0.5 * omega * dt;
+    ft *= (x == 0) ? 1.0 : sin(x) / x;
+  }
+  return ft;
 }
 
 bool gaussian_src_time::is_equal(const src_time &t) const {


### PR DESCRIPTION
Closes #1956.

**The problem**

[`GaussianSource.fourier_transform()`](https://meep.readthedocs.io/en/latest/Python_User_Interface/#gaussiansource) returns the **continuous-time** transform of the idealized envelope:

$$\widetilde G(\omega) = w\\, e^{i\omega t_0} e^{-(\omega - \omega_0)^2 w^2 / 2}, \qquad w=1/\Delta f$$

which is $\tfrac{1}{\sqrt{2\pi}} \int e^{i\omega t}G(t)\\,dt$ for $G(t) \approx e^{-(t-t_0)^2 / 2w^2} e^{-i\omega_0(t-t_0)}$. That is not the current the FDTD loop injects.

**What the simulation actually injects**
- `src_time::current(t, dt) = (p(t+dt) -p(t))/dt` — a finite difference of the dipole envelope $p(t)$ ([`src/meep.hpp:989`](https://github.com/NanoComp/meep/blob/e7d46f2a3711aed91b19a33e69399c35793df9eb/src/meep.hpp#L989)), not an analytic derivative.
- Electric sources: `calc_sources(time()+0.5*dt)` → `step_source(D_stuff)` does `D -= J*dt` ([`src/step.cpp:95`](https://github.com/NanoComp/meep/blob/e7d46f2a3711aed91b19a33e69399c35793df9eb/src/step.cpp#L95),[`100`](https://github.com/NanoComp/meep/blob/e7d46f2a3711aed91b19a33e69399c35793df9eb/src/step.cpp#L100)). Magnetic: `calc_sources(time())` → `step_source(B_stuff)` ([`src/step.cpp:64`](https://github.com/NanoComp/meep/blob/e7d46f2a3711aed91b19a33e69399c35793df9eb/src/step.cpp#L64),[69](https://github.com/NanoComp/meep/blob/e7d46f2a3711aed91b19a33e69399c35793df9eb/src/step.cpp#L69))
- DFT monitors stamp E at `time()` and H at `time()-0.5*dt` ([`src/dft.cpp:250-263`](https://github.com/NanoComp/meep/blob/e7d46f2a3711aed91b19a33e69399c35793df9eb/src/dft.cpp#L250-L263))

**So relative to the field times the DFT uses**, the injected current is the *centered* difference $[p(t+\Delta t/2) - p(t-\Delta t/2)]/\Delta t$ whose transform is $-i\omega\\,\mathrm{sinc}(\omega\Delta t/2)\\,\tilde p(\omega)$. With $\tilde p = \widetilde G/(-i\omega_0)$:

$$\widetilde G_{\Delta t}(\omega) = \frac{\omega}{\omega_0}\\,\mathrm{sinc}\\!\left(\frac{\omega\Delta t}{2}\right)\widetilde G(\omega)\\,\qquad \mathrm{sinc}(x)=\sin x/x$$

Two independent corrections: $\omega/\omega_0$ (exact derivative instead of the $-i\omega_0$ approximation) and $\mathrm{sinc}$ (discrete derivative). **No phase factor** — the centered difference is symmetric about the field time. `is_integrated=True` sources subtract $p(t)$ directly at the exact field time ([`src/update_eh.cpp:128-138`](https://github.com/NanoComp/meep/blob/e7d46f2a3711aed91b19a33e69399c35793df9eb/src/update_eh.cpp#L128-L138)), so they get only the $\omega/\omega_0$ factor.

**Verification**

Closed form vs. brute-force DTFT of the actual `swigobj.current` / `swigobj.dipole` samples: agreement to ~5e-11 at `cutoff=10` for both `is_integrated` values and both `resolution=10` and `40`. (At the default `cutoff=5` the residual is ~2e-2 at the band edges — that is the Gaussian's own truncation, not the formula.)

**Note:** this also explains the comment [`python/adjoint/objective.py:101-106`](https://github.com/NanoComp/meep/blob/e7d46f2a3711aed91b19a33e69399c35793df9eb/python/adjoint/objective.py#L101-L106) ("real parts match, imaginary parts are very different") — that code takes a *forward*-difference DTFT on the $t=n\Delta t$ grid, which carries an extra $e^{-i\pi f\Delta t}$ relative to the field-time convention used here.

<img width="673" height="457" alt="image" src="https://github.com/user-attachments/assets/4aec0dbc-d04c-43a2-a26d-51c3af4e7418" />
