### PR TITLE
[12/13][Adjoint Module] Scalable Pade extrapolation for DFT monitors

### DIFF
--- a/doc/docs/Python_Tutorials/Adjoint_Solver.md
+++ b/doc/docs/Python_Tutorials/Adjoint_Solver.md
@@ -1184,7 +1184,6 @@ def mode_converter_optimization(
 
     return opt
 
-
 if __name__ == "__main__":
     input_flux, input_flux_data = straight_waveguide()
 
@@ -1358,6 +1357,19 @@ if __name__ == "__main__":
         optimal_design_weights=optimal_design_weights,
     )
 ```
+
+Padé acceleration is opt-in for adjoint problems. Pass `pade_samples` to
+enable corrected objective and design-region DFT monitors, and optionally pass
+`pade_tolerance` to stop forward and adjoint runs after two separated,
+full-versus-half-history convergence checks. For example,
+`pade_samples=20, pade_tolerance=1e-4` is an experimental configuration that
+must be validated for the problem at hand. The existing `decay_by` criterion
+remains a fallback. Automatic stopping requires finite-duration sources and is
+not supported for non-finite source end times. Padé extrapolation is not
+supported for LDOS objectives, even without automatic stopping. Run diagnostics are recorded in
+`opt.pade_diagnostics`; a maximum-time exit raises instead of returning a known
+unconverged gradient. The JAX wrapper exposes the same options, but its stopping
+test is monitor-only because it cannot inspect the outer JAX objective.
 
 
 Derivatives with Respect to Shape Parameters

--- a/doc/docs/Python_User_Interface.md.in
+++ b/doc/docs/Python_User_Interface.md.in
@@ -104,6 +104,17 @@ Meep supports a large number of functions to perform computations on the fields.
 @@ Simulation.get_epsilon_grid @@
 @@ Simulation.initialize_field @@
 @@ Simulation.add_dft_fields @@
+
+All chunk-backed DFT monitor constructors (`add_dft_fields`, `add_flux`,
+`add_mode_monitor`, `add_force`, `add_energy`, and `add_near2far`) accept an
+optional `pade_samples` argument. A value of zero preserves ordinary DFT
+accumulation. A value of at least four retains that many recent samples in a
+bounded ring and adds a Padé estimate of the uncomputed future tail when the
+monitor is read. Call `monitor.get_pade_error()` to inspect the per-frequency
+relative correction, full-versus-half-history estimate, temporal drift,
+readiness, retained sample count, and rejected-fit count. A rejected fit falls
+back to the ordinary accumulated DFT value.
+
 @@ Simulation.flux_in_box @@
 @@ Simulation.electric_energy_in_box @@
 @@ Simulation.magnetic_energy_in_box @@
@@ -498,6 +509,7 @@ In particular, a useful value for `until_after_sources` or `until` is often `sto
 @@ stop_when_fields_decayed @@
 @@ stop_when_energy_decayed @@
 @@ stop_when_dft_decayed @@
+@@ stop_when_dft_pade_converged @@
 @@ stop_when_flux_decayed @@
 @@ stop_after_walltime @@
 @@ stop_on_interrupt @@

--- a/doc/docs/Scalable_Pade_Extrapolation_Design.md
+++ b/doc/docs/Scalable_Pade_Extrapolation_Design.md
@@ -1,0 +1,564 @@
+# Scalable Padé Extrapolation for DFT Monitors
+
+Status: Proposed<br>
+Issue: [NanoComp/meep#3217](https://github.com/NanoComp/meep/issues/3217)<br>
+Related implementation: [NanoComp/meep#2440](https://github.com/NanoComp/meep/pull/2440)
+
+## Summary
+
+Add optional, bounded-memory Padé extrapolation to Meep's existing DFT monitors. Each MPI-local `dft_chunk` will retain a fixed number of recent weighted field samples while continuing the ordinary DFT accumulation. When a result is requested, Meep will estimate only the uncomputed future tail and add it to the accumulated DFT.
+
+The initial implementation supports only the frequencies configured on the monitor. Arbitrary-frequency evaluation, pure-Padé operation without configured DFT frequencies, and LDOS support are follow-up projects.
+
+A follow-up phase uses the same corrected DFT infrastructure to accelerate adjoint optimization. It replaces neither the adjoint equations nor the material-gradient calculation; it reduces the number of forward and adjoint FDTD timesteps by stopping after the extrapolated frequency-domain quantities have converged.
+
+## Goals
+
+- Parallelize naturally using the existing `dft_chunk` domain decomposition.
+- Bound additional storage independently of the number of timesteps.
+- Preserve current behavior and allocation when extrapolation is disabled.
+- Make corrected values available to all `dft_chunk`-backed consumers, including fields, flux, force, energy, near-to-far, eigenmode coefficients, and adjoint gradients.
+- Expose the magnitude of the correction and a full-history versus half-history error estimate.
+- Fail safely when a Padé fit is singular, ill-conditioned, or close to a pole.
+- Reduce forward and adjoint timesteps for high-Q optimization problems without changing the default adjoint workflow.
+- Bound Padé fitting and memory overhead for multi-objective and MPI adjoint calculations.
+
+## Non-goals for the initial implementation
+
+- Replacing or changing the existing Python `PadeDFT` class.
+- Evaluating monitors at frequencies not configured during construction.
+- Supporting a monitor with an empty frequency list as a pure-Padé transform.
+- Supporting `Ldos` or `dft_ldos`, which use separate `Fdft` and `Jdft` accumulators rather than `dft_chunk`.
+- Providing a rigorous error bound for nonlinear derived quantities such as flux or force.
+- Differentiating through the finite-time Padé fitting algorithm, pole rejection, or fallback branches.
+- Enabling automatic Padé stopping for continuous sources or LDOS objectives in the first adjoint integration.
+
+## Public API
+
+Add a keyword-only `pade_samples` argument to each chunk-backed monitor constructor:
+
+```python
+sim.add_dft_fields(..., pade_samples=0)
+sim.add_flux(..., pade_samples=0)
+sim.add_mode_monitor(..., pade_samples=0)
+sim.add_force(..., pade_samples=0)
+sim.add_energy(..., pade_samples=0)
+sim.add_near2far(..., pade_samples=0)
+```
+
+Semantics:
+
+- `pade_samples=0` disables extrapolation and preserves existing behavior.
+- `pade_samples=k>0` retains at most the latest `k` samples for every local DFT point and component.
+- Samples use the monitor's existing decimation schedule, so their spacing is `dt * decimation_factor`.
+- The Padé numerator and denominator orders are selected internally from the available sample count.
+- The accepted values are `0` or integers greater than or equal to four. Boolean values are rejected.
+- Before enough samples are available, getters return the ordinary accumulated DFT and report that extrapolation is not ready.
+
+The existing Python `PadeDFT` remains available and unchanged. Its full-history storage and SciPy implementation make it unsuitable as the backend for this feature, but it remains useful for compatibility and comparison.
+
+## Internal architecture
+
+### Ownership
+
+Store the additional state directly on `dft_chunk`. A chunk already owns:
+
+- one component and its spatial DFT points;
+- the configured frequencies and accumulated DFT values;
+- component weights, symmetry phases, and interpolation metadata;
+- decimation and update scheduling;
+- local MPI ownership and persistent-adjoint lifetime.
+
+This placement keeps sampling, storage, fitting, and evaluation local to the rank that owns the field chunk. Tail histories must never be gathered across MPI ranks.
+
+### New chunk state
+
+Conceptually add:
+
+```cpp
+size_t pade_samples;
+size_t pade_count;
+size_t pade_head;
+double pade_last_time;
+double pade_sample_period;
+complex<realnum> *pade_history;
+
+mutable complex<realnum> *effective_dft;
+mutable uint64_t state_generation;
+mutable uint64_t cached_generation;
+mutable pade_status cached_status;
+```
+
+The history layout is point-major, with `N * pade_samples` entries. The raw `dft` array remains unchanged. `effective_dft` is a lazy cache containing the raw accumulator plus the extrapolated future tail.
+
+No history or cache allocation is performed when `pade_samples == 0`.
+
+### Sampling
+
+During `dft_chunk::update_dft`, store the coefficient immediately before multiplication by the absolute-time Fourier phase. If the current update is
+
+```text
+D_i += a_k exp(i omega_i t_k),
+```
+
+the ring stores `a_k`. This preserves the existing spatial interpolation, integration weight, symmetry/Bloch phase, component weight, and quadrature scaling exactly once while keeping the history independent of frequency.
+
+The ring is updated only on actual DFT sampling steps. The ring head is advanced outside the parallel point loop so each thread writes independent spatial entries without contending on shared indexing state.
+
+Electric and magnetic chunks retain their actual sample times; the existing half-timestep staggering must not be removed.
+
+## Numerical method
+
+For `L` available samples, use a near-diagonal Padé approximant with
+
+```text
+q = floor(L / 2)
+p = L - q - 1.
+```
+
+Given retained coefficients `a_0, ..., a_(L-1)`, solve
+
+```text
+sum_(j=1)^q Q_j a_(k-j) = -a_k,
+```
+
+for `k = p+1, ..., p+q`, with `Q_0 = 1`, and recover the numerator coefficients from the matched power series.
+
+Use a small in-tree partial-pivoted complex Gaussian solver with `complex<double>` scratch arithmetic, including in single-precision builds. Typical systems are about 10 by 10 for the suggested 20-sample history, so this avoids making LAPACK a mandatory dependency. A later SVD or rank-revealing implementation may improve noisy-data robustness.
+
+### Future-only correction
+
+The ordinary DFT already includes every retained sample. The Padé contribution must therefore begin strictly after the latest real sample.
+
+Let the retained series start at time `t0`, and define
+
+```text
+z = exp(i omega dt_sample).
+```
+
+If `R(z) = P(z) / Q(z)` matches the retained power series, the correction is
+
+```text
+exp(i omega t0) * (R(z) - sum_(j=0)^(L-1) a_j z^j).
+```
+
+This subtraction is required to prevent double counting. The half-history estimate uses the most recent `floor(L/2)` samples and its own shifted `t0`, but must predict from the same next-sample boundary.
+
+### Failure behavior
+
+Reject a fit when it contains non-finite data, has a pivot below a scale-relative threshold, or evaluates with a non-finite or near-zero denominator. For a rejected point/frequency fit:
+
+- use zero correction, leaving the raw accumulated DFT unchanged;
+- record an invalid-fit status and count;
+- report an infinite error contribution;
+- do not abort the simulation or return NaNs.
+
+The thresholds must be deterministic and covered separately in double- and single-precision tests.
+
+## Corrected-value access
+
+Add a const-facing chunk method such as:
+
+```cpp
+const complex<realnum> *dft_values() const;
+```
+
+It returns raw `dft` immediately when extrapolation is disabled or still warming up. Otherwise it lazily prepares `effective_dft`, caches the result and status for the current generation, and returns the cache until another sampled update or mutation invalidates it.
+
+Prepare the cache once per chunk before entering downstream parallel loops, particularly the near-to-far OpenMP frequency loop. Lazy initialization must not occur concurrently from multiple worker threads.
+
+All reads of stored DFT values must use the accessor. This includes:
+
+- generic DFT array and HDF5 output;
+- flux and complex flux;
+- electric and magnetic energy;
+- Maxwell stress and force;
+- near-to-far propagation;
+- eigenmode overlaps and coefficients;
+- material-grid adjoint gradients;
+- normalization snapshots.
+
+Keep `dft_norm` on the raw accumulator in the initial implementation so `stop_when_dft_decayed` retains its current behavior.
+
+## Error reporting
+
+Add a uniform monitor method without changing existing result types:
+
+```python
+monitor.get_pade_error()
+```
+
+The returned value should include:
+
+```python
+PadeError(
+    relative_correction,
+    relative_estimate,
+    samples,
+    ready,
+    invalid_fits,
+)
+```
+
+The two arrays contain one entry per configured frequency. For every component/list representation, compute a relative spatial norm, then report the maximum ratio across those representations:
+
+```text
+relative_correction = max_c ||tail_n,c|| / ||accumulated_c + tail_n,c||
+relative_estimate = max_c ||tail_n,c - tail_n/2,c|| / ||accumulated_c + tail_n,c||.
+```
+
+This is a conservative convergence diagnostic for the underlying DFT fields, not an error bar on nonlinear derived observables.
+
+The C++ layer returns status data. Python may emit at most one `RuntimeWarning` for an unchanged monitor generation. Repeated queries must not repeat the warning. A sampled update or mutation begins a new generation.
+
+A Padé-specific stopping condition is required for the adjoint-acceleration follow-up described below. It must remain opt-in and must not silently replace or alter `stop_when_dft_decayed`.
+
+## Adjoint acceleration
+
+### Opportunity and current limitation
+
+`OptimizationProblem` performs one forward simulation followed by one adjoint simulation for each objective function. Both the forward and adjoint runs currently terminate with `stop_when_dft_decayed`, which observes changes in the raw accumulated DFT norm. `MeepJaxWrapper` uses the same raw stopping condition for its forward and reverse simulations.
+
+Corrected getters alone therefore improve a manually shortened result but do not reduce runtime automatically. Adjoint acceleration requires an explicit Padé-aware convergence controller.
+
+The speedup comes from fewer FDTD timesteps. Padé does not change the asymptotic cost of the material-gradient loop.
+
+### Quantities that must be corrected together
+
+An accelerated gradient is consistent only when Padé is enabled for the complete adjoint dataflow:
+
+1. Forward objective monitors, whose corrected values determine the objective and `dJ/dq` used to construct adjoint sources.
+2. The three persistent forward design-region DFT monitors for every design region.
+3. The three persistent adjoint design-region DFT monitors created for each adjoint solve.
+4. Every direct forward and adjoint DFT read in `material_grids_addgradient`.
+
+Correcting only the objective or only one design-field leg can produce a plausible objective with a systematically truncated gradient.
+
+Prepare corrected pointers once per forward/adjoint chunk before the native material-gradient loops. Do not fit inside the spatial inner loop.
+
+### Driver API
+
+Add the same two opt-in controls to `OptimizationProblem` and `MeepJaxWrapper`:
+
+```python
+pade_samples: int = 0
+pade_tolerance: Optional[float] = None
+```
+
+- `pade_samples=0` preserves the current adjoint registration, allocation, and stopping behavior.
+- `pade_samples>0` enables corrected fixed-frequency objective and design-region monitors while retaining the current raw-decay stop when `pade_tolerance` is `None`.
+- Setting `pade_tolerance` enables automatic Padé convergence stopping and requires `pade_samples >= 4`.
+- Keep `decay_by` or `dft_threshold` as a raw-decay fallback; do not reinterpret either existing parameter.
+- Values such as `pade_samples=20` and `pade_tolerance=1e-4` are benchmark candidates, not recommended defaults until validated.
+
+Thread `pade_samples` through every chunk-backed `ObjectiveQuantity.register_monitors` implementation and through `install_design_region_monitors` for both forward and adjoint setup. Reject automatic acceleration when an LDOS objective is present.
+
+### Padé convergence controller
+
+Use one explicit combined stopping predicate. Do not pass multiple callable conditions through the current `until_after_sources` list path: its wrappers close over the loop index, so multiple callables may invoke the final condition rather than their corresponding condition.
+
+Automatic convergence initially supports finite-duration sources only. A check is eligible only after every active monitor has collected a complete `pade_samples` history after `last_source_time`. Continuous or otherwise infinite-duration sources must be rejected instead of waiting indefinitely.
+
+At each eligible check, require every active monitor and frequency to be ready and valid, and compute:
+
+```text
+fit_delta = ||F_full - F_half|| /
+            max(||F_full||, absolute_floor)
+
+drift = ||F_full(current) - F_full(previous)|| /
+        max(||F_full(current)||, ||F_full(previous)||, absolute_floor)
+```
+
+Both quantities must be no greater than `pade_tolerance`. `F_half` uses the most recent half-history and predicts from the same future boundary as `F_full`. A negligible zero-valued history is a valid zero tail rather than a failed singular fit.
+
+Exact corrected-vector drift requires a previous corrected snapshot, adding a second `N * Nfreq` cache while automatic convergence is active. Evaluate no more frequently than every `ceil(pade_samples / 2)` new DFT samples so repeated small solves do not erase the timestep savings. Require two passing checks separated by this interval.
+
+The combined predicate records which condition fired:
+
+- `pade_converged`: all Padé checks passed;
+- `raw_decay_fallback`: the existing raw DFT condition passed first;
+- `maximum_time`: neither convergence condition passed before the cap.
+
+For automatic adjoint optimization, `maximum_time` is a failure and raises rather than silently returning a known-unconverged gradient. Fits that are ready, valid, and based on a complete post-source window may still be exposed diagnostically; all other points fall back to raw accumulated values.
+
+### Nonlinear objective confirmation
+
+Field-level Padé diagnostics do not bound error in arbitrary nonlinear user objectives. Ratios near zero, phase objectives, logarithms, and sharp nonlinearities can amplify small monitor errors in both the objective and `dJ/dq`.
+
+`OptimizationProblem` therefore uses a two-level forward gate:
+
+1. Run the inexpensive field-level full/half and drift checks until every objective and forward-design monitor becomes a convergence candidate.
+2. Evaluate the corrected objective arguments, every objective value, and every `dJ/dq`; require finite values and save this first high-level confirmation.
+3. Continue for at least `ceil(pade_samples / 2)` new samples and require field-level candidate convergence again.
+4. Evaluate the corrected arguments, objectives, and derivatives a second time. Stop only if their absolute-plus-relative drift also passes.
+
+If either confirmation fails, discard the candidate and resume field checks. This bounds expensive eigenmode, near-to-far, user-objective, and Autograd work to convergence candidates instead of every sampling interval.
+
+Automatic Padé stopping requires `OptimizationProblem` objective callables to be pure and deterministic. Side-effecting, time-varying, or externally stateful objective functions are unsupported. Record the number and wall time of high-level confirmations.
+
+The JAX wrapper cannot inspect the eventual outer objective or upstream cotangent during its forward invocation. Its initial Padé stop is therefore monitor-only, explicitly experimental, and does not imply a universal objective or gradient error bound.
+
+### Adjoint-source normalization
+
+`ObjectiveQuantity._adj_src_scale` currently computes the transform of an internally synthesized Gaussian source over `T = sim.meep_time()`. A shorter forward run can therefore change the adjoint-source normalization even when the monitored fields have converged.
+
+Refactor this normalization to integrate over the synthesized source's known complete finite support, or evaluate it analytically, so it is independent of the forward stopping time. If that refactor is deferred, automatic stopping must extend the minimum forward runtime through the complete synthesized-source support.
+
+### Gradient meaning
+
+The accelerated adjoint estimates the derivative of the converged, infinite-time physical frequency-domain objective. It is not the exact derivative of the finite-time Padé-corrected objective because the existing adjoint does not differentiate Padé coefficients, pole rejection, or fallback decisions.
+
+Primary correctness comparisons must therefore use:
+
+- a long-run Padé-disabled adjoint gradient; and
+- central finite differences of long-run Padé-disabled objective values.
+
+Finite differences of short Padé-corrected objectives are useful diagnostics but are not the correctness contract.
+
+### Multi-objective memory lifetime
+
+The current `OptimizationProblem` retains the forward design monitors plus every objective's adjoint design monitors until `calculate_gradient`. With `Q` objectives, this can keep `1 + Q` persistent design-monitor sets alive.
+
+For Padé-accelerated adjoints, calculate and store each objective's gradient immediately after its adjoint run, then remove that adjoint monitor set before starting the next objective. This bounds live design storage to one forward and one adjoint set instead of allowing history and corrected caches to scale with `Q`.
+
+### Required run diagnostics
+
+Record one compact result for the forward leg and each adjoint leg before its chunks are removed:
+
+- exit reason;
+- simulated time and timestep count;
+- retained sample count;
+- maximum full-versus-half and corrected-drift ratios;
+- readiness and invalid-fit count or invalid-signal ratio;
+- Padé fitting/checking wall time;
+- for `OptimizationProblem` forward runs, high-level confirmation count and wall time;
+- for JAX, an explicit marker that convergence was monitor-only.
+
+## Mutation and persistence semantics
+
+### Continued runs and time discontinuities
+
+Ordinary consecutive `Simulation.run` calls continue both raw accumulation and tail history. Queries do not consume or materialize the extrapolation.
+
+If the next sampled timestamp is not approximately `pade_last_time + pade_sample_period`, clear the history and cache while retaining the raw accumulator. This prevents fitting across `restart_fields`, which resets simulation time while retaining DFT data, or any other discontinuity in sampling.
+
+### Scaling
+
+`scale_dfts` scales only the raw accumulated DFT and clears the Padé history/cache. It must not scale retained history and later mix it with unscaled samples, and it must not materialize predicted future samples before the simulation continues.
+
+### Subtraction
+
+Treat direct subtraction as snapshot algebra:
+
+```text
+lhs.raw = effective(lhs) - effective(rhs).
+```
+
+Then clear the left-hand history/cache. If accumulation continues, it builds a fresh tail.
+
+### Normalization snapshots
+
+Monitor-level save/load operations and Python `get_*_data`/`load_*_data` APIs serialize a materialized corrected snapshot using the existing fixed-size `N * Nfreq` representation. Importing a snapshot populates raw DFT values and clears history. Histories from separate simulations must never be combined.
+
+### Full simulation checkpoints
+
+Full `fields::dump`/`fields::load` checkpoints have different semantics. They must serialize and restore:
+
+- the raw DFT accumulator;
+- `pade_samples`, ring contents, head, and valid count;
+- sample period and last sample time;
+- cache-invalid state.
+
+The current normalization and checkpoint paths share low-level HDF5 helpers, so the implementation must add separate modes or entry points. If resumable Padé checkpoints are deferred, dump/load must explicitly reject enabled Padé monitors rather than silently saving a materialized prediction that would be double-counted after restart.
+
+## Memory and performance
+
+Additional persistent storage per local chunk for corrected reads is
+
+```text
+O(N * pade_samples),
+```
+
+independent of elapsed timesteps. A lazy corrected cache may add `O(N * Nfreq)` transient or persistent storage. Automatic Padé convergence additionally retains the previous corrected vector for the temporal-drift check, bringing convergence-cache storage to `2 * N * Nfreq`.
+
+For one three-component design-monitor set in double precision, the approximate additional storage is
+
+```text
+3 * Nlocal * (pade_samples + 2 * Nfreq) * 16 bytes,
+```
+
+plus bounded fitting scratch. Forward objective monitors also contribute history and caches until adjoint sources are constructed. Streaming each objective's gradient immediately after its adjoint solve keeps only one forward and one adjoint design-monitor set live.
+
+Sampling adds one complex write per monitored spatial point. Fitting is lazy and rank-local, with approximate work
+
+```text
+O(N q^3 + N Nfreq q),
+```
+
+where `q` is roughly half the retained sample count.
+
+Convergence checks are separated by at least half a history. Padé fitting, drift checks, and high-level objective confirmations must be timed separately; they should remain a minority of accelerated wall time.
+
+Thread `pade_samples` into the pre-run DFT metadata and fragment memory estimator so chunk balancing sees the additional history and cache cost before selecting a layout.
+
+## Implementation sequence
+
+### 1. Freeze contracts and register tests
+
+- Adopt `pade_samples` consistently across Python, SWIG, and C++.
+- Finalize correction, failure, mutation, checkpoint, and normalization semantics.
+- Add a new C++ test executable to both `check_PROGRAMS` and `TESTS`.
+
+### 2. Implement the numerical kernel
+
+- Add the small complex solver and Padé coefficient construction.
+- Add future-tail and full-versus-half-history evaluation.
+- Test exact damped exponential sequences and all failure states.
+
+### 3. Add chunk storage and memory accounting
+
+- Add the ring, timing metadata, generation, cache, and status to `dft_chunk`.
+- Capture samples inside the existing DFT update loop.
+- Include history/cache cost in fragment statistics and chunk balancing.
+- Test wraparound, fixed capacity, cache invalidation, decimation, and time discontinuities.
+
+### 4. Complete fixed-frequency integration
+
+- Thread `pade_samples` through Python, SWIG, and C++ constructors.
+- Convert every direct raw DFT consumer to the corrected-value accessor.
+- Split normalization and checkpoint serialization behavior.
+- Implement and test scaling, subtraction, persistence, and restart semantics.
+
+This stage constitutes the minimum viable implementation of issue #3217.
+
+### 5. Add the error API
+
+- Expose readiness, sample count, invalid-fit count, relative correction, and the full-versus-half-history estimate.
+- Reduce only compact summaries across MPI.
+- Add warning suppression by monitor generation.
+- Add corrected-vector drift support and the optional previous-snapshot cache required by automatic convergence.
+
+### 6. Add opt-in adjoint acceleration
+
+- Refactor adjoint-source normalization so it is independent of the shortened forward runtime.
+- Thread `pade_samples` through objective monitors and forward/adjoint design-region monitors.
+- Replace raw reads in `material_grids_addgradient` with prepared corrected pointers.
+- Add one combined finite-source stopping predicate with sparse full/half and drift checks.
+- Add the two-level `OptimizationProblem` objective/`dJ` confirmation gate.
+- Record per-leg convergence diagnostics and enforce strict maximum-time failure.
+- Calculate each objective's gradient immediately after its adjoint run to bound peak memory.
+- Add experimental monitor-only JAX integration.
+
+### 7. Deferred extensions
+
+- Design arbitrary-frequency evaluation, including interpolation, ordering, output shape, lifetime, and out-of-band behavior.
+- Fix the current zero-frequency-count assumptions before adding pure-Padé operation.
+- Design LDOS support separately.
+
+## Test plan
+
+### Numerical unit tests
+
+- One damped complex exponential with an exact geometric tail.
+- Two or three modes with distinct complex poles and varied amplitudes.
+- Absolute time origin, decimated spacing, and the first predicted `K+1` sample.
+- Real and complex field sequences and odd/even history lengths.
+- Zero, constant, rank-deficient, near-singular, near-pole, and non-finite inputs.
+- Full-history versus half-history error output.
+
+### Chunk and parallel tests
+
+- Ring capacity remains `N * pade_samples` after arbitrarily many timesteps.
+- Aggregate capacity across ranks equals the expected globally owned entries without replicated histories.
+- Corrected arrays and status agree between one and multiple MPI ranks.
+- Electric and magnetic components preserve their half-step phase difference.
+- Repeated queries reuse the cache; sampled updates invalidate it; decimation-skipped steps do not.
+- Cache preparation is safe before OpenMP-enabled downstream loops.
+
+### Python and consumer tests
+
+- Omitted `pade_samples` and explicit zero are bit-for-bit compatible with current output.
+- A short corrected resonator run is closer to a long-run DFT reference than the same uncorrected short run.
+- `get_dft_array` and HDF5 output agree.
+- Flux, force, energy, near-to-far, eigenmode coefficients, and one persistent adjoint-gradient case use corrected values consistently.
+- Error values and statuses are finite and useful on controlled cases without requiring monotonic improvement at every checkpoint.
+
+### Lifecycle tests
+
+- Query, continue, and query again without double counting.
+- `restart_fields` clears history at the time discontinuity while retaining raw accumulation.
+- Scale, continue, and compare with a raw-history reference.
+- Subtract corrected snapshots, clear history, and continue with a fresh tail.
+- Test normalization round trips separately from exact full-checkpoint continuation.
+
+### Adjoint correctness tests
+
+- Compare corrected forward objective quantities, objective values, and `dJ/dq` with a long-run Padé-disabled reference.
+- Compare corrected forward and adjoint design-region fields before forming the gradient.
+- Compare per-frequency and optimizer-facing gradients with a long-run Padé-disabled adjoint.
+- Compare directional derivatives with central finite differences of long-run Padé-disabled objectives.
+- Treat finite differences of short Padé-corrected objectives as diagnostics only.
+- Cover single- and multi-frequency objectives, multiple objective functions, real and complex fields, normalization subtraction, and one persistent-adjoint case.
+- Verify that the forward two-level gate performs exactly two high-level confirmations per successful candidate sequence and rejects unstable objective or `dJ` values.
+- Verify that each adjoint leg stops and reports diagnostics independently.
+- Verify raw-decay fallback, strict maximum-time failure, finite-source rejection, LDOS rejection, and experimental JAX monitor-only behavior.
+- Verify source normalization is independent of the shortened forward stop time, including pulse-bandwidth variation.
+- Verify streamed multi-objective gradient calculation matches the current retained-all-adjoints result.
+
+### CI coverage
+
+Register the numerical and integration tests so they run in the existing serial-double, MPI-double, and MPI-single workflows. The default-zero path must add no allocation and remain bit-for-bit compatible with the existing test suite.
+
+Keep one small DFT-field adjoint case and one compact multi-objective/eigenmode case in per-commit testing. Put broader cylindrical near-to-far, damping, frequency, and finite-difference sweeps in the scheduled adjoint suite.
+
+### Performance evaluation
+
+Use the waveguide-crossing example as a single-objective benchmark and the six-frequency, two-objective mode converter as the representative multi-run benchmark. Test candidate histories of 20 and 40 samples and candidate tolerances of `1e-3` and `1e-4` at one and two MPI ranks.
+
+Record forward and per-adjoint timesteps, total and FDTD-only wall time, Padé fit/check time, confirmation time, objective and gradient error, cosine similarity, directional-derivative error, exit reasons, invalid fits, and per-rank peak RSS. Use one warm-up and five measured repetitions.
+
+The following are provisional rollout targets for these selected benchmarks, not universal guarantees or merge-blocking mathematical claims:
+
+- at least 40% fewer total forward-plus-adjoint FDTD timesteps;
+- at least 1.25x median end-to-end speedup for the single-objective case and 1.5x for the multi-objective mode converter;
+- Padé fitting and convergence checks below 20% of accelerated wall time;
+- double-precision objective error near `1e-4` and gradient/directional-derivative error near `1e-3`;
+- single-precision objective error near `2e-3` and gradient/directional-derivative error near `2e-2`;
+- observed RSS increase within the predicted bounded history/cache/scratch allocation plus 10%; and
+- no non-negligible invalid-fit signal on an exit labeled `pade_converged`.
+
+Do not document a recommended sample-count/tolerance preset until measurements across representative workloads satisfy or deliberately revise these targets.
+
+## Acceptance criteria
+
+1. `pade_samples=0` preserves current behavior and storage.
+2. Additional history remains bounded and distributed across MPI-owned chunks.
+3. Exact synthetic tails verify sign, phase, decimation, and the future-only boundary.
+4. Invalid fits fall back to raw values with deterministic, observable status.
+5. One-rank and multi-rank corrected results agree within precision-appropriate tolerances.
+6. A short corrected FDTD run improves against a long-run reference.
+7. Every advertised chunk-backed consumer uses the corrected-value path.
+8. Scaling, subtraction, restart, normalization, and checkpoint semantics pass dedicated continuation tests.
+9. Memory estimation includes Padé history before chunk balancing.
+10. Adjoint acceleration corrects objective, forward-design, and adjoint-design DFTs together and validates gradients against long-run adjoints and finite differences.
+11. Automatic adjoint stopping uses complete post-source histories, full/half agreement, corrected-vector drift, and required per-leg diagnostics.
+12. Multi-objective adjoint gradients are consumed incrementally so peak design-monitor storage does not scale with the number of objectives.
+13. The default adjoint path remains bit-for-bit compatible and allocates no Padé state.
+14. Arbitrary-frequency, pure-Padé, and LDOS work do not block the fixed-frequency merge.
+
+## Principal risks
+
+- A missed direct access to `dft_chunk::dft` would produce inconsistent corrected and uncorrected outputs.
+- Incorrect time origin or failure to subtract retained terms would double-count samples.
+- Ill-conditioned fits or poles could dominate quadratic quantities without failure-closed evaluation.
+- Treating normalization snapshots as resumable checkpoints would double-count predicted future samples after restart.
+- Scaling or subtracting histories with incompatible accumulation epochs would create invalid fits.
+- Failing to include history in memory estimation could produce poor chunk layouts despite bounded storage.
+- Correcting only the objective, forward design fields, or adjoint design fields would yield an inconsistent gradient.
+- Full-versus-half fit agreement can share systematic bias; automatic stopping also requires temporal drift across separated corrected snapshots.
+- Field-level convergence does not bound arbitrary nonlinear objective or `dJ/dq` error. `OptimizationProblem` therefore requires bounded high-level confirmations, while JAX remains monitor-only and experimental.
+- The accelerated adjoint estimates the converged physical gradient; it does not differentiate the nonlinear Padé fitting and rejection logic.
+- Shortening the forward run without decoupling `_adj_src_scale` from `sim.meep_time()` would change adjoint-source normalization.
+- Retaining every objective's adjoint history and caches would make peak memory scale with the objective count.
+- Continuous sources cannot provide the required post-source history window and must be rejected for automatic Padé stopping.
+- Calling expensive fitting or objective confirmation too frequently could consume the intended FDTD speedup.

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -34,12 +34,13 @@ ADJOINT_TESTS =                                \
     $(TEST_DIR)/test_adjoint_solver.py         \
     $(TEST_DIR)/test_adjoint_utils.py          \
     $(TEST_DIR)/test_adjoint_cyl.py            \
-    $(TEST_DIR)/test_adjoint_symmetry.py       \
-    $(TEST_DIR)/test_adjoint_protocol.py       \
-    $(TEST_DIR)/test_angular_spectrum.py       \
-    $(TEST_DIR)/test_geometry_gradient.py      \
-    $(TEST_DIR)/test_source_gradient.py        \
-    $(TEST_DIR)/test_adjoint_dispersion.py     \
+    $(TEST_DIR)/test_adjoint_dispersion.py             \
+    $(TEST_DIR)/test_adjoint_protocol.py               \
+    $(TEST_DIR)/test_angular_spectrum.py               \
+    $(TEST_DIR)/test_geometry_gradient.py              \
+    $(TEST_DIR)/test_source_gradient.py                \
+    $(TEST_DIR)/test_pade_adjoint.py                   \
+    $(TEST_DIR)/test_pade_api.py                       \
     $(TEST_DIR)/test_adjoint_jax.py
 
 TESTS =                                        \
@@ -47,8 +48,9 @@ TESTS =                                        \
     $(TEST_DIR)/test_absorber_1d.py            \
     $(TEST_DIR)/test_adjoint_adjacent_grids.py \
     $(TEST_DIR)/test_adjoint_chunks.py         \
-    $(TEST_DIR)/test_adjoint_symmetric_grids.py \
     $(TEST_DIR)/test_adjoint_protocol.py       \
+    $(TEST_DIR)/test_adjoint_symmetric_grids.py \
+    $(TEST_DIR)/test_adjoint_symmetry.py    \
     $(TEST_DIR)/test_antenna_radiation.py      \
     $(TEST_DIR)/test_array_metadata.py         \
     $(TEST_DIR)/test_bend_flux.py              \
@@ -64,7 +66,7 @@ TESTS =                                        \
     $(TEST_DIR)/test_cyl_ellipsoid.py          \
     $(TEST_DIR)/test_dft_energy.py             \
     $(TEST_DIR)/test_dft_fields.py             \
-    $(TEST_DIR)/test_dispersive_smoothing.py   \
+    $(TEST_DIR)/test_dispersive_smoothing.py           \
     $(DIFFRACTED_PLANEWAVE_TEST)               \
     $(DISPERSIVE_EIGENMODE_TEST)               \
     $(TEST_DIR)/test_divide_mpi_processes.py   \
@@ -104,10 +106,9 @@ TESTS =                                        \
     $(TEST_DIR)/test_simulation.py             \
     $(TEST_DIR)/test_special_kz.py             \
     $(TEST_DIR)/test_source.py                 \
-    $(TEST_DIR)/test_geometry_gradient.py      \
-    $(TEST_DIR)/test_source_gradient.py        \
+    $(TEST_DIR)/test_geometry_gradient.py              \
+    $(TEST_DIR)/test_source_gradient.py                \
     $(TEST_DIR)/test_stop_when_flux_decayed.py \
-    $(TEST_DIR)/test_subpixel_3d.py            \
     $(TEST_DIR)/test_timing_measurements.py    \
     $(TEST_DIR)/test_user_defined_material.py  \
     $(TEST_DIR)/test_verbosity_mgr.py          \
@@ -252,7 +253,6 @@ pkgpython_PYTHON = __init__.py $(HL_IFACE)
 
 adjointdir = $(pkgpythondir)/adjoint
 adjoint_PYTHON  = $(srcdir)/adjoint/__init__.py              \
-                  $(srcdir)/adjoint/angular_spectrum.py      \
                   $(srcdir)/adjoint/basis.py                 \
                   $(srcdir)/adjoint/objective.py             \
                   $(srcdir)/adjoint/optimization_problem.py  \
@@ -260,8 +260,6 @@ adjoint_PYTHON  = $(srcdir)/adjoint/__init__.py              \
                   $(srcdir)/adjoint/filter_source.py         \
                   $(srcdir)/adjoint/connectivity.py         \
                   $(srcdir)/adjoint/unfilter_design.py        \
-                  $(srcdir)/adjoint/geometry_gradient.py     \
-                  $(srcdir)/adjoint/source_gradient.py       \
                   $(srcdir)/adjoint/wrapper.py               \
                   $(srcdir)/adjoint/utils.py
 

--- a/python/adjoint/geometry_gradient.py
+++ b/python/adjoint/geometry_gradient.py
@@ -194,6 +194,7 @@ def install_geometry_monitors(
     objects,
     frequencies,
     decimation_factor: int = 0,
+    pade_samples: int = 0,
 ) -> List[List[mp.DftFields]]:
     """DFT monitors over each differentiable object's support.
 
@@ -238,6 +239,7 @@ def install_geometry_monitors(
                     yee_grid=True,
                     decimation_factor=decimation_factor,
                     persist=True,
+                    pade_samples=pade_samples,
                 )
                 for component in utils._compute_components(sim)
             ]

--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -2,6 +2,7 @@
 A collection of objects and helper methods for defining objective functions
 used in topology optimization.
 """
+
 import abc
 import warnings
 from collections import namedtuple
@@ -74,6 +75,7 @@ class ObjectiveQuantity(abc.ABC):
         self.sim = sim
         self._eval = None
         self._frequencies = None
+        self._pade_samples = 0
 
     @property
     def frequencies(self):
@@ -88,7 +90,7 @@ class ObjectiveQuantity(abc.ABC):
         """Evaluates the objective quantity."""
 
     @abc.abstractmethod
-    def register_monitors(self, frequencies):
+    def register_monitors(self, frequencies, pade_samples=0):
         """Registers monitors in the forward simulation."""
 
     @abc.abstractmethod
@@ -150,9 +152,15 @@ class ObjectiveQuantity(abc.ABC):
 
     def _adj_src_scale(self, include_resolution=True):
         """Calculates the scale for the adjoint sources."""
-        T = self.sim.meep_time()
         dt = self.sim.fields.dt
         src = self._create_time_profile()
+        # A shortened Padé run must not change adjoint-source normalization.
+        # Preserve the historical integration interval when Padé is disabled.
+        T = (
+            src.start_time + 2 * src.width * src.cutoff
+            if self._pade_samples
+            else self.sim.meep_time()
+        )
 
         if include_resolution:
             num_dims = self.sim._infer_dimensions(self.sim.k_point)
@@ -284,13 +292,15 @@ class EigenmodeCoefficient(ObjectiveQuantity):
         self.decimation_factor = decimation_factor
         self.subtracted_dft_fields = subtracted_dft_fields
 
-    def register_monitors(self, frequencies):
+    def register_monitors(self, frequencies, pade_samples=0):
         self._frequencies = np.asarray(frequencies)
+        self._pade_samples = pade_samples
         self._monitor = self.sim.add_mode_monitor(
             frequencies,
             mp.ModeRegion(center=self.volume.center, size=self.volume.size),
             yee_grid=True,
             decimation_factor=self.decimation_factor,
+            pade_samples=pade_samples,
         )
         if self.subtracted_dft_fields is not None:
             self.sim.load_minus_flux_data(
@@ -411,14 +421,16 @@ class FourierFields(ObjectiveQuantity):
         self.decimation_factor = decimation_factor
         self.subtracted_dft_fields = subtracted_dft_fields
 
-    def register_monitors(self, frequencies):
+    def register_monitors(self, frequencies, pade_samples=0):
         self._frequencies = np.asarray(frequencies)
+        self._pade_samples = pade_samples
         self._monitor = self.sim.add_dft_fields(
             [self.component],
             self._frequencies,
             where=self.volume,
             yee_grid=self.yee_grid,
             decimation_factor=self.decimation_factor,
+            pade_samples=pade_samples,
         )
         if self.subtracted_dft_fields is not None:
             self.sim.load_minus_flux_data(
@@ -534,13 +546,15 @@ class Near2FarFields(ObjectiveQuantity):
         self.nperiods = nperiods
         self.greencyl_tol = greencyl_tol
 
-    def register_monitors(self, frequencies):
+    def register_monitors(self, frequencies, pade_samples=0):
         self._frequencies = np.asarray(frequencies)
+        self._pade_samples = pade_samples
         self._monitor = self.sim.add_near2far(
             self._frequencies,
             *self.Near2FarRegions,
             nperiods=self.nperiods,
             decimation_factor=self.decimation_factor,
+            pade_samples=pade_samples,
         )
         if self.norm_near_fields is not None:
             self.sim.load_minus_near2far_data(
@@ -616,8 +630,11 @@ class LDOS(ObjectiveQuantity):
         super().__init__(sim)
         self.srckwarg = kwargs
 
-    def register_monitors(self, frequencies):
+    def register_monitors(self, frequencies, pade_samples=0):
+        if pade_samples:
+            raise ValueError("Padé extrapolation does not support LDOS objectives")
         self._frequencies = np.asarray(frequencies)
+        self._pade_samples = pade_samples
         self._forward_src = self.sim.sources
         return
 

--- a/python/adjoint/optimization_problem.py
+++ b/python/adjoint/optimization_problem.py
@@ -2,7 +2,9 @@ from collections import namedtuple
 from typing import Callable, List, Union, Optional, Tuple
 
 import numpy as np
+
 import meep as mp
+from meep.simulation import stop_when_dft_pade_converged
 
 from . import LDOS, DesignRegion, utils, ObjectiveQuantity
 from . import source_gradient
@@ -38,8 +40,9 @@ class OptimizationProblem:
         maximum_run_time: Optional[float] = None,
         finite_difference_step: Optional[float] = utils.FD_DEFAULT,
         step_funcs: Optional[List[Callable]] = None,
+        pade_samples: int = 0,
+        pade_tolerance: Optional[float] = None,
     ):
-
         """Initialize an instance of OptimizationProblem.
 
         Args:
@@ -77,6 +80,10 @@ class OptimizationProblem:
           finite_difference_step: the step size for calculation of the
             finite-difference gradients.
           step_funcs: list of step functions to be called at each timestep.
+          pade_samples: number of recent DFT samples retained for bounded-memory
+            Padé extrapolation. Zero (the default) disables extrapolation.
+          pade_tolerance: optional convergence tolerance for automatic Padé stopping.
+            Requires `pade_samples >= 4` and finite-duration sources.
         """
 
         self.step_funcs = step_funcs if step_funcs is not None else []
@@ -141,6 +148,13 @@ class OptimizationProblem:
         self.decimation_factor = decimation_factor
         self.minimum_run_time = minimum_run_time
         self.maximum_run_time = maximum_run_time
+        self.pade_samples = utils.validate_pade_options(pade_samples, pade_tolerance)
+        self.pade_tolerance = pade_tolerance
+        if self.pade_samples and any(
+            isinstance(m, LDOS) for m in self.objective_arguments
+        ):
+            raise ValueError("Padé extrapolation does not support LDOS objectives")
+        self.pade_diagnostics = []
         self.finite_difference_step = (
             finite_difference_step  # step size used in Aᵤ computation
         )
@@ -274,12 +288,21 @@ class OptimizationProblem:
 
         # register user specified monitors
         self.forward_monitors = [
-            m.register_monitors(self.frequencies) for m in self.objective_arguments
+            (
+                m.register_monitors(self.frequencies, pade_samples=self.pade_samples)
+                if self.pade_samples
+                else m.register_monitors(self.frequencies)
+            )
+            for m in self.objective_arguments
         ]
 
         # register design region
         self.forward_design_region_monitors = utils.install_design_region_monitors(
-            self.sim, self.design_regions, self.frequencies, self.decimation_factor
+            self.sim,
+            self.design_regions,
+            self.frequencies,
+            self.decimation_factor,
+            self.pade_samples,
         )
         # an ordinary object has no monitor of its own, so its fields have to be
         # recorded in both runs
@@ -289,6 +312,74 @@ class OptimizationProblem:
             self.frequencies,
             self.decimation_factor,
         )
+
+    @staticmethod
+    def _flatten_confirmation_values(values):
+        flattened = []
+        for value in values:
+            array = np.asarray(value).ravel()
+            flattened.extend(np.real(array))
+            flattened.extend(np.imag(array))
+        return np.asarray(flattened, dtype=float)
+
+    def _forward_confirmation(self):
+        """Values the Padé criterion requires to be stable, not just the fields.
+
+        Uses the same backend dispatch as the adjoint itself rather than
+        autograd's `jacobian` directly.  Hardcoding autograd here silently
+        undid the framework-agnostic objective support: an objective written
+        with `jax.numpy` got traced with autograd's ArrayBox, which JAX then
+        refuses as an argument.  Going through `objective_vjp` also confirms
+        stability of exactly the cotangents that drive the adjoint sources,
+        which is the quantity the gradient actually depends on.
+        """
+        results = [monitor() for monitor in self.objective_arguments]
+        values = list(results)
+        for ar, objective in enumerate(self.objective_functions):
+            value = objective(*results)
+            values.append(value)
+            values.extend(
+                utils.objective_vjp(
+                    objective,
+                    results,
+                    self._cotangent_for(value, ar),
+                    value=value,
+                )
+            )
+        return self._flatten_confirmation_values(values)
+
+    def _run_with_stopping(
+        self, monitors, confirmation=None, monitor_only=False, leg=None
+    ):
+        if self.pade_tolerance is None:
+            self.sim.run(
+                *self.step_funcs,
+                until_after_sources=mp.stop_when_dft_decayed(
+                    self.decay_by, self.minimum_run_time, self.maximum_run_time
+                ),
+            )
+            return None
+
+        utils.validate_finite_sources(self.sim.sources)
+        condition = stop_when_dft_pade_converged(
+            monitors,
+            self.pade_tolerance,
+            self.pade_samples,
+            raw_decay_tol=self.decay_by,
+            minimum_run_time=self.minimum_run_time,
+            maximum_run_time=self.maximum_run_time,
+            confirmation=confirmation,
+            monitor_only=monitor_only,
+        )
+        self.sim.run(*self.step_funcs, until_after_sources=condition)
+        diagnostics = condition.finalize(self.sim)
+        diagnostics["leg"] = leg
+        self.pade_diagnostics.append(diagnostics)
+        if diagnostics["exit_reason"] == "maximum_time":
+            raise RuntimeError(
+                "automatic Padé convergence was not reached before maximum_run_time"
+            )
+        return diagnostics
 
     def forward_run(self):
         # set up monitors
@@ -304,11 +395,14 @@ class OptimizationProblem:
                 ),
             )
         else:
-            self.sim.run(
-                *self.step_funcs,
-                until_after_sources=mp.stop_when_dft_decayed(
-                    self.decay_by, self.minimum_run_time, self.maximum_run_time
+            self._run_with_stopping(
+                [self.forward_monitors, self.forward_design_region_monitors],
+                confirmation=(
+                    self._forward_confirmation
+                    if self.pade_tolerance is not None
+                    else None
                 ),
+                leg="forward",
             )
 
         # record objective quantities from user specified monitors
@@ -328,6 +422,9 @@ class OptimizationProblem:
         self.current_state = "FWD"
 
     def _objective_cotangent(self, ar: int) -> np.ndarray:
+        return self._cotangent_for(self._objective_values[ar], ar)
+
+    def _cotangent_for(self, value, ar: int) -> np.ndarray:
         """Builds the reverse-pass seed for one objective function.
 
         Meep runs a single adjoint simulation per objective function and recovers
@@ -337,7 +434,6 @@ class OptimizationProblem:
         adjoint sources need -- the frequency diagonal of the Jacobian -- is the
         pullback of a cotangent of ones.
         """
-        value = self._objective_values[ar]
         if np.ndim(value) == 0:
             return np.ones((), dtype=np.asarray(value).dtype)
         value = np.asarray(value)
@@ -370,71 +466,106 @@ class OptimizationProblem:
         # set up adjoint sources and monitors
         self.prepare_adjoint_run()
 
-        # flip the m number
-        if utils._check_if_cylindrical(self.sim):
-            self.sim.change_m(-self.sim.m)
-
-        # flip the k point
-        if self.sim.k_point:
-            self.sim.change_k_point(-1 * self.sim.k_point)
-
+        is_cylindrical = utils._check_if_cylindrical(self.sim)
+        original_m = self.sim.m if is_cylindrical else None
+        original_k_point = self.sim.k_point
+        current_adjoint_monitors = None
+        completed = False
         self.adjoint_design_region_monitors = []
+        self._streamed_gradients = []
         self.adjoint_source_monitors = []
         self.adjoint_geometry_monitors = []
-        for ar in range(len(self.objective_functions)):
-            # Reset the fields
-            self.sim.restart_fields()
-            self.sim.clear_dft_monitors()
+        try:
+            if is_cylindrical:
+                self.sim.change_m(-original_m)
+            if original_k_point:
+                self.sim.change_k_point(-1 * original_k_point)
 
-            # Update the sources
-            self.sim.change_sources(self.adjoint_sources[ar])
+            for ar in range(len(self.objective_functions)):
+                # Reset the fields
+                self.sim.restart_fields()
+                self.sim.clear_dft_monitors()
+                current_adjoint_monitors = None
 
-            # register design dft fields
-            self.adjoint_design_region_monitors.append(
-                utils.install_design_region_monitors(
+                # Update the sources
+                self.sim.change_sources(self.adjoint_sources[ar])
+
+                # register design dft fields
+                current_adjoint_monitors = utils.install_design_region_monitors(
                     self.sim,
                     self.design_regions,
                     self.frequencies,
                     self.decimation_factor,
+                    self.pade_samples,
                 )
-            )
+                self.adjoint_design_region_monitors.append(current_adjoint_monitors)
 
-            # register a monitor over each differentiable source's support; the
-            # adjoint field there is the gradient with respect to its currents
-            self.adjoint_geometry_monitors.append(
-                geometry_gradient.install_geometry_monitors(
+                # A monitor over each differentiable object's support, and over
+                # each differentiable source's. These carry the shape and source
+                # derivatives, so they get the same Padé treatment as the design
+                # region -- and they are handed to the stopping condition below,
+                # or the run could stop before *they* have converged.
+                geometry_monitors = geometry_gradient.install_geometry_monitors(
                     self.sim,
                     self.differentiable_objects,
                     self.frequencies,
                     self.decimation_factor,
+                    self.pade_samples,
                 )
-            )
+                self.adjoint_geometry_monitors.append(geometry_monitors)
 
-            self.adjoint_source_monitors.append(
-                source_gradient.install_source_gradient_monitors(
+                source_monitors = source_gradient.install_source_gradient_monitors(
                     self.sim,
                     self.differentiable_sources,
                     self.frequencies,
                     self.decimation_factor,
+                    self.pade_samples,
                 )
-            )
-            self.sim._evaluate_dft_objects()
+                self.adjoint_source_monitors.append(source_monitors)
+                self.sim._evaluate_dft_objects()
 
-            # Adjoint run
-            self.sim.run(
-                *self.step_funcs,
-                until_after_sources=mp.stop_when_dft_decayed(
-                    self.decay_by, self.minimum_run_time, self.maximum_run_time
-                ),
-            )
+                # Adjoint run
+                self._run_with_stopping(
+                    current_adjoint_monitors
+                    + list(geometry_monitors)
+                    + list(source_monitors),
+                    leg=f"adjoint_{ar}",
+                    monitor_only=True,
+                )
 
-        # reset the m number
-        if utils._check_if_cylindrical(self.sim):
-            self.sim.change_m(-self.sim.m)
-
-        # reset the k point
-        if self.sim.k_point:
-            self.sim.change_k_point(-1 * self.sim.k_point)
+                if self.pade_samples:
+                    self._streamed_gradients.append(
+                        [
+                            dr.get_gradient(
+                                self.sim,
+                                current_adjoint_monitors[dri],
+                                self.forward_design_region_monitors[dri],
+                                self.frequencies,
+                                self.finite_difference_step,
+                            )
+                            for dri, dr in enumerate(self.design_regions)
+                        ]
+                    )
+                    # Only the design-region monitors can be released here; the
+                    # geometry and source monitors are read after the loop.
+                    for monitor_set in current_adjoint_monitors:
+                        for monitor in monitor_set:
+                            monitor.remove()
+                    self.adjoint_design_region_monitors[-1] = None
+                    current_adjoint_monitors = None
+            completed = True
+        finally:
+            try:
+                if not completed and current_adjoint_monitors is not None:
+                    for monitor_set in current_adjoint_monitors:
+                        for monitor in monitor_set:
+                            if monitor.swigobj is not None:
+                                monitor.remove()
+            finally:
+                if is_cylindrical:
+                    self.sim.change_m(original_m)
+                if original_k_point:
+                    self.sim.change_k_point(original_k_point)
 
         # update optimizer's state
         self.current_state = "ADJ"
@@ -554,19 +685,22 @@ class OptimizationProblem:
         self.geometry_gradient = self.calculate_geometry_gradient()
 
         # Iterate through all design regions and calculate gradient
-        self.gradient = [
-            [
-                dr.get_gradient(
-                    self.sim,
-                    self.adjoint_design_region_monitors[ar][dri],
-                    self.forward_design_region_monitors[dri],
-                    self.frequencies,
-                    self.finite_difference_step,
-                )
-                for dri, dr in enumerate(self.design_regions)
+        if self.pade_samples:
+            self.gradient = self._streamed_gradients
+        else:
+            self.gradient = [
+                [
+                    dr.get_gradient(
+                        self.sim,
+                        self.adjoint_design_region_monitors[ar][dri],
+                        self.forward_design_region_monitors[dri],
+                        self.frequencies,
+                        self.finite_difference_step,
+                    )
+                    for dri, dr in enumerate(self.design_regions)
+                ]
+                for ar in range(len(self.objective_functions))
             ]
-            for ar in range(len(self.objective_functions))
-        ]
 
         for dri in range(self.num_design_regions):
             for i in range(3):
@@ -658,7 +792,14 @@ class OptimizationProblem:
 
             # initialize design monitors
             self.forward_monitors = [
-                m.register_monitors(self.frequencies) for m in self.objective_arguments
+                (
+                    m.register_monitors(
+                        self.frequencies, pade_samples=self.pade_samples
+                    )
+                    if self.pade_samples
+                    else m.register_monitors(self.frequencies)
+                )
+                for m in self.objective_arguments
             ]
 
             if any(isinstance(m, LDOS) for m in self.objective_arguments):
@@ -692,7 +833,14 @@ class OptimizationProblem:
 
             # initialize design monitors
             self.forward_monitors = [
-                m.register_monitors(self.frequencies) for m in self.objective_arguments
+                (
+                    m.register_monitors(
+                        self.frequencies, pade_samples=self.pade_samples
+                    )
+                    if self.pade_samples
+                    else m.register_monitors(self.frequencies)
+                )
+                for m in self.objective_arguments
             ]
 
             # add monitor used to track dft convergence

--- a/python/adjoint/source_gradient.py
+++ b/python/adjoint/source_gradient.py
@@ -72,6 +72,7 @@ class SourceGradientMonitor:
         frequencies: np.ndarray,
         decimation_factor: Optional[int] = 0,
         component: Optional[int] = None,
+        pade_samples: int = 0,
     ):
         self.source = source
         # A Gaussian beam has no single component: it places four, so each gets
@@ -98,6 +99,7 @@ class SourceGradientMonitor:
         )
         self._check_not_in_pml(sim)
         self.decimation_factor = decimation_factor
+        self.pade_samples = pade_samples
         self._monitor = None
 
     def _check_not_in_pml(self, sim: mp.Simulation) -> None:
@@ -145,7 +147,22 @@ class SourceGradientMonitor:
             where=self.volume,
             yee_grid=True,
             decimation_factor=self.decimation_factor,
+            pade_samples=self.pade_samples,
         )
+
+    def get_pade_error(self):
+        """Delegate to the underlying DFT monitor.
+
+        The adjoint stopping criterion is handed every monitor whose
+        convergence the gradient depends on, including this one -- otherwise a
+        run could stop before the source cotangent has settled. This class wraps
+        a `DftFields` rather than being one, so forward the query.
+        """
+        if self._monitor is None:
+            raise RuntimeError(
+                "the monitor has not been registered yet; call register() first"
+            )
+        return self._monitor.get_pade_error()
 
     def num_points(self, sim: mp.Simulation) -> int:
         """How many grid points this source actually drives.
@@ -215,6 +232,7 @@ def install_source_gradient_monitors(
     sources: List,
     frequencies: np.ndarray,
     decimation_factor: Optional[int] = 0,
+    pade_samples: int = 0,
 ) -> List[SourceGradientMonitor]:
     """Install a DFT monitor over each differentiable source's support."""
     monitors = []
@@ -223,7 +241,12 @@ def install_source_gradient_monitors(
         # places four
         group = [
             SourceGradientMonitor(
-                sim, source, frequencies, decimation_factor, component=component
+                sim,
+                source,
+                frequencies,
+                decimation_factor,
+                component=component,
+                pade_samples=pade_samples,
             )
             for component in source_components(source, sim.dimensions)
         ]

--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -1,3 +1,5 @@
+import math
+import numbers
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union
 
 import numpy as onp
@@ -22,6 +24,45 @@ _Z_AXIS = 1
 
 # default finite difference step size when calculating Aᵤ
 FD_DEFAULT = 1e-3
+
+
+def validate_pade_options(pade_samples: int, pade_tolerance) -> int:
+    """Validate the shared adjoint Padé controls and return a plain int."""
+    if isinstance(pade_samples, (bool, onp.bool_)) or not isinstance(
+        pade_samples, numbers.Integral
+    ):
+        raise TypeError("pade_samples must be an integer")
+    pade_samples = int(pade_samples)
+    if pade_samples < 0 or 0 < pade_samples < 4:
+        raise ValueError("pade_samples must be 0 or at least 4")
+    if pade_tolerance is not None:
+        if pade_samples < 4:
+            raise ValueError("pade_tolerance requires pade_samples >= 4")
+        if (
+            not onp.isscalar(pade_tolerance)
+            or not onp.isfinite(pade_tolerance)
+            or pade_tolerance <= 0
+        ):
+            raise ValueError("pade_tolerance must be a positive finite scalar")
+    return pade_samples
+
+
+def validate_finite_sources(sources: Iterable[mp.Source]) -> None:
+    """Reject sources that cannot provide a complete post-source Padé window."""
+    for source in sources:
+        time_profile = source.src
+        if isinstance(time_profile, mp.GaussianSource):
+            end_time = (
+                time_profile.start_time + 2 * time_profile.width * time_profile.cutoff
+            )
+        else:
+            end_time = getattr(time_profile, "end_time", None)
+        try:
+            finite_end_time = math.isfinite(end_time)
+        except TypeError:
+            finite_end_time = False
+        if not finite_end_time or end_time >= 1e19:
+            raise ValueError("automatic Padé stopping requires finite-duration sources")
 
 
 class DesignRegion:
@@ -133,10 +174,14 @@ def calculate_vjps(
 def register_monitors(
     monitors: List[ObjectiveQuantity],
     frequencies: List[float],
+    pade_samples: int = 0,
 ) -> None:
     """Registers a list of monitors."""
     for monitor in monitors:
-        monitor.register_monitors(frequencies)
+        if pade_samples:
+            monitor.register_monitors(frequencies, pade_samples=pade_samples)
+        else:
+            monitor.register_monitors(frequencies)
 
 
 def install_design_region_monitors(
@@ -144,6 +189,7 @@ def install_design_region_monitors(
     design_regions: List[DesignRegion],
     frequencies: List[float],
     decimation_factor: int = 0,
+    pade_samples: int = 0,
 ) -> List[List[mp.DftFields]]:
     """Installs DFT field monitors at the design regions of the simulation."""
     return [
@@ -155,6 +201,7 @@ def install_design_region_monitors(
                 yee_grid=True,
                 decimation_factor=decimation_factor,
                 persist=True,
+                pade_samples=pade_samples,
             )
             for comp in _compute_components(simulation)
         ]
@@ -346,5 +393,13 @@ def create_adjoint_sources(
     for monitor, dj in zip(monitors, cotangents):
         if onp.any(dj):
             adjoint_sources += monitor.place_adjoint_source(dj)
-    assert adjoint_sources
+
+    # An empty list here is not an error under MPI.  `fourier_sourcedata`
+    # returns one entry per *local* chunk that intersects the monitor, and
+    # `IndexedSource` is inherently per-chunk, so a rank whose chunks miss the
+    # monitor legitimately places nothing -- which is every rank but one for a
+    # point monitor.  The condition worth checking is global and is already
+    # checked above: the cotangents are identical on every rank, so if the
+    # objective really is disconnected from the monitors, the RuntimeError
+    # fires everywhere at once with a message that says so.
     return adjoint_sources

--- a/python/adjoint/wrapper.py
+++ b/python/adjoint/wrapper.py
@@ -95,6 +95,7 @@ import jax.numpy as jnp
 import numpy as onp
 
 import meep as mp
+from meep.simulation import stop_when_dft_pade_converged
 
 from . import DesignRegion, ObjectiveQuantity, utils
 from . import source_gradient
@@ -186,6 +187,10 @@ class MeepJaxWrapper:
           `until_after_sources` is used. See
           https://meep.readthedocs.io/en/latest/Python_User_Interface/#Simulation
           for more information. The default is true.
+        pade_samples: number of recent DFT samples retained for bounded-memory Padé
+          extrapolation. Zero disables extrapolation.
+        pade_tolerance: optional experimental monitor-level convergence tolerance.
+          Requires `pade_samples >= 4` and finite-duration sources.
     """
 
     def __init__(
@@ -200,6 +205,8 @@ class MeepJaxWrapper:
         maximum_run_time: float = onp.inf,
         until_after_sources: bool = True,
         finite_difference_step: float = utils.FD_DEFAULT,
+        pade_samples: int = 0,
+        pade_tolerance: float = None,
     ):
         _warn_if_precision_mismatch()
         self.simulation = simulation
@@ -212,6 +219,9 @@ class MeepJaxWrapper:
         self.maximum_run_time = maximum_run_time
         self.until_after_sources = until_after_sources
         self.finite_difference_step = finite_difference_step
+        self.pade_samples = utils.validate_pade_options(pade_samples, pade_tolerance)
+        self.pade_tolerance = pade_tolerance
+        self.pade_diagnostics = []
 
         # A source whose amplitudes come from JAX is differentiated
         # automatically: the parameters that produced them live upstream in
@@ -228,6 +238,33 @@ class MeepJaxWrapper:
                 )
 
         self._simulate_fn = self._initialize_callable()
+
+    def _run_simulation(self, monitors, leg):
+        run_keyword = "until_after_sources" if self.until_after_sources else "until"
+        if self.pade_tolerance is None:
+            condition = mp.stop_when_dft_decayed(
+                self.dft_threshold, self.minimum_run_time, self.maximum_run_time
+            )
+        else:
+            utils.validate_finite_sources(self.simulation.sources)
+            condition = stop_when_dft_pade_converged(
+                monitors,
+                self.pade_tolerance,
+                self.pade_samples,
+                raw_decay_tol=self.dft_threshold,
+                minimum_run_time=self.minimum_run_time,
+                maximum_run_time=self.maximum_run_time,
+                monitor_only=True,
+            )
+        self.simulation.run(**{run_keyword: condition})
+        if self.pade_tolerance is not None:
+            diagnostics = condition.finalize(self.simulation)
+            diagnostics["leg"] = leg
+            self.pade_diagnostics.append(diagnostics)
+            if diagnostics["exit_reason"] == "maximum_time":
+                raise RuntimeError(
+                    "automatic Padé convergence was not reached before maximum_run_time"
+                )
 
     def __call__(
         self, designs: List[jnp.ndarray], sources: Optional[List[jnp.ndarray]] = None
@@ -290,21 +327,23 @@ class MeepJaxWrapper:
         self._update_sources(source_variables)
         self.simulation.reset_meep()
         self.simulation.change_sources(self.sources)
-        utils.register_monitors(self.monitors, self.frequencies)
+        utils.register_monitors(
+            self.monitors, self.frequencies, pade_samples=self.pade_samples
+        )
         fwd_design_region_monitors = utils.install_design_region_monitors(
             self.simulation,
             self.design_regions,
             self.frequencies,
+            pade_samples=self.pade_samples,
         )
         self.simulation.init_sim()
-        sim_run_args = {
-            "until_after_sources"
-            if self.until_after_sources
-            else "until": mp.stop_when_dft_decayed(
-                self.dft_threshold, self.minimum_run_time, self.maximum_run_time
-            )
-        }
-        self.simulation.run(**sim_run_args)
+        self._run_simulation(
+            [
+                [monitor._monitor for monitor in self.monitors],
+                fwd_design_region_monitors,
+            ],
+            "forward_monitor_only",
+        )
 
         monitor_values = utils.gather_monitor_values(self.monitors)
         # A tuple when the monitors have heterogeneous shapes; `custom_vjp`
@@ -333,6 +372,7 @@ class MeepJaxWrapper:
             self.simulation,
             self.design_regions,
             self.frequencies,
+            pade_samples=self.pade_samples,
         )
         self.adj_source_monitors = source_gradient.install_source_gradient_monitors(
             self.simulation,
@@ -340,14 +380,7 @@ class MeepJaxWrapper:
             self.frequencies,
         )
         self.simulation.init_sim()
-        sim_run_args = {
-            "until_after_sources"
-            if self.until_after_sources
-            else "until": mp.stop_when_dft_decayed(
-                self.dft_threshold, self.minimum_run_time, self.maximum_run_time
-            )
-        }
-        self.simulation.run(**sim_run_args)
+        self._run_simulation(adj_design_region_monitors, "adjoint_monitor_only")
 
         return adj_design_region_monitors
 

--- a/python/meep.i
+++ b/python/meep.i
@@ -42,7 +42,9 @@
 /* this #define from Python's structmember.h, used by swig, conflicts with meep.hpp */
 #undef READONLY
 
+#include <algorithm>
 #include <complex>
+#include <limits>
 #include <string>
 
 #include "config.h"
@@ -500,8 +502,9 @@ void _get_dft_data(meep::dft_chunk *dc, std::complex<double> *cdata, int size) {
 
     for (meep::dft_chunk *cur = dc; cur; cur = cur->next_in_dft) {
         size_t Nchunk = cur->N * cur->omega.size();
+        const std::complex<meep::realnum> *values = cur->dft_values();
         for (size_t i = 0; i < Nchunk; ++i) {
-            cdata[i + istart] = cur->dft[i];
+            cdata[i + istart] = values[i];
         }
         istart += Nchunk;
     }
@@ -521,8 +524,123 @@ void _load_dft_data(meep::dft_chunk *dc, std::complex<double> *cdata, int size) 
         for (size_t i = 0; i < Nchunk; ++i) {
             cur->dft[i] = cdata[i + istart];
         }
+        cur->clear_pade_history();
         istart += Nchunk;
     }
+}
+
+static PyObject *_dft_pade_error_from_chunks(const std::vector<meep::dft_chunk *> &heads,
+                                             size_t nfreq) {
+    /* Accumulate the squared sums and divide once at the end.  Taking a max of
+       per-chunk ratios lets a chunk holding almost no field decide the answer,
+       because its denominator is tiny; summing first weights each chunk by the
+       field it actually carries. */
+    std::vector<double> correction2(nfreq, 0.0);
+    std::vector<double> estimate2(nfreq, 0.0);
+    std::vector<double> drift2(nfreq, 0.0);
+    std::vector<double> magnitude2(nfreq, 0.0);
+    std::vector<double> relative_correction(nfreq, 0.0);
+    std::vector<double> relative_estimate(nfreq, 0.0);
+    std::vector<double> drift(nfreq, 0.0);
+    bool enabled = false;
+    bool ready = true;
+    int samples = std::numeric_limits<int>::max();
+    size_t invalid_fits = 0;
+    double generation = 0;
+
+    for (meep::dft_chunk *head : heads) {
+        for (meep::dft_chunk *cur = head; cur; cur = cur->next_in_dft) {
+            if (!cur->pade_enabled()) continue;
+            enabled = true;
+            const meep::dft_pade_error err = cur->get_pade_error();
+            ready = ready && err.ready;
+            samples = std::min(samples, static_cast<int>(err.samples));
+            invalid_fits += err.invalid_fits;
+            generation = std::max(generation, static_cast<double>(err.generation));
+            const size_t error_nfreq = std::min(
+                nfreq, std::min(err.relative_correction.size(),
+                                std::min(err.relative_estimate.size(), err.drift.size())));
+            for (size_t i = 0; i < error_nfreq; ++i) {
+                if (i < err.correction2.size()) correction2[i] += err.correction2[i];
+                if (i < err.estimate2.size()) estimate2[i] += err.estimate2[i];
+                if (i < err.drift2.size()) drift2[i] += err.drift2[i];
+                if (i < err.magnitude2.size()) magnitude2[i] += err.magnitude2[i];
+            }
+        }
+    }
+
+    const bool any_enabled = meep::or_to_all(enabled);
+    ready = any_enabled && meep::and_to_all(!enabled || ready);
+    samples = meep::min_to_all(enabled ? samples : std::numeric_limits<int>::max());
+    invalid_fits = meep::sum_to_all(invalid_fits);
+    generation = meep::max_to_all(generation);
+    for (size_t i = 0; i < nfreq; ++i) {
+        correction2[i] = meep::sum_to_all(correction2[i]);
+        estimate2[i] = meep::sum_to_all(estimate2[i]);
+        drift2[i] = meep::sum_to_all(drift2[i]);
+        magnitude2[i] = meep::sum_to_all(magnitude2[i]);
+        const double denom = magnitude2[i] > 0 ? magnitude2[i]
+                                               : std::numeric_limits<double>::min();
+        relative_correction[i] = std::sqrt(correction2[i] / denom);
+        relative_estimate[i] = std::isfinite(estimate2[i])
+                                   ? std::sqrt(estimate2[i] / denom)
+                                   : std::numeric_limits<double>::infinity();
+        drift[i] = std::sqrt(drift2[i] / denom);
+    }
+    if (!any_enabled) {
+        samples = 0;
+        std::fill(relative_estimate.begin(), relative_estimate.end(),
+                  std::numeric_limits<double>::infinity());
+        std::fill(drift.begin(), drift.end(), std::numeric_limits<double>::infinity());
+    }
+
+    PyObject *correction_obj = PyList_New(nfreq);
+    PyObject *estimate_obj = PyList_New(nfreq);
+    PyObject *drift_obj = PyList_New(nfreq);
+    /* The field magnitude each ratio was divided by, so a caller combining
+       several monitors can weight them by the field they carry rather than
+       taking a max over ratios of wildly different denominators. */
+    PyObject *magnitude_obj = PyList_New(nfreq);
+    for (size_t i = 0; i < nfreq; ++i) {
+        PyList_SetItem(correction_obj, i, PyFloat_FromDouble(relative_correction[i]));
+        PyList_SetItem(estimate_obj, i, PyFloat_FromDouble(relative_estimate[i]));
+        PyList_SetItem(drift_obj, i, PyFloat_FromDouble(drift[i]));
+        PyList_SetItem(magnitude_obj, i, PyFloat_FromDouble(std::sqrt(magnitude2[i])));
+    }
+
+    PyObject *result = PyTuple_New(8);
+    PyTuple_SetItem(result, 0, correction_obj);
+    PyTuple_SetItem(result, 1, estimate_obj);
+    PyTuple_SetItem(result, 2, drift_obj);
+    PyTuple_SetItem(result, 3, PyLong_FromLong(samples));
+    PyTuple_SetItem(result, 4, PyBool_FromLong(ready));
+    PyTuple_SetItem(result, 5, PyLong_FromSize_t(invalid_fits));
+    PyTuple_SetItem(
+        result, 6, PyLong_FromUnsignedLongLong(static_cast<unsigned long long>(generation)));
+    PyTuple_SetItem(result, 7, magnitude_obj);
+    return result;
+}
+
+PyObject *_get_dft_pade_error(meep::dft_fields *monitor) {
+    return _dft_pade_error_from_chunks({monitor->chunks}, monitor->freq.size());
+}
+
+PyObject *_get_dft_pade_error(meep::dft_flux *monitor) {
+    return _dft_pade_error_from_chunks({monitor->E, monitor->H}, monitor->freq.size());
+}
+
+PyObject *_get_dft_pade_error(meep::dft_force *monitor) {
+    return _dft_pade_error_from_chunks(
+        {monitor->offdiag1, monitor->offdiag2, monitor->diag}, monitor->freq.size());
+}
+
+PyObject *_get_dft_pade_error(meep::dft_energy *monitor) {
+    return _dft_pade_error_from_chunks(
+        {monitor->E, monitor->H, monitor->D, monitor->B}, monitor->freq.size());
+}
+
+PyObject *_get_dft_pade_error(meep::dft_near2far *monitor) {
+    return _dft_pade_error_from_chunks({monitor->F}, monitor->freq.size());
 }
 
 struct kpoint_list {
@@ -690,6 +808,11 @@ PyObject *_get_dft_array(meep::fields *f, dft_type dft, meep::component c, int n
 size_t _get_dft_data_size(meep::dft_chunk *dc);
 void _get_dft_data(meep::dft_chunk *dc, std::complex<double> *cdata, int size);
 void _load_dft_data(meep::dft_chunk *dc, std::complex<double> *cdata, int size);
+PyObject *_get_dft_pade_error(meep::dft_fields *monitor);
+PyObject *_get_dft_pade_error(meep::dft_flux *monitor);
+PyObject *_get_dft_pade_error(meep::dft_force *monitor);
+PyObject *_get_dft_pade_error(meep::dft_energy *monitor);
+PyObject *_get_dft_pade_error(meep::dft_near2far *monitor);
 meep::volume_list *make_volume_list(const meep::volume &v, int c,
                                     std::complex<double> weight,
                                     meep::volume_list *next);
@@ -1713,6 +1836,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         PML,
         Rotate2,
         Rotate4,
+        PadeError,
         Simulation,
         Symmetry,
         DftObj,
@@ -1808,6 +1932,7 @@ PyObject *_get_array_slice_dimensions(meep::fields *f, const meep::volume &where
         stop_after_walltime,
         stop_on_interrupt,
         stop_when_dft_decayed,
+        stop_when_dft_pade_converged,
         stop_when_fields_decayed,
         stop_when_energy_decayed,
         stop_when_flux_decayed,

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -11,6 +11,7 @@ import re
 import signal
 import subprocess
 import sys
+import time
 import warnings
 from collections import OrderedDict, namedtuple
 from typing import Callable, List, NamedTuple, Optional, Tuple, Union
@@ -66,7 +67,34 @@ FluxData = namedtuple("FluxData", ["E", "H"])
 ForceData = namedtuple("ForceData", ["offdiag1", "offdiag2", "diag"])
 NearToFarData = namedtuple("NearToFarData", ["F"])
 
+
+class PadeError(NamedTuple):
+    """Convergence diagnostics for a Padé-enabled DFT monitor."""
+
+    relative_correction: np.ndarray
+    relative_estimate: np.ndarray
+    drift: np.ndarray
+    samples: int
+    ready: bool
+    invalid_fits: int
+    generation: int
+    magnitude: np.ndarray
+
+
 Vector3Type = Union[Vector3, Tuple[float, ...]]
+
+
+def _validate_pade_samples(pade_samples):
+    if isinstance(pade_samples, (bool, np.bool_)) or not isinstance(
+        pade_samples, numbers.Integral
+    ):
+        raise TypeError("pade_samples must be an integer")
+    pade_samples = int(pade_samples)
+    if pade_samples < 0 or 0 < pade_samples < 4:
+        raise ValueError(
+            "pade_samples must be 0 or an integer greater than or equal to 4"
+        )
+    return pade_samples
 
 
 def fix_dft_args(args, i):
@@ -653,11 +681,48 @@ class DftObj:
         self.func = func
         self.args = args
         self.swigobj = None
+        self.pade_samples = 0
+        self._pade_warned_generation = None
 
     def swigobj_attr(self, attr):
         if self.swigobj is None:
             self.swigobj = self.func(*self.args)
         return getattr(self.swigobj, attr)
+
+    def get_pade_error(self):
+        """Return fixed-frequency Padé convergence diagnostics for this monitor."""
+        if self.swigobj is None:
+            self.swigobj = self.func(*self.args)
+        status = mp._get_dft_pade_error(self.swigobj)
+        (
+            relative_correction,
+            relative_estimate,
+            drift,
+            samples,
+            ready,
+            invalid_fits,
+            generation,
+            magnitude,
+        ) = status
+        result = PadeError(
+            relative_correction=np.asarray(relative_correction, dtype=float),
+            relative_estimate=np.asarray(relative_estimate, dtype=float),
+            drift=np.asarray(drift, dtype=float),
+            samples=int(samples),
+            ready=bool(ready),
+            invalid_fits=int(invalid_fits),
+            generation=int(generation),
+            magnitude=np.asarray(magnitude, dtype=float),
+        )
+        if result.invalid_fits and result.generation != self._pade_warned_generation:
+            warnings.warn(
+                "Padé extrapolation rejected one or more DFT fits; raw accumulated "
+                "values are used for those fits.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            self._pade_warned_generation = result.generation
+        return result
 
     @property
     def save_hdf5(self):
@@ -693,6 +758,7 @@ class DftFlux(DftObj):
         self.nfreqs = len(args[0])
         self.regions = args[1]
         self.num_components = 4
+        self.pade_samples = args[-1]
 
     @property
     def flux(self):
@@ -736,6 +802,7 @@ class DftForce(DftObj):
         self.nfreqs = len(args[0])
         self.regions = args[1]
         self.num_components = 6
+        self.pade_samples = args[-1]
 
     @property
     def force(self):
@@ -768,6 +835,7 @@ class DftNear2Far(DftObj):
         self.nperiods = args[1]
         self.regions = args[2]
         self.num_components = 4
+        self.pade_samples = args[-1]
 
     @property
     def farfield(self):
@@ -815,6 +883,7 @@ class DftEnergy(DftObj):
         self.nfreqs = len(args[0])
         self.regions = args[1]
         self.num_components = 12
+        self.pade_samples = args[-1]
 
     @property
     def electric(self):
@@ -842,6 +911,7 @@ class DftFields(DftObj):
         self.nfreqs = len(args[4])
         self.regions = [FieldsRegion(where=args[1], center=args[2], size=args[3])]
         self.num_components = len(args[0])
+        self.pade_samples = args[-1]
 
     @property
     def chunks(self):
@@ -1947,7 +2017,7 @@ class Simulation:
             return volumes
 
         dft_data_list = [
-            mp.dft_data(o.nfreqs, o.num_components, convert_volumes(o))
+            mp.dft_data(o.nfreqs, o.num_components, convert_volumes(o), o.pade_samples)
             for o in self.dft_objects
         ]
 
@@ -3047,7 +3117,7 @@ class Simulation:
 
     def add_dft_fields(self, *args, **kwargs):
         """
-        `add_dft_fields(cs, fcen, df, nfreq, freq, where=None, center=None, size=None, yee_grid=False, decimation_factor=0, persist=False)` ##sig
+        `add_dft_fields(cs, fcen, df, nfreq, freq, where=None, center=None, size=None, yee_grid=False, decimation_factor=0, persist=False, pade_samples=0)` ##sig
 
         Given a list of field components `cs`, compute the Fourier transform of these
         fields for `nfreq` equally spaced frequencies covering the frequency range
@@ -3075,6 +3145,7 @@ class Simulation:
         yee_grid = kwargs.get("yee_grid", False)
         decimation_factor = kwargs.get("decimation_factor", 0)
         persist = kwargs.get("persist", False)
+        pade_samples = _validate_pade_samples(kwargs.get("pade_samples", 0))
         center_v3 = Vector3(*center) if center is not None else None
         size_v3 = Vector3(*size) if size is not None else None
         use_centered_grid = not yee_grid
@@ -3089,6 +3160,7 @@ class Simulation:
                 use_centered_grid,
                 decimation_factor,
                 persist,
+                pade_samples,
             ],
         )
         self.dft_objects.append(dftf)
@@ -3104,6 +3176,7 @@ class Simulation:
         use_centered_grid,
         decimation_factor,
         persist,
+        pade_samples,
     ):
         if self.fields is None:
             self.init_sim()
@@ -3112,7 +3185,13 @@ class Simulation:
         except ValueError:
             where = self.fields.total_volume()
         return self.fields.add_dft_fields(
-            components, where, freq, use_centered_grid, decimation_factor, persist
+            components,
+            where,
+            freq,
+            use_centered_grid,
+            decimation_factor,
+            persist,
+            pade_samples,
         )
 
     def output_dft(self, dft_fields: DftFields, fname: str):
@@ -3144,7 +3223,7 @@ class Simulation:
 
     def add_near2far(self, *args, **kwargs):
         """
-        `add_near2far(fcen, df, nfreq, freq, Near2FarRegions, nperiods=1, decimation_factor=0)`  ##sig
+        `add_near2far(fcen, df, nfreq, freq, Near2FarRegions, nperiods=1, decimation_factor=0, pade_samples=0)`  ##sig
 
         Add a bunch of `Near2FarRegion`s to the current simulation (initializing the
         fields if they have not yet been initialized), telling Meep to accumulate the
@@ -3165,22 +3244,29 @@ class Simulation:
         near2fars = args[1:]
         nperiods = kwargs.get("nperiods", 1)
         decimation_factor = kwargs.get("decimation_factor", 0)
+        pade_samples = _validate_pade_samples(kwargs.get("pade_samples", 0))
         n2f = DftNear2Far(
-            self._add_near2far, [freq, nperiods, near2fars, decimation_factor]
+            self._add_near2far,
+            [freq, nperiods, near2fars, decimation_factor, pade_samples],
         )
         self.dft_objects.append(n2f)
         return n2f
 
-    def _add_near2far(self, freq, nperiods, near2fars, decimation_factor):
+    def _add_near2far(self, freq, nperiods, near2fars, decimation_factor, pade_samples):
         if self.fields is None:
             self.init_sim()
         return self._add_fluxish_stuff(
-            self.fields.add_dft_near2far, freq, near2fars, decimation_factor, nperiods
+            self.fields.add_dft_near2far,
+            freq,
+            near2fars,
+            decimation_factor,
+            pade_samples,
+            nperiods,
         )
 
     def add_energy(self, *args, **kwargs):
         """
-        `add_energy(fcen, df, nfreq, freq, EnergyRegions, decimation_factor=0)`  ##sig
+        `add_energy(fcen, df, nfreq, freq, EnergyRegions, decimation_factor=0, pade_samples=0)`  ##sig
 
         Add a bunch of `EnergyRegion`s to the current simulation (initializing the fields
         if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -3200,15 +3286,22 @@ class Simulation:
         freq = args[0]
         energys = args[1:]
         decimation_factor = kwargs.get("decimation_factor", 0)
-        en = DftEnergy(self._add_energy, [freq, energys, decimation_factor])
+        pade_samples = _validate_pade_samples(kwargs.get("pade_samples", 0))
+        en = DftEnergy(
+            self._add_energy, [freq, energys, decimation_factor, pade_samples]
+        )
         self.dft_objects.append(en)
         return en
 
-    def _add_energy(self, freq, energys, decimation_factor):
+    def _add_energy(self, freq, energys, decimation_factor, pade_samples):
         if self.fields is None:
             self.init_sim()
         return self._add_fluxish_stuff(
-            self.fields.add_dft_energy, freq, energys, decimation_factor
+            self.fields.add_dft_energy,
+            freq,
+            energys,
+            decimation_factor,
+            pade_samples,
         )
 
     def _display_energy(self, name, func, energys):
@@ -3440,7 +3533,7 @@ class Simulation:
 
     def add_force(self, *args, **kwargs):
         """
-        `add_force(fcen, df, nfreq, freq, ForceRegions, decimation_factor=0)`  ##sig
+        `add_force(fcen, df, nfreq, freq, ForceRegions, decimation_factor=0, pade_samples=0)`  ##sig
 
         Add a bunch of `ForceRegion`s to the current simulation (initializing the fields
         if they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -3460,15 +3553,22 @@ class Simulation:
         freq = args[0]
         forces = args[1:]
         decimation_factor = kwargs.get("decimation_factor", 0)
-        force = DftForce(self._add_force, [freq, forces, decimation_factor])
+        pade_samples = _validate_pade_samples(kwargs.get("pade_samples", 0))
+        force = DftForce(
+            self._add_force, [freq, forces, decimation_factor, pade_samples]
+        )
         self.dft_objects.append(force)
         return force
 
-    def _add_force(self, freq, forces, decimation_factor):
+    def _add_force(self, freq, forces, decimation_factor, pade_samples):
         if self.fields is None:
             self.init_sim()
         return self._add_fluxish_stuff(
-            self.fields.add_dft_force, freq, forces, decimation_factor
+            self.fields.add_dft_force,
+            freq,
+            forces,
+            decimation_factor,
+            pade_samples,
         )
 
     def display_forces(self, *forces):
@@ -3553,7 +3653,7 @@ class Simulation:
 
     def add_flux(self, *args, **kwargs):
         """
-        `add_flux(fcen, df, nfreq, freq, FluxRegions, decimation_factor=0)` ##sig
+        `add_flux(fcen, df, nfreq, freq, FluxRegions, decimation_factor=0, pade_samples=0)` ##sig
 
         Add a bunch of `FluxRegion`s to the current simulation (initializing the fields if
         they have not yet been initialized), telling Meep to accumulate the appropriate
@@ -3575,20 +3675,27 @@ class Simulation:
         freq = args[0]
         fluxes = args[1:]
         decimation_factor = kwargs.get("decimation_factor", 0)
-        flux = DftFlux(self._add_flux, [freq, fluxes, decimation_factor])
+        pade_samples = _validate_pade_samples(kwargs.get("pade_samples", 0))
+        flux = DftFlux(self._add_flux, [freq, fluxes, decimation_factor, pade_samples])
         self.dft_objects.append(flux)
         return flux
 
-    def _add_flux(self, freq, fluxes, decimation_factor):
+    def _add_flux(self, freq, fluxes, decimation_factor, pade_samples):
         if self.fields is None:
             self.init_sim()
         return self._add_fluxish_stuff(
-            self.fields.add_dft_flux, freq, fluxes, decimation_factor
+            self.fields.add_dft_flux,
+            freq,
+            fluxes,
+            decimation_factor,
+            pade_samples,
+            True,
+            True,
         )
 
     def add_mode_monitor(self, *args, **kwargs):
         """
-        `add_mode_monitor(fcen, df, nfreq, freq, ModeRegions, decimation_factor=0)`  ##sig
+        `add_mode_monitor(fcen, df, nfreq, freq, ModeRegions, decimation_factor=0, pade_samples=0)`  ##sig
 
         Similar to `add_flux`, but for use with `get_eigenmode_coefficients`.
         """
@@ -3597,13 +3704,17 @@ class Simulation:
         fluxes = args[1:]
         decimation_factor = kwargs.get("decimation_factor", 0)
         yee_grid = kwargs.get("yee_grid", False)
+        pade_samples = _validate_pade_samples(kwargs.get("pade_samples", 0))
         flux = DftFlux(
-            self._add_mode_monitor, [freq, fluxes, yee_grid, decimation_factor]
+            self._add_mode_monitor,
+            [freq, fluxes, yee_grid, decimation_factor, pade_samples],
         )
         self.dft_objects.append(flux)
         return flux
 
-    def _add_mode_monitor(self, freq, fluxes, yee_grid, decimation_factor):
+    def _add_mode_monitor(
+        self, freq, fluxes, yee_grid, decimation_factor, pade_samples
+    ):
         if self.fields is None:
             self.init_sim()
 
@@ -3626,7 +3737,12 @@ class Simulation:
         d = self.fields.normal_direction(v.swigobj) if d0 < 0 else d0
 
         return self.fields.add_mode_monitor(
-            d, v.swigobj, freq, centered_grid, decimation_factor
+            d,
+            v.swigobj,
+            freq,
+            centered_grid,
+            decimation_factor,
+            pade_samples,
         )
 
     def display_fluxes(self, *fluxes):
@@ -3862,7 +3978,7 @@ class Simulation:
         return eigfreq.item()
 
     def _add_fluxish_stuff(
-        self, add_dft_stuff, freq, stufflist, decimation_factor, *args
+        self, add_dft_stuff, freq, stufflist, decimation_factor, pade_samples, *args
     ):
         vol_list = None
 
@@ -3883,7 +3999,7 @@ class Simulation:
                 is_cylindrical=self.is_cylindrical,
             ).swigobj
             vol_list = mp.make_volume_list(v2, c, s.weight, vol_list)
-        stuff = add_dft_stuff(vol_list, freq, decimation_factor, *args)
+        stuff = add_dft_stuff(vol_list, freq, decimation_factor, *args, pade_samples)
         vol_list.__swig_destroy__(vol_list)
 
         return stuff
@@ -5645,6 +5761,198 @@ def stop_when_dft_decayed(tol=1e-11, minimum_run_time=0, maximum_run_time=None):
                 change / closure["maxchange"]
             ) <= tol and _sim.round_time() >= minimum_run_time
 
+    return _stop
+
+
+def stop_when_dft_pade_converged(
+    monitors,
+    tol,
+    pade_samples,
+    raw_decay_tol=1e-11,
+    minimum_run_time=0,
+    maximum_run_time=None,
+    confirmation=None,
+    monitor_only=False,
+):
+    """Stop after two separated, valid Padé convergence checks.
+
+    This condition is intended for finite-duration-source adjoint runs. ``monitors``
+    may be nested and must contain chunk-backed DFT monitor objects. The existing raw
+    DFT-decay criterion remains active as a fallback. ``confirmation``, when provided,
+    is called at field-level convergence candidates and must return the objective values
+    and derivatives that should also be stable.
+    """
+    pade_samples = _validate_pade_samples(pade_samples)
+    if pade_samples == 0:
+        raise ValueError("pade_samples must be at least 4 for Padé stopping")
+    if not np.isscalar(tol) or not np.isfinite(tol) or tol <= 0:
+        raise ValueError("tol must be a positive finite scalar")
+
+    def _flatten(items):
+        for item in items:
+            if isinstance(item, (list, tuple)):
+                yield from _flatten(item)
+            elif item is not None:
+                yield item
+
+    flat_monitors = list(_flatten(monitors))
+    if not flat_monitors:
+        raise ValueError("at least one Padé-enabled DFT monitor is required")
+
+    raw_stop = stop_when_dft_decayed(
+        raw_decay_tol, minimum_run_time, maximum_run_time=None
+    )
+    check_stride = max(1, math.ceil(pade_samples / 2))
+    state = {
+        "exit_reason": None,
+        "last_generations": None,
+        "last_check_timestep": None,
+        "first_confirmation": None,
+        "passing_checks": 0,
+        "confirmation_count": 0,
+        "confirmation_wall_time": 0.0,
+        "pade_wall_time": 0.0,
+        "samples": 0,
+        "relative_correction": math.inf,
+        "relative_estimate": math.inf,
+        "drift": math.inf,
+        "invalid_fits": 0,
+        "ready": False,
+        "monitor_only": bool(monitor_only),
+    }
+
+    def _confirmation_values():
+        start = time.perf_counter()
+        values = np.asarray(confirmation()).ravel()
+        state["confirmation_wall_time"] += time.perf_counter() - start
+        state["confirmation_count"] += 1
+        if not np.all(np.isfinite(values)):
+            return None
+        return values
+
+    def _status():
+        start = time.perf_counter()
+        statuses = [monitor.get_pade_error() for monitor in flat_monitors]
+        state["pade_wall_time"] += time.perf_counter() - start
+        state["samples"] = min(status.samples for status in statuses)
+        state["ready"] = all(status.ready for status in statuses)
+        state["invalid_fits"] = sum(status.invalid_fits for status in statuses)
+        # Combine monitors by the field they carry, not by taking a max of
+        # ratios.  Each monitor reports ||tail|| / ||dft|| for itself, so a
+        # component that is zero by symmetry -- Ey under a y-mirror, say --
+        # reports a large ratio from a numerator and denominator that are both
+        # negligible, and a max lets it veto convergence at any tolerance.
+        # Weighting by ||dft|| and dividing once recovers the honest aggregate
+        # sqrt(sum ||tail||^2 / sum ||dft||^2).
+        def combine(attr):
+            num = 0.0
+            den = 0.0
+            saw = False
+            for status in statuses:
+                ratios = np.asarray(getattr(status, attr), dtype=float).ravel()
+                weights = np.asarray(status.magnitude, dtype=float).ravel()
+                if ratios.size == 0:
+                    continue
+                if weights.size != ratios.size:
+                    # No magnitude to weight with; fall back to the max so the
+                    # criterion stays conservative rather than optimistic.
+                    return max(ratios.max(), 0.0)
+                finite = np.isfinite(ratios)
+                if not finite.all():
+                    return math.inf
+                saw = True
+                num += float(np.sum((ratios * weights) ** 2))
+                den += float(np.sum(weights**2))
+            if not saw or den <= 0:
+                return math.inf
+            return math.sqrt(num / den)
+
+        state["relative_correction"] = combine("relative_correction")
+        state["relative_estimate"] = combine("relative_estimate")
+        state["drift"] = combine("drift")
+        return statuses
+
+    def _stop(sim):
+        # Evaluate on every invocation so the legacy condition initializes its
+        # sampling interval at t=0, but do not honor it before a full post-source
+        # history is available.
+        raw_converged = raw_stop(sim)
+        current_time = sim.round_time()
+        post_source_window = pade_samples * sim.fields.max_decimation() * sim.fields.dt
+        eligible = (
+            current_time >= minimum_run_time
+            and current_time >= sim.fields.last_source_time() + post_source_window
+        )
+        if eligible and raw_converged:
+            state["exit_reason"] = "raw_decay_fallback"
+            return True
+        if maximum_run_time is not None and current_time >= maximum_run_time:
+            state["exit_reason"] = "maximum_time"
+            return True
+        if not eligible:
+            return False
+
+        current_timestep = sim.timestep()
+        timestep_stride = check_stride * max(1, sim.fields.max_decimation())
+        if (
+            state["last_check_timestep"] is not None
+            and current_timestep - state["last_check_timestep"] < timestep_stride
+        ):
+            return False
+        state["last_check_timestep"] = current_timestep
+
+        statuses = _status()
+        generations = tuple(status.generation for status in statuses)
+        if state["last_generations"] is not None and any(
+            generation - previous < check_stride
+            for generation, previous in zip(generations, state["last_generations"])
+        ):
+            return False
+        state["last_generations"] = generations
+
+        field_pass = (
+            state["ready"]
+            and state["invalid_fits"] == 0
+            and np.isfinite(state["relative_estimate"])
+            and np.isfinite(state["drift"])
+            and state["relative_estimate"] <= tol
+            and state["drift"] <= tol
+        )
+        if not field_pass:
+            state["first_confirmation"] = None
+            state["passing_checks"] = 0
+            return False
+
+        if confirmation is None:
+            state["passing_checks"] += 1
+            converged = state["passing_checks"] >= 2
+        else:
+            values = _confirmation_values()
+            if values is None:
+                state["first_confirmation"] = None
+                return False
+            if state["first_confirmation"] is None:
+                state["first_confirmation"] = values.copy()
+                return False
+            converged = np.allclose(
+                values, state["first_confirmation"], rtol=tol, atol=tol
+            )
+            state["first_confirmation"] = None if not converged else values.copy()
+
+        if converged:
+            state["exit_reason"] = "pade_converged"
+            return True
+        return False
+
+    def _finalize(sim):
+        if state["exit_reason"] is None:
+            state["exit_reason"] = "maximum_time"
+        state["simulated_time"] = sim.meep_time()
+        state["timesteps"] = sim.timestep()
+        return dict(state)
+
+    _stop.diagnostics = state
+    _stop.finalize = _finalize
     return _stop
 
 

--- a/python/tests/test_adjoint_chunks.py
+++ b/python/tests/test_adjoint_chunks.py
@@ -137,5 +137,43 @@ class TestAdjointChunks(unittest.TestCase):
         )
 
 
+class TestAdjointSourcePlacement(unittest.TestCase):
+    """`create_adjoint_sources` must tolerate a rank that places nothing.
+
+    `fourier_sourcedata` returns one entry per *local* chunk intersecting the
+    monitor and `IndexedSource` is inherently per-chunk, so under MPI every rank
+    but one places nothing for a point monitor. A bare `assert adjoint_sources`
+    therefore made a point objective fail outright on more than one process.
+
+    This is a unit test rather than a simulation because the condition cannot be
+    reproduced serially: forcing many chunks does not help, since one rank still
+    owns all of them. The contract is what matters -- an empty *local* list is
+    legitimate, while a globally zero cotangent is not.
+    """
+
+    class _Monitor:
+        def __init__(self, sources):
+            self._sources = sources
+
+        def place_adjoint_source(self, dJ):
+            return list(self._sources)
+
+    def test_empty_local_placement_is_allowed(self):
+        monitor = self._Monitor([])
+        out = mpa.utils.create_adjoint_sources([monitor], [np.ones(3)])
+        self.assertEqual(out, [])
+
+    def test_placements_from_several_monitors_are_concatenated(self):
+        a, b = self._Monitor(["a"]), self._Monitor([])
+        out = mpa.utils.create_adjoint_sources([a, b], [np.ones(2), np.ones(2)])
+        self.assertEqual(out, ["a"])
+
+    def test_globally_zero_cotangent_still_raises(self):
+        # The condition that is a real user error is unchanged, and it is global:
+        # the cotangents are identical on every rank.
+        with self.assertRaisesRegex(RuntimeError, "gradient of all monitor values"):
+            mpa.utils.create_adjoint_sources([self._Monitor(["a"])], [np.zeros(3)])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_fragment_stats.py
+++ b/python/tests/test_fragment_stats.py
@@ -61,6 +61,7 @@ class TestFragmentStats(unittest.TestCase):
         sym=[],
         geom=None,
         pml=[],
+        pade_samples=0,
     ):
         mat = mp.Medium(
             epsilon=12,
@@ -91,11 +92,29 @@ class TestFragmentStats(unittest.TestCase):
 
         if dft_vecs:
             if dft_vecs["flux_regions"]:
-                sim.add_flux(1, 0.5, 5, *dft_vecs["flux_regions"])
+                sim.add_flux(
+                    1,
+                    0.5,
+                    5,
+                    *dft_vecs["flux_regions"],
+                    pade_samples=pade_samples,
+                )
             if dft_vecs["n2f_regions"]:
-                sim.add_near2far(1, 0.5, 7, *dft_vecs["n2f_regions"])
+                sim.add_near2far(
+                    1,
+                    0.5,
+                    7,
+                    *dft_vecs["n2f_regions"],
+                    pade_samples=pade_samples,
+                )
             if dft_vecs["force_regions"]:
-                sim.add_force(1, 0.5, 9, *dft_vecs["force_regions"])
+                sim.add_force(
+                    1,
+                    0.5,
+                    9,
+                    *dft_vecs["force_regions"],
+                    pade_samples=pade_samples,
+                )
             if dft_vecs["fields_components"]:
                 sim.add_dft_fields(
                     dft_vecs["fields_components"],
@@ -105,6 +124,7 @@ class TestFragmentStats(unittest.TestCase):
                     where=dft_vecs["fields_where"],
                     center=dft_vecs["fields_center"],
                     size=dft_vecs["fields_size"],
+                    pade_samples=pade_samples,
                 )
 
         gv = sim._create_grid_volume(False)
@@ -195,6 +215,31 @@ class TestFragmentStats(unittest.TestCase):
             mp.Vector3(z=10), mp.Vector3(z=30), 1, dft_vecs=dft_vecs
         )
         self.assertEqual(fs.num_dft_pixels, 4000)
+
+    def test_1d_dft_fields_pade_memory_is_bounded(self):
+        dft_vecs = make_dft_vecs(
+            fldc=mp.Vector3(z=-10),
+            flds=mp.Vector3(z=10),
+            fld_cmp=[mp.X, mp.Y],
+        )
+        raw = self.get_fragment_stats(
+            mp.Vector3(z=10), mp.Vector3(z=30), 1, dft_vecs=dft_vecs
+        )
+        pade = self.get_fragment_stats(
+            mp.Vector3(z=10),
+            mp.Vector3(z=30),
+            1,
+            dft_vecs=dft_vecs,
+            pade_samples=8,
+        )
+
+        # Each spatial point/component has 5 raw-frequency entries. Padé adds
+        # 8 bounded history entries and two possible 5-frequency diagnostic
+        # caches, independently of the eventual simulation duration.
+        self.assertEqual(raw.num_dft_pixels, 4000)
+        self.assertEqual(
+            pade.num_dft_pixels, raw.num_dft_pixels * (8 + 3 * 5) // 5
+        )
 
     def _test_2d(self, sym, pml=[]):
         # A 30 x 30 cell, with a 10 x 10 block in the middle

--- a/python/tests/test_pade_adjoint.py
+++ b/python/tests/test_pade_adjoint.py
@@ -1,0 +1,156 @@
+import unittest
+
+import autograd.numpy as npa
+import numpy as np
+
+import meep as mp
+import meep.adjoint as mpa
+
+
+class TestPadeAdjoint(unittest.TestCase):
+    def _problem(self, weights, pade_samples, run_time, objective_functions=None):
+        fcen = 0.5
+        grid = mp.MaterialGrid(
+            mp.Vector3(1, 1, len(weights)),
+            mp.air,
+            mp.Medium(epsilon=12),
+            weights=np.asarray(weights).reshape(1, 1, -1),
+            do_averaging=False,
+        )
+        region = mpa.DesignRegion(
+            grid,
+            volume=mp.Volume(center=mp.Vector3(), size=mp.Vector3(z=1)),
+        )
+        sim = mp.Simulation(
+            cell_size=mp.Vector3(z=6),
+            dimensions=1,
+            resolution=20,
+            boundary_layers=[mp.PML(1)],
+            geometry=[
+                mp.Block(
+                    center=region.center,
+                    size=region.size,
+                    material=grid,
+                )
+            ],
+            sources=[
+                mp.Source(
+                    mp.GaussianSource(fcen, fwidth=0.3),
+                    component=mp.Ex,
+                    center=mp.Vector3(z=-1.5),
+                )
+            ],
+        )
+        field = mpa.FourierFields(
+            sim,
+            mp.Volume(center=mp.Vector3(z=1.2), size=mp.Vector3(z=0.1)),
+            mp.Ex,
+        )
+        if objective_functions is None:
+            objective_functions = lambda value: npa.abs(value[0, 0]) ** 2
+        return mpa.OptimizationProblem(
+            simulation=sim,
+            objective_functions=objective_functions,
+            objective_arguments=[field],
+            design_regions=[region],
+            frequencies=[fcen],
+            decay_by=1e-30,
+            minimum_run_time=run_time,
+            maximum_run_time=run_time,
+            decimation_factor=1,
+            pade_samples=pade_samples,
+        )
+
+    def _run(
+        self,
+        weights,
+        pade_samples,
+        run_time,
+        objective_functions=None,
+        need_gradient=True,
+    ):
+        problem = self._problem(
+            weights, pade_samples, run_time, objective_functions=objective_functions
+        )
+        value, gradient = problem([np.asarray(weights)], need_gradient=need_gradient)
+        return value, gradient, problem
+
+    def test_gradient_matches_long_run_and_finite_difference(self):
+        """Exercise corrected forward/adjoint design fields in the native gradient."""
+        weights = np.array([0.35, 0.55, 0.7])
+        short_value, short_gradient, short_problem = self._run(
+            weights, pade_samples=12, run_time=1
+        )
+        # The Padé path normalizes its synthesized adjoint source over the
+        # source's complete support. Run the raw reference past that support so
+        # the comparison measures extrapolation rather than normalization time.
+        long_value, long_gradient, long_problem = self._run(
+            weights, pade_samples=0, run_time=220
+        )
+
+        tolerance = 0.02 if mp.is_single_precision() else 0.005
+        np.testing.assert_allclose(short_value, long_value, rtol=tolerance)
+        np.testing.assert_allclose(
+            short_gradient, long_gradient, rtol=tolerance, atol=1e-8
+        )
+        self.assertLess(short_problem.sim.meep_time(), long_problem.sim.meep_time())
+
+        direction = np.array([1.0, -0.5, 0.25])
+        direction /= np.linalg.norm(direction)
+        step = 1e-3
+        plus, _, _ = self._run(
+            weights + step * direction,
+            pade_samples=0,
+            run_time=220,
+            need_gradient=False,
+        )
+        minus, _, _ = self._run(
+            weights - step * direction,
+            pade_samples=0,
+            run_time=220,
+            need_gradient=False,
+        )
+        finite_difference = (float(np.squeeze(plus)) - float(np.squeeze(minus))) / (
+            2 * step
+        )
+        adjoint_derivative = float(np.asarray(short_gradient) @ direction)
+        self.assertAlmostEqual(
+            adjoint_derivative / finite_difference,
+            1.0,
+            delta=0.03 if mp.is_single_precision() else 0.01,
+        )
+
+    def test_streamed_multi_objective_matches_long_run(self):
+        """Streamed Padé gradients match the legacy retained-monitor result."""
+        weights = np.array([0.35, 0.55, 0.7])
+
+        def left(value):
+            return npa.abs(value[0, 0]) ** 2
+
+        def right(value):
+            return npa.abs(value[0, -1]) ** 2
+
+        short_value, short_gradient, short_problem = self._run(
+            weights,
+            pade_samples=12,
+            run_time=1,
+            objective_functions=[left, right],
+        )
+        long_value, long_gradient, _ = self._run(
+            weights,
+            pade_samples=0,
+            run_time=220,
+            objective_functions=[left, right],
+        )
+
+        tolerance = 0.02 if mp.is_single_precision() else 0.005
+        np.testing.assert_allclose(short_value, long_value, rtol=tolerance)
+        np.testing.assert_allclose(
+            short_gradient, long_gradient, rtol=tolerance, atol=1e-8
+        )
+        self.assertEqual(len(short_problem._streamed_gradients), 2)
+        self.assertEqual(short_problem.adjoint_design_region_monitors, [None, None])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_pade_api.py
+++ b/python/tests/test_pade_api.py
@@ -1,0 +1,439 @@
+import unittest
+import warnings
+import tempfile
+from unittest import mock
+
+import numpy as np
+
+import meep as mp
+import meep.adjoint as mpa
+from meep import simulation
+
+
+class PadeMonitorApiTest(unittest.TestCase):
+    def setUp(self):
+        self.sim = mp.Simulation(
+            cell_size=mp.Vector3(1, 1),
+            resolution=10,
+            sources=[
+                mp.Source(
+                    mp.GaussianSource(1.0, fwidth=0.5),
+                    component=mp.Ez,
+                    center=mp.Vector3(),
+                )
+            ],
+        )
+        self.frequency = [1.0]
+        self.volume = mp.Volume(center=mp.Vector3(), size=mp.Vector3(0, 1))
+
+    def test_pade_samples_validation(self):
+        for invalid in (True, 1.5, -1, 1, 2, 3):
+            with self.subTest(invalid=invalid), self.assertRaises(
+                (TypeError, ValueError)
+            ):
+                self.sim.add_dft_fields([mp.Ez], self.frequency, pade_samples=invalid)
+
+    def test_pade_samples_are_deferred_with_each_monitor(self):
+        monitors = [
+            self.sim.add_dft_fields(
+                [mp.Ez], self.frequency, where=self.volume, pade_samples=8
+            ),
+            self.sim.add_flux(
+                self.frequency, mp.FluxRegion(volume=self.volume), pade_samples=8
+            ),
+            self.sim.add_mode_monitor(
+                self.frequency, mp.ModeRegion(volume=self.volume), pade_samples=8
+            ),
+            self.sim.add_force(
+                self.frequency, mp.ForceRegion(volume=self.volume), pade_samples=8
+            ),
+            self.sim.add_energy(
+                self.frequency, mp.EnergyRegion(volume=self.volume), pade_samples=8
+            ),
+            self.sim.add_near2far(
+                self.frequency, mp.Near2FarRegion(volume=self.volume), pade_samples=8
+            ),
+        ]
+        self.assertTrue(all(monitor.args[-1] == 8 for monitor in monitors))
+        self.assertTrue(all(monitor.pade_samples == 8 for monitor in monitors))
+        self.sim._evaluate_dft_objects()
+        self.assertTrue(all(monitor.swigobj is not None for monitor in monitors))
+
+    def test_error_conversion_and_warning_suppression(self):
+        monitor = simulation.DftObj(lambda: object(), [])
+        status = ([0.1], [0.2], [0.3], 8, True, 1, 7, [1.0])
+        with mock.patch.object(
+            mp, "_get_dft_pade_error", return_value=status, create=True
+        ):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                first = monitor.get_pade_error()
+                second = monitor.get_pade_error()
+        self.assertIsInstance(first, simulation.PadeError)
+        np.testing.assert_allclose(first.relative_estimate, [0.2])
+        self.assertEqual(first.generation, second.generation)
+        self.assertEqual(len(caught), 1)
+
+    def test_small_dft_monitor_reports_native_status(self):
+        sim = mp.Simulation(
+            cell_size=mp.Vector3(z=4),
+            dimensions=1,
+            resolution=10,
+            boundary_layers=[mp.PML(1)],
+            sources=[
+                mp.Source(
+                    mp.GaussianSource(0.5, fwidth=0.4),
+                    component=mp.Ex,
+                    center=mp.Vector3(),
+                )
+            ],
+        )
+        frequencies = [0.4, 0.5, 0.6]
+        monitor = sim.add_dft_fields(
+            [mp.Ex], frequencies, where=mp.Volume(center=mp.Vector3()), pade_samples=4
+        )
+        sim.run(until_after_sources=2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            status = monitor.get_pade_error()
+            values = [sim.get_dft_array(monitor, mp.Ex, i) for i in range(3)]
+        self.assertEqual(status.samples, 4)
+        self.assertTrue(status.ready)
+        self.assertEqual(status.relative_estimate.shape, (3,))
+        self.assertTrue(np.all(np.isfinite(values)))
+
+    def test_loading_dft_snapshot_clears_pade_history(self):
+        monitor = self.sim.add_dft_fields(
+            [mp.Ez], self.frequency, where=self.volume, pade_samples=4
+        )
+        self.sim.run(until_after_sources=2)
+        self.assertEqual(monitor.get_pade_error().samples, 4)
+
+        snapshot = self.sim.get_dft_data(monitor.chunks)
+        mp._load_dft_data(monitor.chunks, snapshot)
+        status = monitor.get_pade_error()
+        self.assertEqual(status.samples, 0)
+        self.assertFalse(status.ready)
+
+    def test_full_checkpoint_rejects_pade_monitor(self):
+        self.sim.add_dft_fields(
+            [mp.Ez], self.frequency, where=self.volume, pade_samples=4
+        )
+        self.sim.run(until=1)
+        with tempfile.TemporaryDirectory() as dirname, self.assertRaisesRegex(
+            RuntimeError, "does not yet support resumable Padé"
+        ):
+            self.sim.dump(dirname, dump_structure=False, dump_fields=True)
+
+    def test_short_corrected_dft_matches_long_run(self):
+        sim = mp.Simulation(
+            cell_size=mp.Vector3(z=6),
+            dimensions=1,
+            resolution=20,
+            boundary_layers=[mp.PML(1)],
+            geometry=[
+                mp.Block(
+                    center=mp.Vector3(),
+                    size=mp.Vector3(z=1),
+                    material=mp.Medium(epsilon=12),
+                )
+            ],
+            sources=[
+                mp.Source(
+                    mp.GaussianSource(0.5, fwidth=0.3),
+                    component=mp.Ex,
+                    center=mp.Vector3(),
+                )
+            ],
+        )
+        where = mp.Volume(center=mp.Vector3(z=0.3))
+        raw = sim.add_dft_fields([mp.Ex], [0.5], where=where)
+        pade = sim.add_dft_fields([mp.Ex], [0.5], where=where, pade_samples=12)
+
+        sim.run(until_after_sources=1)
+        short_raw = complex(sim.get_dft_array(raw, mp.Ex, 0))
+        short_corrected = complex(sim.get_dft_array(pade, mp.Ex, 0))
+        sim.run(until_after_sources=40)
+        long_reference = complex(sim.get_dft_array(raw, mp.Ex, 0))
+
+        raw_error = abs(short_raw - long_reference)
+        corrected_error = abs(short_corrected - long_reference)
+        self.assertLess(corrected_error, 0.05 * raw_error)
+
+
+class PadeStoppingTest(unittest.TestCase):
+    class _Fields:
+        t = 100
+        dt = 1.0
+
+        def __init__(self, decimation=1):
+            self.norm = 0
+            self.decimation = decimation
+
+        def max_decimation(self):
+            return self.decimation
+
+        def last_source_time(self):
+            return 0
+
+        def dft_norm(self):
+            self.norm += 1
+            return self.norm
+
+    class _Simulation:
+        def __init__(self, decimation=1):
+            self.fields = PadeStoppingTest._Fields(decimation)
+
+        def round_time(self):
+            return 10
+
+        def meep_time(self):
+            return 10
+
+        def timestep(self):
+            return self.fields.t
+
+        def advance(self, timesteps=1):
+            self.fields.t += timesteps
+
+    class _Monitor:
+        def __init__(self):
+            self.generation = 2
+            self.status_calls = 0
+            self.result_calls = 0
+
+        def get_pade_error(self):
+            self.status_calls += 1
+            self.generation += 2
+            return simulation.PadeError(
+                np.array([0.0]),
+                np.array([1e-8]),
+                np.array([1e-8]),
+                4,
+                True,
+                0,
+                self.generation,
+                np.array([1.0]),
+            )
+
+        def get_result(self):
+            self.result_calls += 1
+
+    def test_requires_two_separated_passes(self):
+        sim = self._Simulation()
+        condition = simulation.stop_when_dft_pade_converged(
+            [self._Monitor()], 1e-4, 4, raw_decay_tol=1e-12
+        )
+        self.assertFalse(condition(sim))
+        sim.advance(2)
+        self.assertTrue(condition(sim))
+        self.assertEqual(condition.finalize(sim)["exit_reason"], "pade_converged")
+
+    def test_two_level_confirmation(self):
+        sim = self._Simulation()
+        calls = []
+
+        def confirmation():
+            calls.append(1)
+            return np.array([2.0, -1.0])
+
+        condition = simulation.stop_when_dft_pade_converged(
+            [self._Monitor()],
+            1e-4,
+            4,
+            raw_decay_tol=1e-12,
+            confirmation=confirmation,
+        )
+        self.assertFalse(condition(sim))
+        sim.advance(2)
+        self.assertTrue(condition(sim))
+        self.assertEqual(len(calls), 2)
+
+    def test_status_is_not_polled_between_accepted_checkpoints(self):
+        sim = self._Simulation(decimation=2)
+        monitor = self._Monitor()
+        condition = simulation.stop_when_dft_pade_converged(
+            [monitor], 1e-4, 4, raw_decay_tol=1e-12
+        )
+
+        self.assertFalse(condition(sim))
+        self.assertEqual(monitor.status_calls, 1)
+        for _ in range(3):
+            sim.advance()
+            monitor.get_result()
+            self.assertFalse(condition(sim))
+            self.assertEqual(monitor.status_calls, 1)
+        sim.advance()
+        monitor.get_result()
+        self.assertTrue(condition(sim))
+        self.assertEqual(monitor.status_calls, 2)
+        self.assertEqual(monitor.result_calls, 4)
+
+    def test_raw_convergence_wins_maximum_time_tie(self):
+        sim = self._Simulation()
+        with mock.patch.object(
+            simulation, "stop_when_dft_decayed", return_value=lambda _sim: True
+        ):
+            condition = simulation.stop_when_dft_pade_converged(
+                [self._Monitor()], 1e-4, 4, maximum_run_time=10
+            )
+        self.assertTrue(condition(sim))
+        self.assertEqual(condition.finalize(sim)["exit_reason"], "raw_decay_fallback")
+
+    def test_maximum_time_remains_strict_without_convergence(self):
+        sim = self._Simulation()
+        with mock.patch.object(
+            simulation, "stop_when_dft_decayed", return_value=lambda _sim: False
+        ):
+            condition = simulation.stop_when_dft_pade_converged(
+                [self._Monitor()], 1e-4, 4, maximum_run_time=10
+            )
+        self.assertTrue(condition(sim))
+        self.assertEqual(condition.finalize(sim)["exit_reason"], "maximum_time")
+
+
+class AdjointPadeOptionsTest(unittest.TestCase):
+    class _Objective(mpa.ObjectiveQuantity):
+        def __call__(self):
+            return None
+
+        def register_monitors(self, frequencies, pade_samples=0):
+            self._frequencies = np.asarray(frequencies)
+            self._pade_samples = pade_samples
+
+        def place_adjoint_source(self, dJ):
+            return []
+
+    class _Simulation:
+        resolution = 10
+
+        class _Fields:
+            dt = 0.1
+
+        fields = _Fields()
+
+        def __init__(self):
+            self.time = 1.0
+            self.sources = []
+
+        def meep_time(self):
+            return self.time
+
+        def _infer_dimensions(self, unused):
+            return 2
+
+        def using_real_fields(self):
+            return False
+
+        k_point = None
+
+    def test_option_validation(self):
+        self.assertEqual(mpa.utils.validate_pade_options(0, None), 0)
+        self.assertEqual(mpa.utils.validate_pade_options(np.int64(8), 1e-4), 8)
+        with self.assertRaises(ValueError):
+            mpa.utils.validate_pade_options(0, 1e-4)
+        with self.assertRaises(TypeError):
+            mpa.utils.validate_pade_options(True, None)
+
+    def test_continuous_source_rejected_for_automatic_stopping(self):
+        source = mp.Source(
+            mp.ContinuousSource(1.0), component=mp.Ez, center=mp.Vector3()
+        )
+        with self.assertRaisesRegex(ValueError, "finite-duration"):
+            mpa.utils.validate_finite_sources([source])
+
+    def test_nonfinite_gaussian_end_time_is_rejected(self):
+        source = mp.Source(
+            mp.GaussianSource(1.0, width=np.inf),
+            component=mp.Ez,
+            center=mp.Vector3(),
+        )
+        with self.assertRaisesRegex(ValueError, "finite-duration"):
+            mpa.utils.validate_finite_sources([source])
+
+    def test_ldos_rejects_pade_samples_without_automatic_stopping(self):
+        sim = self._Simulation()
+        objective = mpa.LDOS(sim)
+        with self.assertRaisesRegex(ValueError, "does not support LDOS"):
+            objective.register_monitors([1.0], pade_samples=8)
+        with self.assertRaisesRegex(ValueError, "does not support LDOS"):
+            mpa.OptimizationProblem(
+                simulation=sim,
+                objective_functions=lambda value: value,
+                objective_arguments=[objective],
+                design_regions=[],
+                frequencies=np.array([1.0]),
+                pade_samples=8,
+            )
+
+    def test_adjoint_source_scale_is_independent_of_shortened_run(self):
+        sim = self._Simulation()
+        objective = self._Objective(sim)
+        objective.register_monitors([1.0], pade_samples=8)
+        short_scale = objective._adj_src_scale()
+        sim.time = 100.0
+        long_scale = objective._adj_src_scale()
+        np.testing.assert_allclose(short_scale, long_scale, rtol=0, atol=0)
+
+    def test_failed_adjoint_run_restores_transforms_and_removes_monitors(self):
+        class FakeSimulation:
+            is_cylindrical = True
+            dimensions = mp.CYLINDRICAL
+
+            def __init__(self):
+                self.m = 3
+                self.k_point = mp.Vector3(0.25, 0, 0)
+
+            def change_m(self, value):
+                self.m = value
+
+            def change_k_point(self, value):
+                self.k_point = value
+
+            def restart_fields(self):
+                pass
+
+            def clear_dft_monitors(self):
+                pass
+
+            def change_sources(self, sources):
+                pass
+
+            def _evaluate_dft_objects(self):
+                pass
+
+        monitor = mock.Mock()
+        problem = mpa.OptimizationProblem.__new__(mpa.OptimizationProblem)
+        problem.sim = FakeSimulation()
+        problem.objective_functions = [lambda: None]
+        problem.design_regions = []
+        problem.frequencies = [1.0]
+        problem.decimation_factor = 1
+        problem.pade_samples = 8
+        problem.forward_design_region_monitors = []
+        problem.finite_difference_step = 1e-3
+        # adjoint_run also installs monitors for differentiable geometry and
+        # sources; this test builds the object attribute by attribute, so it
+        # has to name them even when there are none.
+        problem.differentiable_objects = []
+        problem.differentiable_sources = []
+        problem.prepare_adjoint_run = mock.Mock(
+            side_effect=lambda: setattr(problem, "adjoint_sources", [[]])
+        )
+        problem._run_with_stopping = mock.Mock(side_effect=RuntimeError("timeout"))
+        original_k = problem.sim.k_point
+
+        with mock.patch.object(
+            mpa.utils,
+            "install_design_region_monitors",
+            return_value=[[monitor]],
+        ), self.assertRaisesRegex(RuntimeError, "timeout"):
+            problem.adjoint_run()
+
+        self.assertEqual(problem.sim.m, 3)
+        self.assertEqual(problem.sim.k_point, original_k)
+        monitor.remove.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/dft.cpp
+++ b/src/dft.cpp
@@ -51,8 +51,157 @@ struct dft_chunk_data { // for passing to field::loop_in_chunks as void*
   bool empty_dim[5];
   dft_chunk *dft_chunks;
   int decimation_factor;
+  size_t pade_samples;
   bool persist;
 };
+
+namespace {
+
+typedef std::complex<double> pade_complex;
+
+// Padé evaluation is deliberately performed in double precision in every
+// Meep build.  These fixed, scale-relative limits therefore make acceptance
+// deterministic across single- and double-precision field storage.
+const double pade_min_relative_denominator = 1.0e-8;
+const double pade_max_tail_amplification = 1.0e6;
+
+bool finite_complex(const pade_complex &z) {
+  return std::isfinite(z.real()) && std::isfinite(z.imag());
+}
+
+// Solve A x = b in place using partial pivoting.  Padé histories are small
+// (normally around 20 entries), so an in-tree dense solver avoids imposing a
+// new LAPACK dependency.  All scratch arithmetic is double precision even in
+// single-precision Meep builds.
+bool solve_pade_system(std::vector<pade_complex> &A, std::vector<pade_complex> &b, size_t n) {
+  double matrix_scale = 0.0;
+  for (size_t i = 0; i < A.size(); ++i) {
+    if (!finite_complex(A[i])) return false;
+    matrix_scale = std::max(matrix_scale, std::abs(A[i]));
+  }
+  if (matrix_scale == 0.0) return false;
+  const double pivot_threshold = 128.0 * std::numeric_limits<double>::epsilon() * matrix_scale;
+
+  for (size_t col = 0; col < n; ++col) {
+    size_t pivot = col;
+    double pivot_abs = std::abs(A[col * n + col]);
+    for (size_t row = col + 1; row < n; ++row) {
+      const double candidate = std::abs(A[row * n + col]);
+      if (candidate > pivot_abs) {
+        pivot = row;
+        pivot_abs = candidate;
+      }
+    }
+    if (!(pivot_abs > pivot_threshold) || !std::isfinite(pivot_abs)) return false;
+    if (pivot != col) {
+      for (size_t j = col; j < n; ++j)
+        std::swap(A[col * n + j], A[pivot * n + j]);
+      std::swap(b[col], b[pivot]);
+    }
+
+    const pade_complex diagonal = A[col * n + col];
+    for (size_t row = col + 1; row < n; ++row) {
+      const pade_complex factor = A[row * n + col] / diagonal;
+      A[row * n + col] = 0.0;
+      for (size_t j = col + 1; j < n; ++j)
+        A[row * n + j] -= factor * A[col * n + j];
+      b[row] -= factor * b[col];
+    }
+  }
+
+  for (size_t ii = n; ii-- > 0;) {
+    pade_complex rhs = b[ii];
+    for (size_t j = ii + 1; j < n; ++j)
+      rhs -= A[ii * n + j] * b[j];
+    b[ii] = rhs / A[ii * n + ii];
+    if (!finite_complex(b[ii])) return false;
+  }
+  return true;
+}
+
+// Evaluate the infinite Padé sum and remove the samples which have already
+// been accumulated by the ordinary DFT.  If the nominal near-diagonal fit is
+// rank deficient, progressively lower denominator orders are tried.  This is
+// essential for exact low-mode signals, whose Hankel systems are intentionally
+// low rank.
+bool pade_future_tail(const std::vector<pade_complex> &a, double omega, double t0,
+                      double sample_period, pade_complex &tail) {
+  tail = 0.0;
+  const size_t L = a.size();
+  if (L < 2 || !(sample_period > 0.0) || !std::isfinite(sample_period) || !std::isfinite(t0))
+    return false;
+
+  double signal_scale = 0.0;
+  for (size_t i = 0; i < L; ++i) {
+    if (!finite_complex(a[i])) return false;
+    signal_scale = std::max(signal_scale, std::abs(a[i]));
+  }
+  // A zero history has an exactly zero future tail.  Treating it as a valid
+  // fit avoids spurious singular-fit failures after a field has fully decayed.
+  if (signal_scale <= std::numeric_limits<double>::min()) return true;
+
+  const pade_complex z = std::polar(1.0, omega * sample_period);
+  for (size_t q = L / 2; q != 0; --q) {
+    const size_t p = L - q - 1;
+    std::vector<pade_complex> A(q * q), rhs(q);
+    for (size_t row = 0; row < q; ++row) {
+      const size_t k = p + 1 + row;
+      rhs[row] = -a[k];
+      for (size_t j = 1; j <= q; ++j)
+        A[row * q + (j - 1)] = a[k - j];
+    }
+    if (!solve_pade_system(A, rhs, q)) continue;
+
+    std::vector<pade_complex> Q(q + 1, 0.0);
+    Q[0] = 1.0;
+    for (size_t j = 1; j <= q; ++j)
+      Q[j] = rhs[j - 1];
+    std::vector<pade_complex> P(p + 1, 0.0);
+    for (size_t k = 0; k <= p; ++k)
+      for (size_t j = 0; j <= std::min(k, q); ++j)
+        P[k] += Q[j] * a[k - j];
+
+    pade_complex numerator = P[p];
+    for (size_t k = p; k-- > 0;)
+      numerator = numerator * z + P[k];
+    pade_complex denominator = Q[q];
+    double denominator_scale = std::abs(Q[q]);
+    for (size_t k = q; k-- > 0;) {
+      denominator = denominator * z + Q[k];
+      denominator_scale += std::abs(Q[k]);
+    }
+    const double denominator_threshold =
+        std::max(128.0 * std::numeric_limits<double>::epsilon(), pade_min_relative_denominator) *
+        denominator_scale;
+    if (!(std::abs(denominator) > denominator_threshold) || !finite_complex(denominator)) continue;
+
+    pade_complex partial = a[L - 1];
+    for (size_t k = L - 1; k-- > 0;)
+      partial = partial * z + a[k];
+    const pade_complex candidate =
+        std::polar(1.0, omega * t0) * (numerator / denominator - partial);
+    double history_scale = 0.0;
+    for (size_t k = 0; k < L; ++k)
+      history_scale += std::abs(a[k]);
+    const double tail_amplification = std::abs(candidate) / history_scale;
+    if (!std::isfinite(history_scale) || !finite_complex(candidate) ||
+        !(tail_amplification <= pade_max_tail_amplification))
+      continue;
+    tail = candidate;
+    return true;
+  }
+  return false;
+}
+
+double relative_norm(double numerator2, double denominator2) {
+  if (numerator2 == 0.0) return 0.0;
+  if (!(std::isfinite(numerator2) && std::isfinite(denominator2)))
+    return std::numeric_limits<double>::infinity();
+  const double floor2 = std::numeric_limits<double>::min();
+  return std::sqrt(numerator2 / std::max(denominator2, floor2));
+}
+
+} // namespace
 
 dft_chunk::dft_chunk(fields_chunk *fc_, ivec is_, ivec ie_, vec s0_, vec s1_, vec e0_, vec e1_,
                      double dV0_, double dV1_, component c_, bool use_centered_grid,
@@ -113,6 +262,18 @@ dft_chunk::dft_chunk(fields_chunk *fc_, ivec is_, ivec ie_, vec s0_, vec s1_, ve
   sn = sn_;
   vc = data->vc;
   decimation_factor = data->decimation_factor;
+  pade_samples = data->pade_samples;
+  pade_count = 0;
+  pade_head = 0;
+  pade_last_time = 0.0;
+  pade_sample_period = 0.0;
+  pade_history = NULL;
+  effective_dft = NULL;
+  previous_effective_dft = NULL;
+  pade_generation = 0;
+  pade_cached_generation = std::numeric_limits<unsigned long long>::max();
+  pade_previous_generation = std::numeric_limits<unsigned long long>::max();
+  pade_diagnostic_generation = std::numeric_limits<unsigned long long>::max();
 
   const int Nomega = data->omega.size();
   omega = data->omega;
@@ -123,6 +284,7 @@ dft_chunk::dft_chunk(fields_chunk *fc_, ivec is_, ivec ie_, vec s0_, vec s1_, ve
   dft = new complex<realnum>[N * Nomega];
   for (size_t i = 0; i < N * Nomega; ++i)
     dft[i] = 0.0;
+  if (pade_samples) pade_history = new complex<realnum>[N * pade_samples]();
   for (int i = 0; i < 5; ++i)
     empty_dim[i] = data->empty_dim[i];
 
@@ -134,6 +296,9 @@ dft_chunk::dft_chunk(fields_chunk *fc_, ivec is_, ivec ie_, vec s0_, vec s1_, ve
 dft_chunk::~dft_chunk() {
   delete[] dft;
   delete[] dft_phase;
+  delete[] pade_history;
+  delete[] effective_dft;
+  delete[] previous_effective_dft;
 
   // delete from fields_chunk list
   dft_chunk *cur = fc->dft_chunks;
@@ -180,7 +345,19 @@ dft_chunk *fields::add_dft(component c, const volume &where, const double *freq,
                            dft_chunk *chunk_next, bool sqrt_dV_and_interp_weights,
                            complex<double> extra_weight, bool use_centered_grid, int vc,
                            int decimation_factor, bool persist) {
+  return add_dft(c, where, freq, Nfreq, include_dV_and_interp_weights, stored_weight, chunk_next,
+                 sqrt_dV_and_interp_weights, extra_weight, use_centered_grid, vc, decimation_factor,
+                 persist, 0);
+}
+
+dft_chunk *fields::add_dft(component c, const volume &where, const double *freq, size_t Nfreq,
+                           bool include_dV_and_interp_weights, complex<double> stored_weight,
+                           dft_chunk *chunk_next, bool sqrt_dV_and_interp_weights,
+                           complex<double> extra_weight, bool use_centered_grid, int vc,
+                           int decimation_factor, bool persist, size_t pade_samples) {
   if (coordinate_mismatch(gv.dim, c)) return NULL;
+  if (pade_samples != 0 && pade_samples < 4)
+    meep::abort("pade_samples must be zero or at least four in add_dft");
 
   /* If you call add_dft before adding sources, it will do nothing
      since no fields will be found.   This is almost certainly not
@@ -219,6 +396,7 @@ dft_chunk *fields::add_dft(component c, const volume &where, const double *freq,
     decimation_factor = min_to_all(decimation_factor);
   }
   data.decimation_factor = decimation_factor;
+  data.pade_samples = pade_samples;
 
   data.omega.resize(Nfreq);
   for (size_t i = 0; i < Nfreq; ++i)
@@ -239,12 +417,17 @@ dft_chunk *fields::add_dft(component c, const volume &where, const double *freq,
 
 dft_chunk *fields::add_dft(const volume_list *where, const std::vector<double> &freq,
                            bool include_dV_and_interp_weights, bool persist) {
+  return add_dft(where, freq, include_dV_and_interp_weights, persist, 0);
+}
+
+dft_chunk *fields::add_dft(const volume_list *where, const std::vector<double> &freq,
+                           bool include_dV_and_interp_weights, bool persist, size_t pade_samples) {
   dft_chunk *chunks = 0;
   while (where) {
     if (is_derived(where->c)) meep::abort("derived_component invalid for dft");
     complex<double> stored_weight = where->weight;
     chunks = add_dft(component(where->c), where->v, freq, include_dV_and_interp_weights,
-                     stored_weight, chunks, persist);
+                     stored_weight, chunks, false, 1.0, true, 0, 0, persist, pade_samples);
     where = where->next;
   }
   return chunks;
@@ -268,6 +451,31 @@ void fields_chunk::update_dfts(double timeE, double timeH, int current_step) {
 
 void dft_chunk::update_dft(double time) {
   if (!fc->f[c][0]) return;
+
+  size_t pade_slot = 0;
+  if (pade_samples) {
+    if (pade_count) {
+      const double delta = time - pade_last_time;
+      if (pade_count == 1 || !(pade_sample_period > 0.0)) {
+        if (delta > 0.0)
+          pade_sample_period = delta;
+        else
+          clear_pade_history();
+      }
+      else {
+        const double tolerance =
+            1e-8 * std::max(1.0, std::max(std::abs(delta), std::abs(pade_sample_period)));
+        if (!(delta > 0.0) || std::abs(delta - pade_sample_period) > tolerance)
+          clear_pade_history();
+      }
+    }
+    if (pade_count < pade_samples)
+      pade_slot = (pade_head + pade_count) % pade_samples;
+    else {
+      pade_slot = pade_head;
+      pade_head = (pade_head + 1) % pade_samples;
+    }
+  }
 
   const int Nomega = omega.size();
   for (int i = 0; i < Nomega; ++i)
@@ -297,17 +505,181 @@ void dft_chunk::update_dft(double time) {
         f[cmp] = w * fc->f[c][cmp][idx];
 
     if (numcmp == 2) {
-      complex<realnum> fc(f[0], f[1]);
+      complex<realnum> field_value(f[0], f[1]);
       for (int i = 0; i < Nomega; ++i)
-        dft[Nomega * idx_dft + i] += dft_phase[i] * fc;
+        dft[Nomega * idx_dft + i] += dft_phase[i] * field_value;
+      if (pade_samples)
+        pade_history[idx_dft * pade_samples + pade_slot] = complex<realnum>(scale) * field_value;
     }
     else {
       realnum fr = f[0];
       for (int i = 0; i < Nomega; ++i)
         dft[Nomega * idx_dft + i] +=
             std::complex<realnum>{fr * dft_phase[i].real(), fr * dft_phase[i].imag()};
+      if (pade_samples)
+        pade_history[idx_dft * pade_samples + pade_slot] = complex<realnum>(scale) * fr;
     }
   }
+
+  if (pade_samples) {
+    if (pade_count < pade_samples) ++pade_count;
+    pade_last_time = time;
+    ++pade_generation;
+  }
+}
+
+void dft_chunk::invalidate_pade_cache() {
+  pade_cached_generation = std::numeric_limits<unsigned long long>::max();
+  pade_previous_generation = std::numeric_limits<unsigned long long>::max();
+  pade_diagnostic_generation = std::numeric_limits<unsigned long long>::max();
+  pade_error_cache = dft_pade_error();
+}
+
+void dft_chunk::clear_pade_history() {
+  if (!pade_samples) return;
+  pade_count = 0;
+  pade_head = 0;
+  pade_last_time = 0.0;
+  pade_sample_period = 0.0;
+  ++pade_generation;
+  invalidate_pade_cache();
+}
+
+void dft_chunk::prepare_dft_values() const {
+  if (!pade_samples || pade_cached_generation == pade_generation) return;
+
+  const size_t Nomega = omega.size();
+  const size_t Ndft = N * Nomega;
+  if (!effective_dft) effective_dft = new complex<realnum>[Ndft];
+
+  std::copy(dft, dft + Ndft, effective_dft);
+
+  dft_pade_error info;
+  info.samples = pade_count;
+  info.ready = pade_count >= 4 && pade_sample_period > 0.0;
+  info.generation = pade_generation;
+  info.relative_correction.assign(Nomega, 0.0);
+  info.relative_estimate.assign(Nomega, std::numeric_limits<double>::infinity());
+  info.drift.assign(Nomega, std::numeric_limits<double>::infinity());
+  if (!info.ready) {
+    pade_error_cache = info;
+    pade_cached_generation = pade_generation;
+    return;
+  }
+
+  std::vector<double> correction2(Nomega, 0.0), corrected2(Nomega, 0.0);
+  std::vector<double> estimate2(Nomega, 0.0);
+  std::vector<bool> estimate_valid(Nomega, true);
+  const size_t half_count = pade_count / 2;
+  const double full_t0 = pade_last_time - (pade_count - 1) * pade_sample_period;
+  const double half_t0 = pade_last_time - (half_count - 1) * pade_sample_period;
+
+  std::vector<pade_complex> full(pade_count), half(half_count);
+  for (size_t point = 0; point < N; ++point) {
+    for (size_t j = 0; j < pade_count; ++j) {
+      const size_t ring_index = (pade_head + j) % pade_samples;
+      full[j] = pade_complex(pade_history[point * pade_samples + ring_index]);
+    }
+    std::copy(full.end() - half_count, full.end(), half.begin());
+
+    for (size_t i = 0; i < Nomega; ++i) {
+      pade_complex full_tail, half_tail;
+      const bool full_valid =
+          pade_future_tail(full, omega[i], full_t0, pade_sample_period, full_tail);
+      const bool half_valid =
+          pade_future_tail(half, omega[i], half_t0, pade_sample_period, half_tail);
+      const size_t idx = point * Nomega + i;
+      if (!full_valid) {
+        ++info.invalid_fits;
+        estimate_valid[i] = false;
+      }
+      else {
+        const pade_complex corrected = pade_complex(dft[idx]) + full_tail;
+        const double realnum_max = std::numeric_limits<realnum>::max();
+        if (!finite_complex(corrected) || std::abs(corrected.real()) > realnum_max ||
+            std::abs(corrected.imag()) > realnum_max) {
+          ++info.invalid_fits;
+          estimate_valid[i] = false;
+        }
+        else {
+          effective_dft[idx] = complex<realnum>(corrected);
+          correction2[i] += std::norm(full_tail);
+          if (half_valid)
+            estimate2[i] += std::norm(full_tail - half_tail);
+          else {
+            ++info.invalid_fits;
+            estimate_valid[i] = false;
+          }
+        }
+      }
+      corrected2[i] += std::norm(pade_complex(effective_dft[idx]));
+    }
+  }
+
+  info.correction2.assign(Nomega, 0.0);
+  info.estimate2.assign(Nomega, 0.0);
+  info.magnitude2.assign(Nomega, 0.0);
+  for (size_t i = 0; i < Nomega; ++i) {
+    info.relative_correction[i] = relative_norm(correction2[i], corrected2[i]);
+    if (estimate_valid[i]) info.relative_estimate[i] = relative_norm(estimate2[i], corrected2[i]);
+    info.correction2[i] = correction2[i];
+    info.estimate2[i] = estimate_valid[i] ? estimate2[i] : std::numeric_limits<double>::infinity();
+    info.magnitude2[i] = corrected2[i];
+  }
+  pade_error_cache = info;
+  pade_cached_generation = pade_generation;
+}
+
+const complex<realnum> *dft_chunk::dft_values() const {
+  if (!pade_samples) return dft;
+  prepare_dft_values();
+  return effective_dft;
+}
+
+dft_pade_error dft_chunk::get_pade_error() const {
+  if (!pade_samples) {
+    dft_pade_error info;
+    info.samples = 0;
+    info.ready = false;
+    info.generation = pade_generation;
+    info.relative_correction.assign(omega.size(), 0.0);
+    info.relative_estimate.assign(omega.size(), std::numeric_limits<double>::infinity());
+    info.drift.assign(omega.size(), std::numeric_limits<double>::infinity());
+    info.correction2.assign(omega.size(), 0.0);
+    info.estimate2.assign(omega.size(), 0.0);
+    info.drift2.assign(omega.size(), 0.0);
+    info.magnitude2.assign(omega.size(), 0.0);
+    return info;
+  }
+  prepare_dft_values();
+  if (pade_diagnostic_generation != pade_generation) {
+    const size_t Nomega = omega.size();
+    const size_t Ndft = N * Nomega;
+    const unsigned long long no_generation = std::numeric_limits<unsigned long long>::max();
+    const bool have_previous = pade_previous_generation != no_generation;
+    if (have_previous) {
+      std::vector<double> drift2(Nomega, 0.0), current2(Nomega, 0.0), previous2(Nomega, 0.0);
+      for (size_t point = 0; point < N; ++point)
+        for (size_t i = 0; i < Nomega; ++i) {
+          const size_t idx = point * Nomega + i;
+          const pade_complex current(effective_dft[idx]);
+          const pade_complex previous(previous_effective_dft[idx]);
+          drift2[i] += std::norm(current - previous);
+          current2[i] += std::norm(current);
+          previous2[i] += std::norm(previous);
+        }
+      pade_error_cache.drift2.assign(Nomega, 0.0);
+      for (size_t i = 0; i < Nomega; ++i) {
+        pade_error_cache.drift[i] = relative_norm(drift2[i], std::max(current2[i], previous2[i]));
+        pade_error_cache.drift2[i] = drift2[i];
+      }
+    }
+    if (!previous_effective_dft) previous_effective_dft = new complex<realnum>[Ndft];
+    std::copy(effective_dft, effective_dft + Ndft, previous_effective_dft);
+    pade_previous_generation = pade_generation;
+    pade_diagnostic_generation = pade_generation;
+  }
+  return pade_error_cache;
 }
 
 /* Return the L2 norm of the DFTs themselves.  This is useful
@@ -405,6 +777,7 @@ double dft_chunk::maxomega() const {
 void dft_chunk::scale_dft(complex<double> scale) {
   for (size_t i = 0; i < N * omega.size(); ++i)
     dft[i] *= scale;
+  clear_pade_history();
   if (next_in_dft) next_in_dft->scale_dft(scale);
 }
 
@@ -412,8 +785,11 @@ void dft_chunk::operator-=(const dft_chunk &chunk) {
   if (c != chunk.c || N * omega.size() != chunk.N * chunk.omega.size())
     meep::abort("Mismatched chunks in dft_chunk::operator-=");
 
+  const complex<realnum> *lhs = dft_values();
+  const complex<realnum> *rhs = chunk.dft_values();
   for (size_t i = 0; i < N * omega.size(); ++i)
-    dft[i] -= chunk.dft[i];
+    dft[i] = lhs[i] - rhs[i];
+  clear_pade_history();
 
   if (next_in_dft) {
     if (!chunk.next_in_dft) meep::abort("Mismatched chunk lists in dft_chunk::operator-=");
@@ -459,7 +835,7 @@ void save_dft_hdf5(dft_chunk *dft_chunks, const char *name, h5file *file, const 
 
   for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_dft) {
     size_t Nchunk = cur->N * cur->omega.size() * 2;
-    file->write_chunk(1, &istart, &Nchunk, (realnum *)cur->dft);
+    file->write_chunk(1, &istart, &Nchunk, (realnum *)cur->dft_values());
     istart += Nchunk;
   }
   file->done_writing_chunks();
@@ -490,6 +866,7 @@ void load_dft_hdf5(dft_chunk *dft_chunks, const char *name, h5file *file, const 
   for (dft_chunk *cur = dft_chunks; cur; cur = cur->next_in_dft) {
     size_t Nchunk = cur->N * cur->omega.size() * 2;
     file->read_chunk(1, &istart, &Nchunk, (realnum *)cur->dft);
+    cur->clear_pade_history();
     istart += Nchunk;
   }
 }
@@ -548,10 +925,13 @@ double *dft_flux::flux() {
   for (size_t i = 0; i < Nfreq; ++i)
     F[i] = 0;
   for (dft_chunk *curE = E, *curH = H; curE && curH;
-       curE = curE->next_in_dft, curH = curH->next_in_dft)
+       curE = curE->next_in_dft, curH = curH->next_in_dft) {
+    const complex<realnum> *Evalues = curE->dft_values();
+    const complex<realnum> *Hvalues = curH->dft_values();
     for (size_t k = 0; k < curE->N; ++k)
       for (size_t i = 0; i < Nfreq; ++i)
-        F[i] += real(curE->dft[k * Nfreq + i] * conj(curH->dft[k * Nfreq + i]));
+        F[i] += real(Evalues[k * Nfreq + i] * conj(Hvalues[k * Nfreq + i]));
+  }
   double *Fsum = new double[Nfreq];
   sum_to_all(F, Fsum, int(Nfreq));
   delete[] F;
@@ -564,10 +944,13 @@ std::vector<std::complex<double> > dft_flux::complexflux() {
   for (size_t i = 0; i < Nfreq; ++i)
     F[i] = 0.0;
   for (dft_chunk *curE = E, *curH = H; curE && curH;
-       curE = curE->next_in_dft, curH = curH->next_in_dft)
+       curE = curE->next_in_dft, curH = curH->next_in_dft) {
+    const complex<realnum> *Evalues = curE->dft_values();
+    const complex<realnum> *Hvalues = curH->dft_values();
     for (size_t k = 0; k < curE->N; ++k)
       for (size_t i = 0; i < Nfreq; ++i)
-        F[i] += curE->dft[k * Nfreq + i] * conj(curH->dft[k * Nfreq + i]);
+        F[i] += Evalues[k * Nfreq + i] * conj(Hvalues[k * Nfreq + i]);
+  }
   std::vector<std::complex<double> > Fsum(Nfreq);
   sum_to_all(&F[0], &Fsum[0], int(Nfreq));
   return Fsum;
@@ -602,8 +985,14 @@ void dft_flux::scale_dfts(complex<double> scale) {
   if (H) H->scale_dft(scale);
 }
 
-dft_flux fields::add_dft_flux(const volume_list *where_, const double *freq, size_t Nfreq,
+dft_flux fields::add_dft_flux(const volume_list *where, const double *freq, size_t Nfreq,
                               bool use_symmetry, bool centered_grid, int decimation_factor) {
+  return add_dft_flux(where, freq, Nfreq, use_symmetry, centered_grid, decimation_factor, 0);
+}
+
+dft_flux fields::add_dft_flux(const volume_list *where_, const double *freq, size_t Nfreq,
+                              bool use_symmetry, bool centered_grid, int decimation_factor,
+                              size_t pade_samples) {
   if (!where_) // handle empty list of volumes
     return dft_flux(Ex, Hy, NULL, NULL, freq, Nfreq, v, NO_DIRECTION, use_symmetry);
 
@@ -639,9 +1028,10 @@ dft_flux fields::add_dft_flux(const volume_list *where_, const double *freq, siz
 
     for (int i = 0; i < 2; ++i) {
       E = add_dft(cE[i], where->v, freq, Nfreq, true, where->weight * double(1 - 2 * i), E, false,
-                  std::complex<double>(1.0, 0), centered_grid, 0, decimation_factor);
+                  std::complex<double>(1.0, 0), centered_grid, 0, decimation_factor, false,
+                  pade_samples);
       H = add_dft(cH[i], where->v, freq, Nfreq, false, 1.0, H, false, std::complex<double>(1.0, 0),
-                  centered_grid, 0, decimation_factor);
+                  centered_grid, 0, decimation_factor, false, pade_samples);
     }
 
     where = where->next;
@@ -687,10 +1077,13 @@ double *dft_energy::electric() {
   for (size_t i = 0; i < Nfreq; ++i)
     F[i] = 0;
   for (dft_chunk *curE = E, *curD = D; curE && curD;
-       curE = curE->next_in_dft, curD = curD->next_in_dft)
+       curE = curE->next_in_dft, curD = curD->next_in_dft) {
+    const complex<realnum> *Evalues = curE->dft_values();
+    const complex<realnum> *Dvalues = curD->dft_values();
     for (size_t k = 0; k < curE->N; ++k)
       for (size_t i = 0; i < Nfreq; ++i)
-        F[i] += 0.5 * real(conj(curE->dft[k * Nfreq + i]) * curD->dft[k * Nfreq + i]);
+        F[i] += 0.5 * real(conj(Evalues[k * Nfreq + i]) * Dvalues[k * Nfreq + i]);
+  }
   double *Fsum = new double[Nfreq];
   sum_to_all(F, Fsum, int(Nfreq));
   delete[] F;
@@ -703,10 +1096,13 @@ double *dft_energy::magnetic() {
   for (size_t i = 0; i < Nfreq; ++i)
     F[i] = 0;
   for (dft_chunk *curH = H, *curB = B; curH && curB;
-       curH = curH->next_in_dft, curB = curB->next_in_dft)
+       curH = curH->next_in_dft, curB = curB->next_in_dft) {
+    const complex<realnum> *Hvalues = curH->dft_values();
+    const complex<realnum> *Bvalues = curB->dft_values();
     for (size_t k = 0; k < curH->N; ++k)
       for (size_t i = 0; i < Nfreq; ++i)
-        F[i] += 0.5 * real(conj(curH->dft[k * Nfreq + i]) * curB->dft[k * Nfreq + i]);
+        F[i] += 0.5 * real(conj(Hvalues[k * Nfreq + i]) * Bvalues[k * Nfreq + i]);
+  }
   double *Fsum = new double[Nfreq];
   sum_to_all(F, Fsum, int(Nfreq));
   delete[] F;
@@ -725,8 +1121,13 @@ double *dft_energy::total() {
   return F;
 }
 
-dft_energy fields::add_dft_energy(const volume_list *where_, const double *freq, size_t Nfreq,
+dft_energy fields::add_dft_energy(const volume_list *where, const double *freq, size_t Nfreq,
                                   int decimation_factor) {
+  return add_dft_energy(where, freq, Nfreq, decimation_factor, 0);
+}
+
+dft_energy fields::add_dft_energy(const volume_list *where_, const double *freq, size_t Nfreq,
+                                  int decimation_factor, size_t pade_samples) {
 
   if (!where_) // handle empty list of volumes
     return dft_energy(NULL, NULL, NULL, NULL, freq, Nfreq, v);
@@ -738,13 +1139,13 @@ dft_energy fields::add_dft_energy(const volume_list *where_, const double *freq,
   while (where) {
     LOOP_OVER_FIELD_DIRECTIONS(gv.dim, d) {
       E = add_dft(direction_component(Ex, d), where->v, freq, Nfreq, true, 1.0, E, false, 1.0, true,
-                  0, decimation_factor);
+                  0, decimation_factor, false, pade_samples);
       D = add_dft(direction_component(Dx, d), where->v, freq, Nfreq, false, 1.0, D, false, 1.0,
-                  true, 0, decimation_factor);
+                  true, 0, decimation_factor, false, pade_samples);
       H = add_dft(direction_component(Hx, d), where->v, freq, Nfreq, true, 1.0, H, false, 1.0, true,
-                  0, decimation_factor);
+                  0, decimation_factor, false, pade_samples);
       B = add_dft(direction_component(Bx, d), where->v, freq, Nfreq, false, 1.0, B, false, 1.0,
-                  true, 0, decimation_factor);
+                  true, 0, decimation_factor, false, pade_samples);
     }
     where = where->next;
   }
@@ -837,17 +1238,30 @@ direction fields::normal_direction(const volume &where) const {
 
 dft_flux fields::add_dft_flux(direction d, const volume &where, const double *freq, size_t Nfreq,
                               bool use_symmetry, bool centered_grid, int decimation_factor) {
+  return add_dft_flux(d, where, freq, Nfreq, use_symmetry, centered_grid, decimation_factor, 0);
+}
+
+dft_flux fields::add_dft_flux(direction d, const volume &where, const double *freq, size_t Nfreq,
+                              bool use_symmetry, bool centered_grid, int decimation_factor,
+                              size_t pade_samples) {
   if (d == NO_DIRECTION) d = normal_direction(where);
   volume_list vl(where, direction_component(Sx, d));
-  dft_flux flux = add_dft_flux(&vl, freq, Nfreq, use_symmetry, centered_grid, decimation_factor);
+  dft_flux flux =
+      add_dft_flux(&vl, freq, Nfreq, use_symmetry, centered_grid, decimation_factor, pade_samples);
   flux.normal_direction = d;
   return flux;
 }
 
 dft_flux fields::add_mode_monitor(direction d, const volume &where, const double *freq,
                                   size_t Nfreq, bool centered_grid, int decimation_factor) {
+  return add_mode_monitor(d, where, freq, Nfreq, centered_grid, decimation_factor, 0);
+}
+
+dft_flux fields::add_mode_monitor(direction d, const volume &where, const double *freq,
+                                  size_t Nfreq, bool centered_grid, int decimation_factor,
+                                  size_t pade_samples) {
   return add_dft_flux(d, where, freq, Nfreq, /*use_symmetry=*/false, centered_grid,
-                      decimation_factor);
+                      decimation_factor, pade_samples);
 }
 
 dft_flux fields::add_dft_flux_box(const volume &where, double freq_min, double freq_max,
@@ -916,6 +1330,13 @@ void dft_fields::remove() {
 dft_fields fields::add_dft_fields(component *components, int num_components, const volume where,
                                   const double *freq, size_t Nfreq, bool use_centered_grid,
                                   int decimation_factor, bool persist) {
+  return add_dft_fields(components, num_components, where, freq, Nfreq, use_centered_grid,
+                        decimation_factor, persist, 0);
+}
+
+dft_fields fields::add_dft_fields(component *components, int num_components, const volume where,
+                                  const double *freq, size_t Nfreq, bool use_centered_grid,
+                                  int decimation_factor, bool persist, size_t pade_samples) {
   bool include_dV_and_interp_weights = false;
   bool sqrt_dV_and_interp_weights = false; // default option from meep.hpp (expose to user?)
   std::complex<double> extra_weight = 1.0; // default option from meep.hpp (expose to user?)
@@ -924,9 +1345,22 @@ dft_fields fields::add_dft_fields(component *components, int num_components, con
   for (int nc = 0; nc < num_components; nc++)
     chunks = add_dft(components[nc], where, freq, Nfreq, include_dV_and_interp_weights,
                      stored_weight, chunks, sqrt_dV_and_interp_weights, extra_weight,
-                     use_centered_grid, 0, decimation_factor, persist);
+                     use_centered_grid, 0, decimation_factor, persist, pade_samples);
 
   return dft_fields(chunks, freq, Nfreq, where);
+}
+
+// Keep the pre-Padé exported entry points available for applications linked
+// against an older libmeep.  The implementations with the appended history
+// size live in stress.cpp and near2far.cpp respectively.
+dft_force fields::add_dft_force(const volume_list *where, const double *freq, size_t Nfreq,
+                                int decimation_factor) {
+  return add_dft_force(where, freq, Nfreq, decimation_factor, 0);
+}
+
+dft_near2far fields::add_dft_near2far(const volume_list *where, const double *freq, size_t Nfreq,
+                                      int decimation_factor, int Nperiods) {
+  return add_dft_near2far(where, freq, Nfreq, decimation_factor, Nperiods, 0);
 }
 
 /***************************************************************/
@@ -943,6 +1377,7 @@ complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec m
     meep::abort("process_dft_component: frequency index %d is outside the range of the frequency "
                 "array of size %lu",
                 num_freq, omega.size());
+  const complex<realnum> *values = dft_values();
 
   /*****************************************************************/
   /* compute the size of the chunk we own and its strides etc.     */
@@ -1012,7 +1447,7 @@ complex<double> dft_chunk::process_dft_component(int rank, direction *ds, ivec m
          : c_conjugate == Dielectric ? parent->get_eps(loc)
          : c_conjugate == Permeability
              ? parent->get_mu(loc)
-             : complex<double>(dft[omega.size() * (chunk_idx++) + num_freq]) / stored_weight);
+             : complex<double>(values[omega.size() * (chunk_idx++) + num_freq]) / stored_weight);
     if (include_dV_and_interp_weights && dft_val != 0.0)
       dft_val /= (sqrt_dV_and_interp_weights ? sqrt(w) : w);
 

--- a/src/fields_dump.cpp
+++ b/src/fields_dump.cpp
@@ -106,6 +106,14 @@ void fields::dump_fields_chunk_field(h5file *h5f, bool single_parallel_file,
 }
 
 void fields::dump(const char *filename, bool single_parallel_file) {
+  bool has_pade_dfts = false;
+  for (int i = 0; i < num_chunks; ++i)
+    if (chunks[i]->is_mine())
+      for (dft_chunk *cur = chunks[i]->dft_chunks; cur; cur = cur->next_in_chunk)
+        has_pade_dfts = has_pade_dfts || cur->pade_enabled();
+  if (or_to_all(has_pade_dfts))
+    meep::abort("fields::dump does not yet support resumable Padé DFT monitor state");
+
   if (verbosity > 0) {
     printf("creating fields output file \"%s\" (%d)...\n", filename, single_parallel_file);
   }
@@ -230,6 +238,14 @@ void fields::load_fields_chunk_field(h5file *h5f, bool single_parallel_file,
 }
 
 void fields::load(const char *filename, bool single_parallel_file) {
+  bool has_pade_dfts = false;
+  for (int i = 0; i < num_chunks; ++i)
+    if (chunks[i]->is_mine())
+      for (dft_chunk *cur = chunks[i]->dft_chunks; cur; cur = cur->next_in_chunk)
+        has_pade_dfts = has_pade_dfts || cur->pade_enabled();
+  if (or_to_all(has_pade_dfts))
+    meep::abort("fields::load does not yet support resumable Padé DFT monitor state");
+
   if (verbosity > 0)
     printf("reading fields from file \"%s\" (%d)...\n", filename, single_parallel_file);
 

--- a/src/meep.hpp
+++ b/src/meep.hpp
@@ -1126,6 +1126,26 @@ private:
 
 // dft.cpp
 // this should normally only be created with fields::add_dft
+struct dft_pade_error {
+  std::vector<double> relative_correction;
+  std::vector<double> relative_estimate;
+  std::vector<double> drift;
+  /* The squared sums the ratios above are formed from.  Aggregating a relative
+     error across chunks, processes or monitors has to combine these and divide
+     once -- taking a max of separately-normalised ratios lets a region carrying
+     almost no field veto convergence, because there the denominator is tiny and
+     the ratio is meaningless.  A component that is zero by symmetry does exactly
+     that. */
+  std::vector<double> correction2;
+  std::vector<double> estimate2;
+  std::vector<double> drift2;
+  std::vector<double> magnitude2;
+  size_t samples = 0;
+  bool ready = false;
+  size_t invalid_fits = 0;
+  unsigned long long generation = 0;
+};
+
 class dft_chunk {
 public:
   dft_chunk(fields_chunk *fc_, ivec is_, ivec ie_, vec s0_, vec s1_, vec e0_, vec e1_, double dV0_,
@@ -1136,6 +1156,18 @@ public:
   void update_dft(double time);
   double norm2(grid_volume fgv) const;
   double maxomega() const;
+
+  // Returns the ordinary accumulated DFT plus a Padé estimate of the
+  // uncomputed future tail.  When Padé is disabled, warming up, or a fit is
+  // rejected, the corresponding values are the ordinary accumulated DFT.
+  const std::complex<realnum> *dft_values() const;
+  void prepare_dft_values() const;
+  void clear_pade_history();
+  bool pade_enabled() const { return pade_samples != 0; }
+  size_t get_pade_samples() const { return pade_samples; }
+  size_t get_pade_count() const { return pade_count; }
+  unsigned long long get_pade_generation() const { return pade_generation; }
+  dft_pade_error get_pade_error() const;
 
   void scale_dft(std::complex<double> scale);
 
@@ -1221,6 +1253,21 @@ public:
 
 private:
   int decimation_factor;
+  size_t pade_samples;
+  size_t pade_count;
+  size_t pade_head;
+  double pade_last_time;
+  double pade_sample_period;
+  std::complex<realnum> *pade_history;
+  mutable std::complex<realnum> *effective_dft;
+  mutable std::complex<realnum> *previous_effective_dft;
+  unsigned long long pade_generation;
+  mutable unsigned long long pade_cached_generation;
+  mutable unsigned long long pade_previous_generation;
+  mutable unsigned long long pade_diagnostic_generation;
+  mutable dft_pade_error pade_error_cache;
+
+  void invalidate_pade_cache();
 };
 
 void save_dft_hdf5(dft_chunk *dft_chunks, component c, h5file *file, const char *dprefix = 0,
@@ -2023,10 +2070,11 @@ public:
                      std::complex<double> stored_weight = 1.0, dft_chunk *chunk_next = 0,
                      bool sqrt_dV_and_interp_weights = false,
                      std::complex<double> extra_weight = 1.0, bool use_centered_grid = true,
-                     int vc = 0, int decimation_factor = 0, bool persist = false) {
+                     int vc = 0, int decimation_factor = 0, bool persist = false,
+                     size_t pade_samples = 0) {
     return add_dft(c, where, linspace(freq_min, freq_max, Nfreq), include_dV_and_interp_weights,
                    stored_weight, chunk_next, sqrt_dV_and_interp_weights, extra_weight,
-                   use_centered_grid, vc, decimation_factor, persist);
+                   use_centered_grid, vc, decimation_factor, persist, pade_samples);
   }
   dft_chunk *add_dft(component c, const volume &where, const double *freq, size_t Nfreq,
                      bool include_dV_and_interp_weights = true,
@@ -2034,15 +2082,21 @@ public:
                      bool sqrt_dV_and_interp_weights = false,
                      std::complex<double> extra_weight = 1.0, bool use_centered_grid = true,
                      int vc = 0, int decimation_factor = 0, bool persist = false);
+  dft_chunk *add_dft(component c, const volume &where, const double *freq, size_t Nfreq,
+                     bool include_dV_and_interp_weights, std::complex<double> stored_weight,
+                     dft_chunk *chunk_next, bool sqrt_dV_and_interp_weights,
+                     std::complex<double> extra_weight, bool use_centered_grid, int vc,
+                     int decimation_factor, bool persist, size_t pade_samples);
   dft_chunk *add_dft(component c, const volume &where, const std::vector<double> &freq,
                      bool include_dV_and_interp_weights = true,
                      std::complex<double> stored_weight = 1.0, dft_chunk *chunk_next = 0,
                      bool sqrt_dV_and_interp_weights = false,
                      std::complex<double> extra_weight = 1.0, bool use_centered_grid = true,
-                     int vc = 0, int decimation_factor = 0, bool persist = false) {
+                     int vc = 0, int decimation_factor = 0, bool persist = false,
+                     size_t pade_samples = 0) {
     return add_dft(c, where, freq.data(), freq.size(), include_dV_and_interp_weights, stored_weight,
                    chunk_next, sqrt_dV_and_interp_weights, extra_weight, use_centered_grid, vc,
-                   decimation_factor, persist);
+                   decimation_factor, persist, pade_samples);
   }
   dft_chunk *add_dft_pt(component c, const vec &where, double freq_min, double freq_max,
                         int Nfreq) {
@@ -2052,11 +2106,13 @@ public:
     return add_dft(c, where, freq, false);
   }
   dft_chunk *add_dft(const volume_list *where, double freq_min, double freq_max, int Nfreq,
-                     bool include_dV = true, bool persist = false) {
-    return add_dft(where, linspace(freq_min, freq_max, Nfreq), include_dV, persist);
+                     bool include_dV = true, bool persist = false, size_t pade_samples = 0) {
+    return add_dft(where, linspace(freq_min, freq_max, Nfreq), include_dV, persist, pade_samples);
   }
   dft_chunk *add_dft(const volume_list *where, const std::vector<double> &freq,
                      bool include_dV = true, bool persist = false);
+  dft_chunk *add_dft(const volume_list *where, const std::vector<double> &freq, bool include_dV,
+                     bool persist, size_t pade_samples);
   void update_dfts();
   double dft_norm();
   double dft_maxfreq() const;
@@ -2066,33 +2122,39 @@ public:
   dft_flux add_dft_flux(const volume_list *where, const double *freq, size_t Nfreq,
                         bool use_symmetry = true, bool centered_grid = true,
                         int decimation_factor = 0);
+  dft_flux add_dft_flux(const volume_list *where, const double *freq, size_t Nfreq,
+                        bool use_symmetry, bool centered_grid, int decimation_factor,
+                        size_t pade_samples);
   dft_flux add_dft_flux(const volume_list *where, const std::vector<double> &freq,
                         int decimation_factor = 0, bool use_symmetry = true,
-                        bool centered_grid = true) {
+                        bool centered_grid = true, size_t pade_samples = 0) {
     return add_dft_flux(where, freq.data(), freq.size(), use_symmetry, centered_grid,
-                        decimation_factor);
+                        decimation_factor, pade_samples);
   }
   dft_flux add_dft_flux(const volume_list *where, double freq_min, double freq_max, int Nfreq,
                         bool use_symmetry = true, bool centered_grid = true,
-                        int decimation_factor = 0) {
-    return add_dft_flux(where, linspace(freq_min, freq_max, Nfreq), use_symmetry, centered_grid,
-                        decimation_factor);
+                        int decimation_factor = 0, size_t pade_samples = 0) {
+    return add_dft_flux(where, linspace(freq_min, freq_max, Nfreq), decimation_factor, use_symmetry,
+                        centered_grid, pade_samples);
   }
   dft_flux add_dft_flux(direction d, const volume &where, double freq_min, double freq_max,
                         int Nfreq, bool use_symmetry = true, bool centered_grid = true,
-                        int decimation_factor = 0) {
+                        int decimation_factor = 0, size_t pade_samples = 0) {
     return add_dft_flux(d, where, linspace(freq_min, freq_max, Nfreq), use_symmetry, centered_grid,
-                        decimation_factor);
+                        decimation_factor, pade_samples);
   }
   dft_flux add_dft_flux(direction d, const volume &where, const std::vector<double> &freq,
                         bool use_symmetry = true, bool centered_grid = true,
-                        int decimation_factor = 0) {
+                        int decimation_factor = 0, size_t pade_samples = 0) {
     return add_dft_flux(d, where, freq.data(), freq.size(), use_symmetry, centered_grid,
-                        decimation_factor);
+                        decimation_factor, pade_samples);
   }
   dft_flux add_dft_flux(direction d, const volume &where, const double *freq, size_t Nfreq,
                         bool use_symmetry = true, bool centered_grid = true,
                         int decimation_factor = 0);
+  dft_flux add_dft_flux(direction d, const volume &where, const double *freq, size_t Nfreq,
+                        bool use_symmetry, bool centered_grid, int decimation_factor,
+                        size_t pade_samples);
   dft_flux add_dft_flux_box(const volume &where, double freq_min, double freq_max, int Nfreq);
   dft_flux add_dft_flux_box(const volume &where, const std::vector<double> &freq);
   dft_flux add_dft_flux_plane(const volume &where, double freq_min, double freq_max, int Nfreq);
@@ -2100,33 +2162,42 @@ public:
 
   // a "mode monitor" is just a dft_flux with symmetry reduction turned off.
   dft_flux add_mode_monitor(direction d, const volume &where, double freq_min, double freq_max,
-                            int Nfreq, bool centered_grid = true, int decimation_factor = 0) {
+                            int Nfreq, bool centered_grid = true, int decimation_factor = 0,
+                            size_t pade_samples = 0) {
     return add_mode_monitor(d, where, linspace(freq_min, freq_max, Nfreq), centered_grid,
-                            decimation_factor);
+                            decimation_factor, pade_samples);
   }
   dft_flux add_mode_monitor(direction d, const volume &where, const std::vector<double> &freq,
-                            bool centered_grid = true, int decimation_factor = 0) {
-    return add_mode_monitor(d, where, freq.data(), freq.size(), centered_grid, decimation_factor);
+                            bool centered_grid = true, int decimation_factor = 0,
+                            size_t pade_samples = 0) {
+    return add_mode_monitor(d, where, freq.data(), freq.size(), centered_grid, decimation_factor,
+                            pade_samples);
   }
   dft_flux add_mode_monitor(direction d, const volume &where, const double *freq, size_t Nfreq,
                             bool centered_grid = true, int decimation_factor = 0);
+  dft_flux add_mode_monitor(direction d, const volume &where, const double *freq, size_t Nfreq,
+                            bool centered_grid, int decimation_factor, size_t pade_samples);
 
   dft_fields add_dft_fields(component *components, int num_components, const volume where,
                             double freq_min, double freq_max, int Nfreq,
                             bool use_centered_grid = true, int decimation_factor = 0,
-                            bool persist = false) {
+                            bool persist = false, size_t pade_samples = 0) {
     return add_dft_fields(components, num_components, where, linspace(freq_min, freq_max, Nfreq),
-                          use_centered_grid, decimation_factor, persist);
+                          use_centered_grid, decimation_factor, persist, pade_samples);
   }
   dft_fields add_dft_fields(component *components, int num_components, const volume where,
                             const std::vector<double> &freq, bool use_centered_grid = true,
-                            int decimation_factor = 0, bool persist = false) {
+                            int decimation_factor = 0, bool persist = false,
+                            size_t pade_samples = 0) {
     return add_dft_fields(components, num_components, where, freq.data(), freq.size(),
-                          use_centered_grid, decimation_factor, persist);
+                          use_centered_grid, decimation_factor, persist, pade_samples);
   }
   dft_fields add_dft_fields(component *components, int num_components, const volume where,
                             const double *freq, size_t Nfreq, bool use_centered_grid = true,
                             int decimation_factor = 0, bool persist = false);
+  dft_fields add_dft_fields(component *components, int num_components, const volume where,
+                            const double *freq, size_t Nfreq, bool use_centered_grid,
+                            int decimation_factor, bool persist, size_t pade_samples);
 
   /********************************************************/
   /* process_dft_component is an intermediate-level       */
@@ -2172,40 +2243,51 @@ public:
                              std::complex<double> overlaps[2]);
 
   dft_energy add_dft_energy(const volume_list *where, double freq_min, double freq_max, int Nfreq,
-                            int decimation_factor = 0) {
-    return add_dft_energy(where, linspace(freq_min, freq_max, Nfreq), decimation_factor);
+                            int decimation_factor = 0, size_t pade_samples = 0) {
+    return add_dft_energy(where, linspace(freq_min, freq_max, Nfreq), decimation_factor,
+                          pade_samples);
   }
   dft_energy add_dft_energy(const volume_list *where, const std::vector<double> &freq,
-                            int decimation_factor = 0) {
-    return add_dft_energy(where, freq.data(), freq.size(), decimation_factor);
+                            int decimation_factor = 0, size_t pade_samples = 0) {
+    return add_dft_energy(where, freq.data(), freq.size(), decimation_factor, pade_samples);
   }
   dft_energy add_dft_energy(const volume_list *where, const double *freq, size_t Nfreq,
                             int decimation_factor = 0);
+  dft_energy add_dft_energy(const volume_list *where, const double *freq, size_t Nfreq,
+                            int decimation_factor, size_t pade_samples);
 
   // stress.cpp
   dft_force add_dft_force(const volume_list *where, double freq_min, double freq_max, int Nfreq,
-                          int decimation_factor = 0) {
-    return add_dft_force(where, linspace(freq_min, freq_max, Nfreq), decimation_factor);
+                          int decimation_factor = 0, size_t pade_samples = 0) {
+    return add_dft_force(where, linspace(freq_min, freq_max, Nfreq), decimation_factor,
+                         pade_samples);
   }
   dft_force add_dft_force(const volume_list *where, const std::vector<double> &freq,
-                          int decimation_factor = 0) {
-    return add_dft_force(where, freq.data(), freq.size(), decimation_factor);
+                          int decimation_factor = 0, size_t pade_samples = 0) {
+    return add_dft_force(where, freq.data(), freq.size(), decimation_factor, pade_samples);
   }
   dft_force add_dft_force(const volume_list *where, const double *freq, size_t Nfreq,
                           int decimation_factor = 0);
+  dft_force add_dft_force(const volume_list *where, const double *freq, size_t Nfreq,
+                          int decimation_factor, size_t pade_samples);
 
   // near2far.cpp
   dft_near2far add_dft_near2far(const volume_list *where, double freq_min, double freq_max,
-                                int Nfreq, int decimation_factor = 0, int Nperiods = 1) {
-    return add_dft_near2far(where, linspace(freq_min, freq_max, Nfreq), decimation_factor,
-                            Nperiods);
+                                int Nfreq, int decimation_factor = 0, int Nperiods = 1,
+                                size_t pade_samples = 0) {
+    return add_dft_near2far(where, linspace(freq_min, freq_max, Nfreq), decimation_factor, Nperiods,
+                            pade_samples);
   }
   dft_near2far add_dft_near2far(const volume_list *where, const std::vector<double> &freq,
-                                int decimation_factor = 0, int Nperiods = 1) {
-    return add_dft_near2far(where, freq.data(), freq.size(), decimation_factor, Nperiods);
+                                int decimation_factor = 0, int Nperiods = 1,
+                                size_t pade_samples = 0) {
+    return add_dft_near2far(where, freq.data(), freq.size(), decimation_factor, Nperiods,
+                            pade_samples);
   }
   dft_near2far add_dft_near2far(const volume_list *where, const double *freq, size_t Nfreq,
                                 int decimation_factor = 0, int Nperiods = 1);
+  dft_near2far add_dft_near2far(const volume_list *where, const double *freq, size_t Nfreq,
+                                int decimation_factor, int Nperiods, size_t pade_samples);
   // monitor.cpp
   std::complex<double> get_chi1inv(component, direction, const vec &loc, double frequency = 0,
                                    bool parallel = true, bool *is_frequency_dependent = NULL) const;

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -22,6 +22,10 @@
 
 namespace meep_geom {
 
+double _adjdbg_sum[2] = {0, 0};
+long _adjdbg_n[2] = {0, 0};
+
+
 #define master_printf meep::master_printf
 
 /***************************************************************/
@@ -2544,8 +2548,15 @@ void fragment_stats::compute_dft_stats() {
         // Note: Since geom_boxes_intersect returns true if two planes share a line or two volumes
         // share a line or plane, there are cases where some pixels are counted multiple times.
         size_t overlap_pixels = get_pixels_in_box(&overlap_box, 2);
-        num_dft_pixels +=
-            overlap_pixels * dft_data_list[i].num_freqs * dft_data_list[i].num_components;
+        const size_t num_freqs = dft_data_list[i].num_freqs;
+        const size_t pade_samples = dft_data_list[i].pade_samples;
+        // A Padé-enabled DFT chunk stores a bounded N*pade_samples history. Its
+        // corrected value and previous-diagnostic caches can each add N*num_freqs
+        // entries. Count all possible allocations so pre-run chunk balancing and
+        // memory estimates do not depend on when or how often diagnostics are read.
+        const size_t entries_per_component =
+            num_freqs + (pade_samples ? pade_samples + 2 * num_freqs : 0);
+        num_dft_pixels += overlap_pixels * entries_per_component * dft_data_list[i].num_components;
       }
     }
   }
@@ -2619,7 +2630,11 @@ void fragment_stats::print_stats() const {
 }
 
 dft_data::dft_data(int freqs, int components, std::vector<meep::volume> volumes)
-    : num_freqs(freqs), num_components(components), vols(volumes) {}
+    : dft_data(freqs, components, volumes, 0) {}
+
+dft_data::dft_data(int freqs, int components, std::vector<meep::volume> volumes,
+                   size_t pade_samples)
+    : num_freqs(freqs), num_components(components), pade_samples(pade_samples), vols(volumes) {}
 
 /***************************************************************/
 // Gradient calculation routines needed for material grid
@@ -3132,59 +3147,6 @@ void material_grids_addgradient_point(double *v, vector3 p, double scalegrad, ge
   }
 }
 
-/* Is the point p inside the box [lo,hi] in *every* direction?
-
-   grid_volume::index() is a flat inner product of the per-direction offsets
-   with the strides, so a point that leaves the box in a single direction can
-   still produce an index inside [0,N): in 3d, stepping one pixel off the end
-   in y lands on an unrelated voxel of the next z slab. Guarding only the flat
-   index therefore silently substitutes a neighboring field value. Check each
-   direction separately instead. */
-static bool ivec_in_box(const meep::ivec &p, const meep::ivec &lo, const meep::ivec &hi,
-                        meep::ndim dim) {
-  LOOP_OVER_DIRECTIONS(dim, d) {
-    if (p.in_direction(d) < lo.in_direction(d) || p.in_direction(d) > hi.in_direction(d))
-      return false;
-  }
-  return true;
-}
-
-/* Find the dft_chunk in `chunks` covering the same region as `adj`.
-
-   loop_in_chunks() emits one dft_chunk per (fields_chunk, symmetry image,
-   lattice shift) triple, so that triple identifies a chunk uniquely. It is
-   *not* safe to pair chunks by position in the next_in_dft list: a fields
-   chunk contributes a dft_chunk for a given component only if the monitor
-   overlaps that component's owned grid there, and the yee shifts differ
-   between components, so the per-component lists can have different lengths
-   and different orderings near the edges of the monitor. Returns NULL when
-   this fields chunk holds no data for the requested component. */
-static meep::dft_chunk *matching_dft_chunk(const std::vector<meep::dft_chunk *> &chunks,
-                                           const meep::dft_chunk *adj) {
-  for (size_t i = 0; i < chunks.size(); ++i)
-    if (chunks[i]->fc == adj->fc && chunks[i]->sn == adj->sn && chunks[i]->shift == adj->shift)
-      return chunks[i];
-  return NULL;
-}
-
-/* Look up the forward DFT at point p, or zero if p is outside this chunk.
-
-   The restriction stencil reaches half a pixel (unit_a*2 cancels against the yee
-   shift), so it wants the four forward nodes around the adjoint node. With the
-   persist pad clamped to the component's own grid (see dft.cpp) those all lie
-   inside this chunk's box, the outermost of them being the chunk's ghost layer,
-   which step_boundaries() keeps current, so a lookup should only fall outside
-   it at the cell boundary, where zero is the right answer. */
-static std::complex<meep::realnum> forward_dft_value(const meep::dft_chunk *ch,
-                                                     const meep::grid_volume &gv_fwd,
-                                                     meep::grid_volume &gv, const meep::ivec &p,
-                                                     size_t nf, size_t f_i) {
-  if (ivec_in_box(p, ch->is, ch->ie, gv.dim)) {
-    ptrdiff_t i = gv_fwd.index(ch->c, p);
-    if (i >= 0 && (size_t)i < ch->N) return ch->dft[nf * i + f_i];
-  }
-  return 0;
-
 /* ------------------------------------------------------------------ */
 /* Gradients with respect to a geometric object's centre and size.      */
 /* ------------------------------------------------------------------ */
@@ -3519,6 +3481,61 @@ void geometry_addgradient(double *v, size_t nparams, size_t nf,
   meep::sum_to_all(local.data(), v, int(nf * nparams));
 }
 
+/* Is the point p inside the box [lo,hi] in *every* direction?
+
+   grid_volume::index() is a flat inner product of the per-direction offsets
+   with the strides, so a point that leaves the box in a single direction can
+   still produce an index inside [0,N): in 3d, stepping one pixel off the end
+   in y lands on an unrelated voxel of the next z slab. Guarding only the flat
+   index therefore silently substitutes a neighboring field value. Check each
+   direction separately instead. */
+static bool ivec_in_box(const meep::ivec &p, const meep::ivec &lo, const meep::ivec &hi,
+                        meep::ndim dim) {
+  LOOP_OVER_DIRECTIONS(dim, d) {
+    if (p.in_direction(d) < lo.in_direction(d) || p.in_direction(d) > hi.in_direction(d))
+      return false;
+  }
+  return true;
+}
+
+/* Find the dft_chunk in `chunks` covering the same region as `adj`.
+
+   loop_in_chunks() emits one dft_chunk per (fields_chunk, symmetry image,
+   lattice shift) triple, so that triple identifies a chunk uniquely. It is
+   *not* safe to pair chunks by position in the next_in_dft list: a fields
+   chunk contributes a dft_chunk for a given component only if the monitor
+   overlaps that component's owned grid there, and the yee shifts differ
+   between components, so the per-component lists can have different lengths
+   and different orderings near the edges of the monitor. Returns NULL when
+   this fields chunk holds no data for the requested component. */
+static meep::dft_chunk *matching_dft_chunk(const std::vector<meep::dft_chunk *> &chunks,
+                                           const meep::dft_chunk *adj) {
+  for (size_t i = 0; i < chunks.size(); ++i)
+    if (chunks[i]->fc == adj->fc && chunks[i]->sn == adj->sn && chunks[i]->shift == adj->shift)
+      return chunks[i];
+  return NULL;
+}
+
+/* Look up the forward DFT at point p, or zero if p is outside this chunk.
+
+   The restriction stencil reaches half a pixel (unit_a*2 cancels against the yee
+   shift), so it wants the four forward nodes around the adjoint node. With the
+   persist pad clamped to the component's own grid (see dft.cpp) those all lie
+   inside this chunk's box, the outermost of them being the chunk's ghost layer,
+   which step_boundaries() keeps current, so a lookup should only fall outside
+   it at the cell boundary, where zero is the right answer. */
+static std::complex<meep::realnum> forward_dft_value(const meep::dft_chunk *ch,
+                                                     const std::complex<meep::realnum> *values,
+                                                     const meep::grid_volume &gv_fwd,
+                                                     meep::grid_volume &gv, const meep::ivec &p,
+                                                     size_t nf, size_t f_i) {
+  if (ivec_in_box(p, ch->is, ch->ie, gv.dim)) {
+    ptrdiff_t i = gv_fwd.index(ch->c, p);
+    if (i >= 0 && (size_t)i < ch->N) return values[nf * i + f_i];
+  }
+  return 0;
+}
+
 void material_grids_addgradient(double *v, size_t ng, size_t nf,
                                 std::vector<meep::dft_fields *> fields_a,
                                 std::vector<meep::dft_fields *> fields_f, double *frequencies,
@@ -3537,6 +3554,7 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
   /* ------------------------------------------------------------ */
   std::vector<std::vector<meep::dft_chunk *> > adjoint_dft_chunks;
   std::vector<std::vector<meep::dft_chunk *> > forward_dft_chunks;
+  std::vector<std::vector<const std::complex<meep::realnum> *> > adjoint_dft_values;
   for (int i = 0; i < 3; i++) {
     std::vector<meep::dft_chunk *> c_adjoint_dft_chunks;
     std::vector<meep::dft_chunk *> c_forward_dft_chunks;
@@ -3561,6 +3579,11 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
        chunks are paired spatially below, so this is not an error. */
     adjoint_dft_chunks.push_back(c_adjoint_dft_chunks);
     forward_dft_chunks.push_back(c_forward_dft_chunks);
+
+    std::vector<const std::complex<meep::realnum> *> c_adjoint_dft_values;
+    for (const meep::dft_chunk *chunk : c_adjoint_dft_chunks)
+      c_adjoint_dft_values.push_back(chunk->dft_values());
+    adjoint_dft_values.push_back(c_adjoint_dft_values);
   }
 
   /* ------------------------------------------------------------ */
@@ -3578,6 +3601,7 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
       // loop over each chunk
       for (int cur_chunk = 0; cur_chunk < num_chunks; cur_chunk++) {
         meep::dft_chunk *adj_chunk = adjoint_dft_chunks[ci_adjoint][cur_chunk];
+        const std::complex<meep::realnum> *adj_values = adjoint_dft_values[ci_adjoint][cur_chunk];
         meep::component adjoint_c = adj_chunk->c;
         meep::grid_volume gv_adj = gv.subvolume(adj_chunk->is, adj_chunk->ie, adjoint_c);
 
@@ -3588,6 +3612,7 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
           meep::dft_chunk *fwd_chunk =
               matching_dft_chunk(forward_dft_chunks[ci_forward], adj_chunk);
           if (!fwd_chunk) continue;
+          const std::complex<meep::realnum> *fwd_values = fwd_chunk->dft_values();
           meep::component forward_c = fwd_chunk->c;
           meep::grid_volume gv_fwd = gv.subvolume(fwd_chunk->is, fwd_chunk->ie, forward_c);
 
@@ -3596,13 +3621,18 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
             double cyl_scale;
             IVEC_LOOP_ILOC(gv_adj, ip);
             IVEC_LOOP_LOC(gv_adj, p);
-            std::complex<meep::realnum> adj = adj_chunk->dft[nf * idx_adj + f_i];
+            std::complex<meep::realnum> adj = adj_values[nf * idx_adj + f_i];
             material_type md;
             geps->get_material_pt(md, p);
             /* if we have conductivities (e.g. for damping)
             then we need to make sure we correctly account
             for that here */
             if (!md->trivial) adj *= cond_cmp(adjoint_c, p, frequencies[f_i], geps);
+            if (getenv("MEEP_ADJDBG")) {
+              extern double _adjdbg_sum[2]; extern long _adjdbg_n[2];
+              int b = adj_chunk->sn ? 1 : 0;
+              _adjdbg_sum[b] += std::abs(adj); _adjdbg_n[b]++;
+            }
 
             /**************************************/
             /*            Main Routine            */
@@ -3616,7 +3646,7 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
                  idx_adj is an index into gv_adj and is only valid here because
                  the paired chunks share a fields chunk */
               std::complex<meep::realnum> fwd =
-                  forward_dft_value(fwd_chunk, gv_fwd, gv, ip, nf, f_i);
+                  forward_dft_value(fwd_chunk, fwd_values, gv_fwd, gv, ip, nf, f_i);
               cyl_scale = (gv.dim == meep::Dcyl) ? 2 * p.r()
                                                  : 1; // the pi is already factored in near2far.cpp
               material_grids_addgradient_point(v_local + ng * f_i, vec_to_vector3(p),
@@ -3655,8 +3685,8 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
 // operate on the each eps node
 #pragma unroll
               for (int node = 0; node < 2; node++) { // two nodes
-                fwd1 = forward_dft_value(fwd_chunk, gv_fwd, gv, fwd_pl[node], nf, f_i);
-                fwd2 = forward_dft_value(fwd_chunk, gv_fwd, gv, fwd_pr[node], nf, f_i);
+                fwd1 = forward_dft_value(fwd_chunk, fwd_values, gv_fwd, gv, fwd_pl[node], nf, f_i);
+                fwd2 = forward_dft_value(fwd_chunk, fwd_values, gv_fwd, gv, fwd_pr[node], nf, f_i);
                 fwd_avg = std::complex<meep::realnum>(0.5, 0) * (fwd1 + fwd2);
                 meep::vec eps1 = gv[ieps[node]];
                 cyl_scale = (gv.dim == meep::Dcyl) ? eps1.r() : 1;
@@ -3678,6 +3708,12 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
   /* ------------------------------------------------------------ */
   // Broadcast results
   /* ------------------------------------------------------------ */
+  if (getenv("MEEP_ADJDBG")) {
+    extern double _adjdbg_sum[2]; extern long _adjdbg_n[2];
+    master_printf("ADJDBG sn0 n=%ld sum|adj|=%.8e | sn1 n=%ld sum|adj|=%.8e\n",
+                  _adjdbg_n[0], _adjdbg_sum[0], _adjdbg_n[1], _adjdbg_sum[1]);
+    _adjdbg_sum[0] = _adjdbg_sum[1] = 0; _adjdbg_n[0] = _adjdbg_n[1] = 0;
+  }
   meep::sum_to_all(v_local, v, ng * nf);
 
   /* ------------------------------------------------------------ */
@@ -3686,11 +3722,13 @@ void material_grids_addgradient(double *v, size_t ng, size_t nf,
   // clear the array used for local sum to all
   delete[] v_local;
 
-  // clear all the dft data structures
+  // material_grids_addgradient consumes the adjoint DFT chunks.  Remove them
+  // through their owning dft_fields objects so the owners' chunk heads are
+  // cleared as well.  Deleting the copied pointers above left fields_a with
+  // dangling chunk lists, causing a subsequent dft_fields::remove() (as used
+  // by streamed Padé adjoints) to delete the same chunks a second time.
   for (int i = 0; i < 3; i++) {
-    for (int ii = 0; ii < adjoint_dft_chunks[i].size(); ii++) {
-      delete adjoint_dft_chunks[i][ii];
-    }
+    fields_a[i]->remove();
   }
 
 } // material_grids_addgradient

--- a/src/meepgeom.cpp
+++ b/src/meepgeom.cpp
@@ -3223,6 +3223,61 @@ static void axis_overlap(double lo, double hi, double c, double s, double &overl
   d_dsize = 0.5 * (upper_inside + lower_inside);
 }
 
+/* Is the point p inside the box [lo,hi] in *every* direction?
+
+   grid_volume::index() is a flat inner product of the per-direction offsets
+   with the strides, so a point that leaves the box in a single direction can
+   still produce an index inside [0,N): in 3d, stepping one pixel off the end
+   in y lands on an unrelated voxel of the next z slab. Guarding only the flat
+   index therefore silently substitutes a neighboring field value. Check each
+   direction separately instead. */
+static bool ivec_in_box(const meep::ivec &p, const meep::ivec &lo, const meep::ivec &hi,
+                        meep::ndim dim) {
+  LOOP_OVER_DIRECTIONS(dim, d) {
+    if (p.in_direction(d) < lo.in_direction(d) || p.in_direction(d) > hi.in_direction(d))
+      return false;
+  }
+  return true;
+}
+
+/* Find the dft_chunk in `chunks` covering the same region as `adj`.
+
+   loop_in_chunks() emits one dft_chunk per (fields_chunk, symmetry image,
+   lattice shift) triple, so that triple identifies a chunk uniquely. It is
+   *not* safe to pair chunks by position in the next_in_dft list: a fields
+   chunk contributes a dft_chunk for a given component only if the monitor
+   overlaps that component's owned grid there, and the yee shifts differ
+   between components, so the per-component lists can have different lengths
+   and different orderings near the edges of the monitor. Returns NULL when
+   this fields chunk holds no data for the requested component. */
+static meep::dft_chunk *matching_dft_chunk(const std::vector<meep::dft_chunk *> &chunks,
+                                           const meep::dft_chunk *adj) {
+  for (size_t i = 0; i < chunks.size(); ++i)
+    if (chunks[i]->fc == adj->fc && chunks[i]->sn == adj->sn && chunks[i]->shift == adj->shift)
+      return chunks[i];
+  return NULL;
+}
+
+/* Look up the forward DFT at point p, or zero if p is outside this chunk.
+
+   The restriction stencil reaches half a pixel (unit_a*2 cancels against the yee
+   shift), so it wants the four forward nodes around the adjoint node. With the
+   persist pad clamped to the component's own grid (see dft.cpp) those all lie
+   inside this chunk's box, the outermost of them being the chunk's ghost layer,
+   which step_boundaries() keeps current, so a lookup should only fall outside
+   it at the cell boundary, where zero is the right answer. */
+static std::complex<meep::realnum> forward_dft_value(const meep::dft_chunk *ch,
+                                                     const std::complex<meep::realnum> *values,
+                                                     const meep::grid_volume &gv_fwd,
+                                                     meep::grid_volume &gv, const meep::ivec &p,
+                                                     size_t nf, size_t f_i) {
+  if (ivec_in_box(p, ch->is, ch->ie, gv.dim)) {
+    ptrdiff_t i = gv_fwd.index(ch->c, p);
+    if (i >= 0 && (size_t)i < ch->N) return values[nf * i + f_i];
+  }
+  return 0;
+}
+
 void geometry_addgradient(double *v, size_t nparams, size_t nf,
                           std::vector<meep::dft_fields *> fields_a,
                           std::vector<meep::dft_fields *> fields_f, double *frequencies,
@@ -3479,61 +3534,6 @@ void geometry_addgradient(double *v, size_t nparams, size_t nf,
   }
 
   meep::sum_to_all(local.data(), v, int(nf * nparams));
-}
-
-/* Is the point p inside the box [lo,hi] in *every* direction?
-
-   grid_volume::index() is a flat inner product of the per-direction offsets
-   with the strides, so a point that leaves the box in a single direction can
-   still produce an index inside [0,N): in 3d, stepping one pixel off the end
-   in y lands on an unrelated voxel of the next z slab. Guarding only the flat
-   index therefore silently substitutes a neighboring field value. Check each
-   direction separately instead. */
-static bool ivec_in_box(const meep::ivec &p, const meep::ivec &lo, const meep::ivec &hi,
-                        meep::ndim dim) {
-  LOOP_OVER_DIRECTIONS(dim, d) {
-    if (p.in_direction(d) < lo.in_direction(d) || p.in_direction(d) > hi.in_direction(d))
-      return false;
-  }
-  return true;
-}
-
-/* Find the dft_chunk in `chunks` covering the same region as `adj`.
-
-   loop_in_chunks() emits one dft_chunk per (fields_chunk, symmetry image,
-   lattice shift) triple, so that triple identifies a chunk uniquely. It is
-   *not* safe to pair chunks by position in the next_in_dft list: a fields
-   chunk contributes a dft_chunk for a given component only if the monitor
-   overlaps that component's owned grid there, and the yee shifts differ
-   between components, so the per-component lists can have different lengths
-   and different orderings near the edges of the monitor. Returns NULL when
-   this fields chunk holds no data for the requested component. */
-static meep::dft_chunk *matching_dft_chunk(const std::vector<meep::dft_chunk *> &chunks,
-                                           const meep::dft_chunk *adj) {
-  for (size_t i = 0; i < chunks.size(); ++i)
-    if (chunks[i]->fc == adj->fc && chunks[i]->sn == adj->sn && chunks[i]->shift == adj->shift)
-      return chunks[i];
-  return NULL;
-}
-
-/* Look up the forward DFT at point p, or zero if p is outside this chunk.
-
-   The restriction stencil reaches half a pixel (unit_a*2 cancels against the yee
-   shift), so it wants the four forward nodes around the adjoint node. With the
-   persist pad clamped to the component's own grid (see dft.cpp) those all lie
-   inside this chunk's box, the outermost of them being the chunk's ghost layer,
-   which step_boundaries() keeps current, so a lookup should only fall outside
-   it at the cell boundary, where zero is the right answer. */
-static std::complex<meep::realnum> forward_dft_value(const meep::dft_chunk *ch,
-                                                     const std::complex<meep::realnum> *values,
-                                                     const meep::grid_volume &gv_fwd,
-                                                     meep::grid_volume &gv, const meep::ivec &p,
-                                                     size_t nf, size_t f_i) {
-  if (ivec_in_box(p, ch->is, ch->ie, gv.dim)) {
-    ptrdiff_t i = gv_fwd.index(ch->c, p);
-    if (i >= 0 && (size_t)i < ch->N) return values[nf * i + f_i];
-  }
-  return 0;
 }
 
 void material_grids_addgradient(double *v, size_t ng, size_t nf,

--- a/src/meepgeom.hpp
+++ b/src/meepgeom.hpp
@@ -51,9 +51,12 @@ const double TINY = 1e-20;
 struct dft_data {
   int num_freqs;
   int num_components;
+  size_t pade_samples;
   std::vector<meep::volume> vols;
 
   dft_data(int freqs, int components, std::vector<meep::volume> volumes);
+  dft_data(int freqs, int components, std::vector<meep::volume> volumes,
+           size_t pade_samples);
 };
 
 struct fragment_stats {

--- a/src/near2far.cpp
+++ b/src/near2far.cpp
@@ -359,6 +359,7 @@ void dft_near2far::farfield_lowlevel(std::complex<double> *EH, const vec &x, dou
 
   for (dft_chunk *f = F; f; f = f->next_in_dft) {
     assert(Nfreq == f->omega.size());
+    const std::complex<realnum> *dft_values = f->dft_values();
 
     component c0 = component(f->vc); /* equivalent source component */
 
@@ -383,10 +384,10 @@ void dft_near2far::farfield_lowlevel(std::complex<double> *EH, const vec &x, dou
             double phase = phase0 + i1 * periodic_k[1];
             std::complex<double> cphase = std::polar(1.0, phase);
             if (x.dim == Dcyl)
-              greencyl(EH6, x, freq[i], eps, mu, xs, c0, f->dft[Nfreq * idx_dft + i], f->fc->m,
+              greencyl(EH6, x, freq[i], eps, mu, xs, c0, dft_values[Nfreq * idx_dft + i], f->fc->m,
                        greencyl_tol);
             else
-              green(EH6, x, freq[i], eps, mu, xs, c0, f->dft[Nfreq * idx_dft + i]);
+              green(EH6, x, freq[i], eps, mu, xs, c0, dft_values[Nfreq * idx_dft + i]);
             for (int j = 0; j < 6; ++j)
               EH[i * 6 + j] += EH6[j] * cphase;
           }
@@ -567,7 +568,7 @@ double *dft_near2far::flux(direction df, const volume &where, double resolution)
 static double approxeq(double a, double b) { return fabs(a - b) < 0.5e-11 * (fabs(a) + fabs(b)); }
 
 dft_near2far fields::add_dft_near2far(const volume_list *where, const double *freq, size_t Nfreq,
-                                      int decimation_factor, int Nperiods) {
+                                      int decimation_factor, int Nperiods, size_t pade_samples) {
 
   dft_chunk *F = 0; /* E and H chunks*/
   double eps = 0, mu = 0;
@@ -643,7 +644,7 @@ dft_near2far fields::add_dft_near2far(const volume_list *where, const double *fr
         if (is_electric(c)) s = -s;
 
         F = add_dft(c, w->v, freq, Nfreq, true, s * w->weight, F, false, 1.0, false, c0,
-                    decimation_factor);
+                    decimation_factor, false, pade_samples);
       }
     }
   }

--- a/src/stress.cpp
+++ b/src/stress.cpp
@@ -91,10 +91,12 @@ static void stress_sum(size_t Nfreq, double *F, const dft_chunk *F1, const dft_c
   for (const dft_chunk *curF1 = F1, *curF2 = F2; curF1 && curF2;
        curF1 = curF1->next_in_dft, curF2 = curF2->next_in_dft) {
     complex<double> extra_weight(real(curF1->extra_weight), imag(curF1->extra_weight));
+    const complex<realnum> *F1_values = curF1->dft_values();
+    const complex<realnum> *F2_values = curF2->dft_values();
     for (size_t k = 0; k < curF1->N; ++k)
       for (size_t i = 0; i < Nfreq; ++i)
-        F[i] += real(extra_weight * complex<double>(curF1->dft[k * Nfreq + i]) *
-                     conj(complex<double>(curF2->dft[k * Nfreq + i])));
+        F[i] += real(extra_weight * complex<double>(F1_values[k * Nfreq + i]) *
+                     conj(complex<double>(F2_values[k * Nfreq + i])));
   }
 }
 
@@ -151,7 +153,7 @@ void dft_force::scale_dfts(complex<double> scale) {
    force to be computed, so they should be vector components (such as
    Ex, Ey, ... or Sx, ...)  rather than pseudovectors (like Hx, ...). */
 dft_force fields::add_dft_force(const volume_list *where, const double *freq, size_t Nfreq,
-                                int decimation_factor) {
+                                int decimation_factor, size_t pade_samples) {
   dft_chunk *offdiag1 = 0, *offdiag2 = 0, *diag = 0;
 
   // copy where_ and add cc (conjugate-component) info for symmetry reduction
@@ -176,21 +178,21 @@ dft_force fields::add_dft_force(const volume_list *where, const double *freq, si
 
     if (fd != nd) { // off-diagonal stress-tensor terms
       offdiag1 = add_dft(direction_component(Ex, fd), w->v, freq, Nfreq, true, w->weight, offdiag1,
-                         false, 1.0, true, 0, decimation_factor);
+                         false, 1.0, true, 0, decimation_factor, false, pade_samples);
       offdiag2 = add_dft(direction_component(Ex, nd), w->v, freq, Nfreq, false, 1.0, offdiag2,
-                         false, 1.0, true, 0, decimation_factor);
+                         false, 1.0, true, 0, decimation_factor, false, pade_samples);
       offdiag1 = add_dft(direction_component(Hx, fd), w->v, freq, Nfreq, true, w->weight, offdiag1,
-                         false, 1.0, true, 0, decimation_factor);
+                         false, 1.0, true, 0, decimation_factor, false, pade_samples);
       offdiag2 = add_dft(direction_component(Hx, nd), w->v, freq, Nfreq, false, 1.0, offdiag2,
-                         false, 1.0, true, 0, decimation_factor);
+                         false, 1.0, true, 0, decimation_factor, false, pade_samples);
     }
     else // diagonal stress-tensor terms
       LOOP_OVER_FIELD_DIRECTIONS(gv.dim, d) {
         complex<double> weight1 = w->weight * (d == fd ? +0.5 : -0.5);
         diag = add_dft(direction_component(Ex, d), w->v, freq, Nfreq, true, 1.0, diag, true,
-                       weight1, false, 0, decimation_factor);
+                       weight1, false, 0, decimation_factor, false, pade_samples);
         diag = add_dft(direction_component(Hx, d), w->v, freq, Nfreq, true, 1.0, diag, true,
-                       weight1, false, 0, decimation_factor);
+                       weight1, false, 0, decimation_factor, false, pade_samples);
       }
     everywhere = everywhere | w->v;
   }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 SRC = aniso_disp.cpp bench.cpp bragg_transmission.cpp			\
 convergence_cyl_waveguide.cpp cylindrical.cpp dump_load.cpp flux.cpp    \
-harmonics.cpp integrate.cpp known_results.cpp near2far.cpp              \
+harmonics.cpp integrate.cpp known_results.cpp near2far.cpp pade-dft.cpp \
 one_dimensional.cpp physical.cpp stress_tensor.cpp symmetry.cpp 	\
 three_d.cpp two_dimensional.cpp 2D_convergence.cpp h5test.cpp pml.cpp
 
@@ -16,7 +16,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src -DDATADIR=\"$(srcdir)/\"
 
 .SUFFIXES = .dac .done
 
-check_PROGRAMS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical dump_load flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml pw-source-ll ring-ll cyl-ellipsoid-ll absorber-1d-ll array-slice-ll user-defined-material dft-fields bend-flux-ll array-metadata
+check_PROGRAMS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical dump_load flux harmonics integrate known_results near2far pade-dft one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml pw-source-ll ring-ll cyl-ellipsoid-ll absorber-1d-ll array-slice-ll user-defined-material dft-fields bend-flux-ll array-metadata
 
 array_metadata_SOURCES = array-metadata.cpp
 array_metadata_LDADD   = $(MEEPLIBS)
@@ -53,6 +53,9 @@ known_results_LDADD = $(MEEPLIBS)
 
 near2far_SOURCES = near2far.cpp
 near2far_LDADD = $(MEEPLIBS)
+
+pade_dft_SOURCES = pade-dft.cpp
+pade_dft_LDADD = $(MEEPLIBS)
 
 one_dimensional_SOURCES = one_dimensional.cpp
 one_dimensional_LDADD = $(MEEPLIBS)
@@ -107,7 +110,7 @@ user_defined_material_LDADD   = $(MEEPLIBS)
 
 dist_noinst_DATA = cyl-ellipsoid-eps-ref.h5 array-slice-ll-ref.h5
 
-TESTS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical dump_load flux harmonics integrate known_results near2far one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml
+TESTS = aniso_disp bench bragg_transmission convergence_cyl_waveguide cylindrical dump_load flux harmonics integrate known_results near2far pade-dft one_dimensional physical stress_tensor symmetry three_d two_dimensional 2D_convergence h5test pml
 
 if WITH_MPI
   LOG_COMPILER = $(RUNCODE)

--- a/tests/pade-dft.cpp
+++ b/tests/pade-dft.cpp
@@ -1,0 +1,315 @@
+/* Copyright (C) 2005-2026 Massachusetts Institute of Technology
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <vector>
+
+#include <meep.hpp>
+
+using namespace meep;
+
+double vacuum_eps(const vec &) { return 1.0; }
+
+static void require(bool condition, const char *message) {
+  if (!condition) meep::abort("Padé DFT test failed: %s", message);
+}
+
+static void require_close(std::complex<double> actual, std::complex<double> expected,
+                          double relative_tolerance, const char *message) {
+  const double scale = std::max(1.0, std::abs(expected));
+  if (!(std::abs(actual - expected) <= relative_tolerance * scale))
+    meep::abort("Padé DFT test failed: %s (actual %.16g%+.16gi, expected %.16g%+.16gi)",
+                message, actual.real(), actual.imag(), expected.real(), expected.imag());
+}
+
+static size_t local_chunk_count(dft_chunk *chunks) {
+  size_t count = 0;
+  for (dft_chunk *cur = chunks; cur; cur = cur->next_in_dft)
+    ++count;
+  return count;
+}
+
+static void set_monitor_field(dft_chunk *chunks, double value) {
+  for (dft_chunk *cur = chunks; cur; cur = cur->next_in_dft) {
+    PLOOP_OVER_IVECS(cur->fc->gv, cur->is, cur->ie, idx) {
+      cur->fc->f[cur->c][0][idx] = realnum(value);
+      if (cur->fc->f[cur->c][1]) cur->fc->f[cur->c][1][idx] = 0.0;
+    }
+  }
+}
+
+static void append_sample(dft_chunk *chunks, double value, double time) {
+  set_monitor_field(chunks, value);
+  for (dft_chunk *cur = chunks; cur; cur = cur->next_in_dft)
+    cur->update_dft(time);
+}
+
+static double modal_sample(const std::vector<double> &amplitudes,
+                           const std::vector<double> &ratios, size_t n) {
+  double value = 0.0;
+  for (size_t i = 0; i < amplitudes.size(); ++i)
+    value += amplitudes[i] * std::pow(ratios[i], double(n));
+  return value;
+}
+
+static std::complex<double> modal_sum(const std::vector<double> &amplitudes,
+                                      const std::vector<double> &ratios,
+                                      std::complex<double> z, size_t count) {
+  std::complex<double> sum = 0.0;
+  for (size_t i = 0; i < amplitudes.size(); ++i) {
+    const std::complex<double> rz = ratios[i] * z;
+    sum += amplitudes[i] * (1.0 - std::pow(rz, double(count))) / (1.0 - rz);
+  }
+  return sum;
+}
+
+static std::complex<double> modal_infinite_sum(const std::vector<double> &amplitudes,
+                                               const std::vector<double> &ratios,
+                                               std::complex<double> z) {
+  std::complex<double> sum = 0.0;
+  for (size_t i = 0; i < amplitudes.size(); ++i)
+    sum += amplitudes[i] / (1.0 - ratios[i] * z);
+  return sum;
+}
+
+static void test_analytic_tail(component c, const std::vector<double> &amplitudes,
+                               const std::vector<double> &ratios, size_t history_size,
+                               size_t sample_count, double frequency, double first_time,
+                               int decimation_factor) {
+  grid_volume gv = volone(4.0, 10.0);
+  gv.center_origin();
+  structure s(gv, vacuum_eps);
+  fields f(&s);
+  f.use_real_fields();
+  f.add_point_source(c, gaussian_src_time(0.2, 0.4), vec(0.0), 1.0);
+
+  component components[] = {c};
+  const volume point(vec(0.0), vec(0.0));
+  dft_fields monitor = f.add_dft_fields(components, 1, point, &frequency, 1, false,
+                                        decimation_factor, false, history_size);
+  const double sample_period = decimation_factor * f.dt;
+  for (size_t n = 0; n < sample_count; ++n)
+    append_sample(monitor.chunks, modal_sample(amplitudes, ratios, n),
+                  first_time + n * sample_period);
+
+  require(sum_to_all(local_chunk_count(monitor.chunks)) > 0, "analytic monitor has no chunks");
+  const double tolerance = sizeof(realnum) == sizeof(float) ? 2e-4 : 2e-10;
+  for (dft_chunk *cur = monitor.chunks; cur; cur = cur->next_in_dft) {
+    require(cur->get_pade_count() == history_size, "analytic history did not wrap to capacity");
+    const std::complex<double> z = std::polar(1.0, cur->omega[0] * sample_period);
+    const std::complex<double> phase = std::polar(1.0, cur->omega[0] * first_time);
+    const std::complex<double> raw_expected =
+        cur->scale * phase * modal_sum(amplitudes, ratios, z, sample_count);
+    const std::complex<double> corrected_expected =
+        cur->scale * phase * modal_infinite_sum(amplitudes, ratios, z);
+    const std::complex<double> raw(cur->dft[0]);
+    const std::complex<double> corrected(cur->dft_values()[0]);
+    require_close(raw, raw_expected, tolerance, "ordinary DFT has the wrong sampled value");
+    require_close(corrected, corrected_expected, tolerance,
+                  "Padé correction does not equal the analytic infinite sum");
+    require_close(corrected - raw, corrected_expected - raw_expected, tolerance,
+                  "Padé correction double-counted already accumulated samples");
+    const dft_pade_error error = cur->get_pade_error();
+    require(error.ready, "analytic fit was not ready");
+    require(error.invalid_fits == 0, "analytic damped-mode fit was rejected");
+  }
+}
+
+static void test_rejected_tail(double ratio, const char *message) {
+  const size_t history_size = 8;
+  const double frequency = 0.0;
+  grid_volume gv = volone(4.0, 10.0);
+  gv.center_origin();
+  structure s(gv, vacuum_eps);
+  fields f(&s);
+  f.use_real_fields();
+  f.add_point_source(Ex, gaussian_src_time(0.2, 0.4), vec(0.0), 1.0);
+  component components[] = {Ex};
+  dft_fields monitor = f.add_dft_fields(components, 1, volume(vec(0.0), vec(0.0)), &frequency, 1,
+                                        false, 1, false, history_size);
+  for (size_t n = 0; n < history_size; ++n)
+    append_sample(monitor.chunks, std::pow(ratio, double(n)), 0.75 + n * f.dt);
+
+  for (dft_chunk *cur = monitor.chunks; cur; cur = cur->next_in_dft) {
+    const std::complex<realnum> raw = cur->dft[0];
+    const std::complex<realnum> corrected = cur->dft_values()[0];
+    require(corrected == raw, message);
+    require(cur->get_pade_error().invalid_fits > 0, "rejected Padé fit was not reported");
+  }
+}
+
+static void test_diagnostic_checkpoint_isolation() {
+  const size_t history_size = 8;
+  const double frequency = 0.11;
+  grid_volume gv = volone(4.0, 10.0);
+  gv.center_origin();
+  structure s(gv, vacuum_eps);
+  fields f(&s);
+  f.use_real_fields();
+  f.add_point_source(Ex, gaussian_src_time(0.2, 0.4), vec(0.0), 1.0);
+  component components[] = {Ex};
+  dft_fields monitor = f.add_dft_fields(components, 1, volume(vec(0.0), vec(0.0)), &frequency, 1,
+                                        false, 1, false, history_size);
+  for (size_t n = 0; n < history_size; ++n)
+    append_sample(monitor.chunks, std::pow(0.8, double(n)) + 0.02 * std::pow(0.3, double(n)),
+                  0.5 + n * f.dt);
+
+  for (dft_chunk *cur = monitor.chunks; cur; cur = cur->next_in_dft) {
+    const std::complex<double> checkpoint(cur->dft_values()[0]);
+    const dft_pade_error first = cur->get_pade_error();
+    require(std::isinf(first.drift[0]), "first diagnostic unexpectedly had a drift baseline");
+
+    append_sample(cur, 2.0 * std::pow(0.8, double(history_size)),
+                  0.5 + history_size * f.dt);
+    const std::complex<double> intervening(cur->dft_values()[0]);
+    append_sample(cur, 0.25 * std::pow(0.8, double(history_size + 1)),
+                  0.5 + (history_size + 1) * f.dt);
+    const std::complex<double> current(cur->dft_values()[0]);
+    const double expected = std::abs(current - checkpoint) /
+                            std::max(std::abs(current), std::abs(checkpoint));
+    const double adjacent = std::abs(current - intervening) /
+                            std::max(std::abs(current), std::abs(intervening));
+    const dft_pade_error second = cur->get_pade_error();
+    require(std::abs(second.drift[0] - expected) <= 1e-10 * std::max(1.0, expected),
+            "ordinary corrected-value reads advanced the diagnostic baseline");
+    require(std::abs(expected - adjacent) > 1e-8,
+            "diagnostic isolation fixture did not distinguish adjacent generations");
+    require(cur->get_pade_error().drift[0] == second.drift[0],
+            "repeated diagnostics changed the same-generation baseline");
+    break;
+  }
+}
+
+static void test_lifecycle_and_bounded_storage() {
+  const size_t history_size = 8;
+  const double frequency = 0.2;
+  grid_volume gv = volone(4.0, 10.0);
+  gv.center_origin();
+  structure s(gv, vacuum_eps);
+  fields f(&s);
+  f.use_real_fields();
+  f.add_point_source(Ex, gaussian_src_time(frequency, 0.4), vec(0.0), 1.0);
+
+  component components[] = {Ex};
+  dft_fields enabled_a = f.add_dft_fields(components, 1, f.v, &frequency, 1, true, 1, false,
+                                          history_size);
+  dft_fields enabled_b = f.add_dft_fields(components, 1, f.v, &frequency, 1, true, 1, false,
+                                          history_size);
+  dft_fields disabled = f.add_dft_fields(components, 1, f.v, &frequency, 1, true, 1, false, 0);
+
+  for (size_t step = 0; step < 3 * history_size; ++step)
+    f.step();
+
+  require(sum_to_all(local_chunk_count(enabled_a.chunks)) > 0, "monitor has no chunks");
+  for (dft_chunk *cur = enabled_a.chunks; cur; cur = cur->next_in_dft) {
+    require(cur->pade_enabled(), "enabled monitor did not allocate Padé state");
+    require(cur->get_pade_samples() == history_size, "history capacity changed");
+    require(cur->get_pade_count() == history_size, "history did not remain bounded");
+    const std::complex<realnum> *values = cur->dft_values();
+    require(values == cur->dft_values(), "corrected-value cache was not reused");
+  }
+  for (dft_chunk *cur = disabled.chunks; cur; cur = cur->next_in_dft) {
+    require(!cur->pade_enabled(), "zero history unexpectedly enabled Padé");
+    require(cur->dft_values() == cur->dft, "disabled accessor did not return raw storage");
+  }
+
+  std::vector<std::vector<std::complex<realnum> > > raw_before_scale;
+  for (dft_chunk *cur = enabled_a.chunks; cur; cur = cur->next_in_dft)
+    raw_before_scale.emplace_back(cur->dft, cur->dft + cur->N * cur->omega.size());
+  enabled_a.scale_dfts(2.0);
+  size_t chunk_index = 0;
+  for (dft_chunk *cur = enabled_a.chunks; cur; cur = cur->next_in_dft, ++chunk_index) {
+    require(cur->get_pade_count() == 0, "scaling did not clear history");
+    for (size_t i = 0; i < cur->N * cur->omega.size(); ++i)
+      require(cur->dft[i] == realnum(2.0) * raw_before_scale[chunk_index][i],
+              "scaling materialized a corrected prediction");
+  }
+
+  dft_fields enabled_c = f.add_dft_fields(components, 1, f.v, &frequency, 1, true, 1, false,
+                                          history_size);
+  dft_fields enabled_d = f.add_dft_fields(components, 1, f.v, &frequency, 1, true, 1, false,
+                                          history_size);
+  for (size_t step = 0; step < history_size; ++step)
+    f.step();
+  if (enabled_c.chunks && enabled_d.chunks) {
+    *enabled_c.chunks -= *enabled_d.chunks;
+    for (dft_chunk *cur = enabled_c.chunks; cur; cur = cur->next_in_dft) {
+      require(cur->get_pade_count() == 0, "subtraction did not clear history");
+      for (size_t i = 0; i < cur->N * cur->omega.size(); ++i)
+        require(cur->dft[i] == std::complex<realnum>(0.0, 0.0),
+                "identical corrected snapshots did not subtract to zero");
+    }
+  }
+
+  f.t = 0;
+  f.zero_fields();
+  f.step();
+  for (dft_chunk *cur = enabled_b.chunks; cur; cur = cur->next_in_dft)
+    require(cur->get_pade_count() == 1, "time discontinuity did not start a fresh history");
+}
+
+static void test_exported_overloads_link() {
+  typedef dft_chunk *(fields::*old_add_dft)(component, const volume &, const double *, size_t, bool,
+                                            std::complex<double>, dft_chunk *, bool,
+                                            std::complex<double>, bool, int, int, bool);
+  typedef dft_chunk *(fields::*new_add_dft)(component, const volume &, const double *, size_t, bool,
+                                            std::complex<double>, dft_chunk *, bool,
+                                            std::complex<double>, bool, int, int, bool, size_t);
+  typedef dft_flux (fields::*old_flux)(const volume_list *, const double *, size_t, bool, bool, int);
+  typedef dft_flux (fields::*new_flux)(const volume_list *, const double *, size_t, bool, bool, int,
+                                       size_t);
+  typedef dft_flux (fields::*old_mode)(direction, const volume &, const double *, size_t, bool, int);
+  typedef dft_flux (fields::*new_mode)(direction, const volume &, const double *, size_t, bool, int,
+                                       size_t);
+  typedef dft_fields (fields::*old_fields)(component *, int, const volume, const double *, size_t,
+                                           bool, int, bool);
+  typedef dft_fields (fields::*new_fields)(component *, int, const volume, const double *, size_t,
+                                           bool, int, bool, size_t);
+  typedef dft_energy (fields::*old_energy)(const volume_list *, const double *, size_t, int);
+  typedef dft_energy (fields::*new_energy)(const volume_list *, const double *, size_t, int, size_t);
+  typedef dft_force (fields::*old_force)(const volume_list *, const double *, size_t, int);
+  typedef dft_force (fields::*new_force)(const volume_list *, const double *, size_t, int, size_t);
+  typedef dft_near2far (fields::*old_n2f)(const volume_list *, const double *, size_t, int, int);
+  typedef dft_near2far (fields::*new_n2f)(const volume_list *, const double *, size_t, int, int,
+                                          size_t);
+
+  old_add_dft a0 = static_cast<old_add_dft>(&fields::add_dft);
+  new_add_dft a1 = static_cast<new_add_dft>(&fields::add_dft);
+  old_flux f0 = static_cast<old_flux>(&fields::add_dft_flux);
+  new_flux f1 = static_cast<new_flux>(&fields::add_dft_flux);
+  old_mode m0 = static_cast<old_mode>(&fields::add_mode_monitor);
+  new_mode m1 = static_cast<new_mode>(&fields::add_mode_monitor);
+  old_fields d0 = static_cast<old_fields>(&fields::add_dft_fields);
+  new_fields d1 = static_cast<new_fields>(&fields::add_dft_fields);
+  old_energy e0 = static_cast<old_energy>(&fields::add_dft_energy);
+  new_energy e1 = static_cast<new_energy>(&fields::add_dft_energy);
+  old_force s0 = static_cast<old_force>(&fields::add_dft_force);
+  new_force s1 = static_cast<new_force>(&fields::add_dft_force);
+  old_n2f n0 = static_cast<old_n2f>(&fields::add_dft_near2far);
+  new_n2f n1 = static_cast<new_n2f>(&fields::add_dft_near2far);
+  require(a0 && a1 && f0 && f1 && m0 && m1 && d0 && d1 && e0 && e1 && s0 && s1 && n0 && n1,
+          "old/new exported overloads were not linkable");
+}
+
+int main(int argc, char **argv) {
+  initialize mpi(argc, argv);
+  verbosity = 0;
+
+  test_exported_overloads_link();
+  test_analytic_tail(Ex, {1.0}, {0.72}, 8, 13, 0.17, 1.25, 3);
+  test_analytic_tail(Ex, {1.2, -0.35}, {0.61, -0.28}, 10, 15, 0.09, 0.8, 2);
+  // Magnetic monitors are sampled half a Yee timestep before electric ones.
+  test_analytic_tail(Hy, {0.9}, {0.68}, 8, 12, 0.13, 1.5 - 0.5 / 20.0, 1);
+  test_rejected_tail(1.0 - 1.0e-10, "near-pole fit did not fail closed to the raw DFT");
+  test_rejected_tail(1.0 - 1.0e-7, "unstable amplified tail did not fail closed to the raw DFT");
+  test_diagnostic_checkpoint_isolation();
+  test_lifecycle_and_bounded_storage();
+  return 0;
+}


### PR DESCRIPTION
Stacked on the dispersive-smoothing PR. Addresses #3217.

Accumulates the DFT as usual and extrapolates its tail from the last n samples, which both shortens the run and gives a convergence error estimate that `stop_when_dft_pade_converged` can act on. On a real grating this is ~14% fewer timesteps at matched accuracy.

The estimate is aggregated across monitors and ranks weighted by field magnitude rather than by a max over independently normalised ratios. A component that is near zero for a symmetry reason -- Ey under a y mirror, say -- otherwise has a meaningless ratio that vetoes convergence for everything else; the aggregate went from 3.4e-1 to 1.7e-2 on the case that motivated this.

Also lets a rank place no adjoint source at all. The old assertion was a local check on a globally true condition, so a point monitor landing outside a given rank's chunk deadlocked under MPI.
