### PR TITLE
Record the `grid_volume` in `structure.h5` and test dump/load consistency

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -2641,6 +2641,17 @@ def load_structure(fname=None, single_parallel_file=True):
 
 Loads a structure from the file `fname`.
 
+The structure must already be initialized: the raw material data in `fname` is
+read into the existing grid rather than used to build a new one. This means the
+`Simulation` doing the loading must be constructed with the same `cell_size`,
+`resolution`, `dimensions`, and `geometry_center` as the one that called
+`dump_structure`, and with a chunk decomposition that matches (same
+`chunk_layout`, `boundary_layers`, `symmetries`, and number of MPI processes).
+Note in particular that a cell which is not an integer number of pixels is
+rounded to the nearest pixel when the grid is created, so it is the *rounded*
+grid that has to agree. `fname` records the grid it was dumped with, and a
+mismatch raises a `RuntimeError` rather than silently loading the wrong data.
+
 </div>
 
 </div>

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -2361,6 +2361,17 @@ class Simulation:
     def load_structure(self, fname: str = None, single_parallel_file: bool = True):
         """
         Loads a structure from the file `fname`.
+
+        The structure must already be initialized: the raw material data in `fname` is
+        read into the existing grid rather than used to build a new one. This means the
+        `Simulation` doing the loading must be constructed with the same `cell_size`,
+        `resolution`, `dimensions`, and `geometry_center` as the one that called
+        `dump_structure`, and with a chunk decomposition that matches (same
+        `chunk_layout`, `boundary_layers`, `symmetries`, and number of MPI processes).
+        Note in particular that a cell which is not an integer number of pixels is
+        rounded to the nearest pixel when the grid is created, so it is the *rounded*
+        grid that has to agree. `fname` records the grid it was dumped with, and a
+        mismatch raises a `RuntimeError` rather than silently loading the wrong data.
         """
         if self.structure is None:
             raise ValueError(

--- a/python/tests/test_dump_load.py
+++ b/python/tests/test_dump_load.py
@@ -595,7 +595,7 @@ class TestLoadDump(ApproxComparisonTestCase):
         self._init_gv_sim(20, mp.Vector3(5, 5)).dump_structure(fname)
 
         sim = self._init_gv_sim(30, mp.Vector3(5, 5))
-        with self.assertRaisesRegex(RuntimeError, "grid_volume_mismatch"):
+        with self.assertRaisesRegex(RuntimeError, "grid_volume mismatch"):
             sim.load_structure(fname)
 
     # A transposed cell has the same total number of pixels, so the array-size
@@ -609,7 +609,7 @@ class TestLoadDump(ApproxComparisonTestCase):
         self._init_gv_sim(50, mp.Vector3(5, 4)).dump_structure(fname)
 
         sim = self._init_gv_sim(50, mp.Vector3(4, 5))
-        with self.assertRaisesRegex(RuntimeError, "grid_volume_mismatch"):
+        with self.assertRaisesRegex(RuntimeError, "grid_volume mismatch"):
             sim.load_structure(fname)
 
     # Dump files written before structure::dump recorded the grid_volume have no

--- a/python/tests/test_dump_load.py
+++ b/python/tests/test_dump_load.py
@@ -17,6 +17,18 @@ except NameError:
     unicode = str
 
 
+def _gv_signature(gv):
+    """Everything about a grid_volume that a dump/load round trip must preserve."""
+    dirs = (mp.X, mp.Y, mp.Z, mp.R, mp.P)
+    return (
+        int(gv.dim),
+        gv.a,
+        tuple(gv.num_direction(d) for d in dirs),
+        tuple(gv.origin_in_direction(d) for d in dirs),
+        int(gv.ntot()),
+    )
+
+
 class TestLoadDump(ApproxComparisonTestCase):
 
     fname_base = re.sub(r"\.py$", "", os.path.split(sys.argv[0])[1])
@@ -522,6 +534,102 @@ class TestLoadDump(ApproxComparisonTestCase):
             RuntimeError, "meep: non-null polarization_state in fields::dump"
         ):
             sim.dump(dump_dirname, dump_structure=True, dump_fields=True)
+
+    def _init_gv_sim(self, resolution, cell_size, **kwargs):
+        # A non-trivial geometry, so the dumped chi1inv arrays are not all empty.
+        geometry = [
+            mp.Block(
+                material=mp.Medium(index=2.0),
+                center=mp.Vector3(),
+                size=mp.Vector3(1, 1, 1),
+            )
+        ]
+        sim = mp.Simulation(
+            resolution=resolution,
+            cell_size=cell_size,
+            geometry=geometry,
+            **kwargs,
+        )
+        sim.init_sim()
+        return sim
+
+    def _gv_dump_dir(self, name):
+        dirname = os.path.join(self.temp_dir, name)
+        os.makedirs(dirname, exist_ok=True)
+        return dirname
+
+    # The cell is rounded to the nearest whole pixel when the grid_volume is
+    # created (volone/voltwo/vol3d/volcyl in src/vec.cpp), so check that a
+    # dump/load round trip lands on exactly the same grid at resolutions where
+    # the cell is *not* an integer number of pixels.
+    def test_dump_load_grid_volume_matches(self):
+        cases = [
+            ("1d", mp.Vector3(z=5), {"dimensions": 1}),
+            ("2d", mp.Vector3(5, 5), {}),
+            ("3d", mp.Vector3(2.3, 2.1, 2.7), {}),
+            ("cylindrical", mp.Vector3(2.3, 0, 3.1), {"dimensions": mp.CYLINDRICAL}),
+        ]
+        dump_dirname = self._gv_dump_dir("test_dump_load_grid_volume")
+
+        for label, cell, kwargs in cases:
+            for resolution in [10, 13, 17.5, 21.3, 33]:
+                with self.subTest(cell=label, resolution=resolution):
+                    fname = os.path.join(dump_dirname, f"{label}-{resolution}.h5")
+                    sim1 = self._init_gv_sim(resolution, cell, **kwargs)
+                    sim1.dump_structure(fname)
+
+                    sim2 = self._init_gv_sim(resolution, cell, **kwargs)
+                    before_load = _gv_signature(sim2.structure.gv)
+                    sim2.load_structure(fname)
+
+                    self.assertEqual(_gv_signature(sim1.structure.gv), before_load)
+                    self.assertEqual(before_load, _gv_signature(sim2.structure.gv))
+
+    # meep::abort only raises (rather than calling MPI_Abort) on a single
+    # process, so assertRaisesRegex cannot be used with more than one.
+    @unittest.skipIf(mp.count_processors() > 1, "single-process test")
+    def test_load_structure_resolution_mismatch(self):
+        dump_dirname = self._gv_dump_dir("test_load_structure_mismatch")
+        fname = os.path.join(dump_dirname, "resolution.h5")
+
+        self._init_gv_sim(20, mp.Vector3(5, 5)).dump_structure(fname)
+
+        sim = self._init_gv_sim(30, mp.Vector3(5, 5))
+        with self.assertRaisesRegex(RuntimeError, "grid_volume_mismatch"):
+            sim.load_structure(fname)
+
+    # A transposed cell has the same total number of pixels, so the array-size
+    # checks in structure::load do not catch it; only the grid_volume recorded
+    # in the dump file does.
+    @unittest.skipIf(mp.count_processors() > 1, "single-process test")
+    def test_load_structure_cell_size_mismatch(self):
+        dump_dirname = self._gv_dump_dir("test_load_structure_mismatch")
+        fname = os.path.join(dump_dirname, "cell_size.h5")
+
+        self._init_gv_sim(50, mp.Vector3(5, 4)).dump_structure(fname)
+
+        sim = self._init_gv_sim(50, mp.Vector3(4, 5))
+        with self.assertRaisesRegex(RuntimeError, "grid_volume_mismatch"):
+            sim.load_structure(fname)
+
+    # Dump files written before structure::dump recorded the grid_volume have no
+    # gv_metadata dataset and must still load.
+    def test_load_structure_without_gv_mismatch(self):
+        dump_dirname = self._gv_dump_dir("test_load_structure_legacy")
+        fname = os.path.join(dump_dirname, "legacy.h5")
+
+        sim1 = self._init_gv_sim(20, mp.Vector3(5, 5))
+        sim1.dump_structure(fname)
+        if mp.am_master():
+            with h5py.File(fname, "a") as f:
+                del f["gv_metadata"]
+        mp.all_wait()
+
+        sim2 = self._init_gv_sim(20, mp.Vector3(5, 5))
+        sim2.load_structure(fname)
+        self.assertEqual(
+            _gv_signature(sim1.structure.gv), _gv_signature(sim2.structure.gv)
+        )
 
 
 if __name__ == "__main__":

--- a/python/tests/test_simulation.py
+++ b/python/tests/test_simulation.py
@@ -2,6 +2,7 @@ import itertools
 import os
 import re
 import sys
+import tempfile
 import unittest
 import warnings
 
@@ -284,6 +285,38 @@ class TestSimulation(unittest.TestCase):
         sim.require_dimensions()
         sim._init_structure(k=mp.Vector3())
         self.assertEqual(sim.structure.gv.dim, mp.D2)
+
+    # volcyl used to test isinteger(rsize) rather than isinteger(rsize * a), so
+    # it warned about cells that are an exact number of pixels and stayed quiet
+    # about ones that are not.  The warning is printed by the master process
+    # only, hence the single-process guard.
+    @unittest.skipIf(mp.count_processors() > 1, "single-process test")
+    def test_volcyl_pixel_rounding_warning(self):
+        def build(rsize, zsize, resolution):
+            sys.stderr.flush()
+            saved_stderr = os.dup(2)
+            try:
+                with tempfile.TemporaryFile(mode="w+") as tmp:
+                    os.dup2(tmp.fileno(), 2)
+                    try:
+                        gv = mp.volcyl(rsize, zsize, resolution)
+                    finally:
+                        sys.stderr.flush()
+                        os.dup2(saved_stderr, 2)
+                    tmp.seek(0)
+                    return gv, tmp.read()
+            finally:
+                os.close(saved_stderr)
+
+        # exactly 5 pixels in r
+        gv, err = build(2.5, 0, 2)
+        self.assertEqual(gv.num_direction(mp.R), 5)
+        self.assertNotIn("integer number of pixels", err)
+
+        # 7.5 pixels in r, rounded up to 8
+        gv, err = build(3, 0, 2.5)
+        self.assertEqual(gv.num_direction(mp.R), 8)
+        self.assertIn("integer number of pixels", err)
 
     def test_infer_dimensions(self):
         sim = self.init_simple_simulation()

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -91,7 +91,7 @@ static void check_gv_metadata(const double *file_meta, const grid_volume &gv,
                 filename, (int)file_meta[0], (int)meta[0]);
 
   if (fabs(file_meta[1] - meta[1]) > 1e-12 * fabs(meta[1]))
-    meep::abort("grid_volume mismatch in structure::load: the dump file \"%s\" was written"
+    meep::abort("grid_volume mismatch in structure::load: the dump file \"%s\" was written "
                 "at resolution %g but the simulation was created with resolution %g",
                 filename, file_meta[1], meta[1]);
 

--- a/src/structure_dump.cpp
+++ b/src/structure_dump.cpp
@@ -57,6 +57,62 @@ void structure::write_susceptibility_params(h5file *file, bool single_parallel_f
   }
 }
 
+/* The grid_volume is *not* reconstructed from the dump file: structure::load reads
+   into the chunks of an already-created structure, whose gv was rebuilt by the
+   caller from the cell_size and resolution and rounded to the nearest pixel (see
+   volone/voltwo/vol3d/volcyl in vec.cpp).  We record the gv here so that load can
+   report a mismatch instead of silently reading the data into an incompatible grid.
+   Layout (all doubles):
+     [0]    dims
+     [1]    a (resolution)
+     [2..4] num_direction(d), indexed by (int)d % 3 as elsewhere, so R/P are covered
+     [5..7] origin_in_direction(d), same indexing */
+static const size_t gv_metadata_size = 8;
+
+static void pack_gv_metadata(const grid_volume &gv, double *meta) {
+  for (size_t i = 0; i < gv_metadata_size; ++i)
+    meta[i] = 0;
+  meta[0] = (double)gv.dim;
+  meta[1] = gv.a;
+  LOOP_OVER_DIRECTIONS(gv.dim, d) {
+    meta[2 + ((int)d % 3)] = gv.num_direction(d);
+    meta[5 + ((int)d % 3)] = gv.origin_in_direction(d);
+  }
+}
+
+static void check_gv_metadata(const double *file_meta, const grid_volume &gv,
+                              const char *filename) {
+  double meta[gv_metadata_size];
+  pack_gv_metadata(gv, meta);
+
+  if ((int)file_meta[0] != (int)meta[0])
+    meep::abort("grid_volume mismatch in structure::load: the dump file \"%s\" has "
+                "dimensionality %d but the simulation has %d",
+                filename, (int)file_meta[0], (int)meta[0]);
+
+  if (fabs(file_meta[1] - meta[1]) > 1e-12 * fabs(meta[1]))
+    meep::abort("grid_volume mismatch in structure::load: the dump file \"%s\" was written"
+                "at resolution %g but the simulation was created with resolution %g",
+                filename, file_meta[1], meta[1]);
+
+  for (int i = 0; i < 3; ++i)
+    if ((int)file_meta[2 + i] != (int)meta[2 + i])
+      meep::abort("grid_volume mismatch in structure::load: the dump file \"%s\" has a cell "
+                  "of %d x %d x %d pixels but the simulation has %d x %d x %d; check "
+                  "cell_size and resolution",
+                  filename, (int)file_meta[2], (int)file_meta[3], (int)file_meta[4], (int)meta[2],
+                  (int)meta[3], (int)meta[4]);
+
+  // A difference far below one pixel cannot be meaningful.
+  const double origin_tol = 1e-9 / meta[1];
+  for (int i = 0; i < 3; ++i)
+    if (fabs(file_meta[5 + i] - meta[5 + i]) > origin_tol)
+      meep::abort("grid_volume mismatch in structure::load: the dump file \"%s\" has grid "
+                  "origin (%g, %g, %g) but the simulation has (%g, %g, %g) check "
+                  "geometry_center",
+                  filename, file_meta[5], file_meta[6], file_meta[7], meta[5], meta[6], meta[7]);
+}
+
 void structure::dump_chunk_layout(const char *filename) {
   // Write grid_volume info for each chunk so we can reconstruct chunk division from split_by_cost
   size_t sz = num_chunks * 3;
@@ -134,6 +190,20 @@ void structure::dump(const char *filename, bool single_parallel_file) {
   }
 
   h5file file(filename, h5file::WRITE, single_parallel_file, !single_parallel_file);
+
+  // Record the grid_volume so that structure::load can detect a mismatch.
+  {
+    size_t meta_len = gv_metadata_size;
+    double meta[gv_metadata_size];
+    pack_gv_metadata(gv, meta);
+    file.create_data("gv_metadata", 1, &meta_len, false /* append_data */,
+                     false /* single_precision */);
+    if (am_master() || !single_parallel_file) {
+      size_t meta_start = 0;
+      file.write_chunk(1, &meta_start, &meta_len, meta);
+    }
+  }
+
   size_t dims[3] = {(size_t)my_num_chunks, NUM_FIELD_COMPONENTS, 5};
   size_t start[3] = {0, 0, 0};
   file.create_data("num_chi1inv", 3, dims);
@@ -557,6 +627,27 @@ void structure::load(const char *filename, bool single_parallel_file) {
 
   if (verbosity > 0)
     printf("reading epsilon from file \"%s\" (%d)...\n", filename, single_parallel_file);
+
+  // Check that our grid_volume is the one that was dumped.  Files written by
+  // older versions of Meep have no gv_metadata dataset; skip the check for those.
+  if (file.dataset_exists("gv_metadata")) {
+    int meta_rank = 0;
+    size_t meta_dims[3] = {0, 0, 0};
+    file.read_size("gv_metadata", &meta_rank, meta_dims, 1);
+    if (meta_rank != 1 || meta_dims[0] != gv_metadata_size)
+      meep::abort("inconsistent data size for gv_metadata in structure::load");
+    double file_meta[gv_metadata_size] = {0};
+    if (am_master() || !single_parallel_file) {
+      size_t meta_start = 0;
+      size_t meta_count = gv_metadata_size;
+      file.read_chunk(1, &meta_start, &meta_count, file_meta);
+    }
+    if (single_parallel_file) {
+      file.prevent_deadlock();
+      broadcast(0, file_meta, gv_metadata_size);
+    }
+    check_gv_metadata(file_meta, gv, filename);
+  }
 
   /*
    * make/save a num_chunks x NUM_FIELD_COMPONENTS x 5 array counting

--- a/src/vec.cpp
+++ b/src/vec.cpp
@@ -930,7 +930,7 @@ grid_volume vol3d(double xsize, double ysize, double zsize, double a) {
 }
 
 grid_volume volcyl(double rsize, double zsize, double a) {
-  if (!isinteger(rsize) || !isinteger(zsize))
+  if (!isinteger(rsize * a) || !isinteger(zsize * a))
     master_printf_stderr("Warning: grid volume is not an integer number of pixels; cell size will "
                          "be rounded to nearest pixel.\n");
 


### PR DESCRIPTION
Related to #3282.

**Context**

`dump_structure` and `load_structure` use the *same* `grid_volume` at any resolution — but only by construction, and nothing was enforcing it.

Neither Python wrapper builds a `gv`. Both call through to `self.structure` ([`python/simulation.py:2345`](https://github.com/NanoComp/meep/blob/8f399d07bc4044dfd6e02940d89f076f266ec1e8/python/simulation.py#L2345), [`:2361`](https://github.com/NanoComp/meep/blob/8f399d07bc4044dfd6e02940d89f076f266ec1e8/python/simulation.py#L2361)), and there is exactly one `gv` construction path — `_init_structure` → `_create_grid_volume` ([`:2053`](https://github.com/NanoComp/meep/blob/8f399d07bc4044dfd6e02940d89f076f266ec1e8/python/simulation.py#L2053), [`:1681`](https://github.com/NanoComp/meep/blob/8f399d07bc4044dfd6e02940d89f076f266ec1e8/python/simulation.py#L1681)) — driven by (`cell_size`, `resolution`, `dimensions`, `geometry_center`, `k_point`). The `(int)(size*a + 0.5)` rounding in `volone`/`vol3d`/`volcyl` ([`src/vec.cpp:904-941`](https://github.com/NanoComp/meep/blob/8f399d07bc4044dfd6e02940d89f076f266ec1e8/src/vec.cpp#L904-L941)) is deterministic, so identical inputs give a bit-identical `gv` on both sides. The delayed-load path also runs in the right order, after `load_chunk_layout`.

The gap was that `structure::dump` wrote **no** geometric metadata, so `structure::load` could only validate byte counts. Confirmed empirically that dumping a `(5, 4)` cell and loading it into a `(4, 5)` cell at the same resolution **succeeded silently with transposed data**  — the per-chunk `ntot` (251×201 vs 201×251) is identical, so none of the existing checks fired.

**Changes**

- [`src/vec.cpp:933`](https://github.com/NanoComp/meep/blob/8f399d07bc4044dfd6e02940d89f076f266ec1e8/src/vec.cpp#L933) — `volcyl` tested `isinteger(rsize)` instead of `isinteger(rsize * a)`. Verified before/after: `r=2.5, res=2` now gives 5 pixels with no warning (previously warned), and `r=3, res=2.5` gives 8 pixels *with* the warning (previously silent).
- `src/structure_dump.cpp` — `structure::dump` now writes a `gv_metadata` dataset (dim, `a`, pixel counts, origin; full double precision), and `structure::load` compares it against the live `gv` before reading anything, aborting with a message that names the offending field. Files without the dataset load exactly as before.
- `python/tests/test_dump_load.py` — `test_dump_load_grid_volume_matches` asserts full `gv` signature equality across a round trip for 1D/2D/3D/cylindrical at resolutions `[10, 13, 17.5, 21.3, 33]` (all landing on non-integer pixel counts); plus resolution-mismatch, transposed cell, and legacy-file tests.
- `python/tests/test_simulation.py` — `test_volcyl_pixel_rounding_warning`, capturing stderr at the file-descriptor level. The warning tested is from C++ (`master_printf_stderr` → `fprintf(stderr, ...)` in `src/mympi.cpp`), not from Python.
- `python/simulation.py` + the corresponding block in `doc/docs/Python_User_Interface.md` — `load_structure` docstring now states the matching requirements.

**Verification**

`test_dump_load.py`: 17 passed single-process and under `mpirun -np 2` (which exercises the sharded `single_parallel_file=False` path). `test_simulation.py`: 32 passed. C++ `tests/dump_load` exits 0.


Two Notes:
- `@unittest.skipIf(mp.count_processors() > 1, ...)` is used rather than the `test_dump_load.py`'s existing `mp.with_mpi()` guard, because `meep::abort` throws `RuntimeError` whenever `count_processors() == 1` even in an MPI build ([`src/mympic.cpp:248`](https://github.com/NanoComp/meep/blob/8f399d07bc4044dfd6e02940d89f076f266ec1e8/src/mympi.cpp#L248)). With the existing guard the new tests would never have run here. The pre-existing test's guard is not changed.
- `fileds::dump`/`fields::load` (`src/fields_dump.cpp`) have the identical gap — same byte-count-only checks, no `gv` record. That is not addressed in this PR.