### PR TITLE
[1/2] Fix adjoint gradient chunk-dependence without gathering the DFT monitors

### DIFF
--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -39,6 +39,7 @@ ADJOINT_TESTS =                                \
 TESTS =                                        \
     $(TEST_DIR)/test_3rd_harm_1d.py            \
     $(TEST_DIR)/test_absorber_1d.py            \
+    $(TEST_DIR)/test_adjoint_chunks.py         \
     $(TEST_DIR)/test_antenna_radiation.py      \
     $(TEST_DIR)/test_array_metadata.py         \
     $(TEST_DIR)/test_bend_flux.py              \

--- a/python/tests/test_adjoint_chunks.py
+++ b/python/tests/test_adjoint_chunks.py
@@ -1,0 +1,141 @@
+"""The 3d adjoint gradient must not depend on how the cell is split into chunks.
+
+`material_grids_addgradient` assembles the gradient by walking the forward and
+adjoint DFT chunks. Before the chunk-independent rewrite it (a) paired forward
+and adjoint chunks by list position, which is not a spatial correspondence once
+a component is missing from some chunk, (b) skipped cross terms when the two
+lists had different lengths, and (c) looked up the neighboring forward node with
+chunk-local index arithmetic guarded only against the flat index leaving
+[0, N) -- a 3d point outside the chunk can still have an in-range flat index, so
+the lookup either aliased to an unrelated voxel or substituted zero.
+
+All three only bite where a chunk boundary crosses the design region, so the
+error appears with MPI but is *not* an MPI bug: forcing the same split in a
+serial run reproduces it exactly. That is what this test does, so it runs in
+every CI job rather than only the MPI ones.
+
+A directional finite-difference check compresses the gradient onto a single
+number, and this error survives that: measured on the pre-fix build, probing
+along g/|g| gave fd/adjoint = 1.0008 while the gradient vector itself was 44%
+off in L2. Comparing the gradient vectors directly is what catches it.
+
+The tolerance is therefore what the *field solve* can reproduce across a
+different split, not what the gradient assembly contributes; see the comment on
+`tol` below.
+"""
+
+import unittest
+
+import numpy as np
+from autograd import numpy as npa
+
+import meep as mp
+import meep.adjoint as mpa
+
+RESOLUTION = 12
+DESIGN_N = 6
+SEED = 0
+
+
+def _gradient(num_chunks):
+    """Adjoint gradient of |alpha|^2 for a fixed problem at a forced chunk count."""
+    si, clad = mp.Medium(index=3.48), mp.Medium(index=1.44)
+    pml, port_pad, side_pad = 0.5, 0.8, 0.5
+    design, thickness = 1.0, 0.22
+
+    sx = 2 * pml + 2 * port_pad + design
+    sy = 2 * pml + 2 * side_pad + design
+    sz = 2 * pml + 2 * side_pad + thickness
+
+    weights = np.random.default_rng(SEED).uniform(0.2, 0.8, size=DESIGN_N * DESIGN_N)
+    grid = mp.MaterialGrid(
+        mp.Vector3(DESIGN_N, DESIGN_N, 1),
+        clad,
+        si,
+        weights=weights.reshape(DESIGN_N, DESIGN_N, 1),
+        do_averaging=False,
+    )
+    region = mpa.DesignRegion(
+        grid,
+        volume=mp.Volume(
+            center=mp.Vector3(), size=mp.Vector3(design, design, thickness)
+        ),
+    )
+
+    fcen = 1 / 1.55
+    port = mp.Vector3(0, sy - 2 * pml, sz - 2 * pml)
+    sim = mp.Simulation(
+        cell_size=mp.Vector3(sx, sy, sz),
+        resolution=RESOLUTION,
+        boundary_layers=[mp.PML(pml)],
+        default_material=clad,
+        geometry=[
+            mp.Block(
+                center=mp.Vector3(),
+                size=mp.Vector3(mp.inf, 0.5, thickness),
+                material=si,
+            ),
+            mp.Block(center=region.center, size=region.size, material=grid),
+        ],
+        sources=[
+            mp.EigenModeSource(
+                mp.GaussianSource(fcen, fwidth=0.1 * fcen),
+                center=mp.Vector3(-(design / 2 + port_pad / 2)),
+                size=port,
+                eig_band=1,
+            )
+        ],
+        eps_averaging=False,
+        num_chunks=num_chunks,
+    )
+    monitor = mpa.EigenmodeCoefficient(
+        sim,
+        mp.Volume(center=mp.Vector3(design / 2 + port_pad / 2), size=port),
+        mode=1,
+    )
+    opt = mpa.OptimizationProblem(
+        simulation=sim,
+        objective_functions=[lambda c: npa.abs(c) ** 2],
+        objective_arguments=[monitor],
+        design_regions=[region],
+        frequencies=[fcen],
+        decay_by=1e-6,
+    )
+    f0, gradient = opt([weights], need_gradient=True)
+    return (
+        float(np.squeeze(f0)),
+        np.asarray(np.real(np.squeeze(gradient)), dtype=np.float64).reshape(-1),
+    )
+
+
+class TestAdjointChunks(unittest.TestCase):
+    def test_gradient_independent_of_chunk_division(self):
+        # Both counts are >= the process count, so this is a genuine change of
+        # chunk division in serial and under MPI alike.
+        np_ = mp.count_processors()
+        f0_a, g_a = _gradient(num_chunks=np_)
+        f0_b, g_b = _gradient(num_chunks=3 * np_)
+
+        # A single-precision build cannot resolve either check to 1e-9. The
+        # objective alone -- which no gradient code touches -- already moves by
+        # one float ulp (1.2e-7) when the cell is split differently under MPI,
+        # and the gradient inherits that. The looser bound is still four orders
+        # of magnitude below the defect this test guards against.
+        tol = 1e-5 if mp.is_single_precision() else 1e-9
+
+        # the forward solve was never chunk-dependent; if this trips, the test
+        # problem itself changed rather than the gradient assembly
+        self.assertAlmostEqual(f0_a / f0_b, 1.0, delta=tol)
+
+        rel = np.linalg.norm(g_a - g_b) / np.linalg.norm(g_a)
+        # Pre-fix this comparison read 4.7e-1. Post-fix the only difference is
+        # summation order in the collective reductions: measured 3e-16 (serial,
+        # where there are none) to 2e-12 (np 8) in double precision, 1.5e-7 in
+        # single.
+        self.assertLess(
+            rel, tol, f"gradient changed by {rel:.3e} under a different chunk split"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -84,8 +84,16 @@ dft_chunk::dft_chunk(fields_chunk *fc_, ivec is_, ivec ie_, vec s0_, vec s1_, ve
   if (persist) {
     is_old = is_;
     ie_old = ie_;
-    is = max(is - one_ivec(fc->gv.dim) * 2, fc->gv.little_corner());
-    ie = min(ie + one_ivec(fc->gv.dim) * 2, fc->gv.big_corner());
+    /* Clamp to this component's own grid, not to the centered grid. Component c
+       runs from little_corner()+iyee_shift(c) to big_corner()+iyee_shift(c) (cf.
+       LOOP_OVER_VOL), so clamping to the bare corners truncates the topmost node
+       of a yee-shifted direction -- precisely the ghost node that the adjoint
+       restriction stencil reaches for, and which step_boundaries() already keeps
+       current. It also left `is` off the component lattice, which desynchronized
+       the LOOP_OVER_IVECS counter from grid_volume::index(). */
+    const ivec shift_c = fc->gv.iyee_shift(c);
+    is = max(is - one_ivec(fc->gv.dim) * 2, fc->gv.little_corner() + shift_c);
+    ie = min(ie + one_ivec(fc->gv.dim) * 2, fc->gv.big_corner() + shift_c);
   }
 
   if (use_centered_grid)
@@ -341,8 +349,17 @@ double dft_chunk::norm2(grid_volume fgv) const {
   if (persist) {
     grid_volume subgv = fgv.subvolume(is, ie, c);
     LOOP_OVER_IVECS(subgv, is_old, ie_old, idx) {
+      /* index by position: the loop counter is not a valid dft[] index here,
+         because the persist pad can leave `is` off this component's yee lattice
+         and only grid_volume::index() accounts for the yee shift. Getting this
+         wrong makes dft_norm() -- and hence stop_when_dft_decayed() -- depend on
+         the chunk division, which is exactly what the comment above promises it
+         does not. */
+      IVEC_LOOP_ILOC(subgv, ip);
+      ptrdiff_t didx = subgv.index(c, ip);
+      if (didx < 0 || (size_t)didx >= N) continue;
       for (size_t i = 0; i < Nomega; ++i)
-        sum += sqr(dft[Nomega * idx + i]);
+        sum += sqr(dft[Nomega * didx + i]);
     }
   }
   /* note we place the if outside of the

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -84,13 +84,8 @@ dft_chunk::dft_chunk(fields_chunk *fc_, ivec is_, ivec ie_, vec s0_, vec s1_, ve
   if (persist) {
     is_old = is_;
     ie_old = ie_;
-    /* Clamp to this component's own grid, not to the centered grid. Component c
-       runs from little_corner()+iyee_shift(c) to big_corner()+iyee_shift(c) (cf.
-       LOOP_OVER_VOL), so clamping to the bare corners truncates the topmost node
-       of a yee-shifted direction -- precisely the ghost node that the adjoint
-       restriction stencil reaches for, and which step_boundaries() already keeps
-       current. It also left `is` off the component lattice, which desynchronized
-       the LOOP_OVER_IVECS counter from grid_volume::index(). */
+    /* Clamp to this component's persist-padded grid, which is one cell bigger than the
+       usual "owned" grid given by big_owned_corner(). */
     const ivec shift_c = fc->gv.iyee_shift(c);
     is = max(is - one_ivec(fc->gv.dim) * 2, fc->gv.little_corner() + shift_c);
     ie = min(ie + one_ivec(fc->gv.dim) * 2, fc->gv.big_corner() + shift_c);

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -349,17 +349,8 @@ double dft_chunk::norm2(grid_volume fgv) const {
   if (persist) {
     grid_volume subgv = fgv.subvolume(is, ie, c);
     LOOP_OVER_IVECS(subgv, is_old, ie_old, idx) {
-      /* index by position: the loop counter is not a valid dft[] index here,
-         because the persist pad can leave `is` off this component's yee lattice
-         and only grid_volume::index() accounts for the yee shift. Getting this
-         wrong makes dft_norm() -- and hence stop_when_dft_decayed() -- depend on
-         the chunk division, which is exactly what the comment above promises it
-         does not. */
-      IVEC_LOOP_ILOC(subgv, ip);
-      ptrdiff_t didx = subgv.index(c, ip);
-      if (didx < 0 || (size_t)didx >= N) continue;
       for (size_t i = 0; i < Nomega; ++i)
-        sum += sqr(dft[Nomega * didx + i]);
+        sum += sqr(dft[Nomega * idx + i]);
     }
   }
   /* note we place the if outside of the

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2972,19 +2972,7 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
             double cyl_scale;
             IVEC_LOOP_ILOC(gv_adj, ip);
             IVEC_LOOP_LOC(gv_adj, p);
-            /* Index the DFT array by position, NOT by the LOOP_OVER_IVECS counter.
-               The `persist` pad clamps is/ie to fc->gv, whose corners live on the
-               centered grid, so `is` can land off this component's yee lattice.
-               update_dft() and grid_volume::index() both absorb that consistently
-               (index() subtracts iyee_shift, see vec.cpp:476), but the loop
-               counter's idx0 does not, so when (is_old - is) is odd it is off by a
-               whole stride. The clamp only bites where the monitor meets a chunk
-               boundary, which is what made the gradient depend on the chunk
-               division. */
-            ptrdiff_t adj_idx = gv_adj.index(adjoint_c, ip);
-            std::complex<meep::realnum> adj = (adj_idx >= 0 && (size_t)adj_idx < adj_chunk->N)
-                                                  ? adj_chunk->dft[nf * adj_idx + f_i]
-                                                  : std::complex<meep::realnum>(0, 0);
+            std::complex<meep::realnum> adj = adj_chunk->dft[nf * idx_adj + f_i];
             material_type md;
             geps->get_material_pt(md, p);
             /* if we have conductivities (e.g. for damping)

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -2841,6 +2841,60 @@ void material_grids_addgradient_point(double *v, vector3 p, double scalegrad, ge
   }
 }
 
+/* Is the point p inside the box [lo,hi] in *every* direction?
+
+   grid_volume::index() is a flat inner product of the per-direction offsets
+   with the strides, so a point that leaves the box in a single direction can
+   still produce an index inside [0,N): in 3d, stepping one pixel off the end
+   in y lands on an unrelated voxel of the next z slab. Guarding only the flat
+   index therefore silently substitutes a neighboring field value. Check each
+   direction separately instead. */
+static bool ivec_in_box(const meep::ivec &p, const meep::ivec &lo, const meep::ivec &hi,
+                        meep::ndim dim) {
+  LOOP_OVER_DIRECTIONS(dim, d) {
+    if (p.in_direction(d) < lo.in_direction(d) || p.in_direction(d) > hi.in_direction(d))
+      return false;
+  }
+  return true;
+}
+
+/* Find the dft_chunk in `chunks` covering the same region as `adj`.
+
+   loop_in_chunks() emits one dft_chunk per (fields_chunk, symmetry image,
+   lattice shift) triple, so that triple identifies a chunk uniquely. It is
+   *not* safe to pair chunks by position in the next_in_dft list: a fields
+   chunk contributes a dft_chunk for a given component only if the monitor
+   overlaps that component's owned grid there, and the yee shifts differ
+   between components, so the per-component lists can have different lengths
+   and different orderings near the edges of the monitor. Returns NULL when
+   this fields chunk holds no data for the requested component. */
+static meep::dft_chunk *matching_dft_chunk(const std::vector<meep::dft_chunk *> &chunks,
+                                           const meep::dft_chunk *adj) {
+  for (size_t i = 0; i < chunks.size(); ++i)
+    if (chunks[i]->fc == adj->fc && chunks[i]->sn == adj->sn && chunks[i]->shift == adj->shift)
+      return chunks[i];
+  return NULL;
+}
+
+/* Look up the forward DFT at point p, or zero if p is outside this chunk.
+
+   The restriction stencil reaches half a pixel (unit_a*2 cancels against the yee
+   shift), so it wants the four forward nodes around the adjoint node. With the
+   persist pad clamped to the component's own grid (see dft.cpp) those all lie
+   inside this chunk's box, the outermost of them being the chunk's ghost layer,
+   which step_boundaries() keeps current, so a lookup should only fall outside
+   it at the cell boundary, where zero is the right answer. */
+static std::complex<meep::realnum> forward_dft_value(const meep::dft_chunk *ch,
+                                                     const meep::grid_volume &gv_fwd,
+                                                     meep::grid_volume &gv, const meep::ivec &p,
+                                                     size_t nf, size_t f_i) {
+  if (ivec_in_box(p, ch->is, ch->ie, gv.dim)) {
+    ptrdiff_t i = gv_fwd.index(ch->c, p);
+    if (i >= 0 && (size_t)i < ch->N) return ch->dft[nf * i + f_i];
+  }
+  return 0;
+}
+
 void material_grids_addgradient(double *v, size_t ng, size_t nf,
                                 std::vector<meep::dft_fields *> fields_a,
                                 std::vector<meep::dft_fields *> fields_f, double *frequencies,
@@ -2878,10 +2932,9 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
       c_forward_dft_chunks.push_back(current_forward_chunk);
       current_forward_chunk = current_forward_chunk->next_in_dft;
     }
-    if (c_adjoint_dft_chunks.size() != c_forward_dft_chunks.size())
-      meep::abort("The number of adjoint chunks (%ld) is not equal to the number of forward chunks "
-                  "(%ld).\n",
-                  c_adjoint_dft_chunks.size(), c_forward_dft_chunks.size());
+    /* NOTE: the adjoint and forward chunk counts may legitimately differ, both
+       from each other and between components -- see matching_dft_chunk(). The
+       chunks are paired spatially below, so this is not an error. */
     adjoint_dft_chunks.push_back(c_adjoint_dft_chunks);
     forward_dft_chunks.push_back(c_forward_dft_chunks);
   }
@@ -2906,9 +2959,11 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
 
         // loop over forward components
         for (int ci_forward = 0; ci_forward < 3; ci_forward++) {
-          size_t num_f_chunks = forward_dft_chunks[ci_forward].size();
-          if ((num_f_chunks == 0) || (cur_chunk >= num_f_chunks)) continue;
-          meep::dft_chunk *fwd_chunk = forward_dft_chunks[ci_forward][cur_chunk];
+          /* pair the forward chunk with this adjoint chunk *spatially*, not by
+             position in the per-component chunk list */
+          meep::dft_chunk *fwd_chunk =
+              matching_dft_chunk(forward_dft_chunks[ci_forward], adj_chunk);
+          if (!fwd_chunk) continue;
           meep::component forward_c = fwd_chunk->c;
           meep::grid_volume gv_fwd = gv.subvolume(fwd_chunk->is, fwd_chunk->ie, forward_c);
 
@@ -2917,7 +2972,19 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
             double cyl_scale;
             IVEC_LOOP_ILOC(gv_adj, ip);
             IVEC_LOOP_LOC(gv_adj, p);
-            std::complex<meep::realnum> adj = adj_chunk->dft[nf * idx_adj + f_i];
+            /* Index the DFT array by position, NOT by the LOOP_OVER_IVECS counter.
+               The `persist` pad clamps is/ie to fc->gv, whose corners live on the
+               centered grid, so `is` can land off this component's yee lattice.
+               update_dft() and grid_volume::index() both absorb that consistently
+               (index() subtracts iyee_shift, see vec.cpp:476), but the loop
+               counter's idx0 does not, so when (is_old - is) is odd it is off by a
+               whole stride. The clamp only bites where the monitor meets a chunk
+               boundary, which is what made the gradient depend on the chunk
+               division. */
+            ptrdiff_t adj_idx = gv_adj.index(adjoint_c, ip);
+            std::complex<meep::realnum> adj = (adj_idx >= 0 && (size_t)adj_idx < adj_chunk->N)
+                                                  ? adj_chunk->dft[nf * adj_idx + f_i]
+                                                  : std::complex<meep::realnum>(0, 0);
             material_type md;
             geps->get_material_pt(md, p);
             /* if we have conductivities (e.g. for damping)
@@ -2933,7 +3000,11 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
 
             /* trivial case, no interpolation/restriction needed        */
             if (forward_c == adjoint_c) {
-              std::complex<meep::realnum> fwd = fwd_chunk->dft[nf * idx_adj + f_i];
+              /* index the forward chunk with its *own* index for this point;
+                 idx_adj is an index into gv_adj and is only valid here because
+                 the paired chunks share a fields chunk */
+              std::complex<meep::realnum> fwd =
+                  forward_dft_value(fwd_chunk, gv_fwd, gv, ip, nf, f_i);
               cyl_scale = (gv.dim == meep::Dcyl) ? 2 * p.r()
                                                  : 1; // the pi is already factored in near2far.cpp
               material_grids_addgradient_point(v_local + ng * f_i, vec_to_vector3(p),
@@ -2952,7 +3023,6 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
               Then we perform our inner product at these nodes.
               */
               std::complex<meep::realnum> fwd_avg, fwd1, fwd2;
-              ptrdiff_t fwd1_idx, fwd2_idx;
 
               // identify the first corner of the forward fields
               meep::ivec fwd_p = ip + gv.iyee_shift(forward_c) - gv.iyee_shift(adjoint_c);
@@ -2973,14 +3043,8 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
 // operate on the each eps node
 #pragma unroll
               for (int node = 0; node < 2; node++) { // two nodes
-                fwd1_idx = gv_fwd.index(forward_c, fwd_pl[node]);
-                fwd1 = ((fwd1_idx >= fwd_chunk->N) || (fwd1_idx < 0))
-                           ? 0
-                           : fwd_chunk->dft[nf * fwd1_idx + f_i];
-                fwd2_idx = gv_fwd.index(forward_c, fwd_pr[node]);
-                fwd2 = ((fwd2_idx >= fwd_chunk->N) || (fwd2_idx < 0))
-                           ? 0
-                           : fwd_chunk->dft[nf * fwd2_idx + f_i];
+                fwd1 = forward_dft_value(fwd_chunk, gv_fwd, gv, fwd_pl[node], nf, f_i);
+                fwd2 = forward_dft_value(fwd_chunk, gv_fwd, gv, fwd_pr[node], nf, f_i);
                 fwd_avg = std::complex<meep::realnum>(0.5, 0) * (fwd1 + fwd2);
                 meep::vec eps1 = gv[ieps[node]];
                 cyl_scale = (gv.dim == meep::Dcyl) ? eps1.r() : 1;


### PR DESCRIPTION
(written by me)

This is a lighter alternative to #3264, for #2578 (but I use the same test, thanks!)

@jin-castle picked up on a few bugs we had in the existing adjoint-/forward-fields recombination routine. In particular:
* We were assuming chunks in the linked lists were always aligned. This is fine for isotropic materials (e.g. no smoothing) but breaks down when there are cross terms (due to anisotropic material tensors).
* Some of the indexing wasn't properly taking into account the extra halo/padded region we use. Particularly important again for the cross terms.
* In 3D, the indexing had some bugs in that third dimension where we were wrapping around (aliasing) into the wrong part toward the end of the chunk.

Note that this doesn't require serializing the DFT fields (e.g. broadcasting to all the processes) and the tests show notable gradient accuracy. In particular, no dependence on the number of chunks.

(cc @stevengj , @oskooi )


