### PR TITLE
[4/13][Adjoint Module] Enable proper JAX support in adjoint solver

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,15 @@
   computing a gradient raised `AxisError: axis 1 is out of bounds for array of
   dimension 1`.
 
+* Adjoint solver: `meep.adjoint.value_and_jacobian` transforms a loss function
+  that returns one value per frequency into one that also returns a gradient for
+  each of them, for worst-case (minimax) optimization over a bandwidth. It is the
+  counterpart of `jax.value_and_grad`, accepts arbitrary pytrees, differentiates
+  parameters that never reach Meep alongside the design weights, and costs a
+  single forward and adjoint simulation regardless of the number of frequencies.
+  `jax.jacrev` cannot do this cheaply, since it evaluates the reverse pass -- and
+  so a full timestepping run -- once per output.
+
 ## Meep 1.34.0
 
 7/9/2026

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,38 @@
 # Meep Release Notes
 
+## Meep 1.35.0 (in progress)
+
+* Adjoint solver: objective functions are now differentiated with a single
+  vector-Jacobian product instead of a full frequency Jacobian per objective
+  argument. For an objective of $M$ arguments at $F$ frequencies this reduces
+  the reverse passes from $M \times F$ to one and the peak memory for the
+  objective gradient from $O(F^2 N)$ to $O(F N)$, where $N$ is the number of
+  values a monitor contributes. Gradients are unchanged apart from summation
+  order.
+
+* Adjoint solver: objective functions may be written with `jax.numpy` instead of
+  `autograd.numpy` and passed to `OptimizationProblem` directly, with no wrapper
+  or annotation; they are recognized by the array type they return and
+  differentiated with `jax.vjp`. An objective function may also supply its own
+  pullback via a `vjp(cotangent, *args)` attribute, for an analytic derivative or
+  another framework. JAX remains an optional dependency.
+
+* Adjoint solver: `MeepJaxWrapper` now accepts any objective quantity, not only
+  `EigenmodeCoefficient`. When the monitors have heterogeneous shapes it returns
+  a tuple of per-monitor arrays; when every monitor yields one value per
+  frequency it returns the same rank-2 `(monitor, frequency)` array as before.
+
+* Adjoint solver: `ObjectiveQuantity.place_adjoint_source` now takes a cotangent
+  with the shape of the quantity's own value. The previous
+  `(nfreq,) + value_shape` Jacobian is still accepted with a
+  `DeprecationWarning` and will be rejected in a future release. This only
+  affects code that calls `place_adjoint_source` directly or subclasses
+  `ObjectiveQuantity`.
+
+* Adjoint solver: an objective function that returns a vector whose length is
+  neither 1 nor the number of frequencies now raises `ValueError` instead of
+  silently producing a misshapen gradient.
+
 ## Meep 1.34.0
 
 7/9/2026

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,10 @@
   neither 1 nor the number of frequencies now raises `ValueError` instead of
   silently producing a misshapen gradient.
 
+* Adjoint solver: bugfix for `MeepJaxWrapper` at a single frequency, where
+  computing a gradient raised `AxisError: axis 1 is out of bounds for array of
+  dimension 1`.
+
 ## Meep 1.34.0
 
 7/9/2026

--- a/doc/docs/Python_Tutorials/Adjoint_Solver.md
+++ b/doc/docs/Python_Tutorials/Adjoint_Solver.md
@@ -143,8 +143,48 @@ grads[2]    (nfreq,)
 
 Note that `thickness` and `tilt` are differentiated even though Meep has never
 seen them: everything downstream of the `wrapped_meep(...)` call is ordinary JAX.
-The parameters may be arbitrary pytrees, in which case the Jacobian is the same
-tree with a frequency axis added to each leaf.
+
+### Grouping the parameters into a pytree
+
+Realistic problems have more than three parameters, and passing them positionally
+gets unwieldy. The parameters may be any pytree — a `NamedTuple`, a dataclass, a
+dict, or a nesting of them — and the Jacobian comes back as the *same tree* with a
+frequency axis added to each leaf:
+
+```py
+class Stack(NamedTuple):
+    thickness: jnp.ndarray     # (3,) oxide, antireflection coating, air
+    index: jnp.ndarray         # (3,)
+
+class Params(NamedTuple):
+    latent: jnp.ndarray        # (601,) design variables
+    stack: Stack
+    tilt: float                # fiber tilt, in degrees
+    offset: float              # lateral fiber position
+
+def loss(p):
+    rho = mpa.tanh_projection(mpa.conic_filter(p.latent, R, L, dy, RES), beta, 0.5)
+    (ez, hx) = wrapped_meep([rho])
+    field = propagate(ez, hx, p.stack)     # a stratified-media propagator, say
+    return fiber_overlap(field, p.tilt, p.offset)      # (nfreq,)
+
+values, jacobian = mpa.value_and_jacobian(loss)(params)
+jax.tree_util.tree_map(lambda leaf: leaf.shape, jacobian)
+```
+
+```
+Params(latent=(5, 601),
+       stack=Stack(thickness=(5, 3), index=(5, 3)),
+       tilt=(5,),
+       offset=(5,))
+```
+
+A parameter may appear on both sides of the simulation — `p.latent` above feeds
+the design region, and could equally appear in a regularizer after the Meep call.
+The two contributions are summed.
+
+The same applies to the scalar case: `jax.value_and_grad(loss)(params)` returns a
+gradient with the structure of `params`, with no frequency axis.
 
 The whole Jacobian costs **one forward simulation and one adjoint simulation**,
 independent of the number of frequencies. `jax.jacrev` cannot achieve this: it

--- a/doc/docs/Python_Tutorials/Adjoint_Solver.md
+++ b/doc/docs/Python_Tutorials/Adjoint_Solver.md
@@ -41,6 +41,92 @@ demonstrated in several tutorials below.
 
 [TOC]
 
+Writing Objective Functions
+---------------------------
+
+An objective function passed to `OptimizationProblem` receives the values of the
+`objective_arguments`, in the order they were given, and returns either a scalar
+or one value per frequency. Each objective function costs one adjoint
+timestepping run, and a single run yields the gradient at every frequency, which
+is what makes worst-case (minimax) formulations over a bandwidth affordable.
+
+That per-frequency gradient is only meaningful when entry $f$ of a
+frequency-vector-valued objective depends on the monitor values at frequency $f$
+alone. A single adjoint field cannot carry independent sensitivities for
+different frequencies, so an objective that mixes them — say, one that divides
+the transmission at one wavelength by the transmission at another — needs to be
+split into separate entries of `objective_functions`, one adjoint run each.
+
+Objective functions are differentiated with
+[autograd](https://github.com/HIPS/autograd) by default, so they must be written
+with `autograd.numpy` rather than plain `numpy`:
+
+```py
+from autograd import numpy as npa
+
+def objective(mode_coeff, dft_fields):
+    return npa.abs(mode_coeff)**2 + npa.sum(npa.abs(dft_fields)**2, axis=1)
+```
+
+### Objective functions written in JAX
+
+If [JAX](https://github.com/google/jax) is installed, an objective function may
+be written with `jax.numpy` instead. Nothing else changes — there is no wrapper
+or annotation, and the two kinds of objective function can be mixed in the same
+`objective_functions` list. Meep recognizes a JAX objective because it returns a
+JAX array, and differentiates it with `jax.vjp`:
+
+```py
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)   # match Meep's double precision
+
+def objective(mode_coeff, dft_fields):
+    return jnp.abs(mode_coeff)**2 + jnp.sum(jnp.abs(dft_fields)**2, axis=1)
+
+opt = mpa.OptimizationProblem(
+    simulation=sim,
+    objective_functions=[objective],
+    objective_arguments=[mode_monitor, dft_monitor],
+    design_regions=[design_region],
+    frequencies=frequencies,
+)
+```
+
+This is useful when the objective involves post-processing that is easier to
+express — or faster to evaluate — in JAX. Note that JAX defaults to 32-bit
+dtypes, so `jax_enable_x64` should be enabled to match a double-precision Meep
+build; Meep warns if it is not.
+
+### Supplying a pullback directly
+
+For an analytic derivative, or for a framework Meep does not recognize, an
+objective function may carry its own pullback as a `vjp(cotangent, *args)`
+attribute returning one cotangent per argument. It takes precedence over
+everything above:
+
+```py
+def objective(mode_coeff):
+    return npa.abs(mode_coeff)**2
+
+objective.vjp = lambda cotangent, mode_coeff: (2 * cotangent * npa.conj(mode_coeff),)
+```
+
+### Relationship to `MeepJaxWrapper`
+
+The above is distinct from `MeepJaxWrapper`, which turns the entire simulation
+into a JAX-differentiable callable so that the design variables, the objective,
+and anything else in the loss are all traced by JAX. Write a JAX objective
+function when Meep owns the optimization loop and you want a gradient at each
+frequency; use `MeepJaxWrapper` when JAX owns the loop, which also lets you
+differentiate with respect to parameters Meep knows nothing about. Its docstring
+in `meep/adjoint/wrapper.py` has a worked example.
+
+JAX is an optional dependency. If it is not installed, JAX objective functions
+are simply not recognized and `mpa.MeepJaxWrapper` is absent; everything else
+works unchanged.
+
 Broadband Waveguide Mode Converter with Minimum Feature Size
 ------------------------------------------------------------
 

--- a/doc/docs/Python_Tutorials/Adjoint_Solver.md
+++ b/doc/docs/Python_Tutorials/Adjoint_Solver.md
@@ -46,35 +46,54 @@ Writing Objective Functions
 
 An objective function passed to `OptimizationProblem` receives the values of the
 `objective_arguments`, in the order they were given, and returns either a scalar
-or one value per frequency. Each objective function costs one adjoint
-timestepping run, and a single run yields the gradient at every frequency, which
-is what makes worst-case (minimax) formulations over a bandwidth affordable.
-
-That per-frequency gradient is only meaningful when entry $f$ of a
-frequency-vector-valued objective depends on the monitor values at frequency $f$
-alone. A single adjoint field cannot carry independent sensitivities for
-different frequencies, so an objective that mixes them — say, one that divides
-the transmission at one wavelength by the transmission at another — needs to be
-split into separate entries of `objective_functions`, one adjoint run each.
-
-Objective functions are differentiated with
-[autograd](https://github.com/HIPS/autograd) by default, so they must be written
-with `autograd.numpy` rather than plain `numpy`:
+or one value per frequency. They are differentiated with
+[autograd](https://github.com/HIPS/autograd), so they must be written with
+`autograd.numpy` rather than plain `numpy`:
 
 ```py
 from autograd import numpy as npa
 
 def objective(mode_coeff, dft_fields):
     return npa.abs(mode_coeff)**2 + npa.sum(npa.abs(dft_fields)**2, axis=1)
+
+opt = mpa.OptimizationProblem(
+    simulation=sim,
+    objective_functions=[objective],
+    objective_arguments=[mode_monitor, dft_monitor],
+    design_regions=[design_region],
+    frequencies=frequencies,
+)
+
+value, gradient = opt([rho])
 ```
 
-### Objective functions written in JAX
+Each objective function costs one adjoint timestepping run, so a list of them
+costs one run each.
+
+### A gradient at each frequency
+
+A single adjoint run yields the gradient at *every* frequency, not just the
+gradient of some scalar reduction over them. That is what makes worst-case
+(minimax) formulations over a bandwidth affordable: `gradient` above is an array
+of design weights by frequencies, one column per frequency, and an optimizer such
+as nlopt can treat those columns as separate constraints. See
+[examples/adjoint_optimization/mode_converter.py](https://github.com/NanoComp/meep/blob/master/python/examples/adjoint_optimization/mode_converter.py)
+for a worked epigraph formulation.
+
+Those per-frequency gradients are only meaningful when entry $f$ of a
+frequency-vector-valued objective depends on the monitor values at frequency $f$
+alone. A single adjoint field cannot carry independent sensitivities for
+different frequencies, so an objective that mixes them — say, one that divides
+the transmission at one wavelength by the transmission at another — has to be
+split into separate entries of `objective_functions`, one adjoint run each.
+
+### Meep does not care which framework you use
 
 If [JAX](https://github.com/google/jax) is installed, an objective function may
 be written with `jax.numpy` instead. Nothing else changes — there is no wrapper
-or annotation, and the two kinds of objective function can be mixed in the same
-`objective_functions` list. Meep recognizes a JAX objective because it returns a
-JAX array, and differentiates it with `jax.vjp`:
+or annotation, and the two kinds may be mixed in the same `objective_functions`
+list. Meep recognizes a JAX objective because it returns a JAX array, and
+differentiates it with `jax.vjp`:
 
 ```py
 import jax
@@ -84,14 +103,6 @@ jax.config.update("jax_enable_x64", True)   # match Meep's double precision
 
 def objective(mode_coeff, dft_fields):
     return jnp.abs(mode_coeff)**2 + jnp.sum(jnp.abs(dft_fields)**2, axis=1)
-
-opt = mpa.OptimizationProblem(
-    simulation=sim,
-    objective_functions=[objective],
-    objective_arguments=[mode_monitor, dft_monitor],
-    design_regions=[design_region],
-    frequencies=frequencies,
-)
 ```
 
 This is useful when the objective involves post-processing that is easier to
@@ -99,12 +110,9 @@ express — or faster to evaluate — in JAX. Note that JAX defaults to 32-bit
 dtypes, so `jax_enable_x64` should be enabled to match a double-precision Meep
 build; Meep warns if it is not.
 
-### Supplying a pullback directly
-
-For an analytic derivative, or for a framework Meep does not recognize, an
-objective function may carry its own pullback as a `vjp(cotangent, *args)`
-attribute returning one cotangent per argument. It takes precedence over
-everything above:
+For an analytic derivative, or a framework Meep does not recognize, an objective
+function may carry its own pullback as a `vjp(cotangent, *args)` attribute
+returning one cotangent per argument. It takes precedence over both of the above:
 
 ```py
 def objective(mode_coeff):
@@ -113,25 +121,63 @@ def objective(mode_coeff):
 objective.vjp = lambda cotangent, mode_coeff: (2 * cotangent * npa.conj(mode_coeff),)
 ```
 
-### A gradient for each frequency, with JAX
+Letting JAX Own the Optimization
+--------------------------------
 
-Worst-case (minimax) optimization over a bandwidth needs a separate gradient for
-each frequency rather than the gradient of a scalar reduction over them.
-`OptimizationProblem` returns exactly that — its `gradient` has a frequency axis
-— and `meep.adjoint.value_and_jacobian` is the equivalent for the JAX path. It is
-a function transform, the counterpart of `jax.value_and_grad`, so the loss
-function is written exactly as it would be for a scalar objective:
+Everything above has Meep driving the optimization: it calls the objective
+function and hands back a gradient. `MeepJaxWrapper` inverts that. It turns a
+whole simulation into a JAX-differentiable callable, mapping design weights to
+monitor values, so that the design variables, the objective, and anything else in
+the loss are traced by JAX end to end:
+
+```py
+wrapped_meep = mpa.MeepJaxWrapper(
+    simulation, sources, monitors, design_regions, frequencies
+)
+
+def loss(rho):
+    s1p, _, s2p, _ = wrapped_meep([rho])       # -> monitor values
+    return jnp.mean(jnp.abs(s2p / s1p)**2)     # scalar
+
+value, gradient = jax.value_and_grad(loss)(rho)
+```
+
+The forward and adjoint simulations happen inside a `jax.custom_vjp`, so the
+gradient is the true adjoint gradient, not a numerical differentiation of the
+solver.
+
+The reason to reach for this is that **anything else in the loss is
+differentiated too**, for free, because it is just JAX. A filter and projection
+applied to the design weights, a propagator applied to the output fields, the
+angle of a fiber the field is coupled into — none of it is known to Meep, and all
+of it gets a gradient:
 
 ```py
 def loss(rho, thickness, tilt):
-    (dft,) = wrapped_meep([rho])              # a MeepJaxWrapper call
-    return postprocess(dft, thickness, tilt)  # one value per frequency
+    (dft,) = wrapped_meep([rho])
+    return postprocess(dft, thickness, tilt)   # scalar
+
+value, (d_rho, d_thickness, d_tilt) = jax.value_and_grad(
+    loss, argnums=(0, 1, 2))(rho, 1.8, 8.0)
+```
+
+### A gradient at each frequency, with `MeepJaxWrapper`
+
+`jax.value_and_grad` requires a scalar loss, which rules out the minimax
+formulations described above. `meep.adjoint.value_and_jacobian` is its
+counterpart for a loss returning one value per frequency. The loss is written
+exactly as it would be for the scalar case:
+
+```py
+def loss(rho, thickness, tilt):
+    (dft,) = wrapped_meep([rho])
+    return postprocess(dft, thickness, tilt)   # (nfreq,)
 
 values, grads = mpa.value_and_jacobian(loss, argnums=(0, 1, 2))(rho, 1.8, 8.0)
 ```
 
-Every leaf of `grads` is the corresponding parameter's shape with a leading
-frequency axis, so `grads[1][f]` is the gradient of `values[f]` with respect to
+Each gradient is the corresponding parameter's shape with a leading frequency
+axis, so `grads[1][f]` is the gradient of `values[f]` with respect to
 `thickness`:
 
 ```
@@ -141,15 +187,26 @@ grads[1]    (nfreq,)
 grads[2]    (nfreq,)
 ```
 
-Note that `thickness` and `tilt` are differentiated even though Meep has never
-seen them: everything downstream of the `wrapped_meep(...)` call is ordinary JAX.
+The whole Jacobian costs **one forward simulation and one adjoint simulation**,
+independent of the number of frequencies. `jax.jacrev` cannot achieve this: it
+evaluates the reverse pass once per output component, and here each evaluation
+would be a full timestepping run. That is why this is a transform rather than
+something a JAX transformation does for you.
 
-### Grouping the parameters into a pytree
+The loss must call a `MeepJaxWrapper` exactly once. That call is where the
+transform splits it into the part producing the design weights and the part
+post-processing the monitor values. The block-diagonality requirement from above
+applies to the second part only: entry $f$ may read the *monitor values* at
+frequency $f$ alone, while dependence on parameters that bypass the simulation is
+unrestricted, since those are differentiated directly.
 
-Realistic problems have more than three parameters, and passing them positionally
-gets unwieldy. The parameters may be any pytree — a `NamedTuple`, a dataclass, a
-dict, or a nesting of them — and the Jacobian comes back as the *same tree* with a
-frequency axis added to each leaf:
+### Parameterizing with a pytree
+
+Realistic problems have more parameters than fit comfortably in a positional
+signature, and they fall into three groups: preprocessing that turns latent
+variables into design weights, the design degrees of freedom themselves, and
+post-processing applied to the fields. A pytree holds all three, and the Jacobian
+comes back as the *same tree* with a frequency axis added to each leaf:
 
 ```py
 class Stack(NamedTuple):
@@ -157,16 +214,22 @@ class Stack(NamedTuple):
     index: jnp.ndarray         # (3,)
 
 class Params(NamedTuple):
-    latent: jnp.ndarray        # (601,) design variables
-    stack: Stack
-    tilt: float                # fiber tilt, in degrees
-    offset: float              # lateral fiber position
+    latent: jnp.ndarray        # (601,) design degrees of freedom
+    beta: float                # preprocessing: projection strength
+    stack: Stack               # post-processing: the layers above the chip
+    tilt: float                # post-processing: fiber tilt, in degrees
+
+def project(x, beta, eta=0.5):
+    """The usual tanh projection, written in jax.numpy -- see the note below."""
+    return (jnp.tanh(beta * eta) + jnp.tanh(beta * (x - eta))) / (
+        jnp.tanh(beta * eta) + jnp.tanh(beta * (1 - eta))
+    )
 
 def loss(p):
-    rho = mpa.tanh_projection(mpa.conic_filter(p.latent, R, L, dy, RES), beta, 0.5)
+    rho = project(conic_filter(p.latent), p.beta)   # preprocessing, in jax.numpy
     (ez, hx) = wrapped_meep([rho])
-    field = propagate(ez, hx, p.stack)     # a stratified-media propagator, say
-    return fiber_overlap(field, p.tilt, p.offset)      # (nfreq,)
+    field = propagate(ez, hx, p.stack)          # a stratified-media propagator, say
+    return fiber_overlap(field, p.tilt)         # (nfreq,)
 
 values, jacobian = mpa.value_and_jacobian(loss)(params)
 jax.tree_util.tree_map(lambda leaf: leaf.shape, jacobian)
@@ -174,57 +237,41 @@ jax.tree_util.tree_map(lambda leaf: leaf.shape, jacobian)
 
 ```
 Params(latent=(5, 601),
+       beta=(5,),
        stack=Stack(thickness=(5, 3), index=(5, 3)),
-       tilt=(5,),
-       offset=(5,))
+       tilt=(5,))
 ```
 
-A parameter may appear on both sides of the simulation — `p.latent` above feeds
-the design region, and could equally appear in a regularizer after the Meep call.
-The two contributions are summed.
+Note that the mapping has to be written in the same framework as the rest of the
+loss. `mpa.conic_filter`, `mpa.tanh_projection`, and the other helpers in
+`meep.adjoint.filters` are written with `autograd.numpy`, so calling them inside
+a JAX loss raises `TracerArrayConversionError` — autograd's numpy cannot consume
+a JAX tracer. Write the filter and projection with `jax.numpy`, as above. This
+applies only to `MeepJaxWrapper` losses; the filters work normally in an
+`OptimizationProblem` objective, which is what the tutorials below use.
 
-The same applies to the scalar case: `jax.value_and_grad(loss)(params)` returns a
-gradient with the structure of `params`, with no frequency axis.
+`p.latent` and `p.beta` reach the simulation and are differentiated through the
+adjoint; `p.stack` and `p.tilt` never reach it and are differentiated directly.
+Nothing in the call distinguishes them. A parameter may also appear on both sides
+— `p.latent` could equally show up in a regularizer after the Meep call — in
+which case the two contributions are summed.
 
-The whole Jacobian costs **one forward simulation and one adjoint simulation**,
-independent of the number of frequencies. `jax.jacrev` cannot achieve this: it
-evaluates the reverse pass once per output component, and here each evaluation
-would be a full timestepping run. That is why this is a transform rather than
-something a JAX transformation does for you.
+The same holds in the scalar case: `jax.value_and_grad(loss)(params)` returns a
+gradient with the structure of `params`, without the frequency axis.
 
-To feed the result to an optimizer that wants a flat `(nfreq, num_parameters)`
+To feed the result to an optimizer wanting a flat `(nfreq, num_parameters)`
 matrix — nlopt's `add_inequality_mconstraint`, for instance — flatten it with
 `jax.flatten_util.ravel_pytree`, which orders the columns consistently with the
 flattened parameters:
 
 ```py
 flat_params, unravel = jax.flatten_util.ravel_pytree(params)
-jacobian = jax.vmap(lambda row: jax.flatten_util.ravel_pytree(row)[0])(grads)
+jacobian = jax.vmap(lambda row: jax.flatten_util.ravel_pytree(row)[0])(jacobian)
 ```
 
-As with `OptimizationProblem`, the dependence of the loss on the *monitor values*
-must be block diagonal in frequency — entry $f$ may only read the monitor values
-at frequency $f$ — because a single adjoint field cannot carry independent
-sensitivities for different frequencies. Dependence on parameters that bypass the
-simulation is unrestricted, since those are differentiated directly.
-
-The loss function must call a `MeepJaxWrapper` exactly once; that call is where
-the transform splits it into the part that produces the design weights and the
-part that post-processes the monitor values.
-
-### Relationship to `MeepJaxWrapper`
-
-The above is distinct from `MeepJaxWrapper`, which turns the entire simulation
-into a JAX-differentiable callable so that the design variables, the objective,
-and anything else in the loss are all traced by JAX. Write a JAX objective
-function when Meep owns the optimization loop and you want a gradient at each
-frequency; use `MeepJaxWrapper` when JAX owns the loop, which also lets you
-differentiate with respect to parameters Meep knows nothing about. Its docstring
-in `meep/adjoint/wrapper.py` has a worked example.
-
-JAX is an optional dependency. If it is not installed, JAX objective functions
-are simply not recognized and `mpa.MeepJaxWrapper` is absent; everything else
-works unchanged.
+JAX is an optional dependency throughout. If it is not installed, JAX objective
+functions are simply not recognized and `mpa.MeepJaxWrapper` and
+`mpa.value_and_jacobian` are absent; everything else works unchanged.
 
 Broadband Waveguide Mode Converter with Minimum Feature Size
 ------------------------------------------------------------

--- a/doc/docs/Python_Tutorials/Adjoint_Solver.md
+++ b/doc/docs/Python_Tutorials/Adjoint_Solver.md
@@ -113,6 +113,65 @@ def objective(mode_coeff):
 objective.vjp = lambda cotangent, mode_coeff: (2 * cotangent * npa.conj(mode_coeff),)
 ```
 
+### A gradient for each frequency, with JAX
+
+Worst-case (minimax) optimization over a bandwidth needs a separate gradient for
+each frequency rather than the gradient of a scalar reduction over them.
+`OptimizationProblem` returns exactly that — its `gradient` has a frequency axis
+— and `meep.adjoint.value_and_jacobian` is the equivalent for the JAX path. It is
+a function transform, the counterpart of `jax.value_and_grad`, so the loss
+function is written exactly as it would be for a scalar objective:
+
+```py
+def loss(rho, thickness, tilt):
+    (dft,) = wrapped_meep([rho])              # a MeepJaxWrapper call
+    return postprocess(dft, thickness, tilt)  # one value per frequency
+
+values, grads = mpa.value_and_jacobian(loss, argnums=(0, 1, 2))(rho, 1.8, 8.0)
+```
+
+Every leaf of `grads` is the corresponding parameter's shape with a leading
+frequency axis, so `grads[1][f]` is the gradient of `values[f]` with respect to
+`thickness`:
+
+```
+values      (nfreq,)
+grads[0]    (nfreq,) + rho.shape
+grads[1]    (nfreq,)
+grads[2]    (nfreq,)
+```
+
+Note that `thickness` and `tilt` are differentiated even though Meep has never
+seen them: everything downstream of the `wrapped_meep(...)` call is ordinary JAX.
+The parameters may be arbitrary pytrees, in which case the Jacobian is the same
+tree with a frequency axis added to each leaf.
+
+The whole Jacobian costs **one forward simulation and one adjoint simulation**,
+independent of the number of frequencies. `jax.jacrev` cannot achieve this: it
+evaluates the reverse pass once per output component, and here each evaluation
+would be a full timestepping run. That is why this is a transform rather than
+something a JAX transformation does for you.
+
+To feed the result to an optimizer that wants a flat `(nfreq, num_parameters)`
+matrix — nlopt's `add_inequality_mconstraint`, for instance — flatten it with
+`jax.flatten_util.ravel_pytree`, which orders the columns consistently with the
+flattened parameters:
+
+```py
+flat_params, unravel = jax.flatten_util.ravel_pytree(params)
+jacobian = jax.vmap(lambda row: jax.flatten_util.ravel_pytree(row)[0])(grads)
+```
+
+As with `OptimizationProblem`, the dependence of the loss on the *monitor values*
+must be block diagonal in frequency — entry $f$ may only read the monitor values
+at frequency $f$ — because a single adjoint field cannot carry independent
+sensitivities for different frequencies. Dependence on parameters that bypass the
+simulation is unrestricted, since those are differentiated directly.
+
+The loss function must call a `MeepJaxWrapper` exactly once; that call is where
+the transform splits it into the part that produces the design weights and the
+part that post-processes the monitor values.
+
 ### Relationship to `MeepJaxWrapper`
 
 The above is distinct from `MeepJaxWrapper`, which turns the entire simulation

--- a/python/Makefile.am
+++ b/python/Makefile.am
@@ -35,6 +35,7 @@ ADJOINT_TESTS =                                \
     $(TEST_DIR)/test_adjoint_utils.py          \
     $(TEST_DIR)/test_adjoint_cyl.py            \
     $(TEST_DIR)/test_adjoint_symmetry.py       \
+    $(TEST_DIR)/test_adjoint_protocol.py       \
     $(TEST_DIR)/test_adjoint_jax.py
 
 TESTS =                                        \
@@ -43,6 +44,7 @@ TESTS =                                        \
     $(TEST_DIR)/test_adjoint_adjacent_grids.py \
     $(TEST_DIR)/test_adjoint_chunks.py         \
     $(TEST_DIR)/test_adjoint_symmetric_grids.py \
+    $(TEST_DIR)/test_adjoint_protocol.py       \
     $(TEST_DIR)/test_antenna_radiation.py      \
     $(TEST_DIR)/test_array_metadata.py         \
     $(TEST_DIR)/test_bend_flux.py              \

--- a/python/adjoint/__init__.py
+++ b/python/adjoint/__init__.py
@@ -20,6 +20,9 @@ from .connectivity import *
 
 from .unfilter_design import *
 
+# JAX is an optional dependency; everything that needs it lives in `wrapper`.
+# Importing it also registers JAX as a way to differentiate objective functions,
+# so objective functions written with `jax.numpy` need no special treatment.
 try:
     from .wrapper import MeepJaxWrapper
 except ModuleNotFoundError as _:

--- a/python/adjoint/__init__.py
+++ b/python/adjoint/__init__.py
@@ -24,6 +24,6 @@ from .unfilter_design import *
 # Importing it also registers JAX as a way to differentiate objective functions,
 # so objective functions written with `jax.numpy` need no special treatment.
 try:
-    from .wrapper import MeepJaxWrapper
+    from .wrapper import MeepJaxWrapper, value_and_jacobian
 except ModuleNotFoundError as _:
     pass

--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -103,9 +103,7 @@ class ObjectiveQuantity(abc.ABC):
 
     def _cotangent(self, dJ) -> np.ndarray:
         """Validates the cotangent handed to `place_adjoint_source`."""
-        return _as_cotangent(
-            dJ, np.shape(self.get_evaluation()), type(self).__name__
-        )
+        return _as_cotangent(dJ, np.shape(self.get_evaluation()), type(self).__name__)
 
     def get_evaluation(self):
         """Evaluates the objective quantity."""
@@ -222,7 +220,7 @@ class EigenmodeCoefficient(ObjectiveQuantity):
         kpoint_func_overlap_idx: Optional[int] = 0,
         decimation_factor: Optional[int] = 0,
         subtracted_dft_fields: Optional[FluxData] = None,
-        **kwargs
+        **kwargs,
     ):
         """Initialize an instance of a differentiable frequency-dependent
         eigenmode coefficient.

--- a/python/adjoint/objective.py
+++ b/python/adjoint/objective.py
@@ -3,8 +3,9 @@ A collection of objects and helper methods for defining objective functions
 used in topology optimization.
 """
 import abc
+import warnings
 from collections import namedtuple
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Tuple
 
 import numpy as np
 from meep.simulation import py_v3_to_vec, FluxData, NearToFarData
@@ -14,6 +15,48 @@ import meep as mp
 from .filter_source import FilteredSource
 
 Grid = namedtuple("Grid", ["x", "y", "z", "w"])
+
+
+def _as_cotangent(dJ, value_shape: Tuple[int, ...], quantity_name: str) -> np.ndarray:
+    """Normalizes the array passed to `ObjectiveQuantity.place_adjoint_source`.
+
+    The argument is a cotangent with exactly the shape of the objective
+    quantity's own value, i.e. of `ObjectiveQuantity.__call__`.
+
+    Before the objective function was differentiated with a vector-Jacobian
+    product, `OptimizationProblem` used `autograd.jacobian` and passed the full
+    `(nfreq,) + value_shape` Jacobian, which each `place_adjoint_source`
+    implementation contracted itself. That shape is still accepted, with a
+    `DeprecationWarning`, for one release.
+
+    Args:
+      dJ: the array to normalize.
+      value_shape: the shape of the objective quantity's value.
+      quantity_name: the class name, used in diagnostics.
+
+    Returns:
+      An array of shape `value_shape`.
+    """
+    dJ = np.atleast_1d(np.asarray(dJ))
+    value_shape = tuple(value_shape)
+    if dJ.shape == value_shape:
+        return dJ
+    if dJ.ndim == len(value_shape) + 1 and dJ.shape[1:] == value_shape:
+        warnings.warn(
+            f"{quantity_name}.place_adjoint_source() was passed a Jacobian of "
+            f"shape {dJ.shape}. It now expects a cotangent of shape "
+            f"{value_shape} -- the shape of the quantity's own value -- with the "
+            "objective's frequency dimension already contracted by the caller. "
+            "Contracting the leading axis for backwards compatibility; this "
+            "fallback will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return np.sum(dJ, axis=0)
+    raise ValueError(
+        f"{quantity_name}.place_adjoint_source() expected a cotangent of shape "
+        f"{value_shape}, but got an array of shape {dJ.shape}."
+    )
 
 
 class ObjectiveQuantity(abc.ABC):
@@ -50,7 +93,19 @@ class ObjectiveQuantity(abc.ABC):
 
     @abc.abstractmethod
     def place_adjoint_source(self, dJ):
-        """Places appropriate sources for the adjoint simulation."""
+        """Places appropriate sources for the adjoint simulation.
+
+        Args:
+          dJ: the cotangent of the objective function with respect to this
+            quantity, with the same shape as the quantity's value (i.e. the
+            return value of `__call__`).
+        """
+
+    def _cotangent(self, dJ) -> np.ndarray:
+        """Validates the cotangent handed to `place_adjoint_source`."""
+        return _as_cotangent(
+            dJ, np.shape(self.get_evaluation()), type(self).__name__
+        )
 
     def get_evaluation(self):
         """Evaluates the objective quantity."""
@@ -229,9 +284,7 @@ class EigenmodeCoefficient(ObjectiveQuantity):
         return self._monitor
 
     def place_adjoint_source(self, dJ):
-        dJ = np.atleast_1d(dJ)
-        if dJ.ndim == 2:
-            dJ = np.sum(dJ, axis=1)
+        dJ = self._cotangent(dJ)
         time_src = self._create_time_profile()
         da_dE = 0.5 * self._cscale
         scale = self._adj_src_scale()
@@ -362,28 +415,20 @@ class FourierFields(ObjectiveQuantity):
         time_src = self._create_time_profile()
         sources = []
 
+        dJ = np.ascontiguousarray(self._cotangent(dJ), dtype=np.complex128)
+
+        # `fourier_sourcedata` indexes dJ as a flat, C-ordered buffer whose
+        # slowest axis is frequency, so the element count must agree with the
+        # monitor Meep actually allocated.
         mon_size = self.sim.fields.dft_monitor_size(
             self._monitor.swigobj, self.volume.swigobj, self.component
         )
-        dJ = dJ.astype(np.complex128)
-        if (
-            np.prod(mon_size) * self.num_freq != dJ.size
-            and np.prod(mon_size) * self.num_freq**2 != dJ.size
-        ):
-            raise ValueError("The format of J is incorrect!")
-
-        # The objective function J is a vector. Each component corresponds to a frequency.
-        if np.prod(mon_size) * self.num_freq**2 == dJ.size and self.num_freq > 1:
-            dJ = np.sum(dJ, axis=1)
-        """The adjoint solver requires the objective function
-        to be scalar valued with regard to objective arguments
-        and position, but the function may be vector valued
-        with regard to frequency. In this case, the Jacobian
-        will be of the form [F,F,...] where F is the number of
-        frequencies. Because of linearity, we can sum across the
-        second frequency dimension to calculate a frequency
-        scale factor for each point (rather than a scale vector).
-        """
+        if np.prod(mon_size) * self.num_freq != dJ.size:
+            raise ValueError(
+                f"The cotangent has {dJ.size} elements but this monitor holds "
+                f"{np.prod(mon_size)} points at each of {self.num_freq} "
+                "frequencies."
+            )
 
         all_fouriersrcdata = self._monitor.swigobj.fourier_sourcedata(
             self.volume.swigobj, self.component, self.sim.fields, dJ
@@ -489,10 +534,9 @@ class Near2FarFields(ObjectiveQuantity):
         return self._monitor
 
     def place_adjoint_source(self, dJ):
+        dJ = self._cotangent(dJ)
         time_src = self._create_time_profile()
         sources = []
-        if dJ.ndim == 4:
-            dJ = np.sum(dJ, axis=0)
 
         farpt_list = np.array([list(pi) for pi in self.far_pts]).flatten()
         far_pt0 = self.far_pts[0]
@@ -563,9 +607,7 @@ class LDOS(ObjectiveQuantity):
 
     def place_adjoint_source(self, dJ):
         time_src = self._create_time_profile()
-        if dJ.ndim == 2:
-            dJ = np.sum(dJ, axis=1)
-        dJ = dJ.flatten()
+        dJ = self._cotangent(dJ).flatten()
         sources = []
         forward_f_scale = np.array(
             [self._ldos_scale / self._ldos_Jdata[k] for k in range(self.num_freq)]

--- a/python/adjoint/optimization_problem.py
+++ b/python/adjoint/optimization_problem.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from typing import Callable, List, Union, Optional, Tuple
 
 import numpy as np
-from autograd import grad, jacobian
+from autograd import jacobian
 
 import meep as mp
 

--- a/python/adjoint/optimization_problem.py
+++ b/python/adjoint/optimization_problem.py
@@ -2,8 +2,6 @@ from collections import namedtuple
 from typing import Callable, List, Union, Optional, Tuple
 
 import numpy as np
-from autograd import jacobian
-
 import meep as mp
 
 from . import LDOS, DesignRegion, utils, ObjectiveQuantity
@@ -155,6 +153,7 @@ class OptimizationProblem:
         self.current_state = "INIT"
 
         self.gradient = []
+        self._objective_values = []
 
     def __call__(
         self,
@@ -283,7 +282,10 @@ class OptimizationProblem:
         # record objective quantities from user specified monitors
         self.results_list = [m() for m in self.objective_arguments]
         # evaluate objectives
-        self.f0 = [fi(*self.results_list) for fi in self.objective_functions]
+        self._objective_values = [
+            fi(*self.results_list) for fi in self.objective_functions
+        ]
+        self.f0 = list(self._objective_values)
         if len(self.f0) == 1:
             self.f0 = self.f0[0]
 
@@ -293,17 +295,43 @@ class OptimizationProblem:
         # update solver's current state
         self.current_state = "FWD"
 
+    def _objective_cotangent(self, ar: int) -> np.ndarray:
+        """Builds the reverse-pass seed for one objective function.
+
+        Meep runs a single adjoint simulation per objective function and recovers
+        a gradient at every frequency from it, which is only valid when each
+        component of a frequency-vector-valued objective depends on the monitor
+        values at its own frequency alone. Under that assumption the quantity the
+        adjoint sources need -- the frequency diagonal of the Jacobian -- is the
+        pullback of a cotangent of ones.
+        """
+        value = self._objective_values[ar]
+        if np.ndim(value) == 0:
+            return np.ones((), dtype=np.asarray(value).dtype)
+        value = np.asarray(value)
+        if value.size not in (1, self.nf):
+            raise ValueError(
+                f"objective_functions[{ar}] returned {value.size} values. Meep's "
+                "single-adjoint-simulation formulation requires each objective "
+                f"function to be scalar or to return one value per frequency "
+                f"({self.nf}). Pass independent scalar objectives as separate "
+                "entries of `objective_functions` instead."
+            )
+        return np.ones(value.shape, dtype=value.dtype)
+
     def prepare_adjoint_run(self):
-        # Compute adjoint sources
+        # Compute adjoint sources. One reverse pass through each objective
+        # function yields the cotangents for all of its objective arguments.
         self.adjoint_sources = [[] for _ in range(len(self.objective_functions))]
         for ar in range(len(self.objective_functions)):
-            for mi, m in enumerate(self.objective_arguments):
-                dJ = jacobian(self.objective_functions[ar], mi)(*self.results_list)
-                # get gradient of objective w.r.t. monitor
-                if np.any(dJ):
-                    self.adjoint_sources[ar] += m.place_adjoint_source(
-                        dJ
-                    )  # place the appropriate adjoint sources
+            dJ = utils.objective_vjp(
+                self.objective_functions[ar],
+                self.results_list,
+                self._objective_cotangent(ar),
+            )
+            self.adjoint_sources[ar] = utils.create_adjoint_sources(
+                self.objective_arguments, dJ
+            )
 
     def adjoint_run(self):
         # set up adjoint sources and monitors

--- a/python/adjoint/optimization_problem.py
+++ b/python/adjoint/optimization_problem.py
@@ -328,6 +328,7 @@ class OptimizationProblem:
                 self.objective_functions[ar],
                 self.results_list,
                 self._objective_cotangent(ar),
+                value=self._objective_values[ar],
             )
             self.adjoint_sources[ar] = utils.create_adjoint_sources(
                 self.objective_arguments, dJ

--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -112,6 +112,11 @@ def calculate_vjps(
         )
         for i, design_region in enumerate(design_regions)
     ]
+    # `DesignRegion.get_gradient` squeezes the frequency axis away when there is
+    # only one frequency, so restore it rather than indexing an axis that may not
+    # be there.
+    num_freqs = onp.asarray(frequencies).size
+    vjps = [vjp.reshape(-1, num_freqs) for vjp in vjps]
     if sum_freq_partials:
         vjps = [
             onp.sum(vjp, axis=_GRADIENT_FREQ_AXIS).reshape(shape)

--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterable, List, Sequence, Tuple
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple
 
 import numpy as onp
 from autograd import make_vjp
@@ -220,20 +220,60 @@ def validate_and_update_design(
         design_region.update_design_parameters(design_variable.flatten())
 
 
+_VJP_BACKENDS: List[Tuple[Callable[[Any], bool], Callable]] = []
+
+
+def register_vjp_backend(
+    matches: Callable[[Any], bool],
+    vjp: Callable[[Callable, Tuple, Any], Sequence[onp.ndarray]],
+) -> None:
+    """Registers a way to differentiate objective functions of some flavor.
+
+    This is how support for an autodifferentiation framework other than autograd
+    is added without the rest of `meep.adjoint` importing it, and without the
+    user having to wrap or annotate their objective function. `wrapper` calls
+    this for JAX when it is imported, which happens only if JAX is installed.
+
+    Args:
+      matches: given the value an objective function returned, whether this
+        backend should differentiate that function. Recognizing the framework's
+        own array type is the intended test.
+      vjp: called as `vjp(objective_function, args, cotangent)` and returning one
+        cotangent per element of `args`, as plain NumPy arrays.
+    """
+    _VJP_BACKENDS.append((matches, vjp))
+
+
+def _select_vjp_backend(value) -> Optional[Callable]:
+    """Returns the backend that claims `value`, or None for autograd."""
+    if value is None:
+        return None
+    for matches, vjp in _VJP_BACKENDS:
+        if matches(value):
+            return vjp
+    return None
+
+
 def objective_vjp(
     objective_function: Callable,
     args: Sequence[onp.ndarray],
     cotangent,
+    value=None,
 ) -> Tuple[onp.ndarray, ...]:
     """Pulls a cotangent back through an objective function.
 
     This is a *single* reverse pass that yields the cotangent with respect to
     every element of `args` at once.
 
-    An objective function may supply its own pullback by exposing a
-    `vjp(cotangent, *args)` method, in which case it is used in place of
-    autograd. This is how objective functions written against another
-    autodifferentiation framework participate; see `wrapper.JaxObjective`.
+    Objective functions are differentiated with autograd by default. Two things
+    override that, in order:
+
+    1. a `vjp(cotangent, *args)` method on the objective function itself, for a
+       hand-written or analytic pullback;
+    2. a backend registered with `register_vjp_backend` whose predicate accepts
+       `value`, which is how an objective function written with another
+       autodifferentiation framework is differentiated by that framework without
+       the user having to declare anything. `wrapper` registers one for JAX.
 
     Args:
       objective_function: the objective function, called as
@@ -241,6 +281,8 @@ def objective_vjp(
       args: the values of the objective quantities, in registration order.
       cotangent: the seed of the reverse pass, in the vector space of the
         objective function's output.
+      value: what `objective_function(*args)` returned, used to select a backend.
+        If omitted, autograd is used.
 
     Returns:
       One cotangent per element of `args`, each with that element's shape.
@@ -250,8 +292,12 @@ def objective_vjp(
     if callable(user_vjp):
         cotangents = tuple(user_vjp(cotangent, *args))
     else:
-        vjp, _ = make_vjp(lambda packed: objective_function(*packed))(args)
-        cotangents = tuple(vjp(cotangent))
+        backend = _select_vjp_backend(value)
+        if backend is not None:
+            cotangents = tuple(backend(objective_function, args, cotangent))
+        else:
+            vjp, _ = make_vjp(lambda packed: objective_function(*packed))(args)
+            cotangents = tuple(vjp(cotangent))
     if len(cotangents) != len(args):
         raise ValueError(
             f"The objective function's vjp returned {len(cotangents)} "

--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -1,6 +1,7 @@
-from typing import Iterable, List, Tuple
+from typing import Callable, Iterable, List, Sequence, Tuple
 
 import numpy as onp
+from autograd import make_vjp
 
 import meep as mp
 
@@ -219,14 +220,70 @@ def validate_and_update_design(
         design_region.update_design_parameters(design_variable.flatten())
 
 
+def objective_vjp(
+    objective_function: Callable,
+    args: Sequence[onp.ndarray],
+    cotangent,
+) -> Tuple[onp.ndarray, ...]:
+    """Pulls a cotangent back through an objective function.
+
+    This is a *single* reverse pass that yields the cotangent with respect to
+    every element of `args` at once.
+
+    An objective function may supply its own pullback by exposing a
+    `vjp(cotangent, *args)` method, in which case it is used in place of
+    autograd. This is how objective functions written against another
+    autodifferentiation framework participate; see `wrapper.JaxObjective`.
+
+    Args:
+      objective_function: the objective function, called as
+        `objective_function(*args)`.
+      args: the values of the objective quantities, in registration order.
+      cotangent: the seed of the reverse pass, in the vector space of the
+        objective function's output.
+
+    Returns:
+      One cotangent per element of `args`, each with that element's shape.
+    """
+    args = tuple(args)
+    user_vjp = getattr(objective_function, "vjp", None)
+    if callable(user_vjp):
+        cotangents = tuple(user_vjp(cotangent, *args))
+    else:
+        vjp, _ = make_vjp(lambda packed: objective_function(*packed))(args)
+        cotangents = tuple(vjp(cotangent))
+    if len(cotangents) != len(args):
+        raise ValueError(
+            f"The objective function's vjp returned {len(cotangents)} "
+            f"cotangents for {len(args)} objective arguments."
+        )
+    return cotangents
+
+
 def create_adjoint_sources(
-    monitors: Iterable[ObjectiveQuantity], monitor_values_grad: onp.ndarray
+    monitors: Sequence[ObjectiveQuantity],
+    monitor_values_grad: Sequence[onp.ndarray],
 ) -> List[mp.Source]:
-    monitor_values_grad = onp.asarray(
-        monitor_values_grad,
-        dtype=onp.complex64 if mp.is_single_precision() else onp.complex128,
-    )
-    if not onp.any(monitor_values_grad):
+    """Places the adjoint sources for one adjoint simulation.
+
+    Args:
+      monitors: the objective quantities registered in the forward run.
+      monitor_values_grad: one cotangent per monitor, each with the shape of
+        that monitor's own value.
+
+    Returns:
+      The list of adjoint sources.
+    """
+    # Everything downstream -- `_adj_src_scale`, `FilteredSource`, and the
+    # `std::complex<double>` buffers the C++ source constructors read -- works in
+    # double precision, so upcast here rather than round-tripping through the
+    # field precision.
+    cotangents = [onp.asarray(dj, dtype=onp.complex128) for dj in monitor_values_grad]
+    if len(cotangents) != len(monitors):
+        raise ValueError(
+            f"Got {len(cotangents)} cotangents for {len(monitors)} monitors."
+        )
+    if not any(onp.any(dj) for dj in cotangents):
         raise RuntimeError(
             "The gradient of all monitor values is zero, which "
             "means that no adjoint sources can be placed to set "
@@ -238,12 +295,7 @@ def create_adjoint_sources(
             "objective function output."
         )
     adjoint_sources = []
-    for monitor_idx, monitor in enumerate(monitors):
-        # `dj` for each monitor will have a shape of (num frequencies,)
-        dj = onp.asarray(
-            monitor_values_grad[monitor_idx],
-            dtype=onp.complex64 if mp.is_single_precision() else onp.complex128,
-        )
+    for monitor, dj in zip(monitors, cotangents):
         if onp.any(dj):
             adjoint_sources += monitor.place_adjoint_source(dj)
     assert adjoint_sources

--- a/python/adjoint/utils.py
+++ b/python/adjoint/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union
 
 import numpy as onp
 from autograd import make_vjp
@@ -91,11 +91,6 @@ def _compute_components(sim: mp.Simulation) -> List[int]:
     )
 
 
-def _make_at_least_nd(x: onp.ndarray, dims: int = 3) -> onp.ndarray:
-    """Makes an array have at least the specified number of dimensions."""
-    return onp.reshape(x, x.shape + onp.maximum(dims - x.ndim, 0) * (1,))
-
-
 def calculate_vjps(
     simulation: mp.Simulation,
     design_regions: List[DesignRegion],
@@ -162,22 +157,24 @@ def install_design_region_monitors(
     ]
 
 
-def gather_monitor_values(monitors: List[ObjectiveQuantity]) -> onp.ndarray:
-    """Gathers the mode monitor overlap values as a rank 2 ndarray.
+def gather_monitor_values(
+    monitors: Sequence[ObjectiveQuantity],
+) -> Union[onp.ndarray, Tuple[onp.ndarray, ...]]:
+    """Gathers the values of a list of objective quantities.
 
     Args:
-      monitors: the mode monitors.
+      monitors: the objective quantities.
 
     Returns:
-      a rank-2 ndarray, where the dimensions are (monitor, frequency), of dtype
-      complex128.  Note that these values refer to the mode as oriented (i.e. they
-      are unidirectional).
+      If every monitor yields one value per frequency -- as `EigenmodeCoefficient`
+      and `LDOS` do -- a rank-2 ndarray whose dimensions are (monitor,
+      frequency). Otherwise, for example when a `FourierFields` monitor
+      contributes a whole plane of values, a tuple with one array per monitor.
     """
-    monitor_values = [monitor() for monitor in monitors]
-    monitor_values = onp.array(monitor_values)
-    assert monitor_values.ndim in [1, 2]
-    monitor_values = _make_at_least_nd(monitor_values, 2)
-    return monitor_values
+    values = [onp.atleast_1d(onp.asarray(monitor())) for monitor in monitors]
+    shapes = {value.shape for value in values}
+    is_stackable = bool(values) and len(shapes) == 1 and values[0].ndim == 1
+    return onp.stack(values) if is_stackable else tuple(values)
 
 
 def validate_and_update_design(

--- a/python/adjoint/wrapper.py
+++ b/python/adjoint/wrapper.py
@@ -553,9 +553,7 @@ def value_and_jacobian(loss: Callable, argnums=0) -> Callable:
 
         if isinstance(argnums, int):
             implicit = implicit[0]
-        jacobian = jax.tree_util.tree_map(
-            lambda a, b: a + b, explicit, implicit
-        )
+        jacobian = jax.tree_util.tree_map(lambda a, b: a + b, explicit, implicit)
         return values, jacobian
 
     return evaluate

--- a/python/adjoint/wrapper.py
+++ b/python/adjoint/wrapper.py
@@ -54,10 +54,7 @@ import numpy as onp
 
 import meep as mp
 
-from . import DesignRegion, EigenmodeCoefficient, utils
-
-_norm_fn = onp.linalg.norm
-_reduce_fn = onp.max
+from . import DesignRegion, ObjectiveQuantity, utils
 
 
 class MeepJaxWrapper:
@@ -66,8 +63,8 @@ class MeepJaxWrapper:
     Attributes:
         simulation: the pre-configured Meep simulation object.
         sources: a list of Meep sources for the forward simulation.
-        monitors: a list of eigenmode coefficient monitors from the `meep.adjoint`
-          module.
+        monitors: a list of objective quantities from the `meep.adjoint` module,
+          such as `EigenmodeCoefficient` or `FourierFields`.
         design_regions: a list of design regions from the `meep.adjoint` module.
         frequencies: the list of frequencies, in normalized Meep units.
         measurement_interval: the time interval between DFT field convergence
@@ -90,13 +87,11 @@ class MeepJaxWrapper:
           for more information. The default is true.
     """
 
-    _log_fn = print
-
     def __init__(
         self,
         simulation: mp.Simulation,
         sources: List[mp.Source],
-        monitors: List[EigenmodeCoefficient],
+        monitors: List[ObjectiveQuantity],
         design_regions: List[DesignRegion],
         frequencies: List[float],
         dft_threshold: float = 1e-11,

--- a/python/adjoint/wrapper.py
+++ b/python/adjoint/wrapper.py
@@ -1,6 +1,33 @@
-"""Wrapper for converting a Meep simulation into a differentiable JAX callable function.
+"""JAX interoperability for `meep.adjoint`.
 
-Usage example:
+This module holds everything in `meep.adjoint` that needs JAX, so that JAX stays
+an optional dependency: it is imported behind a guard in `meep/adjoint/__init__.py`
+and nothing else in the package imports it.
+
+It does two things.
+
+Importing it registers JAX with `utils.register_vjp_backend`, so an objective
+function written with `jax.numpy` and handed to `OptimizationProblem` is
+differentiated by JAX rather than autograd. Nothing needs to be declared or
+wrapped -- writing a JAX objective differs from writing an autograd objective
+only in which numpy it imports:
+
+```
+def objective(mode_coeff, dft_fields):
+    return jnp.abs(mode_coeff)**2 + jnp.sum(jnp.abs(dft_fields)**2, axis=1)
+
+opt = mpa.OptimizationProblem(
+    simulation=simulation,
+    objective_functions=[objective],
+    objective_arguments=[mpa.EigenmodeCoefficient(...), mpa.FourierFields(...)],
+    design_regions=[mpa.DesignRegion(...)],
+    frequencies=frequencies,
+)
+```
+
+`MeepJaxWrapper` is the other direction: it turns a whole Meep simulation into a
+JAX-differentiable callable, so the design variables, the objective, and anything
+else in the loss are all traced by JAX. Usage example:
 ```
 import jax.numpy as jnp
 import meep as mp
@@ -46,7 +73,8 @@ def loss(x):
 value, grad = jax.value_and_grad(loss)(x)
 ```
 """
-from typing import Callable, Iterable, List, Tuple
+import warnings
+from typing import Callable, Iterable, List, Sequence, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -55,6 +83,64 @@ import numpy as onp
 import meep as mp
 
 from . import DesignRegion, ObjectiveQuantity, utils
+
+_warned_about_precision = False
+
+
+def _warn_if_precision_mismatch() -> None:
+    """Warns when JAX would silently narrow Meep's double-precision fields.
+
+    JAX defaults to 32-bit dtypes, so a double-precision Meep build feeding
+    complex128 monitor values into JAX loses half its digits without any error.
+    The usual symptom is a finite-difference gradient check that agrees to only
+    three or four digits, which reads as a physics problem rather than a dtype
+    problem.
+    """
+    global _warned_about_precision
+    if _warned_about_precision:
+        return
+    if not jax.config.jax_enable_x64 and not mp.is_single_precision():
+        _warned_about_precision = True
+        warnings.warn(
+            "Meep was built in double precision but JAX's x64 mode is off, so "
+            "JAX will narrow complex128 monitor values to complex64 and the "
+            "gradients will carry roughly single-precision accuracy. Add\n\n"
+            "    jax.config.update('jax_enable_x64', True)\n\n"
+            "before constructing the objective to keep double precision.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+
+
+def _returns_jax_array(value) -> bool:
+    """Whether an objective function's return value came from JAX."""
+    return isinstance(value, jax.Array)
+
+
+def _jax_objective_vjp(
+    objective_function: Callable, args: Tuple, cotangent
+) -> Tuple[onp.ndarray, ...]:
+    """Differentiates an objective function written with `jax.numpy`.
+
+    Registered with `utils.register_vjp_backend`, so an objective function that
+    returns a JAX array is differentiated by JAX automatically -- writing one is
+    no different from writing an autograd objective, apart from which numpy it
+    imports.
+    """
+    _warn_if_precision_mismatch()
+    value, pullback = jax.vjp(objective_function, *[jnp.asarray(arg) for arg in args])
+    if not isinstance(value, jax.Array):
+        raise TypeError(
+            "An objective function must return a single array or scalar, but "
+            f"{objective_function} returned {type(value)}."
+        )
+    # `_objective_cotangent` builds the seed in NumPy, which is float64 even when
+    # JAX is running in its default 32-bit mode.
+    cotangent = jnp.asarray(cotangent).astype(value.dtype).reshape(value.shape)
+    return tuple(onp.asarray(grad) for grad in pullback(cotangent))
+
+
+utils.register_vjp_backend(_returns_jax_array, _jax_objective_vjp)
 
 
 class MeepJaxWrapper:

--- a/python/adjoint/wrapper.py
+++ b/python/adjoint/wrapper.py
@@ -72,7 +72,21 @@ def loss(x):
 
 value, grad = jax.value_and_grad(loss)(x)
 ```
+
+For worst-case (minimax) optimization the loss returns one value per frequency
+rather than a scalar, and `value_and_jacobian` returns a gradient for each of
+them -- still from a single adjoint simulation. Parameters that never reach Meep
+are differentiated alongside the design weights:
+
+```
+def loss(rho, thickness, tilt):
+    (dft,) = wrapped_meep([rho])
+    return postprocess(dft, thickness, tilt)   # (num frequencies,)
+
+values, grads = mpa.value_and_jacobian(loss, argnums=(0, 1, 2))(rho, 1.8, 8.0)
+```
 """
+import contextlib
 import warnings
 from typing import Callable, Iterable, List, Sequence, Tuple, Union
 
@@ -224,6 +238,8 @@ class MeepJaxWrapper:
           values, it is a tuple with one array per monitor, in the order the
           monitors were given.
         """
+        if _active_recorder is not None:
+            return _active_recorder(self, designs)
         return self._simulate_fn(designs)
 
     def _run_fwd_simulation(
@@ -340,3 +356,206 @@ class MeepJaxWrapper:
         simulate.defvjp(_simulate_fwd, _simulate_rev)
 
         return simulate
+
+
+class _WrapperCallRecorder:
+    """Splits a loss function apart at its `MeepJaxWrapper` call.
+
+    `value_and_jacobian` needs to see the user's loss function as three pieces:
+    whatever maps the parameters to design weights before the simulation, the
+    simulation itself, and the post-processing after it. The user writes a single
+    function, so the split is recovered by having the wrapper cooperate. The first
+    pass runs the forward simulation and records what crossed the boundary; later
+    passes replay that recording instead of simulating, which leaves the pieces
+    before and after the call as ordinary differentiable JAX.
+    """
+
+    def __init__(self):
+        self.wrapper = None
+        self.designs = None
+        self.design_shapes = None
+        self.monitor_values = None
+        self.fwd_monitors = None
+        self.num_calls = 0
+        self.substitute = None
+
+    def __call__(self, wrapper: "MeepJaxWrapper", designs):
+        self.num_calls += 1
+        if self.wrapper is None:
+            self.wrapper = wrapper
+        elif self.wrapper is not wrapper:
+            raise ValueError(
+                "value_and_jacobian supports a loss function that calls a single "
+                "MeepJaxWrapper; this one called two or more. Each simulation "
+                "needs its own adjoint run, so compute their Jacobians "
+                "separately and combine the rows yourself."
+            )
+        # Overwritten on every pass. On the first it holds concrete arrays; on
+        # the traced passes it holds tracers, which is what the design mapping's
+        # pullback is recovered from.
+        self.designs = list(designs)
+        if self.monitor_values is None:
+            self.design_shapes = [onp.shape(design) for design in designs]
+            self.monitor_values, self.fwd_monitors = wrapper._run_fwd_simulation(
+                designs
+            )
+        return self.monitor_values if self.substitute is None else self.substitute
+
+
+_active_recorder = None
+
+
+@contextlib.contextmanager
+def _recording(recorder: _WrapperCallRecorder):
+    global _active_recorder
+    previous, _active_recorder = _active_recorder, recorder
+    try:
+        yield
+    finally:
+        _active_recorder = previous
+
+
+def _split_args(args: Tuple, argnums):
+    """Partitions positional arguments into differentiated and held-fixed."""
+    indices = (argnums,) if isinstance(argnums, int) else tuple(argnums)
+    differentiated = tuple(args[i] for i in indices)
+
+    def rebuild(new_values):
+        merged = list(args)
+        for position, index in enumerate(indices):
+            merged[index] = new_values[position]
+        return tuple(merged)
+
+    return indices, differentiated, rebuild
+
+
+def value_and_jacobian(loss: Callable, argnums=0) -> Callable:
+    """Transforms a per-frequency loss function into one that also returns its Jacobian.
+
+    Worst-case (minimax) optimization over a bandwidth needs a separate gradient
+    for each frequency rather than the gradient of a scalar reduction over them.
+    This is the counterpart of `jax.value_and_grad` for that case:
+
+        def loss(rho, thickness, tilt):
+            (dft,) = wrapped_meep([rho])              # a MeepJaxWrapper call
+            return postprocess(dft, thickness, tilt)  # one value per frequency
+
+        values, grads = mpa.value_and_jacobian(loss, argnums=(0, 1, 2))(
+            rho, thickness, tilt)
+
+    Every leaf of `grads` is the corresponding parameter's shape with a leading
+    frequency axis, so `grads[1][f]` is the gradient of `values[f]` with respect
+    to `thickness`. Parameters that Meep knows nothing about -- a layer stack fed
+    to a propagator, a fiber tilt -- are differentiated alongside the design
+    weights, and arbitrary pytrees are supported throughout.
+
+    The whole Jacobian costs one forward simulation and one adjoint simulation,
+    independent of the number of frequencies. `jax.jacrev` cannot achieve this:
+    it evaluates the reverse pass once per output component, and here each
+    evaluation would be a full timestepping run.
+
+    As in `OptimizationProblem`, the dependence of the objective on the *monitor
+    values* must be block diagonal in frequency -- entry `f` may only read the
+    monitor values at frequency `f` -- because a single adjoint field cannot
+    carry independent sensitivities for different frequencies. Dependence on
+    parameters that bypass the simulation is unrestricted, since those are
+    differentiated directly.
+
+    Args:
+      loss: a function whose positional arguments are the parameters and whose
+        return value is a 1-D array with one entry per frequency. It must call a
+        `MeepJaxWrapper` exactly once.
+      argnums: which positional arguments to differentiate, following the
+        convention of `jax.value_and_grad`.
+
+    Returns:
+      A function with the same signature as `loss`, returning
+      `(values, jacobian)`.
+    """
+
+    def evaluate(*args):
+        recorder = _WrapperCallRecorder()
+        indices, differentiated, rebuild = _split_args(args, argnums)
+
+        with _recording(recorder):
+            # Pass 1: the only forward simulation.
+            values = loss(*args)
+            if recorder.num_calls == 0:
+                raise ValueError(
+                    "The loss function never called a MeepJaxWrapper, so there "
+                    "is no simulation to differentiate. Use jax.jacrev for a "
+                    "function that does not involve Meep."
+                )
+            if recorder.num_calls != 1:
+                raise ValueError(
+                    f"The loss function called a MeepJaxWrapper "
+                    f"{recorder.num_calls} times; value_and_jacobian supports "
+                    "exactly one call, since it drives a single adjoint "
+                    "simulation."
+                )
+            wrapper = recorder.wrapper
+            num_frequencies = onp.asarray(wrapper.frequencies).size
+            if not isinstance(values, jax.Array) or jnp.ndim(values) != 1:
+                raise TypeError(
+                    "The loss function must return a 1-D JAX array with one "
+                    f"entry per frequency, but it returned {type(values)} with "
+                    f"shape {jnp.shape(values)}."
+                )
+            if values.shape[0] != num_frequencies:
+                raise ValueError(
+                    f"The loss function returned {values.shape[0]} values; "
+                    f"value_and_jacobian expects one per frequency, i.e. "
+                    f"({num_frequencies},). Use jax.value_and_grad for a scalar "
+                    "loss."
+                )
+
+            # From here on the recorder replays the recorded monitor values, so
+            # nothing below runs another simulation.
+
+            # (1) How the parameters reach the loss without passing through the
+            # simulation -- a layer stack, a fiber tilt, a regularizer.
+            explicit = jax.jacrev(loss, argnums=argnums)(*args)
+
+            # (2) How the loss depends on the monitor values. Seeding with ones
+            # extracts the frequency diagonal of that Jacobian, which is what the
+            # adjoint sources need; see `utils.objective_vjp`.
+            def evaluate_at_monitor_values(monitor_values):
+                recorder.substitute = monitor_values
+                try:
+                    return loss(*args)
+                finally:
+                    recorder.substitute = None
+
+            _, pull_monitor_values = jax.vjp(
+                evaluate_at_monitor_values, recorder.monitor_values
+            )
+            cotangent = pull_monitor_values(jnp.ones_like(values))[0]
+
+            # (3) The only adjoint simulation. Keeping the frequency axis of the
+            # design-region contraction is what makes the rows separable.
+            adjoint_monitors = wrapper._run_adjoint_simulation(cotangent)
+            rows = wrapper._calculate_vjps(
+                recorder.fwd_monitors,
+                adjoint_monitors,
+                recorder.design_shapes,
+                sum_freq_partials=False,
+            )
+            rows = [jnp.moveaxis(jnp.asarray(row), -1, 0) for row in rows]
+
+            # (4) Carry each row back through whatever produced the design
+            # weights. Pure JAX, so `vmap` over the frequency axis is free.
+            def designs_from(*values_to_differentiate):
+                loss(*rebuild(values_to_differentiate))
+                return recorder.designs
+
+            _, pull_designs = jax.vjp(designs_from, *differentiated)
+            implicit = jax.vmap(pull_designs)(rows)
+
+        if isinstance(argnums, int):
+            implicit = implicit[0]
+        jacobian = jax.tree_util.tree_map(
+            lambda a, b: a + b, explicit, implicit
+        )
+        return values, jacobian
+
+    return evaluate

--- a/python/adjoint/wrapper.py
+++ b/python/adjoint/wrapper.py
@@ -74,7 +74,7 @@ value, grad = jax.value_and_grad(loss)(x)
 ```
 """
 import warnings
-from typing import Callable, Iterable, List, Sequence, Tuple
+from typing import Callable, Iterable, List, Sequence, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -186,6 +186,7 @@ class MeepJaxWrapper:
         until_after_sources: bool = True,
         finite_difference_step: float = utils.FD_DEFAULT,
     ):
+        _warn_if_precision_mismatch()
         self.simulation = simulation
         self.sources = sources
         self.monitors = monitors
@@ -199,8 +200,10 @@ class MeepJaxWrapper:
 
         self._simulate_fn = self._initialize_callable()
 
-    def __call__(self, designs: List[jnp.ndarray]) -> jnp.ndarray:
-        """Performs a Meep simulation, taking a list of designs and returning mode overlaps.
+    def __call__(
+        self, designs: List[jnp.ndarray]
+    ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, ...]]:
+        """Performs a Meep simulation, taking designs and returning monitor values.
 
         Args:
           designs: a list of design variables as 1D, 2D, or 3D JAX arrays. Valid shapes for
@@ -213,14 +216,19 @@ class MeepJaxWrapper:
           (25, 1), or (25, 1, 1) would be compatible with a `grid_size` of (25, 1, 1).
 
         Returns:
-          a complex-valued JAX ndarray of differentiable mode monitor overlaps values with
-          a shape of (num monitors, num frequencies).
+          The differentiable values of the monitors. If every monitor yields one
+          value per frequency -- as `EigenmodeCoefficient` and `LDOS` do -- this
+          is a single complex-valued JAX ndarray with a shape of (num monitors,
+          num frequencies). If the monitors have heterogeneous shapes, for
+          example when a `FourierFields` monitor contributes a whole plane of
+          values, it is a tuple with one array per monitor, in the order the
+          monitors were given.
         """
         return self._simulate_fn(designs)
 
     def _run_fwd_simulation(
         self, design_variables: Iterable[onp.ndarray]
-    ) -> (jnp.ndarray, List[List[mp.DftFields]]):
+    ) -> Tuple[Union[jnp.ndarray, Tuple[jnp.ndarray, ...]], List[List[mp.DftFields]]]:
         """Runs forward simulation, returning monitor values and design region fields."""
         utils.validate_and_update_design(self.design_regions, design_variables)
         self.simulation.reset_meep()
@@ -242,10 +250,13 @@ class MeepJaxWrapper:
         self.simulation.run(**sim_run_args)
 
         monitor_values = utils.gather_monitor_values(self.monitors)
-        return (jnp.asarray(monitor_values), fwd_design_region_monitors)
+        # A tuple when the monitors have heterogeneous shapes; `custom_vjp`
+        # handles either, and the cotangent arrives with a matching structure.
+        monitor_values = jax.tree_util.tree_map(jnp.asarray, monitor_values)
+        return (monitor_values, fwd_design_region_monitors)
 
     def _run_adjoint_simulation(
-        self, monitor_values_grad: onp.ndarray
+        self, monitor_values_grad: Union[onp.ndarray, Sequence[onp.ndarray]]
     ) -> List[List[mp.DftFields]]:
         """Runs adjoint simulation, returning design region fields."""
         if not self.design_regions:
@@ -297,11 +308,11 @@ class MeepJaxWrapper:
             finite_difference_step=self.finite_difference_step,
         )
 
-    def _initialize_callable(self) -> Callable[[List[jnp.ndarray]], jnp.ndarray]:
+    def _initialize_callable(self) -> Callable:
         """Initializes the callable JAX function and registers its VJP."""
 
         @jax.custom_vjp
-        def simulate(design_variables: List[jnp.ndarray]) -> jnp.ndarray:
+        def simulate(design_variables: List[jnp.ndarray]):
             monitor_values, _ = self._run_fwd_simulation(design_variables)
             return monitor_values
 

--- a/python/tests/test_adjoint_jax.py
+++ b/python/tests/test_adjoint_jax.py
@@ -503,9 +503,7 @@ class WrapperTest(ApproxComparisonTestCase):
             mpa.value_and_jacobian(lambda r: jnp.zeros(len(frequencies)) + r.sum())(x)
 
         with self.assertRaisesRegex(ValueError, "exactly one call"):
-            mpa.value_and_jacobian(
-                lambda r: loss(r, 1.0, 0.0) + loss(r, 1.0, 0.0)
-            )(x)
+            mpa.value_and_jacobian(lambda r: loss(r, 1.0, 0.0) + loss(r, 1.0, 0.0))(x)
 
     def test_monitor_values_are_stacked_when_homogeneous(self):
         """Mode monitors alone still come back as one (monitor, frequency) array.
@@ -584,14 +582,10 @@ class WrapperTest(ApproxComparisonTestCase):
             perturbation = _FD_STEP * jax.random.normal(
                 jax.random.PRNGKey(seed), x.shape
             )
-            projection.append(
-                onp.dot(perturbation.ravel(), adjoint_grad.ravel())
-            )
+            projection.append(onp.dot(perturbation.ravel(), adjoint_grad.ravel()))
             fd_projection.append(loss_fn(x + perturbation) - value)
 
-        self.assertClose(
-            onp.stack(projection), onp.stack(fd_projection), epsilon=_TOL
-        )
+        self.assertClose(onp.stack(projection), onp.stack(fd_projection), epsilon=_TOL)
 
 
 if __name__ == "__main__":

--- a/python/tests/test_adjoint_jax.py
+++ b/python/tests/test_adjoint_jax.py
@@ -184,6 +184,20 @@ class WrapperTest(ApproxComparisonTestCase):
     @parameterized.parameterized.expand(
         [
             (
+                "1550_singlefreq_gaussian_port1",
+                [1 / 1.55],
+                0.1,
+                0.5,
+                0,
+            ),
+            (
+                "1550_singlefreq_gaussian_port2",
+                [1 / 1.55],
+                0.1,
+                0.5,
+                1,
+            ),
+            (
                 "1500_1550bw_01relative_gaussian_port1",
                 onp.linspace(1 / 1.50, 1 / 1.55, 3).tolist(),
                 0.1,

--- a/python/tests/test_adjoint_jax.py
+++ b/python/tests/test_adjoint_jax.py
@@ -304,6 +304,92 @@ class WrapperTest(ApproxComparisonTestCase):
             epsilon=_TOL,
         )
 
+    def test_monitor_values_are_stacked_when_homogeneous(self):
+        """Mode monitors alone still come back as one (monitor, frequency) array.
+
+        User code indexes the return value as `monitor_values[i, :]`, so monitors
+        that all yield a single value per frequency must keep stacking even now
+        that heterogeneous monitors are supported.
+        """
+        frequencies = onp.linspace(1 / 1.50, 1 / 1.60, 3).tolist()
+        (
+            simulation,
+            sources,
+            monitors,
+            design_regions,
+            frequencies,
+        ) = build_straight_wg_simulation(frequencies=frequencies)
+
+        wrapped_meep = mpa.MeepJaxWrapper(
+            simulation, [sources[0]], monitors, design_regions, frequencies
+        )
+        design_shape = tuple(
+            int(i) for i in design_regions[0].design_parameters.grid_size
+        )[:2]
+        monitor_values = wrapped_meep([onp.ones(design_shape) * 0.5])
+
+        self.assertIsInstance(monitor_values, jnp.ndarray)
+        self.assertEqual(monitor_values.shape, (len(monitors), len(frequencies)))
+        self.assertEqual(monitor_values[0, :].shape, (len(frequencies),))
+
+    def test_heterogeneous_monitor_gradients(self):
+        """A FourierFields monitor alongside mode monitors.
+
+        `FourierFields` contributes a whole plane of values rather than one per
+        frequency, so the wrapper returns a tuple and `custom_vjp` carries a
+        matching tuple of cotangents back to `place_adjoint_source`.
+        """
+        frequencies = onp.linspace(1 / 1.50, 1 / 1.60, 3).tolist()
+        (
+            simulation,
+            sources,
+            monitors,
+            design_regions,
+            frequencies,
+        ) = build_straight_wg_simulation(frequencies=frequencies)
+
+        # Inside the non-PML region, past the edge of the design region.
+        monitors = monitors + [
+            mpa.FourierFields(
+                simulation,
+                mp.Volume(center=mp.Vector3(0.75, 0), size=mp.Vector3(0, 0.5)),
+                mp.Ez,
+            )
+        ]
+
+        design_shape = tuple(
+            int(i) for i in design_regions[0].design_parameters.grid_size
+        )[:2]
+        x = onp.ones(design_shape) * 0.5
+
+        def loss_fn(x):
+            wrapped_meep = mpa.MeepJaxWrapper(
+                simulation, [sources[0]], monitors, design_regions, frequencies
+            )
+            monitor_values = wrapped_meep([x])
+            # A tuple, not an array: the last entry has a spatial dimension.
+            *mode_coeffs, dft_fields = monitor_values
+            transmission = jnp.abs(mode_coeffs[2] / mode_coeffs[0]) ** 2
+            intensity = jnp.sum(jnp.abs(dft_fields) ** 2, axis=1)
+            return jnp.mean(transmission + intensity)
+
+        value, adjoint_grad = jax.value_and_grad(loss_fn)(x)
+
+        projection = []
+        fd_projection = []
+        for seed in range(3):
+            perturbation = _FD_STEP * jax.random.normal(
+                jax.random.PRNGKey(seed), x.shape
+            )
+            projection.append(
+                onp.dot(perturbation.ravel(), adjoint_grad.ravel())
+            )
+            fd_projection.append(loss_fn(x + perturbation) - value)
+
+        self.assertClose(
+            onp.stack(projection), onp.stack(fd_projection), epsilon=_TOL
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_adjoint_jax.py
+++ b/python/tests/test_adjoint_jax.py
@@ -318,6 +318,145 @@ class WrapperTest(ApproxComparisonTestCase):
             epsilon=_TOL,
         )
 
+    def _minimax_setup(self, num_frequencies=3):
+        """A loss returning one value per frequency, with non-Meep parameters."""
+        frequencies = onp.linspace(1 / 1.50, 1 / 1.60, num_frequencies).tolist()
+        (
+            simulation,
+            sources,
+            monitors,
+            design_regions,
+            frequencies,
+        ) = build_straight_wg_simulation(frequencies=frequencies)
+        wrapped_meep = mpa.MeepJaxWrapper(
+            simulation, [sources[0]], monitors, design_regions, frequencies
+        )
+        design_shape = tuple(
+            int(i) for i in design_regions[0].design_parameters.grid_size
+        )[:2]
+
+        def loss(rho, weight, bias):
+            s1p, _, s2p, _ = wrapped_meep([rho])
+            # `weight` and `bias` never reach Meep, so they exercise the path
+            # that is differentiated directly rather than adjointly.
+            return weight * jnp.abs(s2p / s1p) ** 2 + bias
+
+        return wrapped_meep, loss, onp.ones(design_shape) * 0.5, frequencies
+
+    def _count_simulations(self, wrapped_meep):
+        """Patches the wrapper to count forward and adjoint timestepping runs."""
+        counts = {"forward": 0, "adjoint": 0}
+        run_forward = wrapped_meep._run_fwd_simulation
+        run_adjoint = wrapped_meep._run_adjoint_simulation
+
+        def counting_forward(*args, **kwargs):
+            counts["forward"] += 1
+            return run_forward(*args, **kwargs)
+
+        def counting_adjoint(*args, **kwargs):
+            counts["adjoint"] += 1
+            return run_adjoint(*args, **kwargs)
+
+        wrapped_meep._run_fwd_simulation = counting_forward
+        wrapped_meep._run_adjoint_simulation = counting_adjoint
+        return counts
+
+    def test_value_and_jacobian(self):
+        """A gradient per frequency, for Meep and non-Meep parameters alike.
+
+        The reference for row `f` is `jax.grad` of component `f`, which costs one
+        adjoint run per row. `value_and_jacobian` produces every row from one.
+        """
+        wrapped_meep, loss, x, frequencies = self._minimax_setup()
+        num_frequencies = len(frequencies)
+        weight, bias = 2.5, 0.75
+
+        counts = self._count_simulations(wrapped_meep)
+        values, (d_rho, d_weight, d_bias) = mpa.value_and_jacobian(
+            loss, argnums=(0, 1, 2)
+        )(x, weight, bias)
+
+        self.assertEqual(counts, {"forward": 1, "adjoint": 1})
+        self.assertEqual(values.shape, (num_frequencies,))
+        self.assertEqual(d_rho.shape, (num_frequencies,) + x.shape)
+        self.assertEqual(d_weight.shape, (num_frequencies,))
+        self.assertEqual(d_bias.shape, (num_frequencies,))
+
+        for f in range(num_frequencies):
+            reference = jax.grad(lambda *a: loss(*a)[f], argnums=(0, 1, 2))(
+                x, weight, bias
+            )
+            # Parameters that bypass Meep are differentiated directly, so they
+            # agree exactly.
+            self.assertClose(
+                onp.asarray([d_weight[f], d_bias[f]]),
+                onp.asarray([reference[1], reference[2]]),
+                epsilon=1e-13,
+                msg=f"row {f} non-Meep parameters",
+            )
+            # The design row agrees to the accuracy of the reference route, not
+            # of this one: seeding a single frequency asks `FilteredSource` to
+            # synthesize exact zeros at the others, which it can only
+            # approximate. Cross-checked against `OptimizationProblem`, which
+            # drives the adjoint the same way this does, the rows agree to
+            # roundoff.
+            tol = 1e-2 if mp.is_single_precision() else 5e-3
+            self.assertClose(
+                onp.asarray(d_rho[f]).ravel(),
+                onp.asarray(reference[0]).ravel(),
+                epsilon=tol,
+                msg=f"row {f} design",
+            )
+
+        rows = onp.asarray(d_rho).reshape(num_frequencies, -1)
+        spread = onp.abs(rows[0] - rows[-1]).max() / onp.abs(rows).max()
+        self.assertGreater(spread, 1e-3, "rows are identical; test is vacuous")
+
+    def test_value_and_jacobian_pytree(self):
+        """Parameters may be an arbitrary pytree; the Jacobian mirrors it."""
+        wrapped_meep, scalar_loss, x, frequencies = self._minimax_setup()
+        num_frequencies = len(frequencies)
+
+        params = {
+            "design": {"rho": x},
+            "post": (2.5, onp.array([0.75, 0.25])),
+        }
+
+        def loss(p):
+            weight, bias = p["post"]
+            s1p, _, s2p, _ = wrapped_meep([p["design"]["rho"]])
+            return weight * jnp.abs(s2p / s1p) ** 2 + jnp.sum(bias)
+
+        counts = self._count_simulations(wrapped_meep)
+        values, jacobian = mpa.value_and_jacobian(loss)(params)
+
+        self.assertEqual(counts, {"forward": 1, "adjoint": 1})
+        self.assertEqual(
+            jax.tree_util.tree_structure(jacobian),
+            jax.tree_util.tree_structure(params),
+        )
+        shapes = jax.tree_util.tree_map(lambda leaf: leaf.shape, jacobian)
+        self.assertEqual(shapes["design"]["rho"], (num_frequencies,) + x.shape)
+        self.assertEqual(shapes["post"][0], (num_frequencies,))
+        self.assertEqual(shapes["post"][1], (num_frequencies, 2))
+
+    def test_value_and_jacobian_errors(self):
+        wrapped_meep, loss, x, frequencies = self._minimax_setup()
+
+        with self.assertRaisesRegex(ValueError, "one per frequency"):
+            mpa.value_and_jacobian(lambda r: loss(r, 1.0, 0.0)[:1])(x)
+
+        with self.assertRaisesRegex(TypeError, "1-D JAX array"):
+            mpa.value_and_jacobian(lambda r: jnp.sum(loss(r, 1.0, 0.0)))(x)
+
+        with self.assertRaisesRegex(ValueError, "never called a MeepJaxWrapper"):
+            mpa.value_and_jacobian(lambda r: jnp.zeros(len(frequencies)) + r.sum())(x)
+
+        with self.assertRaisesRegex(ValueError, "exactly one call"):
+            mpa.value_and_jacobian(
+                lambda r: loss(r, 1.0, 0.0) + loss(r, 1.0, 0.0)
+            )(x)
+
     def test_monitor_values_are_stacked_when_homogeneous(self):
         """Mode monitors alone still come back as one (monitor, frequency) array.
 

--- a/python/tests/test_adjoint_jax.py
+++ b/python/tests/test_adjoint_jax.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -26,6 +27,13 @@ _TOL = 0.1 if mp.is_single_precision() else 0.025
 _NUM_DES_REG_MON = 3
 
 mp.verbosity(0)
+
+
+class _PostProcessing(NamedTuple):
+    """Stands in for parameters that never reach Meep, e.g. a layer stack."""
+
+    weight: float
+    bias: onp.ndarray
 
 
 def build_straight_wg_simulation(
@@ -417,15 +425,17 @@ class WrapperTest(ApproxComparisonTestCase):
         wrapped_meep, scalar_loss, x, frequencies = self._minimax_setup()
         num_frequencies = len(frequencies)
 
+        # A NamedTuple nested inside a dict, since both are common and users
+        # reach for NamedTuples and dataclasses for anything realistic.
         params = {
             "design": {"rho": x},
-            "post": (2.5, onp.array([0.75, 0.25])),
+            "post": _PostProcessing(weight=2.5, bias=onp.array([0.75, 0.25])),
         }
 
         def loss(p):
-            weight, bias = p["post"]
+            post = p["post"]
             s1p, _, s2p, _ = wrapped_meep([p["design"]["rho"]])
-            return weight * jnp.abs(s2p / s1p) ** 2 + jnp.sum(bias)
+            return post.weight * jnp.abs(s2p / s1p) ** 2 + jnp.sum(post.bias)
 
         counts = self._count_simulations(wrapped_meep)
         values, jacobian = mpa.value_and_jacobian(loss)(params)
@@ -436,9 +446,49 @@ class WrapperTest(ApproxComparisonTestCase):
             jax.tree_util.tree_structure(params),
         )
         shapes = jax.tree_util.tree_map(lambda leaf: leaf.shape, jacobian)
+        self.assertIsInstance(shapes["post"], _PostProcessing)
         self.assertEqual(shapes["design"]["rho"], (num_frequencies,) + x.shape)
-        self.assertEqual(shapes["post"][0], (num_frequencies,))
-        self.assertEqual(shapes["post"][1], (num_frequencies, 2))
+        self.assertEqual(shapes["post"].weight, (num_frequencies,))
+        self.assertEqual(shapes["post"].bias, (num_frequencies, 2))
+
+    def test_value_and_jacobian_parameter_on_both_paths(self):
+        """A parameter that both shapes the design and is used downstream.
+
+        `rho` reaches the loss twice here: through the simulation, which needs
+        the adjoint run, and directly through a regularizer, which does not. The
+        two contributions have to be summed, and nothing else in this file
+        exercises that.
+        """
+        wrapped_meep, _, x, frequencies = self._minimax_setup()
+        num_frequencies = len(frequencies)
+        regularization = 5.0
+
+        def loss(rho):
+            s1p, _, s2p, _ = wrapped_meep([rho])
+            return jnp.abs(s2p / s1p) ** 2 + regularization * jnp.sum(rho**2)
+
+        counts = self._count_simulations(wrapped_meep)
+        values, jacobian = mpa.value_and_jacobian(loss)(x)
+        self.assertEqual(counts, {"forward": 1, "adjoint": 1})
+
+        # Guard against the test being unable to see the direct term at all.
+        direct = 2 * regularization * x
+        self.assertGreater(
+            onp.abs(direct).max() / onp.abs(onp.asarray(jacobian)).max(),
+            0.1,
+            "the direct contribution is negligible here, so dropping it "
+            "entirely would still pass the comparison below",
+        )
+
+        tol = 1e-2 if mp.is_single_precision() else 5e-3
+        for f in range(num_frequencies):
+            reference = jax.grad(lambda r: loss(r)[f])(x)
+            self.assertClose(
+                onp.asarray(jacobian[f]).ravel(),
+                onp.asarray(reference).ravel(),
+                epsilon=tol,
+                msg=f"row {f}",
+            )
 
     def test_value_and_jacobian_errors(self):
         wrapped_meep, loss, x, frequencies = self._minimax_setup()

--- a/python/tests/test_adjoint_jax.py
+++ b/python/tests/test_adjoint_jax.py
@@ -395,11 +395,13 @@ class WrapperTest(ApproxComparisonTestCase):
                 x, weight, bias
             )
             # Parameters that bypass Meep are differentiated directly, so they
-            # agree exactly.
+            # agree to whatever precision the monitor values carry -- exactly in
+            # a double-precision build, and to about seven digits in a
+            # single-precision one, since the reference re-runs the simulation.
             self.assertClose(
                 onp.asarray([d_weight[f], d_bias[f]]),
                 onp.asarray([reference[1], reference[2]]),
-                epsilon=1e-13,
+                epsilon=1e-6 if mp.is_single_precision() else 1e-13,
                 msg=f"row {f} non-Meep parameters",
             )
             # The design row agrees to the accuracy of the reference route, not

--- a/python/tests/test_adjoint_protocol.py
+++ b/python/tests/test_adjoint_protocol.py
@@ -270,27 +270,41 @@ class TestJaxIsOptional(unittest.TestCase):
         )
         np.testing.assert_allclose(cotangent, 2 * value.conj())
 
-    def test_no_jax_import_outside_wrapper(self):
-        """Only `wrapper.py` may import JAX, and it is guarded in `__init__.py`.
+    def test_jax_importing_modules_are_all_behind_the_guard(self):
+        """Any module that imports JAX must only be reachable behind the guard.
 
-        Without this, adding `import jax` to any other module of the package
-        would break every user who does not have JAX installed, and the failure
-        would only show up in an environment nobody runs tests in.
+        Without this, adding `import jax` to a module that `__init__.py` imports
+        unconditionally would break every user who does not have JAX installed,
+        and the failure would only show up in an environment nobody runs tests
+        in. The invariant is not "only wrapper.py" -- it is that the set of
+        modules importing JAX is contained in the set imported inside the
+        `try: ... except ModuleNotFoundError` block.
         """
         adjoint_dir = os.path.dirname(os.path.abspath(mpa.__file__))
+        with open(os.path.join(adjoint_dir, "__init__.py")) as f:
+            init_source = f.read()
+
+        guarded_block = init_source[init_source.index("try:") :]
+        guarded = {
+            f"{name}.py"
+            for name in re.findall(r"^\s*from \.(\w+) import", guarded_block, re.M)
+        }
+        self.assertTrue(guarded, "no guarded imports found in __init__.py")
+
         pattern = re.compile(r"^\s*(?:import\s+jax|from\s+jax)", re.MULTILINE)
-        offenders = []
+        importers = set()
         for name in sorted(os.listdir(adjoint_dir)):
-            if not name.endswith(".py") or name == "wrapper.py":
+            if not name.endswith(".py") or name == "__init__.py":
                 continue
             with open(os.path.join(adjoint_dir, name)) as f:
                 if pattern.search(f.read()):
-                    offenders.append(name)
+                    importers.add(name)
+
         self.assertEqual(
-            offenders,
-            [],
-            "JAX may only be imported from meep/adjoint/wrapper.py, which is "
-            "imported behind a ModuleNotFoundError guard in __init__.py.",
+            importers - guarded,
+            set(),
+            "these modules import JAX but are not imported behind the "
+            "ModuleNotFoundError guard in meep/adjoint/__init__.py",
         )
 
 

--- a/python/tests/test_adjoint_protocol.py
+++ b/python/tests/test_adjoint_protocol.py
@@ -1,0 +1,553 @@
+"""Tests for how `meep.adjoint` differentiates objective functions.
+
+These cover the contract between `OptimizationProblem` and `ObjectiveQuantity`
+rather than the physics: that a single vector-Jacobian product reproduces the
+frequency contraction of the Jacobian that Meep used to build explicitly, that
+`place_adjoint_source` validates the cotangent it is handed, and that an
+objective function written in JAX differentiates identically to the same
+function written in autograd.
+
+Everything except `TestJaxObjectiveFunctionGradient` runs without an FDTD simulation.
+"""
+import os
+import re
+import unittest
+import warnings
+
+import numpy as np
+from autograd import jacobian
+from autograd import numpy as npa
+from autograd.extend import defvjp, primitive
+
+import meep as mp
+
+try:
+    import meep.adjoint as mpa
+except ImportError:
+    import adjoint as mpa
+
+from meep.adjoint import utils
+from utils import ApproxComparisonTestCase
+
+try:
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp
+except ImportError:
+    jax = None
+
+
+NUM_FREQ = 3
+
+
+class _StubQuantity(mpa.ObjectiveQuantity):
+    """A minimal `ObjectiveQuantity` that records the cotangent it receives."""
+
+    def __init__(self, value):
+        self._eval = np.asarray(value)
+        self._frequencies = np.arange(NUM_FREQ, dtype=float)
+        self.received = None
+
+    def __call__(self):
+        return self._eval
+
+    def register_monitors(self, frequencies):
+        self._frequencies = np.asarray(frequencies)
+        return None
+
+    def place_adjoint_source(self, dJ):
+        self.received = self._cotangent(dJ)
+        return []
+
+
+def _random(shape, seed) -> np.ndarray:
+    rng = np.random.RandomState(seed)
+    return rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+
+
+_reverse_passes = []
+
+
+@primitive
+def _count_reverse_passes(x):
+    """Identity whose VJP records that a reverse pass traversed it."""
+    return x
+
+
+defvjp(
+    _count_reverse_passes,
+    lambda ans, x: lambda g: (_reverse_passes.append(None), g)[1],
+)
+
+
+class TestObjectiveVJP(ApproxComparisonTestCase):
+    """`utils.objective_vjp` versus the Jacobian it replaced."""
+
+    def test_matches_legacy_jacobian_contraction(self):
+        """One VJP reproduces the contracted Jacobian, for every value shape.
+
+        Meep used to call `autograd.jacobian` per objective argument and let each
+        `place_adjoint_source` sum away one of the two frequency axes. Those two
+        routes agree exactly whenever the objective is block diagonal in
+        frequency, which is the assumption the whole single-adjoint-simulation
+        formulation rests on. The shapes below are those of
+        `EigenmodeCoefficient`/`LDOS`, `FourierFields`, and `Near2FarFields`.
+        """
+        cases = {
+            "per_frequency": (NUM_FREQ,),
+            "plane": (NUM_FREQ, 4, 5),
+            "near2far": (7, NUM_FREQ, 6),
+        }
+        for name, shape in cases.items():
+            with self.subTest(shape=name):
+                value = _random(shape, seed=hash(name) % 2**31)
+                freq_axis = 1 if name == "near2far" else 0
+                weights = _random(shape, seed=17)
+
+                def objective(x):
+                    # Block diagonal in frequency: entry f touches only the
+                    # frequency-f slice of x.
+                    return npa.sum(
+                        npa.abs(x * weights) ** 2,
+                        axis=tuple(i for i in range(len(shape)) if i != freq_axis),
+                    )
+
+                # Legacy: (nfreq,) + shape Jacobian, contracted along the
+                # objective's output axis.
+                legacy = np.sum(jacobian(objective)(value), axis=0)
+
+                (cotangent,) = utils.objective_vjp(
+                    objective, (value,), np.ones(NUM_FREQ)
+                )
+
+                self.assertEqual(cotangent.shape, shape)
+                self.assertClose(
+                    legacy.ravel(), cotangent.ravel(), epsilon=1e-13, msg=name
+                )
+
+    def test_multi_argument_single_pass(self):
+        """Cotangents for every argument from one call, matching separate VJPs."""
+        a = _random((NUM_FREQ,), seed=1)
+        b = _random((NUM_FREQ, 6), seed=2)
+        c = _random((NUM_FREQ,), seed=3)
+
+        def objective(a, b, c):
+            return npa.abs(a + npa.sum(b, axis=1) + c) ** 2
+
+        together = utils.objective_vjp(objective, (a, b, c), np.ones(NUM_FREQ))
+        self.assertEqual(len(together), 3)
+
+        for i, arg in enumerate((a, b, c)):
+            separate = np.sum(jacobian(objective, i)(a, b, c), axis=0)
+            self.assertEqual(together[i].shape, arg.shape)
+            self.assertClose(
+                separate.ravel(), together[i].ravel(), epsilon=1e-13, msg=f"arg{i}"
+            )
+
+    def test_single_reverse_pass(self):
+        """One forward trace and one reverse pass, not one per argument per frequency.
+
+        Guards the performance claim. `autograd.jacobian` traces the forward pass
+        once and then replays the tape once per output component, so the route
+        this replaced -- a `jacobian` call per objective argument -- cost
+        (num arguments) forward traces and (num arguments) x (num frequencies)
+        reverse passes.
+        """
+        args = (_random((NUM_FREQ,), 4), _random((NUM_FREQ, 3), 5))
+        forward_traces = []
+
+        def objective(a, b):
+            forward_traces.append(None)
+            # `_count_reverse_passes` is the identity, but its VJP is recorded on
+            # every tape that reaches the output, so it fires exactly once per
+            # reverse pass.
+            return _count_reverse_passes(npa.abs(a + npa.sum(b, axis=1)) ** 2)
+
+        _reverse_passes.clear()
+        utils.objective_vjp(objective, args, np.ones(NUM_FREQ))
+        self.assertEqual(len(forward_traces), 1)
+        self.assertEqual(len(_reverse_passes), 1)
+
+        # For contrast, the route this replaced.
+        forward_traces.clear()
+        _reverse_passes.clear()
+        for i in range(len(args)):
+            jacobian(objective, i)(*args)
+        self.assertEqual(len(forward_traces), len(args))
+        self.assertEqual(len(_reverse_passes), len(args) * NUM_FREQ)
+
+    def test_scalar_objective(self):
+        """A scalar-valued objective needs a scalar seed, not a vector of ones."""
+        value = _random((NUM_FREQ, 4), seed=6)
+
+        def objective(x):
+            return npa.sum(npa.abs(x) ** 2)
+
+        (cotangent,) = utils.objective_vjp(objective, (value,), 1.0)
+        self.assertEqual(cotangent.shape, value.shape)
+        self.assertClose(
+            jacobian(objective)(value).ravel(), cotangent.ravel(), epsilon=1e-13
+        )
+
+
+class TestCotangentContract(unittest.TestCase):
+    """`place_adjoint_source` validates the shape of what it is handed."""
+
+    def test_accepts_value_shape(self):
+        quantity = _StubQuantity(_random((NUM_FREQ, 5), seed=7))
+        cotangent = _random((NUM_FREQ, 5), seed=8)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # no deprecation for the new contract
+            quantity.place_adjoint_source(cotangent)
+        np.testing.assert_array_equal(quantity.received, cotangent)
+
+    def test_accepts_legacy_jacobian_with_warning(self):
+        """The pre-VJP Jacobian shape still works, contracted, with a warning."""
+        quantity = _StubQuantity(_random((NUM_FREQ, 5), seed=9))
+        legacy = _random((NUM_FREQ, NUM_FREQ, 5), seed=10)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            quantity.place_adjoint_source(legacy)
+        deprecations = [w for w in caught if w.category is DeprecationWarning]
+        self.assertEqual(len(deprecations), 1)
+        np.testing.assert_allclose(quantity.received, np.sum(legacy, axis=0))
+
+    def test_scalar_cotangent_for_single_frequency(self):
+        """A bare scalar is accepted where the value is a single frequency."""
+        quantity = _StubQuantity(np.array([1.0 + 2.0j]))
+        quantity.place_adjoint_source(3.0 + 4.0j)
+        np.testing.assert_array_equal(quantity.received, np.array([3.0 + 4.0j]))
+
+    def test_rejects_mismatched_shape(self):
+        quantity = _StubQuantity(_random((NUM_FREQ, 5), seed=11))
+        with self.assertRaisesRegex(ValueError, "expected a cotangent of shape"):
+            quantity.place_adjoint_source(_random((NUM_FREQ, 4), seed=12))
+
+
+class TestGatherMonitorValues(unittest.TestCase):
+    """`utils.gather_monitor_values` stacks what it can and tuples the rest."""
+
+    def test_stacks_homogeneous_per_frequency_values(self):
+        """Monitors that all yield one value per frequency stack as before.
+
+        The rank-2 (monitor, frequency) array is what `MeepJaxWrapper` has always
+        returned, and user code indexes it as `monitor_values[0, :]`.
+        """
+        monitors = [_StubQuantity(_random((NUM_FREQ,), seed=s)) for s in (13, 14)]
+        values = utils.gather_monitor_values(monitors)
+        self.assertIsInstance(values, np.ndarray)
+        self.assertEqual(values.shape, (2, NUM_FREQ))
+
+    def test_stacks_scalar_values(self):
+        monitors = [_StubQuantity(np.array(1.0 + 1j)) for _ in range(3)]
+        values = utils.gather_monitor_values(monitors)
+        self.assertIsInstance(values, np.ndarray)
+        self.assertEqual(values.shape, (3, 1))
+
+    def test_tuples_heterogeneous_values(self):
+        monitors = [
+            _StubQuantity(_random((NUM_FREQ,), seed=15)),
+            _StubQuantity(_random((NUM_FREQ, 4, 5), seed=16)),
+        ]
+        values = utils.gather_monitor_values(monitors)
+        self.assertIsInstance(values, tuple)
+        self.assertEqual([v.shape for v in values], [(NUM_FREQ,), (NUM_FREQ, 4, 5)])
+
+
+class TestJaxIsOptional(unittest.TestCase):
+    """JAX must stay an optional dependency of `meep.adjoint`."""
+
+    def test_autograd_is_the_default_backend(self):
+        """An autograd objective is unaffected by any registered backend."""
+        value = _random((NUM_FREQ, 4), seed=24)
+
+        def objective(x):
+            return npa.sum(npa.abs(x) ** 2, axis=1)
+
+        (cotangent,) = utils.objective_vjp(
+            objective, (value,), np.ones(NUM_FREQ), value=objective(value)
+        )
+        np.testing.assert_allclose(cotangent, 2 * value.conj())
+
+    def test_no_jax_import_outside_wrapper(self):
+        """Only `wrapper.py` may import JAX, and it is guarded in `__init__.py`.
+
+        Without this, adding `import jax` to any other module of the package
+        would break every user who does not have JAX installed, and the failure
+        would only show up in an environment nobody runs tests in.
+        """
+        adjoint_dir = os.path.dirname(os.path.abspath(mpa.__file__))
+        pattern = re.compile(r"^\s*(?:import\s+jax|from\s+jax)", re.MULTILINE)
+        offenders = []
+        for name in sorted(os.listdir(adjoint_dir)):
+            if not name.endswith(".py") or name == "wrapper.py":
+                continue
+            with open(os.path.join(adjoint_dir, name)) as f:
+                if pattern.search(f.read()):
+                    offenders.append(name)
+        self.assertEqual(
+            offenders,
+            [],
+            "JAX may only be imported from meep/adjoint/wrapper.py, which is "
+            "imported behind a ModuleNotFoundError guard in __init__.py.",
+        )
+
+
+@unittest.skipIf(jax is None, "jax is not installed")
+class TestJaxObjectiveFunction(ApproxComparisonTestCase):
+    """An objective written in JAX differentiates like the autograd version.
+
+    A JAX objective is a plain function passed straight to `OptimizationProblem`:
+    there is nothing to wrap or declare. It is recognized because it returns a
+    JAX array, and `wrapper` registers JAX as a way to differentiate such
+    functions when it is imported.
+    """
+
+    def test_dispatches_on_return_type(self):
+        """A bare jax.numpy function is differentiated by JAX, not autograd."""
+        value = _random((NUM_FREQ, 4), seed=30)
+
+        def objective(x):
+            # autograd cannot trace this: jnp rejects autograd's boxes.
+            return jnp.sum(jnp.abs(x) ** 2, axis=1)
+
+        cotangent = np.ones(NUM_FREQ)
+        (got,) = utils.objective_vjp(
+            objective, (value,), cotangent, value=objective(value)
+        )
+        self.assertEqual(got.shape, value.shape)
+        self.assertClose(2 * value.conj().ravel(), got.ravel(), epsilon=1e-13)
+
+        # Without the return value there is nothing to dispatch on, so autograd
+        # is used -- and fails, rather than silently doing something else.
+        with self.assertRaises(Exception):
+            utils.objective_vjp(objective, (value,), cotangent)
+
+    def test_agrees_with_autograd(self):
+        """The two frameworks' complex cotangent conventions must coincide.
+
+        A real-valued objective of complex monitor values is the case that
+        matters, and it is the one where a conjugation-convention mismatch would
+        silently produce a gradient of the right magnitude pointing the wrong
+        way.
+        """
+        a = _random((NUM_FREQ,), seed=18)
+        b = _random((NUM_FREQ, 6), seed=19)
+        weights = np.random.RandomState(20).standard_normal(6)
+
+        def build(xp):
+            def objective(a, b):
+                overlap = xp.sum(b * weights, axis=1)
+                return xp.abs(overlap) ** 2 / xp.abs(a) ** 2 + xp.real(
+                    a * xp.conj(overlap)
+                )
+
+            return objective
+
+        autograd_objective = build(npa)
+        jax_objective = build(jnp)
+
+        self.assertClose(
+            autograd_objective(a, b),
+            np.asarray(jax_objective(a, b)),
+            epsilon=1e-13,
+        )
+
+        cotangent = np.ones(NUM_FREQ)
+        expected = utils.objective_vjp(
+            autograd_objective, (a, b), cotangent, value=autograd_objective(a, b)
+        )
+        actual = utils.objective_vjp(
+            jax_objective, (a, b), cotangent, value=jax_objective(a, b)
+        )
+
+        self.assertEqual(len(actual), len(expected))
+        for i, (want, got) in enumerate(zip(expected, actual)):
+            self.assertEqual(got.shape, want.shape)
+            self.assertClose(
+                want.ravel(), got.ravel(), epsilon=1e-12, msg=f"arg{i}"
+            )
+            # A conjugated convention would be a much larger error than the
+            # tolerance above; assert it explicitly so the test names the failure.
+            self.assertGreater(
+                np.abs(want - np.conj(got)).max(),
+                1e-6 * np.abs(want).max(),
+                msg=f"arg{i}: cotangent is real, so the conjugation check is vacuous",
+            )
+
+    def test_scalar_objective(self):
+        value = _random((NUM_FREQ, 4), seed=21)
+
+        def objective(x):
+            return jnp.sum(jnp.abs(x) ** 2)
+
+        (cotangent,) = utils.objective_vjp(
+            objective, (value,), 1.0, value=objective(value)
+        )
+        self.assertEqual(cotangent.shape, value.shape)
+        self.assertClose(
+            2 * value.conj().ravel(), cotangent.ravel(), epsilon=1e-13
+        )
+
+    def test_rejects_non_array_output(self):
+        def objective(x):
+            return (jnp.sum(x), jnp.sum(x))
+
+        # A tuple return is not dispatched to JAX (it is not a jax.Array), so
+        # force the backend directly to check its own diagnostic.
+        from meep.adjoint import wrapper
+
+        with self.assertRaisesRegex(TypeError, "single array or scalar"):
+            wrapper._jax_objective_vjp(objective, (_random((NUM_FREQ,), 22),), 1.0)
+
+    def test_explicit_vjp_takes_precedence(self):
+        """A hand-written pullback wins over any registered backend.
+
+        This is the escape hatch for an analytic derivative, or for a framework
+        with no registered backend.
+        """
+        value = _random((NUM_FREQ, 4), seed=23)
+        sentinel = np.full(value.shape, 7.0 + 0j)
+
+        def objective(x):
+            return jnp.sum(jnp.abs(x) ** 2, axis=1)
+
+        objective.vjp = lambda cotangent, *args: (sentinel,)
+
+        (cotangent,) = utils.objective_vjp(
+            objective, (value,), np.ones(NUM_FREQ), value=objective(value)
+        )
+        np.testing.assert_array_equal(cotangent, sentinel)
+
+
+@unittest.skipIf(jax is None, "jax is not installed")
+class TestJaxObjectiveFunctionGradient(ApproxComparisonTestCase):
+    """End-to-end: a JAX objective driving `OptimizationProblem`.
+
+    The two objective arguments are `FourierFields` monitors of different rank,
+    so this also exercises passing cotangents of heterogeneous shape through
+    `utils.create_adjoint_sources`.
+
+    Deliberately no `EigenmodeCoefficient`: MPB warm-starts from the previous
+    solve, so repeating an otherwise identical run reproduces a mode coefficient
+    only to about 1e-8. That is far below every physics tolerance in the suite,
+    but it would put a floor under the framework-equivalence comparison below,
+    which should be exact to roundoff.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.resolution = 20
+        cls.silicon = mp.Medium(epsilon=12)
+        cls.sxy = 5.0
+        cls.dpml = 1.0
+        cls.fcen = 1 / 1.55
+        cls.frequencies = [cls.fcen * 0.98, cls.fcen, cls.fcen * 1.02]
+        cls.design_region_size = mp.Vector3(1.0, 1.0)
+        cls.Nx = int(cls.design_region_size.x * cls.resolution) + 1
+        cls.Ny = int(cls.design_region_size.y * cls.resolution) + 1
+
+        rng = np.random.RandomState(4321)
+        cls.p = 0.5 * rng.rand(cls.Nx * cls.Ny)
+        cls.dp = 1e-4 * rng.rand(cls.Nx * cls.Ny)
+
+    def _solve(self, design_params, use_jax: bool, need_gradient: bool = True):
+        """Runs one forward (and optionally adjoint) solve of a small problem."""
+        matgrid = mp.MaterialGrid(
+            mp.Vector3(self.Nx, self.Ny),
+            mp.air,
+            self.silicon,
+            weights=np.ones((self.Nx, self.Ny)),
+        )
+        design_region = mpa.DesignRegion(
+            matgrid,
+            volume=mp.Volume(
+                center=mp.Vector3(),
+                size=mp.Vector3(self.design_region_size.x, self.design_region_size.y),
+            ),
+        )
+        sim = mp.Simulation(
+            resolution=self.resolution,
+            cell_size=mp.Vector3(self.sxy, self.sxy),
+            boundary_layers=[mp.PML(self.dpml)],
+            sources=[
+                mp.Source(
+                    mp.GaussianSource(self.fcen, fwidth=0.2 * self.fcen),
+                    component=mp.Ez,
+                    center=mp.Vector3(-1.25, 0),
+                    size=mp.Vector3(0, 2.0),
+                )
+            ],
+            geometry=[
+                mp.Block(
+                    center=design_region.center,
+                    size=design_region.size,
+                    material=matgrid,
+                )
+            ],
+        )
+
+        # Two objective arguments of different rank: a line of Ez, shaped
+        # (nfreq, ny), and a patch of Hy, shaped (nfreq, nx, ny).
+        obj_args = [
+            mpa.FourierFields(
+                sim,
+                mp.Volume(center=mp.Vector3(1.0, 0), size=mp.Vector3(0, 0.6)),
+                mp.Ez,
+            ),
+            mpa.FourierFields(
+                sim,
+                mp.Volume(center=mp.Vector3(-1.0, 0.2), size=mp.Vector3(0.3, 0.4)),
+                mp.Hy,
+            ),
+        ]
+
+        def build(xp):
+            def objective(ez_line, hy_patch):
+                return xp.sum(xp.abs(ez_line) ** 2, axis=1) + xp.sum(
+                    xp.abs(hy_patch) ** 2, axis=(1, 2)
+                )
+
+            return objective
+
+        # Nothing distinguishes the two at the call site: a JAX objective is a
+        # plain function, recognized by the array type it returns.
+        objective = build(jnp) if use_jax else build(npa)
+
+        opt = mpa.OptimizationProblem(
+            simulation=sim,
+            objective_functions=objective,
+            objective_arguments=obj_args,
+            design_regions=[design_region],
+            frequencies=self.frequencies,
+        )
+        return opt([design_params], need_gradient=need_gradient)
+
+    def test_matches_autograd_gradient(self):
+        """Same objective, two frameworks, same value and same gradient."""
+        jax_value, jax_grad = self._solve(self.p, use_jax=True)
+        autograd_value, autograd_grad = self._solve(self.p, use_jax=False)
+
+        self.assertClose(jax_value, autograd_value, epsilon=1e-12)
+        self.assertClose(
+            np.asarray(jax_grad).ravel(),
+            np.asarray(autograd_grad).ravel(),
+            epsilon=1e-10,
+        )
+
+    def test_matches_finite_difference(self):
+        """The JAX-derived adjoint gradient is the real gradient."""
+        value, grad = self._solve(self.p, use_jax=True)
+        perturbed, _ = self._solve(self.p + self.dp, use_jax=True, need_gradient=False)
+
+        grad = np.atleast_2d(np.asarray(grad))
+        adjoint_dd = (self.dp[None, :] @ grad).ravel()
+        finite_difference_dd = np.asarray(perturbed) - np.asarray(value)
+
+        tol = 0.075 if mp.is_single_precision() else 0.005
+        self.assertClose(adjoint_dd, finite_difference_dd, epsilon=tol)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_adjoint_protocol.py
+++ b/python/tests/test_adjoint_protocol.py
@@ -365,9 +365,7 @@ class TestJaxObjectiveFunction(ApproxComparisonTestCase):
         self.assertEqual(len(actual), len(expected))
         for i, (want, got) in enumerate(zip(expected, actual)):
             self.assertEqual(got.shape, want.shape)
-            self.assertClose(
-                want.ravel(), got.ravel(), epsilon=1e-12, msg=f"arg{i}"
-            )
+            self.assertClose(want.ravel(), got.ravel(), epsilon=1e-12, msg=f"arg{i}")
             # A conjugated convention would be a much larger error than the
             # tolerance above; assert it explicitly so the test names the failure.
             self.assertGreater(
@@ -386,9 +384,7 @@ class TestJaxObjectiveFunction(ApproxComparisonTestCase):
             objective, (value,), 1.0, value=objective(value)
         )
         self.assertEqual(cotangent.shape, value.shape)
-        self.assertClose(
-            2 * value.conj().ravel(), cotangent.ravel(), epsilon=1e-13
-        )
+        self.assertClose(2 * value.conj().ravel(), cotangent.ravel(), epsilon=1e-13)
 
     def test_rejects_non_array_output(self):
         def objective(x):

--- a/python/tests/test_adjoint_protocol.py
+++ b/python/tests/test_adjoint_protocol.py
@@ -539,11 +539,19 @@ class TestJaxObjectiveFunctionGradient(ApproxComparisonTestCase):
         jax_value, jax_grad = self._solve(self.p, use_jax=True)
         autograd_value, autograd_grad = self._solve(self.p, use_jax=False)
 
-        self.assertClose(jax_value, autograd_value, epsilon=1e-12)
+        # Two separate simulations of the same problem, reaching the same
+        # gradient by different arithmetic. They can only agree to the precision
+        # the monitor values carry, which is about seven digits when Meep is
+        # built in single precision.
+        if mp.is_single_precision():
+            value_tolerance, gradient_tolerance = 1e-5, 1e-4
+        else:
+            value_tolerance, gradient_tolerance = 1e-12, 1e-10
+        self.assertClose(jax_value, autograd_value, epsilon=value_tolerance)
         self.assertClose(
             np.asarray(jax_grad).ravel(),
             np.asarray(autograd_grad).ravel(),
-            epsilon=1e-10,
+            epsilon=gradient_tolerance,
         )
 
     def test_matches_finite_difference(self):


### PR DESCRIPTION
> Recreated so the whole series can form a single GitHub stack. Native stacked pull requests cannot include PRs opened from a fork, and this branch was previously hosted on one. The content and description are unchanged; earlier review discussion is on the superseded PR linked below, which remains readable.

_Supersedes #3280._

This PR makes Jax a "first-class" citizen within Meep's adjoint model. While meep technically supported Jax already, the interface was buggy, lacked several important features, and didn't play nice with the existing autograd engine. This resolves that.

**Allow users to specify their objective function using either autograd's `numpy` or jax's `numpy`**. The backend handles the vjps automatically. You can't mix and match though (e.g. use meep's autograd filters with a jax objective).
```python
from autograd import numpy as npa

def objective(mode_coeff, dft_fields):
    return npa.abs(mode_coeff)**2 + npa.sum(npa.abs(dft_fields)**2, axis=1)
```
OR
```python
from jax import numpy as npj

def objective(mode_coeff, dft_fields):
    return npj.abs(mode_coeff)**2 + npj.sum(npj.abs(dft_fields)**2, axis=1)
```
Meep handles both just fine:
```python
opt = mpa.OptimizationProblem(
    simulation=sim,
    objective_functions=[objective],
    objective_arguments=[mode_monitor, dft_monitor],
    design_regions=[design_region],
    frequencies=frequencies,
)

value, gradient = opt([rho])
```

**Extend `MeepJaxWrapper` to properly support single-frequency objectives and vector-valued (multi-frequency) objectives**. There was a bug in the single-frequency case. The multi-frequency case previously required the user to scalarize the objective (e.g. reduce across the frequency/wavelength dimension). You can now specify a vector-valued objective function (like you can with the standard `OptimizationProblem` API) and jax will return a dense jacobian:


```py
def loss(rho, thickness, tilt):
    (dft,) = wrapped_meep([rho])
    return postprocess(dft, thickness, tilt)   # scalar

value, (d_rho, d_thickness, d_tilt) = jax.value_and_grad(
    loss, argnums=(0, 1, 2))(rho, 1.8, 8.0)
```

**Package optimization parameters as pytrees** (and return the gradient as an organized pytree). The end2end jax workflow allows you to chain operations before the meep simulations (preprocessing) and after (postprocessing). The user may want to collect gradients with parameters that tune these routines too. But bookeeping all of this is a pain. So we adopt the same approach e.g. `fmmax` uses via pytrees. You can pass a single pytree (a Dict/NamedTuple) to your objective function and the gradient routine will _also_ produce a pytree. This also works with vector-valued objectives (e.g. for minimax optimization):

```py
class Stack(NamedTuple):
    thickness: jnp.ndarray     # (3,) oxide, antireflection coating, air
    index: jnp.ndarray         # (3,)

class Params(NamedTuple):
    latent: jnp.ndarray        # (601,) design degrees of freedom
    beta: float                # preprocessing: projection strength
    stack: Stack               # post-processing: the layers above the chip
    tilt: float                # post-processing: fiber tilt, in degrees

def project(x, beta, eta=0.5):
    """The usual tanh projection, written in jax.numpy -- see the note below."""
    return (jnp.tanh(beta * eta) + jnp.tanh(beta * (x - eta))) / (
        jnp.tanh(beta * eta) + jnp.tanh(beta * (1 - eta))
    )

def loss(p):
    rho = project(conic_filter(p.latent), p.beta)   # preprocessing, in jax.numpy
    (ez, hx) = wrapped_meep([rho])
    field = propagate(ez, hx, p.stack)          # a stratified-media propagator, say
    return fiber_overlap(field, p.tilt)         # (nfreq,)

values, jacobian = mpa.value_and_jacobian(loss)(params)
jax.tree_util.tree_map(lambda leaf: leaf.shape, jacobian)
```

**Various other bug fixes and removed antipatterns.**