### PR TITLE
Medium: reject nonzero off-diagonal conductivity that the solver ignores

### DIFF
--- a/python/geom.py
+++ b/python/geom.py
@@ -448,6 +448,16 @@ class Medium:
         self.D_conductivity_offdiag = Vector3(*D_conductivity_offdiag)
         self.B_conductivity_diag = Vector3(*B_conductivity_diag)
         self.B_conductivity_offdiag = Vector3(*B_conductivity_offdiag)
+        for name in ("D_conductivity_offdiag", "B_conductivity_offdiag"):
+            offdiag = getattr(self, name)
+            if offdiag.x != 0 or offdiag.y != 0 or offdiag.z != 0:
+                raise ValueError(
+                    f"nonzero {name} is not supported: the time stepping "
+                    "implements only diagonal electric/magnetic conductivity, "
+                    "so the off-diagonal part would be silently ignored. For "
+                    "anisotropic off-diagonal absorption, use a Lorentzian or "
+                    "Drude susceptibility with sigma_offdiag."
+                )
         self.valid_freq_range = valid_freq_range
 
     def __repr__(self):

--- a/python/geom.py
+++ b/python/geom.py
@@ -451,7 +451,7 @@ class Medium:
         for name in ("D_conductivity_offdiag", "B_conductivity_offdiag"):
             offdiag = getattr(self, name)
             if offdiag.x != 0 or offdiag.y != 0 or offdiag.z != 0:
-                raise ValueError(
+                raise NotImplementedError(
                     f"nonzero {name} is not supported: the time stepping "
                     "implements only diagonal electric/magnetic conductivity, "
                     "so the off-diagonal part would be silently ignored. For "

--- a/python/tests/test_geom.py
+++ b/python/tests/test_geom.py
@@ -278,6 +278,31 @@ class TestMedium(unittest.TestCase):
         self.assertEqual(m.B_conductivity_diag.y, 2)
         self.assertEqual(m.B_conductivity_diag.z, 2)
 
+    def test_D_conductivity_offdiag_rejected(self):
+        # The solver only implements diagonal conductivity: medium_struct has
+        # no off-diagonal conductivity fields, so a nonzero value here would
+        # be silently ignored by the time stepping.
+        with self.assertRaises(ValueError):
+            gm.Medium(
+                D_conductivity_diag=gm.Vector3(1, 1, 0),
+                D_conductivity_offdiag=gm.Vector3(1, 0, 0),
+            )
+
+    def test_B_conductivity_offdiag_rejected(self):
+        with self.assertRaises(ValueError):
+            gm.Medium(
+                B_conductivity_diag=gm.Vector3(1, 1, 0),
+                B_conductivity_offdiag=gm.Vector3(1, 0, 0),
+            )
+
+    def test_conductivity_zero_offdiag_accepted(self):
+        m = gm.Medium(
+            D_conductivity_diag=gm.Vector3(1, 1, 0),
+            D_conductivity_offdiag=gm.Vector3(0, 0, 0),
+            B_conductivity_offdiag=gm.Vector3(),
+        )
+        self.assertEqual(m.D_conductivity_diag.x, 1)
+
     def test_E_chi2(self):
         m = gm.Medium(E_chi2=2)
         self.assertEqual(m.E_chi2_diag.x, 2)

--- a/python/tests/test_geom.py
+++ b/python/tests/test_geom.py
@@ -282,14 +282,14 @@ class TestMedium(unittest.TestCase):
         # The solver only implements diagonal conductivity: medium_struct has
         # no off-diagonal conductivity fields, so a nonzero value here would
         # be silently ignored by the time stepping.
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             gm.Medium(
                 D_conductivity_diag=gm.Vector3(1, 1, 0),
                 D_conductivity_offdiag=gm.Vector3(1, 0, 0),
             )
 
     def test_B_conductivity_offdiag_rejected(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotImplementedError):
             gm.Medium(
                 B_conductivity_diag=gm.Vector3(1, 1, 0),
                 B_conductivity_offdiag=gm.Vector3(1, 0, 0),


### PR DESCRIPTION
`mp.Medium` accepts `D_conductivity_offdiag` and `B_conductivity_offdiag`,
and `Medium.epsilon()` / `Medium.mu()` include them in the effective tensor
they return, but the solver never receives them: `medium_struct` carries
only `D_conductivity_diag` / `B_conductivity_diag`
(src/material_data.hpp), the Python-to-C++ transfer reads only the
diagonal attributes (python/typemap_utils.cpp), and the time stepping
applies conductivity per field component along its own direction
(src/step_db.cpp). So a user can set an anisotropic conductivity tensor
with off-diagonal elements, check the material with `Medium.epsilon()`
and see them included, and then run a simulation in which the tensor is
silently truncated to its diagonal.

To check that this is an O(1) physics discrepancy rather than
discretization error, I ran a planewave at normal incidence on a
half-space with eps = 2.25 and sigma_D = R(45deg) diag(2,0,0) R(45deg)^T
(i.e. `D_conductivity_diag=(1,1,0)`, `D_conductivity_offdiag=(1,0,0)`),
with the source polarized along the lossless principal axis of the
requested tensor. The exact complex-index Fresnel result for the
requested tensor is T = 0.960 at the monitor; the diagonal-truncated
medium sigma = diag(1,1,0) predicts T = 0.0699. Measured transmittance:

    resolution      50        100       200       400
    T measured    0.06867   0.06946   0.06973   0.06983

The measurement converges to the truncated-tensor prediction (and the
deviation from the requested physics stays at 0.89, flat in resolution),
and the results are identical whether the source is polarized along the
lossy or the lossless principal axis. A bulk propagation check shows the
same thing from another angle: an x-polarized wave in that medium
develops exactly zero Ey at any resolution, while the requested tensor
would couple the two components. (Runs with meep 1.34.0 from
conda-forge; the Python layer and the conductivity code paths are
identical between v1.34.0 and current master.)

Some history, for context: the two parameters were introduced together
with the `Medium.epsilon()` / `Medium.mu()` evaluation machinery (#862),
which does use them; #3246 recently fixed the `B_conductivity_offdiag`
assignment, which makes the reported `mu()` correct but does not reach
the time stepping; and no test exercised the solver-side path, so
nothing ever caught the gap.

This PR makes the gap loud instead of silent: `Medium.__init__` now
raises `ValueError` when either off-diagonal conductivity is nonzero,
with a message pointing at the supported route for anisotropic
off-diagonal absorption (a Lorentzian or Drude susceptibility with
`sigma_offdiag`, which the core does implement). The default zero
off-diagonal is unaffected, and I found no code in the repository or its
tests that passes a nonzero value. Three regression tests are added to
`test_geom.py` next to the existing conductivity tests.

I am happy to rework this in whichever direction you prefer:

- a warning instead of an error, if constructing such a `Medium` purely
  for `Medium.epsilon()` evaluations should remain possible;
- or full tensor static conductivity in the core, which the
  susceptibility machinery (per component-direction `sigma[c][d]`)
  suggests is feasible: this PR is only the minimal fail-loud step and
  does not preclude that.

A related, smaller inconsistency I can file separately if useful:
`Medium.transform()` rotates epsilon, mu and the susceptibilities but
leaves the conductivities untouched, so rotating a lossy medium also
silently drops the intended anisotropy.
