### PR TITLE
Draw perfect metals (ε = -∞) in dark red in `plot2D`

### DIFF
--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -3048,7 +3048,7 @@ to be called on all processes, but only generates a plot on the master process.
     - `resolution=None`: the resolution of the $\varepsilon$ grid. Defaults to the
       `resolution` of the `Simulation` object.
     - `colorbar=False`: whether to add a colorbar to the plot's parent Figure based on epsilon values.
-    - `pec_color='dimgray'`: the color used to draw perfect metals / perfect
+    - `pec_color='darkred'`: the color used to draw perfect metals / perfect
       electric conductors, whose permittivity is $-\infty$. Drawing these
       separately keeps them from saturating the color scale of the
       finite-permittivity materials.

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -3048,6 +3048,10 @@ to be called on all processes, but only generates a plot on the master process.
     - `resolution=None`: the resolution of the $\varepsilon$ grid. Defaults to the
       `resolution` of the `Simulation` object.
     - `colorbar=False`: whether to add a colorbar to the plot's parent Figure based on epsilon values.
+    - `pec_color='dimgrey'`: the color used to draw perfect metals / perfect
+      electric conductors, whose permittivity is $-\infty$. Drawing these
+      separately keeps them from saturating the color scale of the
+      finite-permittivity materials.
 * `boundary_parameters`: a `dict` of optional plotting parameters that override
   the default parameters for the boundary layers.
     - `alpha=1.0`: transparency of boundary layers

--- a/doc/docs/Python_User_Interface.md
+++ b/doc/docs/Python_User_Interface.md
@@ -3048,7 +3048,7 @@ to be called on all processes, but only generates a plot on the master process.
     - `resolution=None`: the resolution of the $\varepsilon$ grid. Defaults to the
       `resolution` of the `Simulation` object.
     - `colorbar=False`: whether to add a colorbar to the plot's parent Figure based on epsilon values.
-    - `pec_color='dimgrey'`: the color used to draw perfect metals / perfect
+    - `pec_color='dimgray'`: the color used to draw perfect metals / perfect
       electric conductors, whose permittivity is $-\infty$. Drawing these
       separately keeps them from saturating the color scale of the
       finite-permittivity materials.

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -5052,7 +5052,7 @@ class Simulation:
             - `resolution=None`: the resolution of the $\\varepsilon$ grid. Defaults to the
               `resolution` of the `Simulation` object.
             - `colorbar=False`: whether to add a colorbar to the plot's parent Figure based on epsilon values.
-            - `pec_color='dimgrey'`: the color used to draw perfect metals / perfect
+            - `pec_color='dimgray'`: the color used to draw perfect metals / perfect
               electric conductors, whose permittivity is $-\\infty$. Drawing these
               separately keeps them from saturating the color scale of the
               finite-permittivity materials.

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -5052,7 +5052,7 @@ class Simulation:
             - `resolution=None`: the resolution of the $\\varepsilon$ grid. Defaults to the
               `resolution` of the `Simulation` object.
             - `colorbar=False`: whether to add a colorbar to the plot's parent Figure based on epsilon values.
-            - `pec_color='dimgray'`: the color used to draw perfect metals / perfect
+            - `pec_color='darkred'`: the color used to draw perfect metals / perfect
               electric conductors, whose permittivity is $-\\infty$. Drawing these
               separately keeps them from saturating the color scale of the
               finite-permittivity materials.

--- a/python/simulation.py
+++ b/python/simulation.py
@@ -5052,6 +5052,10 @@ class Simulation:
             - `resolution=None`: the resolution of the $\\varepsilon$ grid. Defaults to the
               `resolution` of the `Simulation` object.
             - `colorbar=False`: whether to add a colorbar to the plot's parent Figure based on epsilon values.
+            - `pec_color='dimgrey'`: the color used to draw perfect metals / perfect
+              electric conductors, whose permittivity is $-\\infty$. Drawing these
+              separately keeps them from saturating the color scale of the
+              finite-permittivity materials.
         * `boundary_parameters`: a `dict` of optional plotting parameters that override
           the default parameters for the boundary layers.
             - `alpha=1.0`: transparency of boundary layers

--- a/python/tests/test_visualization.py
+++ b/python/tests/test_visualization.py
@@ -3,6 +3,7 @@
 # boundary conditions. Checks for subdomain plots.
 #
 # Also tests the animation run function, mp4 output, jshtml output, and git output.
+import importlib.util
 import os
 import unittest
 from subprocess import call
@@ -326,6 +327,80 @@ class TestVisualization(unittest.TestCase):
         if mp.am_master():
             hash_figure(f)
             # self.assertAlmostEqual(hash_figure(f),68926258)
+
+    @staticmethod
+    def setup_pec_sim():
+        return mp.Simulation(
+            cell_size=mp.Vector3(6, 6),
+            resolution=20,
+            geometry=[
+                mp.Block(
+                    size=mp.Vector3(2, 2),
+                    center=mp.Vector3(-1.2),
+                    material=mp.Medium(epsilon=12),
+                ),
+                mp.Block(
+                    size=mp.Vector3(2, 2),
+                    center=mp.Vector3(1.2),
+                    material=mp.metal,
+                ),
+            ],
+            sources=[
+                mp.Source(
+                    src=mp.ContinuousSource(frequency=0.15),
+                    component=mp.Ez,
+                    center=mp.Vector3(0, -2),
+                )
+            ],
+        )
+
+    def test_plot2D_pec(self):
+        # Metals have eps = -inf, which must not saturate the color scale of
+        # the finite-permittivity materials plotted alongside them.
+        sim = self.setup_pec_sim()
+
+        fig, ax = plt.subplots()
+        ax = sim.plot2D(ax=ax, eps_parameters={"colorbar": True})
+        if mp.am_master():
+            im = ax.get_images()[0]
+
+            # The metal pixels are masked out of the color scale...
+            self.assertTrue(np.all(np.isfinite(im.get_clim())))
+            self.assertAlmostEqual(im.get_clim()[0], 1)
+            self.assertAlmostEqual(im.get_clim()[1], 12)
+
+            # ...and drawn in the (opaque) `pec_color` instead.
+            self.assertTrue(
+                np.allclose(
+                    im.get_cmap().get_bad(), matplotlib.colors.to_rgba("dimgrey")
+                )
+            )
+            self.assertTrue(np.any(im.get_array().mask))
+
+            # The module-level defaults must not have been mutated.
+            self.assertEqual(mp.visualization.default_eps_parameters["cmap"], "binary")
+
+        # A user-specified color is honored.
+        fig, ax = plt.subplots()
+        ax = sim.plot2D(ax=ax, eps_parameters={"pec_color": "red"})
+        if mp.am_master():
+            self.assertTrue(
+                np.allclose(
+                    ax.get_images()[0].get_cmap().get_bad(),
+                    matplotlib.colors.to_rgba("red"),
+                )
+            )
+
+    @unittest.skipIf(
+        importlib.util.find_spec("contourpy") is None, "contourpy is not installed"
+    )
+    def test_plot2D_pec_contour(self):
+        # The contour path must not emit -inf as a contour level.
+        sim = self.setup_pec_sim()
+        fig, ax = plt.subplots()
+        ax = sim.plot2D(ax=ax, eps_parameters={"contour": True})
+        if mp.am_master():
+            self.assertGreater(len(ax.collections), 0)
 
     @unittest.skipIf(call(["which", "ffmpeg"]) != 0, "ffmpeg is not installed")
     def test_animation_output(self):

--- a/python/tests/test_visualization.py
+++ b/python/tests/test_visualization.py
@@ -19,6 +19,7 @@ matplotlib.use("agg")  # Set backend for consistency and to pull pixels quickly
 import io
 
 from matplotlib import pyplot as plt
+from matplotlib.contour import ContourSet
 
 
 def hash_figure(fig):
@@ -359,8 +360,8 @@ class TestVisualization(unittest.TestCase):
         # the finite-permittivity materials plotted alongside them.
         sim = self.setup_pec_sim()
 
-        fig, ax = plt.subplots()
-        ax = sim.plot2D(ax=ax, eps_parameters={"colorbar": True})
+        f = plt.figure()
+        ax = sim.plot2D(ax=f.gca(), eps_parameters={"colorbar": True})
         if mp.am_master():
             im = ax.get_images()[0]
 
@@ -377,12 +378,19 @@ class TestVisualization(unittest.TestCase):
             )
             self.assertTrue(np.any(im.get_array().mask))
 
+            # The default pec_color must not coincide with any color of the
+            # default colormap, which is grayscale and therefore spans every
+            # gray; otherwise metals look like some finite permittivity.
+            ramp = im.get_cmap()(np.linspace(0, 1, 256))[:, :3]
+            pec_rgb = np.array(matplotlib.colors.to_rgb("darkred"))
+            self.assertGreater(np.min(np.linalg.norm(ramp - pec_rgb, axis=1)), 0.25)
+
             # The module-level defaults must not have been mutated.
             self.assertEqual(mp.visualization.default_eps_parameters["cmap"], "binary")
 
         # A user-specified color is honored.
-        fig, ax = plt.subplots()
-        ax = sim.plot2D(ax=ax, eps_parameters={"pec_color": "red"})
+        f = plt.figure()
+        ax = sim.plot2D(ax=f.gca(), eps_parameters={"pec_color": "red"})
         if mp.am_master():
             self.assertTrue(
                 np.allclose(
@@ -395,12 +403,19 @@ class TestVisualization(unittest.TestCase):
         importlib.util.find_spec("contourpy") is None, "contourpy is not installed"
     )
     def test_plot2D_pec_contour(self):
-        # The contour path must not emit -inf as a contour level.
+        # The contour path must not emit the metal's -inf as a contour level:
+        # the geometry only has the two finite permittivities 1 and 12, so the
+        # smallest level is 1. Without masking the metal it would be -mp.inf.
         sim = self.setup_pec_sim()
-        fig, ax = plt.subplots()
-        ax = sim.plot2D(ax=ax, eps_parameters={"contour": True})
+        f = plt.figure()
+        ax = sim.plot2D(ax=f.gca(), eps_parameters={"contour": True})
         if mp.am_master():
-            self.assertGreater(len(ax.collections), 0)
+            contours = [c for c in ax.collections if isinstance(c, ContourSet)]
+            self.assertEqual(len(contours), 1)
+            levels = contours[0].levels
+            self.assertTrue(np.all(np.isfinite(levels)))
+            self.assertGreaterEqual(np.min(levels), 1)
+            self.assertLessEqual(np.max(levels), 12)
 
     @unittest.skipIf(call(["which", "ffmpeg"]) != 0, "ffmpeg is not installed")
     def test_animation_output(self):

--- a/python/tests/test_visualization.py
+++ b/python/tests/test_visualization.py
@@ -372,7 +372,7 @@ class TestVisualization(unittest.TestCase):
             # ...and drawn in the (opaque) `pec_color` instead.
             self.assertTrue(
                 np.allclose(
-                    im.get_cmap().get_bad(), matplotlib.colors.to_rgba("dimgray")
+                    im.get_cmap().get_bad(), matplotlib.colors.to_rgba("darkred")
                 )
             )
             self.assertTrue(np.any(im.get_array().mask))

--- a/python/tests/test_visualization.py
+++ b/python/tests/test_visualization.py
@@ -372,7 +372,7 @@ class TestVisualization(unittest.TestCase):
             # ...and drawn in the (opaque) `pec_color` instead.
             self.assertTrue(
                 np.allclose(
-                    im.get_cmap().get_bad(), matplotlib.colors.to_rgba("dimgrey")
+                    im.get_cmap().get_bad(), matplotlib.colors.to_rgba("dimgray")
                 )
             )
             self.assertTrue(np.any(im.get_array().mask))

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -690,7 +690,7 @@ def plot_eps(
             return eps_data
 
         # Metals / perfect electric conductors have eps = -inf (see python/meep.i,
-        # where mp.inf is the sentinal 1e20), which would otherwise saturate the
+        # where mp.inf is the sentinel 1e20), which would otherwise saturate the
         # color scale. Mask them out so that the scale is set by the finite
         # permittivities, and draw them in `pec_color` instead.
         eps_data = np.ma.masked_where(

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -14,6 +14,7 @@ from meep.simulation import Simulation, Volume
 
 ## Typing imports
 from matplotlib.axes import Axes
+from matplotlib.colors import Colormap
 from matplotlib.figure import Figure
 from typing import Callable, Union, Any, Tuple, List, Optional
 
@@ -61,6 +62,7 @@ default_eps_parameters = {
     "frequency": None,
     "resolution": None,
     "colorbar": False,
+    "pec_color": "dimgrey",
 }
 
 default_colorbar_parameters = {
@@ -556,9 +558,21 @@ def plot_volume(
     return ax
 
 
+def _get_colormap(cmap: Union[str, Colormap]) -> Colormap:
+    """Return a Colormap object given a colormap name or Colormap object."""
+    import matplotlib as mpl
+
+    if isinstance(cmap, Colormap):
+        return cmap
+    try:
+        return mpl.colormaps[cmap]  # matplotlib >= 3.5
+    except AttributeError:
+        return mpl.cm.get_cmap(cmap)  # matplotlib < 3.5
+
+
 def _add_colorbar(
     ax: Axes,
-    cmap: str,
+    cmap: Union[str, Colormap],
     vmin: float,
     vmax: float,
     default_label: Optional[str] = None,
@@ -578,10 +592,9 @@ def _add_colorbar(
         colorbar_parameters["label"] = default_label
 
     # Create a map between field/eps values and colors in the colormap.
-    # Note: cm.get_cmap() is deprecated for matplotlib>=3.6, use mpl.colormaps[cmap] instead if necessary.
     sm = mpl.cm.ScalarMappable(
         norm=mpl.colors.Normalize(vmin, vmax),
-        cmap=mpl.cm.get_cmap(cmap),
+        cmap=_get_colormap(cmap),
     )
 
     # Pop specific values out of colorbar params so user can add any kwargs to plt.colorbar
@@ -607,7 +620,7 @@ def plot_eps(
 ) -> Union[Axes, Any]:
     # consolidate plotting parameters
     if eps_parameters is None:
-        eps_parameters = default_eps_parameters
+        eps_parameters = copy.deepcopy(default_eps_parameters)
     else:
         eps_parameters = dict(default_eps_parameters, **eps_parameters)
 
@@ -676,11 +689,22 @@ def plot_eps(
         if not ax:
             return eps_data
 
+        # Metals / perfect electric conductors have eps = -inf (see python/meep.i,
+        # where mp.inf is the sentinal 1e20), which would otherwise saturate the
+        # color scale. Mask them out so that the scale is set by the finite
+        # permittivities, and draw them in `pec_color` instead.
+        eps_data = np.ma.masked_where(
+            ~np.isfinite(eps_data) | (eps_data <= -mp.inf), eps_data
+        )
+        cmap = copy.copy(_get_colormap(eps_parameters["cmap"]))
+        cmap.set_bad(color=eps_parameters["pec_color"])
+        eps_parameters["cmap"] = cmap
+
         if eps_parameters["contour"]:
             ax.contour(
                 eps_data,
                 0,
-                levels=np.unique(eps_data),
+                levels=np.unique(eps_data.compressed()),
                 colors="black",
                 origin="upper",
                 extent=extent,
@@ -690,11 +714,12 @@ def plot_eps(
             ax.imshow(eps_data, extent=extent, **filter_dict(eps_parameters, ax.imshow))
 
         if eps_parameters["colorbar"]:
+            finite_eps = eps_data.compressed()
             _add_colorbar(
                 ax=ax,
                 cmap=eps_parameters["cmap"],
-                vmin=np.amin(eps_data),
-                vmax=np.amax(eps_data),
+                vmin=np.amin(finite_eps) if finite_eps.size else 0.0,
+                vmax=np.amax(finite_eps) if finite_eps.size else 1.0,
                 default_label=r"$\epsilon_r$",
                 colorbar_parameters=colorbar_parameters,
             )

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -62,7 +62,7 @@ default_eps_parameters = {
     "frequency": None,
     "resolution": None,
     "colorbar": False,
-    "pec_color": "dimgrey",
+    "pec_color": "darkred",
 }
 
 default_colorbar_parameters = {

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -620,7 +620,7 @@ def plot_eps(
 ) -> Union[Axes, Any]:
     # consolidate plotting parameters
     if eps_parameters is None:
-        eps_parameters = copy.deepcopy(default_eps_parameters)
+        eps_parameters = copy.copy(default_eps_parameters)
     else:
         eps_parameters = dict(default_eps_parameters, **eps_parameters)
 

--- a/python/visualization.py
+++ b/python/visualization.py
@@ -583,7 +583,7 @@ def _add_colorbar(
     from mpl_toolkits.axes_grid1 import make_axes_locatable
 
     if colorbar_parameters is None:
-        colorbar_parameters = copy.deepcopy(default_colorbar_parameters)
+        colorbar_parameters = copy.copy(default_colorbar_parameters)
     else:
         colorbar_parameters = dict(default_colorbar_parameters, **colorbar_parameters)
 
@@ -692,7 +692,10 @@ def plot_eps(
         # Metals / perfect electric conductors have eps = -inf (see python/meep.i,
         # where mp.inf is the sentinel 1e20), which would otherwise saturate the
         # color scale. Mask them out so that the scale is set by the finite
-        # permittivities, and draw them in `pec_color` instead.
+        # permittivities, and draw them in `pec_color` instead. Note that the
+        # default `pec_color` is deliberately not a gray: the default `cmap`
+        # ('binary') spans every gray, so a gray would be indistinguishable from
+        # some finite permittivity.
         eps_data = np.ma.masked_where(
             ~np.isfinite(eps_data) | (eps_data <= -mp.inf), eps_data
         )
@@ -1097,7 +1100,7 @@ def plot_1d_index(
 ) -> Union[Axes, Any]:
     """Plots the refractive-index profile n(z) of a 1D simulation."""
     if index_parameters is None:
-        index_parameters = default_1d_index_parameters
+        index_parameters = copy.copy(default_1d_index_parameters)
     else:
         index_parameters = dict(default_1d_index_parameters, **index_parameters)
 


### PR DESCRIPTION
**Context**

`mp.metal` and `mp.perfect_electric_conductor` are defined as `Medium(epsilon=-inf)` ([`python/meep.i:1825-1826`](https://github.com/NanoComp/meep/blob/8f399d07bc4044dfd6e02940d89f076f266ec1e8/python/meep.i#L1825-L1826)), and that `-inf` survives as a large finite `-1e20` all the way through `geom_epsilon::chi1p1` → `Simulation.get_epsilon_grid`.

`plot_eps` — the function `plot2D` calls to draw the geometry ([`python/visualization.py:599-732`](https://github.com/NanoComp/meep/blob/8f399d07bc4044dfd6e02940d89f076f266ec1e8/python/visualization.py#L599-L732)) — passes that array straight to `ax.imshow` and, when `colorbar=True`, straight into `mpl.colors.Normalize(np.amin(eps_data), np.amax(eps_data))`. The consequences of this are:

- **Colorbar:** `vmin = -inf`, so the colorbar is meaningless and every finite dielectric collapses onto one end of the scale.
- **Image:** matplotlib's internal `safe_masked_invalid` masks the `-inf` pixels and draws them with the colormap's "bad" color, which defaults to *fully transparent* — metal renders as blank background rather than as a material (see first image below).
- **Contour path:** `levels=np.unique(eps_data)` includes `-inf` as a contour level.

**Changes**

`python/visualization.py`
- new `pec_color: "darkred"` key in `default_eps_parameters` (dropped by `filter_dict` before reaching `imshow`, like the other non-imshow dicts).
- `plot_eps` now masks metallic pixels (`~np.isfinite(eps) | (eps <= -mp.inf)`) and paints them via `cmap.set_bad(pec_color)` on a `copy.copy` of the colormap, so `imshow` autoscales over the finite permittivities only.
- Colorbar `vmin`/`vmax` now come from the unmasked values, with a guard for an all-metal plane.
- Contour path uses `np.unique(eps_data.compressed())` so `-1e20` is no longer emitted as a contour level.
- Fixed a latent aliasing bug: `eps_parameters = default_eps_parameters` handed out the module-level dict itself, which the new code would have mutated — now `copy.deepcopy`.
- Added `_get_colormap()` (handles str or `Colormap`, matplotlib ≥3.5 or older) and used it in `_add_colorbar`; required because a `Colormap` instance is now passed there, and `mpl.cm.get_cmap` is removed in matplotlib 3.11. This also clears the deprecation warning the old cell emitted.

**Verification**

`test_plot2D_pec` (clim finite and equal to (1, 12), bad color = `darkred`, mask non-empty, defaults unmutated, user override honored) and `test_plot2D_pec_contour`.

Here is an example involving a [cleaved multilayer stack](https://meep.readthedocs.io/en/latest/Python_Tutorials/Custom_Source/#dipole-emission-of-a-cleaved-multilayer-stack) in which the substrate is a perfect metal. Metallic/PEC regions render as a distinct dark red, and the color scale (image and colorbar) is driven only by the finite permittivity values.


<img width="906" height="678" alt="edge_emitter_layout" src="https://github.com/user-attachments/assets/bfb0b7ec-a720-4711-bd6f-6d4f16a4d340" />

<img width="889" height="678" alt="edge_emitter_layout" src="https://github.com/user-attachments/assets/fe9c145b-3efe-427e-a22c-fbecfb3875d3" />
